### PR TITLE
Improve Docker layer cache reuse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,16 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# Build from the checked-out source tree (works for any clone/snapshot of
-# the repo — no dependency on a published release bundle).
+COPY package.json bun.lock ./
+RUN bun install
+
+COPY web/package.json web/bun.lock ./web/
+RUN cd web && bun install
+
 COPY . .
 
 RUN set -eux; \
-  bun install; \
   cd web; \
-  bun install; \
   bun run build; \
   cd /app; \
   mkdir -p /data/repos /data/lfg; \

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.184.1",
@@ -482,6 +483,8 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 
@@ -1458,6 +1461,8 @@
     "typed-emitter": ["typed-emitter@2.1.0", "", { "optionalDependencies": { "rxjs": "*" } }, "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 


### PR DESCRIPTION
## Summary
- Copy root and web package manifests before dependency installs so Docker can reuse install layers across source-only changes.
- Move the full source copy until after dependency layers and keep the existing runtime setup intact.
- Update `web/bun.lock` so the web package manifest is lockfile-consistent under Bun 1.3.13.

## Validation
- `git diff --check origin/main...origin/session_lfg-833601`
- `git merge-tree origin/main origin/session_lfg-833601`
- `bun install --frozen-lockfile`
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run build`

Docker was not available locally, so I could not run an image build in this environment.