### PR TITLE
Fix session recovery and persistent worktree root

### DIFF
--- a/src/agents/backends/aisdk-session.ts
+++ b/src/agents/backends/aisdk-session.ts
@@ -31,7 +31,11 @@ import {
   writeEntry,
 } from "../../aisdk-registry.ts";
 import { normalizeLineMessages, type SessionMsg } from "../../sessions.ts";
-import { indexSessionMessagesDirect, sessionHasIndexedMessages } from "../../transcript-index.ts";
+import {
+  indexSessionMessagesDirect,
+  reindexFileHistoryUnderSessionKey,
+  sessionHasIndexedMessages,
+} from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
 import { readFileSync, statSync } from "node:fs";
 
@@ -180,6 +184,13 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   // an existing session. Fresh sessions mint the deterministic id up front
   // (sessionId and resume are mutually exclusive on the SDK).
   const resuming = sessionHasIndexedMessages(sessionId);
+  // Legacy claude sessions have their history under a native ~/.claude JSONL
+  // file path, not the synthetic session key — so a resumed pane would render
+  // empty. Seed the synthetic key from that file history so the transcript is
+  // visible and new turns append to it. Done AFTER `resuming` is captured, so
+  // the SDK still starts in `{ sessionId }` mode (no resume of an id the SDK
+  // never minted) — visibility now, continuation as a fresh underlying thread.
+  if (!resuming) reindexFileHistoryUnderSessionKey(sessionId);
 
   const publishDraft = makeDraftPublisher(sessionId);
 

--- a/src/agents/backends/codex-aisdk-session.ts
+++ b/src/agents/backends/codex-aisdk-session.ts
@@ -30,7 +30,7 @@ import {
   writeEntry,
 } from "../../aisdk-registry.ts";
 import type { SessionMsg } from "../../sessions.ts";
-import { indexSessionMessagesDirect } from "../../transcript-index.ts";
+import { indexSessionMessagesDirect, reindexFileHistoryUnderSessionKey } from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 
@@ -205,6 +205,15 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
   try {
     process.chdir(cwd);
   } catch {}
+
+  // Resuming a codex thread under a fresh control-plane key: the thread's history
+  // was tailed into the index under its native threadId, so the pane keyed by
+  // `key` would render empty. Seed the synthetic key from the threadId's history
+  // (no-op if the key already has rows or the thread has none) — visible history
+  // now, new turns append after it. See reindexFileHistoryUnderSessionKey.
+  if (resumeThreadId && resumeThreadId !== key) {
+    reindexFileHistoryUnderSessionKey(key, resumeThreadId);
+  }
 
   const { Codex } = await import("@openai/codex-sdk");
   const codexPathOverride = resolveCodexPathOverride();

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -47,7 +47,7 @@ function branchExists(repo: string, branch: string): boolean {
 }
 
 function sessionWorktreeOwner(absCwd: string): string | null {
-  const wtRoot = resolve(process.env.LFG_WORKTREE_ROOT ?? "/tmp/lfg-wt");
+  const wtRoot = resolve(process.env.LFG_WORKTREE_ROOT ?? `${homedir()}/lfg-worktrees`);
   const rel = relative(wtRoot, absCwd);
   if (!rel || rel.startsWith("..") || rel === ".." || rel.startsWith("/")) return null;
   const name = rel.split(/[\\/]/).filter(Boolean)[0];
@@ -72,7 +72,7 @@ function sessionWorktreeOwner(absCwd: string): string | null {
 }
 
 function isSessionWorktreePath(absCwd: string): boolean {
-  const wtRoot = resolve(process.env.LFG_WORKTREE_ROOT ?? "/tmp/lfg-wt");
+  const wtRoot = resolve(process.env.LFG_WORKTREE_ROOT ?? `${homedir()}/lfg-worktrees`);
   const rel = relative(wtRoot, absCwd);
   return !!rel && !rel.startsWith("..") && rel !== ".." && !rel.startsWith("/");
 }

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -510,6 +510,67 @@ export function sessionHasIndexedMessages(sessionId: string): boolean {
     .get(key);
 }
 
+// Seed the synthetic per-session read model (`lfg://session/<id>`) from history
+// that was indexed under a real FILE path. Two cases:
+//   - claude: legacy sessions indexed by their native ~/.claude JSONL before the
+//     direct-SDK aisdk harness existed, keyed under the file path with the lfg
+//     session id (sourceSessionId defaults to sessionId).
+//   - codex: the rollout JSONL is tailed under the native threadId, so a session
+//     resumed under a fresh control-plane key must pull from that threadId
+//     (pass it as sourceSessionId).
+// A resumed harness serves only the synthetic key, and `indexedMessagePage`
+// filters (WHERE path = ?), so without this the pane renders empty. Copying the
+// rows under the synthetic key makes the full history visible; new turns then
+// append after them via indexSessionMessagesDirect. No-op when the synthetic key
+// already has rows (working/new sessions) or when there is no file-path history,
+// so it can never regress a healthy session.
+export function reindexFileHistoryUnderSessionKey(
+  sessionId: string,
+  sourceSessionId: string = sessionId,
+): number {
+  init();
+  const key = sessionIndexKey(sessionId);
+  const d = database();
+  if (d.query("SELECT 1 FROM transcript_messages WHERE path = ? LIMIT 1").get(key)) return 0;
+  const src = d
+    .query<
+      { message_id: string | null; role: string; kind: string; ts: number; text: string },
+      [string]
+    >(
+      `SELECT message_id, role, kind, ts, text
+         FROM transcript_messages
+        WHERE session_id = ? AND path NOT LIKE 'lfg://%'
+        ORDER BY byte_offset ASC, id ASC`,
+    )
+    .all(sourceSessionId);
+  if (!src.length) return 0;
+  let seq = 0;
+  const inserted = d.transaction((rows: typeof src) => {
+    const msgStmt = d.query(`
+      INSERT OR IGNORE INTO transcript_messages
+        (id, session_id, path, message_id, byte_offset, ts, role, kind, text)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const ftsStmt = d.query(`
+      INSERT INTO transcript_messages_fts (id, session_id, text)
+      SELECT ?, ?, ?
+      WHERE NOT EXISTS (SELECT 1 FROM transcript_messages_fts WHERE id = ?)
+    `);
+    let n = 0;
+    for (const r of rows) {
+      const id = `${key}\0${r.message_id ?? String(seq)}\0${seq}`;
+      const result = msgStmt.run(id, sessionId, key, r.message_id, seq, r.ts, r.role, r.kind, r.text);
+      n += Number(result.changes ?? 0);
+      ftsStmt.run(id, sessionId, r.text, id);
+      seq++;
+    }
+    return n;
+  })(src);
+  directNextOffset.set(key, seq);
+  pageTotalCache.delete(key);
+  return inserted;
+}
+
 function cursorFor(path: string): { offset: number; size: number; mtimeMs: number } | null {
   init();
   return database()

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -3,12 +3,19 @@
 // lfg itself and voice-orchestrator sessions.
 
 import { existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import { basename, dirname, resolve } from "node:path";
 import { MAIN_REF } from "./agents/collectors/git-fresh.ts";
 import { listManaged } from "./managed.ts";
 import { tmuxHasSession } from "./tmux.ts";
 
-export const WORKTREE_ROOT = "/tmp/lfg-wt";
+// Persistent, env-overridable. Never default to /tmp: it is cleared on reboot
+// (systemd-tmpfiles), which silently destroys every live session's worktree —
+// including uncommitted work. Keep this in sync with the same default in
+// projects.ts (a shared import would create a projects→worktree→tmux cycle).
+export const WORKTREE_ROOT = resolve(
+  process.env.LFG_WORKTREE_ROOT ?? `${homedir()}/lfg-worktrees`,
+);
 
 export type SessionWorktree = {
   repoRoot: string;


### PR DESCRIPTION
## Summary

- move session worktrees from `/tmp` to persistent `~/lfg-worktrees` storage
- restore full Claude and Codex transcript history when resuming sessions

## Validation

- `bun test` (30 passed)
- `bun run typecheck`