### PR TITLE
[codex] add Railway and Hetzner launch paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,42 @@ curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh 
 For a non-interactive Tailscale setup:
 
 ```bash
-TS_AUTHKEY=tskey-auth-xxxx \
-  curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh \
+  | TS_AUTHKEY=tskey-auth-xxxx bash
 ```
 
 The setup script downloads the latest release, installs production dependencies,
 writes `.env`, starts the server as a user service, and configures
 `tailscale serve` when Tailscale is available.
+
+## One-click Launch
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/BennyKok/lfg)
+
+Railway is useful for a hosted demo, but `lfg` works best on the machine that
+has your repos, `tmux`, and authenticated agent CLIs. See
+[deploy/railway](./deploy/railway/README.md) for details.
+
+For Hetzner, use the cloud-init template in
+[deploy/hetzner](./deploy/hetzner/README.md). Hetzner's official deploy button
+only preselects Hetzner App images, so the repo ships a first-boot installer
+instead.
+
+Railway user requirements:
+
+- Railway account and GitHub access to this repo.
+- Keep Public Networking disabled unless you put auth in front of `lfg`.
+- Optional provider keys in Railway variables, such as `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, or `ELEVENLABS_API_KEY`.
+
+Hetzner user requirements:
+
+- Hetzner Cloud account, SSH public key, and either the `hcloud` CLI or Console.
+- Tailscale account plus an ephemeral/preauthorized auth key for unattended
+  setup. The installer joins the server with `tailscale up --authkey ...` and
+  exposes the loopback-only UI through `tailscale serve`.
+- After boot, authenticate `claude`, `codex`, or `opencode` on the server, or
+  configure API-key based providers in `.env`.
 
 ## Local Development
 

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -1,0 +1,57 @@
+# Hetzner Cloud
+
+Hetzner does not provide arbitrary GitHub-repo deploy buttons like Railway. Its
+official "Deploy to Hetzner Cloud" button only preselects one of Hetzner's App
+images. For `lfg`, use cloud-init or the `hcloud` CLI to create a normal Ubuntu
+server and run `scripts/setup.sh` on first boot.
+
+The installer keeps `lfg` bound to `127.0.0.1` and exposes it through
+`tailscale serve`. Do not open the `lfg` port to the public internet.
+
+## One-command Server Create
+
+1. Copy `cloud-init.yaml` and replace:
+   - `REPLACE_WITH_YOUR_PUBLIC_SSH_KEY`
+   - `CHANGE_ME_TS_AUTHKEY`
+2. Create the server:
+
+```bash
+hcloud server create \
+  --name lfg-1 \
+  --type cpx21 \
+  --image ubuntu-24.04 \
+  --location fsn1 \
+  --user-data-from-file deploy/hetzner/cloud-init.yaml
+```
+
+3. Watch first boot:
+
+```bash
+ssh lfg@<server-ip> 'tail -f /var/log/cloud-init-output.log'
+```
+
+4. Check the app:
+
+```bash
+ssh lfg@<server-ip> 'systemctl --user status lfg --no-pager'
+ssh lfg@<server-ip> 'journalctl --user -u lfg -f'
+```
+
+When Tailscale is configured, the installer prints the tailnet-only HTTPS URL.
+
+## Manual Console Flow
+
+If you prefer the Hetzner Console:
+
+1. Create an Ubuntu 24.04 server.
+2. Paste the contents of `cloud-init.yaml` into the **Cloud config** field.
+3. Create the server.
+4. SSH in as `lfg` after cloud-init completes.
+
+## Updating
+
+SSH into the server as `lfg` and run:
+
+```bash
+lfg setup
+```

--- a/deploy/hetzner/cloud-init.yaml
+++ b/deploy/hetzner/cloud-init.yaml
@@ -1,0 +1,33 @@
+#cloud-config
+#
+# Hetzner Cloud user-data template for lfg.
+#
+# Replace CHANGE_ME_TS_AUTHKEY with an ephemeral, preauthorized Tailscale auth
+# key before creating the server. If you do not want Tailscale setup at boot,
+# remove `TS_AUTHKEY=CHANGE_ME_TS_AUTHKEY` from the install command below and
+# SSH in to run `tailscale up` later.
+
+package_update: true
+package_upgrade: false
+
+users:
+  - name: lfg
+    groups: sudo
+    shell: /bin/bash
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ssh-ed25519 REPLACE_WITH_YOUR_PUBLIC_SSH_KEY
+
+runcmd:
+  - mkdir -p /home/lfg/repos
+  - chown -R lfg:lfg /home/lfg/repos
+  - |
+    sudo -iu lfg bash -lc '
+      export LFG_DIR="$HOME/lfg"
+      export LFG_REPOS_ROOT="$HOME/repos"
+      export LFG_INSTALL_MODE=release
+      curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | TS_AUTHKEY=CHANGE_ME_TS_AUTHKEY bash
+    '
+
+final_message: "lfg install finished. Check cloud-init output and the lfg user service logs."

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -1,0 +1,34 @@
+# Railway
+
+Railway is a demo-friendly deployment target for `lfg`. It can run the web UI
+and API from this repository, but it does not have your local repositories,
+`tmux` sessions, or authenticated agent CLIs unless you add them to that
+container yourself.
+
+Use Railway for a quick hosted preview. For day-to-day agent work, install
+`lfg` on the machine that already has your repos and CLI credentials.
+
+## Deploy from GitHub
+
+1. Push this repository to GitHub.
+2. In Railway, create a new project from the GitHub repository.
+3. Railway will pick up `railway.json`.
+4. Set any optional provider secrets in Railway variables, for example:
+   - `ANTHROPIC_API_KEY`
+   - `OPENAI_API_KEY`
+   - `ELEVENLABS_API_KEY`
+
+`railway.json` binds the app to `0.0.0.0` and Railway's injected `$PORT`.
+
+## Template Button
+
+The README uses Railway's generic GitHub-template URL. After creating a
+published Railway template from the Railway dashboard, replace that README link
+with the assigned template URL:
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](RAILWAY_TEMPLATE_URL)
+```
+
+Published Railway template URLs are assigned by Railway after publishing; this
+repo cannot know the final URL ahead of time.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "bun install"
+  },
+  "deploy": {
+    "startCommand": "LFG_HOST=0.0.0.0 LFG_PORT=${PORT:-8766} bun run serve",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,7 +9,7 @@
 # Brand-new VPS (run as a normal sudo user, NOT root):
 #   curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | bash
 #   # or non-interactively, with the Tailscale auth key supplied up front:
-#   TS_AUTHKEY=tskey-auth-xxxx curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | TS_AUTHKEY=tskey-auth-xxxx bash
 #
 # Re-run / update after install:
 #   lfg setup

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -204,7 +204,7 @@ import { startFleetWatcher, subscribeFleet, type FleetEvent } from "../voice-bus
 import { handleElevenLlm, handleElevenToken } from "../voice-eleven-llm.ts";
 import { resolveVoiceIntent, type VoiceIntentRequest } from "../voice-intent.ts";
 
-const PORT = Number(process.env.LFG_PORT ?? 8766);
+const PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
 // Bind to loopback by default — the UI is meant to be reached over Tailscale
 // (via `tailscale serve`), never the public internet. Override LFG_HOST only
 // if you understand the exposure.


### PR DESCRIPTION
## Summary

Adds concrete one-click/self-host launch paths for Railway and Hetzner:

- Adds `railway.json` so Railway can build and start the app with its injected `$PORT`.
- Adds Railway docs explaining the hosted-demo use case, public networking caution, and template URL flow.
- Adds Hetzner cloud-init and docs for bootstrapping an Ubuntu server with `scripts/setup.sh` and Tailscale.
- Updates the README with Railway/Hetzner user requirements and the Tailscale auth-key requirement.
- Fixes the documented `TS_AUTHKEY` pipe form so the variable is available to the setup script's `bash` process.
- Lets `lfg serve` honor `process.env.PORT` as a fallback behind `LFG_PORT`.

## Validation

- `railway.json` parses successfully.
- `deploy/hetzner/cloud-init.yaml` parses successfully with the repo's `yaml` dependency.
- Railway-style start command boots on an injected `PORT` and prints the expected local URL.

## Notes

A full repo-level `bun run tsc --noEmit` still fails on existing unrelated TypeScript configuration/errors, including web files being checked without JSX/DOM settings.