### PR TITLE
fix: bound agent swarm memory and concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ LFG_REPOS_ROOT=
 # whatsapp). Defaults to the current working directory when unset.
 LFG_REPO=
 
+# Maximum simultaneously-running LFG subagents. Additional create/delegate
+# calls wait in a FIFO queue. The dashboard setting can choose 1-6 at runtime.
+LFG_MAX_CONCURRENT_AGENTS=6
+
 # Comma-separated roster for optional per-user session tagging (Gravatar avatars
 # in the UI). Each entry is `email` or `email:displayname` — the optional name is
 # shown in the UI instead of the raw email. Leave empty for single-user.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -434,6 +434,16 @@ install_linux_service() {
   say "Installing the systemd user service (${SERVICE})..."
   UNIT_DIR="$HOME/.config/systemd/user"
   mkdir -p "$UNIT_DIR"
+  cat > "$UNIT_DIR/lfg-agents.slice" <<'UNIT'
+[Unit]
+Description=LFG managed agent memory boundary
+
+[Slice]
+# Keep reclaim local to the swarm. memory.high throttles first; memory.max is
+# the last-resort cgroup OOM boundary. Idle anonymous pages may use swap.
+MemoryHigh=4G
+MemoryMax=5G
+UNIT
   cat > "$UNIT_DIR/$SERVICE.service" <<UNIT
 [Unit]
 Description=lfg - self-hosted AI coding agent control plane

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -19,6 +19,7 @@ import {
   spawnManagedSession,
   managedCursorSessionArgv,
   cursorChatIdFromOutput,
+  containedAgentCommand,
   parsePrompt,
 } from "./tmux.ts";
 
@@ -120,6 +121,22 @@ describe("coding agent adapter contract", () => {
     ]);
     expect(cursorChatIdFromOutput(`Created chat: ${nativeSessionId}\n`)).toBe(nativeSessionId);
     expect(cursorChatIdFromOutput("chat creation failed")).toBeNull();
+  });
+
+  test("contained subagents run in the shared slice with cleanup and OOM priority", () => {
+    const argv = containedAgentCommand(["/usr/bin/example-agent", "--task", "hello"], {
+      name: "lfg-test",
+      cwd: "/tmp/lfg-test",
+      lfgSessionId: "session-id",
+    });
+    if (process.platform !== "linux") return;
+    expect(argv).toContain("--slice=lfg-agents.slice");
+    expect(argv).toContain("--property=KillMode=control-group");
+    expect(argv).toContain("--property=OOMScoreAdjust=200");
+    expect(argv).toContain("--setenv=LFG_SESSION_ID=session-id");
+    expect(argv).toContain("--setenv=AGENT_BROWSER_SESSION=lfg-test");
+    expect(argv.some((part) => part.startsWith("--setenv=DBUS_SESSION_BUS_ADDRESS="))).toBe(true);
+    expect(argv.slice(-3)).toEqual(["/usr/bin/example-agent", "--task", "hello"]);
   });
 
   test("cursor approval prompts are surfaced to the shared prompt UI", () => {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -295,7 +295,11 @@ export async function cmdMcp() {
       const data = await api(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text, mode }),
+        body: JSON.stringify({
+          text,
+          mode,
+          fromSessionId: process.env.LFG_SESSION_ID?.trim() || undefined,
+        }),
       });
       return result(data);
     },

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -175,6 +175,7 @@ import {
 } from "../repos-store.ts";
 import { projectName, reposRoot } from "../projects.ts";
 import { resolveSessionCwd, startWorktreeSweep } from "../worktree.ts";
+import { SubagentLimiter } from "../subagent-limiter.ts";
 import {
   synthesizeTts,
   transcribeStt,
@@ -217,6 +218,7 @@ import {
 import {
   DEFAULT_TIME_ZONE,
   getGlobalSettings,
+  getGlobalSettingsSync,
   setGlobalSettings,
   validTimeZone,
   type GlobalSettings,
@@ -357,6 +359,24 @@ const PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
 // if you understand the exposure.
 const HOST = process.env.LFG_HOST ?? "127.0.0.1";
 const MAX_LFG_SUBAGENT_DEPTH = 4;
+const subagentLimiter = new SubagentLimiter(getGlobalSettingsSync().maxConcurrentAgents);
+
+function agentCapacity() {
+  const snapshot = subagentLimiter.snapshot();
+  return {
+    max: snapshot.max,
+    active: snapshot.active.length,
+    queued: snapshot.queued.length,
+  };
+}
+
+function restoreSubagentLimiter(): void {
+  subagentLimiter.restore(
+    listManaged()
+      .filter((session) => session.spawnedBy === "subagent" && tmuxHasSession(session.tmuxName))
+      .map((session) => session.tmuxName),
+  );
+}
 
 marked.setOptions({ gfm: true, breaks: false });
 
@@ -1635,6 +1655,9 @@ function prepareLoginTerminal(kind: string, command: string): string {
 }
 
 export async function cmdServe() {
+  restoreSubagentLimiter();
+  const limiterReaper = setInterval(() => subagentLimiter.reconcile(tmuxHasSession), 2_000);
+  limiterReaper.unref();
   const liveWs = createLiveWsSupport({
     evlog,
     getAgentRun: agentRunSnapshot,
@@ -2194,7 +2217,15 @@ export async function cmdServe() {
             if (!validTimeZone(timeZone)) return err(400, `invalid timezone "${timeZone}"`);
             patch.timeZone = timeZone;
           }
-          return json({ settings: await setGlobalSettings(patch) });
+          if (b?.maxConcurrentAgents !== undefined) {
+            const max = Number(b.maxConcurrentAgents);
+            if (!Number.isInteger(max) || max < 1 || max > 6)
+              return err(400, "maxConcurrentAgents must be an integer from 1 to 6");
+            patch.maxConcurrentAgents = max;
+          }
+          const settings = await setGlobalSettings(patch);
+          subagentLimiter.setMax(settings.maxConcurrentAgents);
+          return json({ settings, agentCapacity: agentCapacity() });
         }
         return err(405, "method not allowed");
       }
@@ -2248,6 +2279,7 @@ export async function cmdServe() {
             models: boot.models ?? null,
             settings: boot.settings ?? null,
             sessions: boot.sessions ?? null,
+            agentCapacity: agentCapacity(),
             users: boot.users ?? null,
             repos: boot.repos ?? null,
             skills: boot.skills ?? null,
@@ -3241,7 +3273,7 @@ export async function cmdServe() {
         const sessions = await listSessionsCached();
         warmChatTranscripts(sessions);
         warmRenderedBacklogs(sessions, 40);
-        return json({ sessions });
+        return json({ sessions, agentCapacity: agentCapacity() });
       }
 
       if (path === "/api/install") {
@@ -3818,12 +3850,19 @@ export async function cmdServe() {
           assignedUser = cursor?.assignedUser ?? undefined;
         }
         const tmuxName = `lfg-${randomBytes(3).toString("hex")}`;
+        const isSubagent = spawnedBy === "subagent";
+        const admission = isSubagent
+          ? await subagentLimiter.acquire(tmuxName)
+          : { queuedForMs: 0 };
         const cwdResolved = resolveSessionCwd(repo.cwd, tmuxName, {
           voice: !!body?.voice,
           worktree: body?.worktree,
           selfRepo: SELF_REPO,
         });
-        if (!cwdResolved.ok) return err(502, cwdResolved.error);
+        if (!cwdResolved.ok) {
+          if (isSubagent) subagentLimiter.release(tmuxName);
+          return err(502, cwdResolved.error);
+        }
         const cwd = cwdResolved.cwd;
         const worktree = cwdResolved.worktree;
         // For the voice orchestrator, append a live snapshot of every OTHER
@@ -3909,7 +3948,7 @@ export async function cmdServe() {
         if (assignedUser) assignUser(tmuxName, assignedUser);
         const r: { ok: boolean; error?: string; nativeSessionId?: string } =
           agent === "codex"
-            ? spawnManagedCodexSession({ name: tmuxName, cwd, prompt, model: resolvedModel, thinkingLevel, lfgSessionId: launchId, lfgUser: assignedUser })
+            ? spawnManagedCodexSession({ name: tmuxName, cwd, prompt, model: resolvedModel, thinkingLevel, lfgSessionId: launchId, lfgUser: assignedUser, containInAgentSlice: isSubagent })
             : agent === "grok"
               ? spawnManagedGrokSession({
                   name: tmuxName,
@@ -3919,6 +3958,7 @@ export async function cmdServe() {
                   thinkingLevel,
                   lfgSessionId: launchId,
                   lfgUser: assignedUser,
+                  containInAgentSlice: isSubagent,
                 })
             : agent === "cursor"
               ? spawnManagedCursorSession({
@@ -3928,6 +3968,7 @@ export async function cmdServe() {
                   model: resolvedModel ?? "auto",
                   lfgSessionId: launchId,
                   lfgUser: assignedUser,
+                  containInAgentSlice: isSubagent,
                 })
             : agent === "aisdk"
               ? spawnManagedAisdkSession({
@@ -3939,6 +3980,7 @@ export async function cmdServe() {
                   thinkingLevel,
                   lfgSessionId: launchId,
                   lfgUser: assignedUser,
+                  containInAgentSlice: isSubagent,
                 })
               : agent === "codex-aisdk"
                 ? spawnManagedCodexAisdkSession({
@@ -3949,7 +3991,8 @@ export async function cmdServe() {
                     key: codexAisdkKey!,
                     thinkingLevel,
                     lfgSessionId: launchId,
-                  lfgUser: assignedUser,
+                    lfgUser: assignedUser,
+                    containInAgentSlice: isSubagent,
                   })
                 : agent === "opencode"
                   ? spawnManagedOpencodeAisdkSession({
@@ -3959,10 +4002,12 @@ export async function cmdServe() {
                       model: resolvedModel ?? OPENCODE_DEFAULT_MODEL,
                       key: opencodeKey!,
                       lfgSessionId: launchId,
-                  lfgUser: assignedUser,
+                      lfgUser: assignedUser,
+                      containInAgentSlice: isSubagent,
                     })
-                  : spawnManagedSession({ name: tmuxName, cwd, prompt, model: resolvedModel, thinkingLevel, lfgSessionId: launchId, lfgUser: assignedUser });
+                  : spawnManagedSession({ name: tmuxName, cwd, prompt, model: resolvedModel, thinkingLevel, lfgSessionId: launchId, lfgUser: assignedUser, containInAgentSlice: isSubagent });
         if (!r.ok) {
+          if (isSubagent) subagentLimiter.release(tmuxName);
           removeManaged(tmuxName);
           assignUser(tmuxName, null);
           return err(502, r.error || "failed to start session");
@@ -4004,6 +4049,9 @@ export async function cmdServe() {
           // whether the child landed under the right user instead of guessing.
           assignedUser: assignedUser ?? null,
           worktree: worktree?.path ?? null,
+          concurrency: isSubagent
+            ? { max: subagentLimiter.max, queuedForMs: admission.queuedForMs }
+            : undefined,
         });
       }
 
@@ -4322,6 +4370,7 @@ export async function cmdServe() {
           const body = (await req.json().catch(() => null)) as {
             text?: string;
             mode?: "steer" | "queue";
+            fromSessionId?: string;
           } | null;
           const text = body?.text?.trim();
           if (!text) return err(400, "expected { text }");
@@ -4332,6 +4381,26 @@ export async function cmdServe() {
           if (!sess) return err(404, "session not found");
           const sent = sendPromptToLiveSession(sess, text, { mode });
           if (!sent.ok) return err(409, sent.error || "couldn't send message");
+          // Terminal reports also end the child lifecycle. Once this response
+          // has flushed, close the managed child; its transient service reaps
+          // browser/helper descendants and frees the next concurrency slot.
+          if (/^\[subagent (?:complete|blocked|failed)\]/i.test(text) && body?.fromSessionId) {
+            const sender = (await listSessions()).find(
+              (session) =>
+                session.sessionId === body.fromSessionId ||
+                session.nativeSessionId === body.fromSessionId,
+            );
+            const senderParent = sender?.parentSessionId ?? sender?.parentNativeSessionId;
+            if (sender?.managed && sender.spawnedBy === "subagent" && senderParent === m[1]) {
+              setTimeout(() => {
+                void fetch(`http://127.0.0.1:${PORT}/api/sessions/${body.fromSessionId}/close`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ source: "subagent-terminal-state" }),
+                });
+              }, 1_500);
+            }
+          }
           return json({ ok: true, msg: sent.msg });
         }
       }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,13 +1,21 @@
 import { mkdirSync, readFileSync } from "node:fs";
+import { Database } from "bun:sqlite";
 import { PATHS } from "./config.ts";
 import { join } from "node:path";
+import {
+  MAX_CONCURRENT_AGENTS_LIMIT,
+  maxConcurrentAgents,
+} from "./subagent-limiter.ts";
 
 export type GlobalSettings = {
   timeZone: string;
+  maxConcurrentAgents: number;
 };
 
-const SETTINGS_PATH = join(PATHS.data, "settings.json");
+const LEGACY_SETTINGS_PATH = join(PATHS.data, "settings.json");
+const SETTINGS_DB_PATH = join(PATHS.data, "lfg.sqlite");
 export const DEFAULT_TIME_ZONE = "Asia/Hong_Kong";
+let db: Database | null = null;
 
 function envTimeZone(): string {
   return process.env.LFG_SCHED_TZ || DEFAULT_TIME_ZONE;
@@ -26,15 +34,74 @@ function sanitize(input: Partial<GlobalSettings> | null | undefined): GlobalSett
   const timeZone = typeof input?.timeZone === "string" && validTimeZone(input.timeZone)
     ? input.timeZone
     : envTimeZone();
-  return { timeZone };
+  const requestedMax = Number(input?.maxConcurrentAgents);
+  const maxAgents = Number.isInteger(requestedMax) && requestedMax > 0
+    ? Math.min(requestedMax, MAX_CONCURRENT_AGENTS_LIMIT)
+    : maxConcurrentAgents();
+  return { timeZone, maxConcurrentAgents: maxAgents };
+}
+
+function settingsDb(): Database {
+  if (db) return db;
+  mkdirSync(PATHS.data, { recursive: true });
+  const opened = new Database(SETTINGS_DB_PATH, { create: true });
+  opened.exec("PRAGMA journal_mode = WAL");
+  opened.exec("PRAGMA busy_timeout = 5000");
+  opened.exec(`
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key TEXT PRIMARY KEY,
+      value_json TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS settings_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at INTEGER NOT NULL
+    );
+  `);
+
+  const migrated = opened
+    .query<{ found: number }, []>(
+      "SELECT 1 AS found FROM settings_migrations WHERE name = 'legacy-settings-json-v1'",
+    )
+    .get();
+  if (!migrated) {
+    let legacy: Partial<GlobalSettings> | null = null;
+    try {
+      legacy = JSON.parse(readFileSync(LEGACY_SETTINGS_PATH, "utf8")) as Partial<GlobalSettings>;
+    } catch {}
+    const initial = sanitize(legacy);
+    const write = opened.query(
+      "INSERT OR IGNORE INTO app_settings (key, value_json, updated_at) VALUES (?, ?, ?)",
+    );
+    const migrate = opened.transaction(() => {
+      const now = Date.now();
+      write.run("timeZone", JSON.stringify(initial.timeZone), now);
+      write.run("maxConcurrentAgents", JSON.stringify(initial.maxConcurrentAgents), now);
+      opened
+        .query("INSERT INTO settings_migrations (name, applied_at) VALUES (?, ?)")
+        .run("legacy-settings-json-v1", now);
+    });
+    migrate();
+  }
+  db = opened;
+  return opened;
+}
+
+function readStoredSettings(): Partial<GlobalSettings> {
+  const rows = settingsDb()
+    .query<{ key: string; value_json: string }, []>("SELECT key, value_json FROM app_settings")
+    .all();
+  const stored: Record<string, unknown> = {};
+  for (const row of rows) {
+    try {
+      stored[row.key] = JSON.parse(row.value_json);
+    } catch {}
+  }
+  return stored as Partial<GlobalSettings>;
 }
 
 export function getGlobalSettingsSync(): GlobalSettings {
-  try {
-    return sanitize(JSON.parse(readFileSync(SETTINGS_PATH, "utf8")) as Partial<GlobalSettings>);
-  } catch {
-    return sanitize(null);
-  }
+  return sanitize(readStoredSettings());
 }
 
 export async function getGlobalSettings(): Promise<GlobalSettings> {
@@ -44,7 +111,15 @@ export async function getGlobalSettings(): Promise<GlobalSettings> {
 export async function setGlobalSettings(patch: Partial<GlobalSettings>): Promise<GlobalSettings> {
   const current = getGlobalSettingsSync();
   const next = sanitize({ ...current, ...patch });
-  mkdirSync(PATHS.data, { recursive: true });
-  await Bun.write(SETTINGS_PATH, JSON.stringify(next, null, 2));
+  const database = settingsDb();
+  const write = database.query(`
+    INSERT INTO app_settings (key, value_json, updated_at) VALUES (?, ?, ?)
+    ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json, updated_at = excluded.updated_at
+  `);
+  database.transaction(() => {
+    const now = Date.now();
+    write.run("timeZone", JSON.stringify(next.timeZone), now);
+    write.run("maxConcurrentAgents", JSON.stringify(next.maxConcurrentAgents), now);
+  })();
   return next;
 }

--- a/src/subagent-limiter.test.ts
+++ b/src/subagent-limiter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { maxConcurrentAgents, SubagentLimiter } from "./subagent-limiter.ts";
+
+describe("subagent concurrency limiter", () => {
+  test("uses a conservative default and validates overrides", () => {
+    expect(maxConcurrentAgents({} as NodeJS.ProcessEnv)).toBe(6);
+    expect(maxConcurrentAgents({ LFG_MAX_CONCURRENT_AGENTS: "2" } as NodeJS.ProcessEnv)).toBe(2);
+    expect(maxConcurrentAgents({ LFG_MAX_CONCURRENT_AGENTS: "0" } as NodeJS.ProcessEnv)).toBe(6);
+    expect(maxConcurrentAgents({ LFG_MAX_CONCURRENT_AGENTS: "20" } as NodeJS.ProcessEnv)).toBe(6);
+  });
+
+  test("queues beyond the cap and admits in FIFO order", async () => {
+    const limiter = new SubagentLimiter(2);
+    await limiter.acquire("one");
+    await limiter.acquire("two");
+    let admitted = false;
+    const third = limiter.acquire("three").then(() => { admitted = true; });
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+    expect(limiter.snapshot().queued).toEqual(["three"]);
+    limiter.release("one");
+    await third;
+    expect(limiter.snapshot().active).toEqual(["two", "three"]);
+  });
+
+  test("reaps vanished restored sessions", () => {
+    const limiter = new SubagentLimiter(2);
+    limiter.restore(["gone", "alive"]);
+    limiter.reconcile((name) => name === "alive");
+    expect(limiter.snapshot().active).toEqual(["alive"]);
+  });
+
+  test("restores over-cap legacy sessions without admitting more", async () => {
+    const limiter = new SubagentLimiter(2);
+    limiter.restore(["one", "two", "legacy-extra"]);
+    let admitted = false;
+    void limiter.acquire("queued").then(() => { admitted = true; });
+    limiter.release("one");
+    await Promise.resolve();
+    expect(admitted).toBe(false);
+    limiter.release("two");
+    await Promise.resolve();
+    expect(admitted).toBe(true);
+  });
+
+  test("updates capacity at runtime and drains queued work", async () => {
+    const limiter = new SubagentLimiter(1);
+    await limiter.acquire("one");
+    let admitted = false;
+    const second = limiter.acquire("two").then(() => { admitted = true; });
+    limiter.setMax(2);
+    await second;
+    expect(admitted).toBe(true);
+    expect(limiter.snapshot().max).toBe(2);
+  });
+});

--- a/src/subagent-limiter.ts
+++ b/src/subagent-limiter.ts
@@ -1,0 +1,90 @@
+export const DEFAULT_MAX_CONCURRENT_AGENTS = 6;
+export const MAX_CONCURRENT_AGENTS_LIMIT = 6;
+
+export function maxConcurrentAgents(env = process.env): number {
+  const raw = env.LFG_MAX_CONCURRENT_AGENTS?.trim();
+  if (!raw) return DEFAULT_MAX_CONCURRENT_AGENTS;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0
+    ? Math.min(parsed, MAX_CONCURRENT_AGENTS_LIMIT)
+    : DEFAULT_MAX_CONCURRENT_AGENTS;
+}
+
+type Waiter = {
+  name: string;
+  queuedAt: number;
+  resolve: (value: { queuedForMs: number }) => void;
+};
+
+/**
+ * Process-local admission control for LFG-managed subagents. A lease remains
+ * held for the lifetime of the tmux session, not merely for the create request.
+ * The systemd slice is the authoritative memory boundary; this limiter keeps
+ * normal operation comfortably below it.
+ */
+export class SubagentLimiter {
+  private _max: number;
+  private active = new Map<string, number>();
+  private queue: Waiter[] = [];
+
+  constructor(max = maxConcurrentAgents()) {
+    this._max = Math.max(1, Math.min(MAX_CONCURRENT_AGENTS_LIMIT, Math.floor(max)));
+  }
+
+  get max(): number {
+    return this._max;
+  }
+
+  setMax(max: number): void {
+    this._max = Math.max(1, Math.min(MAX_CONCURRENT_AGENTS_LIMIT, Math.floor(max)));
+    this.drain();
+  }
+
+  restore(names: Iterable<string>): void {
+    for (const name of names) {
+      if (!this.active.has(name)) this.active.set(name, 0);
+    }
+  }
+
+  acquire(name: string): Promise<{ queuedForMs: number }> {
+    if (this.active.has(name)) return Promise.resolve({ queuedForMs: 0 });
+    if (this.active.size < this._max) {
+      this.active.set(name, Date.now());
+      return Promise.resolve({ queuedForMs: 0 });
+    }
+    return new Promise((resolve) => {
+      this.queue.push({ name, queuedAt: Date.now(), resolve });
+    });
+  }
+
+  release(name: string): boolean {
+    const removed = this.active.delete(name);
+    if (removed) this.drain();
+    return removed;
+  }
+
+  reconcile(isAlive: (name: string) => boolean, now = Date.now()): void {
+    for (const [name, acquiredAt] of this.active) {
+      // A newly admitted request has a short window before tmux exists.
+      if (acquiredAt > 0 && now - acquiredAt < 10_000) continue;
+      if (!isAlive(name)) this.active.delete(name);
+    }
+    this.drain();
+  }
+
+  snapshot(): { max: number; active: string[]; queued: string[] } {
+    return {
+      max: this._max,
+      active: [...this.active.keys()],
+      queued: this.queue.map((waiter) => waiter.name),
+    };
+  }
+
+  private drain(): void {
+    while (this.active.size < this._max && this.queue.length) {
+      const waiter = this.queue.shift()!;
+      this.active.set(waiter.name, Date.now());
+      waiter.resolve({ queuedForMs: Date.now() - waiter.queuedAt });
+    }
+  }
+}

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -71,6 +71,59 @@ function addSessionEnv(argv: string[], sessionId?: string | null, user?: string 
   if (env.length) argv.splice(i + 1, 0, ...env);
 }
 
+type AgentContainment = {
+  name: string;
+  cwd: string;
+  lfgSessionId?: string | null;
+  lfgUser?: string | null;
+};
+
+/**
+ * Run a subagent as a transient user service in the aggregate agent slice.
+ * A service (rather than a scope) gives systemd a main process: when it exits,
+ * KillMode=control-group reaps helper daemons such as agent-browser. Blocking
+ * the service's session bus also prevents Chromium from moving itself into an
+ * unrestricted app-org.chromium scope outside the slice.
+ */
+export function containedAgentCommand(command: string[], opts: AgentContainment): string[] {
+  if (process.platform !== "linux") return command;
+  const systemdRun = Bun.which("systemd-run") ?? "/usr/bin/systemd-run";
+  const uid = typeof process.getuid === "function" ? process.getuid() : 1000;
+  const argv = [
+    systemdRun,
+    "--user",
+    "--quiet",
+    "--pty",
+    "--wait",
+    "--collect",
+    `--unit=lfg-agent-${opts.name}`,
+    "--slice=lfg-agents.slice",
+    `--working-directory=${opts.cwd}`,
+    "--property=Type=exec",
+    "--property=KillMode=control-group",
+    "--property=OOMScoreAdjust=200",
+    `--setenv=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${uid}/lfg-agent-no-session-bus`,
+    `--setenv=AGENT_BROWSER_SESSION=${opts.name}`,
+    "--setenv=AGENT_BROWSER_IDLE_TIMEOUT_MS=300000",
+  ];
+  if (process.env.PATH) argv.push(`--setenv=PATH=${process.env.PATH}`);
+  if (opts.lfgSessionId) argv.push(`--setenv=LFG_SESSION_ID=${opts.lfgSessionId}`);
+  if (opts.lfgUser) argv.push(`--setenv=LFG_USER=${opts.lfgUser}`);
+  return [...argv, "--", ...command];
+}
+
+function containTmuxCommand(
+  argv: string[],
+  executable: string,
+  enabled: boolean | undefined,
+  opts: AgentContainment,
+): void {
+  if (!enabled) return;
+  const commandIndex = argv.indexOf(executable);
+  if (commandIndex < 0) throw new Error(`agent executable not found in tmux argv: ${executable}`);
+  argv.splice(commandIndex, argv.length - commandIndex, ...containedAgentCommand(argv.slice(commandIndex), opts));
+}
+
 // Resolve the `claude` executable to an absolute path. We must NOT rely on a
 // bare `claude` in the spawn: when lfg runs as a systemd service its PATH
 // often lacks ~/.local/bin, so `tmux new-session … claude` can't exec claude
@@ -346,6 +399,7 @@ export function spawnManagedSession(opts: {
   resume?: string;
   lfgSessionId?: string;
   lfgUser?: string | null;
+  containInAgentSlice?: boolean;
 }): { ok: boolean; error?: string } {
   const dec = new TextDecoder();
   ensureFolderTrusted(opts.cwd);
@@ -371,6 +425,7 @@ export function spawnManagedSession(opts: {
   // an empty composer — the first message never gets submitted).
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
+  containTmuxCommand(argv, claudeBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -413,6 +468,7 @@ export function spawnManagedCodexSession(opts: {
   thinkingLevel?: string;
   lfgSessionId?: string;
   lfgUser?: string | null;
+  containInAgentSlice?: boolean;
 }): { ok: boolean; error?: string } {
   const dec = new TextDecoder();
   const argv = [
@@ -437,6 +493,7 @@ export function spawnManagedCodexSession(opts: {
   if (opts.thinkingLevel) argv.push("-c", `reasoning_effort=${JSON.stringify(opts.thinkingLevel)}`);
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
+  containTmuxCommand(argv, codexBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -451,6 +508,7 @@ export function spawnManagedGrokSession(opts: {
   thinkingLevel?: string;
   lfgSessionId?: string;
   lfgUser?: string | null;
+  containInAgentSlice?: boolean;
 }): { ok: boolean; error?: string } {
   const dec = new TextDecoder();
   const argv = [
@@ -473,6 +531,7 @@ export function spawnManagedGrokSession(opts: {
   if (effort) argv.push("--effort", effort);
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
+  containTmuxCommand(argv, grokBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -487,6 +546,7 @@ export type ManagedCursorSessionOptions = {
   lfgSessionId?: string;
   lfgUser?: string | null;
   nativeSessionId?: string;
+  containInAgentSlice?: boolean;
 };
 
 export function managedCursorSessionArgv(opts: ManagedCursorSessionOptions): string[] {
@@ -541,6 +601,7 @@ export function spawnManagedCursorSession(opts: ManagedCursorSessionOptions): {
   const nativeSessionId = cursorChatIdFromOutput(dec.decode(chat.stdout));
   if (!nativeSessionId) return { ok: false, error: "cursor create-chat returned no chat id" };
   const argv = managedCursorSessionArgv({ ...opts, nativeSessionId });
+  containTmuxCommand(argv, cursorBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -592,6 +653,7 @@ export function spawnManagedAisdkSession(opts: {
   thinkingLevel?: string;
   lfgSessionId?: string;
   lfgUser?: string | null;
+  containInAgentSlice?: boolean;
 }): { ok: boolean; error?: string } {
   const dec = new TextDecoder();
   // The provider drives the bundled claude binary, which still honors the trust
@@ -613,6 +675,10 @@ export function spawnManagedAisdkSession(opts: {
   if (opts.thinkingLevel) argv.push("--thinking-level", opts.thinkingLevel);
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId ?? opts.sessionId, opts.lfgUser);
+  containTmuxCommand(argv, process.execPath, opts.containInAgentSlice, {
+    ...opts,
+    lfgSessionId: opts.lfgSessionId ?? opts.sessionId,
+  });
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -633,6 +699,7 @@ export function spawnManagedCodexAisdkSession(opts: {
   thinkingLevel?: string;
   lfgSessionId?: string;
   lfgUser?: string | null;
+  containInAgentSlice?: boolean;
   // When set, resume this existing codex rollout/thread instead of starting a
   // fresh persistent thread — the harness seeds its threadId with it.
   resume?: string;
@@ -658,6 +725,10 @@ export function spawnManagedCodexAisdkSession(opts: {
   if (opts.resume) argv.push("--resume", opts.resume);
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId ?? opts.key, opts.lfgUser);
+  containTmuxCommand(argv, process.execPath, opts.containInAgentSlice, {
+    ...opts,
+    lfgSessionId: opts.lfgSessionId ?? opts.key,
+  });
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -679,6 +750,7 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   lfgSessionId?: string;
   lfgUser?: string | null;
   resume?: string;
+  containInAgentSlice?: boolean;
 }): { ok: boolean; error?: string } {
   const dec = new TextDecoder();
   // Harmless for opencode: ensureFolderTrusted only patches ~/.claude.json and
@@ -699,6 +771,10 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   if (opts.resume) argv.push("--resume", opts.resume);
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId ?? opts.key, opts.lfgUser);
+  containTmuxCommand(argv, process.execPath, opts.containInAgentSlice, {
+    ...opts,
+    lfgSessionId: opts.lfgSessionId ?? opts.key,
+  });
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -450,6 +450,13 @@ type ModelCatalogItem = {
 
 type GlobalSettings = {
   timeZone: string;
+  maxConcurrentAgents: number;
+};
+
+type AgentCapacity = {
+  max: number;
+  active: number;
+  queued: number;
 };
 
 type BootstrapPayload = {
@@ -458,6 +465,7 @@ type BootstrapPayload = {
   codingAgents?: CodingAgentInfo[] | null;
   models?: ModelCatalogItem[] | null;
   settings?: GlobalSettings | null;
+  agentCapacity?: AgentCapacity | null;
   sessions?: Session[] | null;
   users?: User[] | null;
   repos?: Repo[] | null;
@@ -3066,7 +3074,16 @@ export function App() {
   const [tab, setTab] = useState<string>("live");
   const extNavTabs = useExtensionNavTabs();
   const [autoAgents, setAutoAgents] = useState<AutoAgent[]>([]);
-  const [settings, setSettings] = useState<GlobalSettings>({ timeZone: DEFAULT_SCHED_TZ });
+  const [settings, setSettings] = useState<GlobalSettings>({
+    timeZone: DEFAULT_SCHED_TZ,
+    maxConcurrentAgents: 6,
+  });
+  const [agentCapacity, setAgentCapacity] = useState<AgentCapacity>({
+    max: 6,
+    active: 0,
+    queued: 0,
+  });
+  const previousQueuedAgents = useRef(0);
   const [schedTz, setSchedTz] = useState<string>(DEFAULT_SCHED_TZ);
   const [findings, setFindings] = useState<AutoFinding[]>([]);
   const [toastedFindingIds, setToastedFindingIds] = useState<Set<string>>(() => new Set());
@@ -3236,7 +3253,11 @@ export function App() {
     setAgents(payload.agents ?? []);
     setCodingAgents(payload.codingAgents ?? []);
     setModelCatalog(buildAgentModelCatalog(payload.models));
-    setSettings(payload.settings ?? { timeZone: payload.auto?.tz ?? DEFAULT_SCHED_TZ });
+    setSettings(payload.settings ?? {
+      timeZone: payload.auto?.tz ?? DEFAULT_SCHED_TZ,
+      maxConcurrentAgents: 6,
+    });
+    if (payload.agentCapacity) setAgentCapacity(payload.agentCapacity);
     // Guard sessions to [] — it feeds `allLiveSessions`/`liveSessions` which
     // call `.filter()` unconditionally on render, so a malformed/empty payload
     // must degrade to an empty live view rather than crash.
@@ -3359,11 +3380,12 @@ export function App() {
   }, [hideToastedFinding, showToastedFinding]);
 
   const refreshSessions = useCallback(async (_opts?: { retireLaunchId?: string }) => {
-    const payload = await api<{ sessions: Session[] }>("/api/sessions");
+    const payload = await api<{ sessions: Session[]; agentCapacity?: AgentCapacity }>("/api/sessions");
     // Guard to [] — `sessions` is consumed by `.filter()`/`.map()` on render
     // (allLiveSessions) and just below, so a missing field must not crash.
     const sessionList = payload.sessions ?? [];
     setSessions(sessionList);
+    if (payload.agentCapacity) setAgentCapacity(payload.agentCapacity);
     setError((current) => (current === "not found" ? null : current));
     // Prune tombstones the server has finally forgotten, so the set can't grow
     // unbounded and a recycled sid is never wrongly suppressed.
@@ -3374,6 +3396,16 @@ export function App() {
       return next.size === prev.size ? prev : next;
     });
   }, []);
+
+  useEffect(() => {
+    const previous = previousQueuedAgents.current;
+    previousQueuedAgents.current = agentCapacity.queued;
+    if (agentCapacity.queued > previous) {
+      toast.warning(
+        `Agent limit reached — ${agentCapacity.queued} waiting, ${agentCapacity.active}/${agentCapacity.max} running`,
+      );
+    }
+  }, [agentCapacity]);
 
   useEffect(() => {
     let cancelled = false;
@@ -4087,12 +4119,13 @@ export function App() {
   }
 
   const updateSettings = useCallback(async (patch: Partial<GlobalSettings>) => {
-    const payload = await api<{ settings: GlobalSettings }>("/api/settings", {
+    const payload = await api<{ settings: GlobalSettings; agentCapacity?: AgentCapacity }>("/api/settings", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
     setSettings(payload.settings);
+    if (payload.agentCapacity) setAgentCapacity(payload.agentCapacity);
     setSchedTz(payload.settings.timeZone);
   }, []);
 
@@ -4510,6 +4543,7 @@ export function App() {
             extTabs={extNavTabs}
             onOpenExt={setTab}
             settings={settings}
+            agentCapacity={agentCapacity}
             onSettingsChange={updateSettings}
           />
         )}
@@ -14110,6 +14144,76 @@ function TimeZoneSettingsSection({
   );
 }
 
+function AgentConcurrencySettingsSection({
+  settings,
+  capacity,
+  onChange,
+}: {
+  settings: GlobalSettings;
+  capacity: AgentCapacity;
+  onChange: (patch: Partial<GlobalSettings>) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+
+  async function save(maxConcurrentAgents: number) {
+    if (maxConcurrentAgents === settings.maxConcurrentAgents || saving) return;
+    setSaving(true);
+    try {
+      await onChange({ maxConcurrentAgents });
+      toast.success(`Agent limit set to ${maxConcurrentAgents}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not update agent limit");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-2">
+      <h2 className="px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Agent capacity
+      </h2>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card/40">
+        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-primary text-white">
+              <Bot className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-medium">Concurrent subagents</div>
+              <div className={cn(
+                "text-xs",
+                capacity.queued > 0 ? "font-medium text-warning" : "text-muted-foreground",
+              )}>
+                {capacity.queued > 0
+                  ? `Limit reached · ${capacity.queued} waiting`
+                  : `${capacity.active} running now`}
+              </div>
+            </div>
+          </div>
+          <label className="flex shrink-0 items-center gap-1 rounded-full bg-muted px-3 py-1.5">
+            <select
+              value={settings.maxConcurrentAgents}
+              onChange={(event) => void save(Number(event.target.value))}
+              disabled={saving}
+              aria-label="Maximum concurrent subagents"
+              className="appearance-none bg-transparent text-right text-xs font-medium outline-none"
+            >
+              {[1, 2, 3, 4, 5, 6].map((count) => (
+                <option key={count} value={count}>{count}</option>
+              ))}
+            </select>
+            <ChevronDown className="size-3 text-muted-foreground/70" />
+          </label>
+        </div>
+      </div>
+      <p className="px-4 text-xs text-muted-foreground">
+        Extra subagents wait in a queue. The 5 GB kernel memory ceiling still protects the VM.
+      </p>
+    </section>
+  );
+}
+
 function CodingAgentAuthDialog({
   session,
   onSessionChange,
@@ -15088,6 +15192,7 @@ function SettingsView({
   toggleTheme,
   user,
   settings,
+  agentCapacity,
   onSettingsChange,
   onOpenTerminal,
   onOpenBrowser,
@@ -15103,6 +15208,7 @@ function SettingsView({
   toggleTheme: () => void;
   user: string | null;
   settings: GlobalSettings;
+  agentCapacity: AgentCapacity;
   onSettingsChange: (patch: Partial<GlobalSettings>) => Promise<void>;
   onOpenTerminal: () => void;
   onOpenBrowser: () => void;
@@ -15158,6 +15264,12 @@ function SettingsView({
       </section>
 
       <TimeZoneSettingsSection settings={settings} onChange={onSettingsChange} />
+
+      <AgentConcurrencySettingsSection
+        settings={settings}
+        capacity={agentCapacity}
+        onChange={onSettingsChange}
+      />
 
       <PwaInstallSettingsSection />
 


### PR DESCRIPTION
## What changed

- cap LFG subagent concurrency at a configurable 1–6 workers and queue overflow requests FIFO
- run every managed subagent in `lfg-agents.slice` with a 4 GB `MemoryHigh`, 5 GB `MemoryMax`, and deliberate `OOMScoreAdjust=200`
- contain and reap agent-browser/Chrome descendants when a subagent finishes
- persist global settings in SQLite, with an idempotent migration from the legacy JSON settings file
- expose the live concurrency limit and queue state in Settings, including a warning when the cap is reached
- provision the agent slice during Linux setup

## Why

An unbounded subagent swarm exhausted memory on a 7.6 GB host and drove the entire machine into reclaim stalls before the global OOM killer fired. The cgroup boundary makes memory pressure local to the swarm, while the app-level cap keeps normal operation below that boundary.

## Validation

- `bun test` — 38 passing
- `bun run typecheck`
- `bun run build` in `web/`
- live four-worker queue test: three admitted under the original test cap and the fourth admitted only after a slot opened
- live cgroup/Chrome containment probe
- `/proc/pressure/memory` remained at `full avg60=0.00` during representative load
