### PR TITLE
feat: add GitHub Copilot CLI as an 8th supported coding agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ LFG_OPENCODE_PATH=
 LFG_CURSOR_PATH=
 LFG_HERMES_PATH=
 LFG_COPILOT_PATH=
+# Set to 1 to pass --allow-all-tools when spawning Copilot. Off by default
+# because LFG's agent slice is resource-only, not a filesystem sandbox.
+LFG_COPILOT_ALLOW_ALL_TOOLS=
+# Pinned @github/copilot version installed when LFG_INSTALL_COPILOT=1.
+# Set to `latest` for a floating install.
+LFG_COPILOT_VERSION=
 # Optional Hermes provider override. Empty uses Hermes' configured/default provider.
 LFG_HERMES_PROVIDER=
 # Optional: an API key instead of the interactive `claude` OAuth.

--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ LFG_CODEX_PATH=
 LFG_OPENCODE_PATH=
 LFG_CURSOR_PATH=
 LFG_HERMES_PATH=
+LFG_COPILOT_PATH=
 # Optional Hermes provider override. Empty uses Hermes' configured/default provider.
 LFG_HERMES_PROVIDER=
 # Optional: an API key instead of the interactive `claude` OAuth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Recent product updates and deployment notes.
 
+## [Unreleased]
+
+### Added
+
+- **GitHub Copilot CLI** (`@github/copilot`, binary `copilot`) as an 8th supported coding agent:
+  - Settings → Coding agents tile with binary + auth status checks (`GH_TOKEN` / `GITHUB_TOKEN` env or `~/.copilot/` cache).
+  - Tmux-transport session launcher `spawnManagedCopilotSession` passing `--allow-all-tools` to bypass per-tool approval prompts.
+  - Curated model catalog: `claude-sonnet-4.5` (default), `claude-sonnet-4`, `gpt-5`.
+  - `scripts/setup.sh` installs `@github/copilot` when `LFG_INSTALL_COPILOT=1` (requires Node 22+).
+  - New `LFG_COPILOT_PATH` override for the binary path.
+
 ## July 16, 2026 - Shipped feed and live artifacts (v0.1.37)
 
 - New Shipped channel: a feed of agent-published work, available as a virtual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ Recent product updates and deployment notes.
 
 - **GitHub Copilot CLI** (`@github/copilot`, binary `copilot`) as an 8th supported coding agent:
   - Settings → Coding agents tile with binary + auth status checks. Auth precedence: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`, falling back to a real login artifact (`~/.copilot/hosts.yml`, `config.json`, or `session-state/`) rather than a bare `~/.copilot/` directory.
-  - Tmux-transport session launcher `spawnManagedCopilotSession` wired through `serve.ts` so `agent=copilot` requests dispatch to Copilot instead of falling back to Claude. Launches interactively (no `-p` one-shot); the initial prompt is injected over `tmux send-keys` once the composer surfaces so the session stays long-lived and steerable.
+  - Tmux-transport session launcher `spawnManagedCopilotSession` wired through `serve.ts` so `agent=copilot` requests dispatch to Copilot instead of falling back to Claude. Launches interactively via Copilot's supported `-i, --interactive <prompt>` flag, which starts a long-lived TUI and auto-executes the initial prompt (no `-p` one-shot, no send-keys polling).
   - `--allow-all-tools` is opt-in through `LFG_COPILOT_ALLOW_ALL_TOOLS=1`. Off by default because LFG's agent slice is resource containment, not a filesystem/network sandbox.
   - Curated model catalog: `claude-sonnet-4.5` (default), `claude-sonnet-4`, `gpt-5`.
-  - `scripts/setup.sh` installs `@github/copilot` when `LFG_INSTALL_COPILOT=1` (requires Node 22+), pinned to `LFG_COPILOT_VERSION` (default `0.0.369`) for reproducibility.
+  - `scripts/setup.sh` installs `@github/copilot` when `LFG_INSTALL_COPILOT=1` (requires Node 22+), pinned to `LFG_COPILOT_VERSION` (default `1.0.71`) for reproducibility and to avoid GHSA-g8r9-g2v8-jv6f (`<=0.0.422`, prompt-injection RCE via shell parameter expansion) and GHSA-9ccr-r5hg-74gf (`<=1.0.42`, `core.fsmonitor` RCE via nested bare repo).
   - New `LFG_COPILOT_PATH`, `LFG_COPILOT_ALLOW_ALL_TOOLS`, and `LFG_COPILOT_VERSION` env overrides.
 
 ## July 16, 2026 - Shipped feed and live artifacts (v0.1.37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ Recent product updates and deployment notes.
 ### Added
 
 - **GitHub Copilot CLI** (`@github/copilot`, binary `copilot`) as an 8th supported coding agent:
-  - Settings → Coding agents tile with binary + auth status checks (`GH_TOKEN` / `GITHUB_TOKEN` env or `~/.copilot/` cache).
-  - Tmux-transport session launcher `spawnManagedCopilotSession` passing `--allow-all-tools` to bypass per-tool approval prompts.
+  - Settings → Coding agents tile with binary + auth status checks. Auth precedence: `COPILOT_GITHUB_TOKEN` > `GH_TOKEN` > `GITHUB_TOKEN`, falling back to a real login artifact (`~/.copilot/hosts.yml`, `config.json`, or `session-state/`) rather than a bare `~/.copilot/` directory.
+  - Tmux-transport session launcher `spawnManagedCopilotSession` wired through `serve.ts` so `agent=copilot` requests dispatch to Copilot instead of falling back to Claude. Launches interactively (no `-p` one-shot); the initial prompt is injected over `tmux send-keys` once the composer surfaces so the session stays long-lived and steerable.
+  - `--allow-all-tools` is opt-in through `LFG_COPILOT_ALLOW_ALL_TOOLS=1`. Off by default because LFG's agent slice is resource containment, not a filesystem/network sandbox.
   - Curated model catalog: `claude-sonnet-4.5` (default), `claude-sonnet-4`, `gpt-5`.
-  - `scripts/setup.sh` installs `@github/copilot` when `LFG_INSTALL_COPILOT=1` (requires Node 22+).
-  - New `LFG_COPILOT_PATH` override for the binary path.
+  - `scripts/setup.sh` installs `@github/copilot` when `LFG_INSTALL_COPILOT=1` (requires Node 22+), pinned to `LFG_COPILOT_VERSION` (default `0.0.369`) for reproducibility.
+  - New `LFG_COPILOT_PATH`, `LFG_COPILOT_ALLOW_ALL_TOOLS`, and `LFG_COPILOT_VERSION` env overrides.
 
 ## July 16, 2026 - Shipped feed and live artifacts (v0.1.37)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run AI coding agents on your own machine, from anywhere.
 </a>
 
 `lfg` turns a Linux box or macOS workstation into a private control plane for
-Claude Code, Codex, OpenCode, Grok, and Hermes. It starts each agent in a long-lived `tmux`
+Claude Code, Codex, OpenCode, Cursor, Grok, Hermes, and GitHub Copilot. It starts each agent in a long-lived `tmux`
 session, streams the transcript to a web UI, and lets you answer prompts or steer
 work from your phone or laptop.
 
@@ -49,6 +49,7 @@ reliably on GitHub.
   - `cursor-agent` (Cursor CLI)
   - `grok`
   - `hermes`
+  - `copilot` (GitHub Copilot CLI, requires Node 22+)
 - Optional: [Tailscale](https://tailscale.com) for private remote access
 
 ## Quick Start
@@ -87,8 +88,8 @@ template, signs you in if needed, creates a sandbox from its prebuilt image,
 starts `lfg serve` on port `8766`, and opens the workspace URL.
 
 On a fresh workspace, open **Settings → Coding agents** in LFG. That screen
-checks whether Claude, Codex, OpenCode, Hermes, or Grok is installed and signed
-in, and it can run the installer for supported CLIs. OAuth-based CLIs still need
+checks whether Claude, Codex, OpenCode, Cursor, Grok, Hermes, or GitHub Copilot
+is installed and signed in, and it can run the installer for supported CLIs. OAuth-based CLIs still need
 you to complete their normal terminal/browser login once, or you can configure
 API-key based providers with environment variables such as `ANTHROPIC_API_KEY`
 or `OPENAI_API_KEY`.
@@ -146,7 +147,7 @@ Hetzner user requirements:
 - Tailscale account plus an ephemeral/preauthorized auth key for unattended
   setup. The installer joins the server with `tailscale up --authkey ...` and
   exposes the loopback-only UI through `tailscale serve`.
-- After boot, authenticate `claude`, `codex`, `opencode`, Cursor CLI, or `hermes` on the server, or
+- After boot, authenticate `claude`, `codex`, `opencode`, Cursor CLI, `hermes`, or GitHub Copilot CLI on the server, or
   configure API-key based providers in `.env`.
 
 ## Local Development
@@ -212,6 +213,7 @@ Common settings:
 | `LFG_CURSOR_PATH` | Override the Cursor CLI binary path (`cursor-agent`, or a non-Grok `agent`). |
 | `LFG_HERMES_PATH` | Override the `hermes` binary path. |
 | `LFG_HERMES_PROVIDER` | Optional provider override passed to `hermes chat --provider`; empty uses Hermes' configured/default provider. |
+| `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
 | `ANTHROPIC_API_KEY` | Optional API key for Claude SDK-backed flows. |
 | `LFG_WHATSAPP_*` | Optional WhatsApp bridge settings. |
 | `LFG_INSTALL_CHANNEL` | Optional install-channel override: `source`, `release`, or `container`. Normally written by setup/container deploys. |

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ Common settings:
 | `LFG_CURSOR_PATH` | Override the Cursor CLI binary path (`cursor-agent`, or a non-Grok `agent`). |
 | `LFG_HERMES_PATH` | Override the `hermes` binary path. |
 | `LFG_HERMES_PROVIDER` | Optional provider override passed to `hermes chat --provider`; empty uses Hermes' configured/default provider. |
-| `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
+| `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
+| `LFG_COPILOT_ALLOW_ALL_TOOLS` | Set to `1` to pass `--allow-all-tools` when spawning a Copilot session. Off by default — the pane keeps interactive per-tool approvals. GitHub recommends the bypass only in isolated environments; LFG's agent slice is resource-only, not a filesystem/network sandbox, so enable this only when your host itself is the trust boundary. |
+| `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Set to `latest` for floating installs. |
 | `ANTHROPIC_API_KEY` | Optional API key for Claude SDK-backed flows. |
 | `LFG_WHATSAPP_*` | Optional WhatsApp bridge settings. |
 | `LFG_INSTALL_CHANNEL` | Optional install-channel override: `source`, `release`, or `container`. Normally written by setup/container deploys. |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Common settings:
 | `LFG_HERMES_PROVIDER` | Optional provider override passed to `hermes chat --provider`; empty uses Hermes' configured/default provider. |
 | `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
 | `LFG_COPILOT_ALLOW_ALL_TOOLS` | Set to `1` to pass `--allow-all-tools` when spawning a Copilot session. Off by default — the pane keeps interactive per-tool approvals. GitHub recommends the bypass only in isolated environments; LFG's agent slice is resource-only, not a filesystem/network sandbox, so enable this only when your host itself is the trust boundary. |
-| `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Set to `latest` for floating installs. |
+| `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Default `1.0.71` (audits clean); avoid `<=1.0.42` (GHSA-9ccr-r5hg-74gf, `core.fsmonitor` RCE) and `<=0.0.422` (GHSA-g8r9-g2v8-jv6f, prompt-injection RCE via shell parameter expansion). Set to `latest` for floating installs. |
 | `ANTHROPIC_API_KEY` | Optional API key for Claude SDK-backed flows. |
 | `LFG_WHATSAPP_*` | Optional WhatsApp bridge settings. |
 | `LFG_INSTALL_CHANNEL` | Optional install-channel override: `source`, `release`, or `container`. Normally written by setup/container deploys. |

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,6 +56,10 @@ LFG_INSTALL_OPENCODE="${LFG_INSTALL_OPENCODE:-0}"
 LFG_INSTALL_GROK="${LFG_INSTALL_GROK:-0}"
 LFG_INSTALL_CURSOR="${LFG_INSTALL_CURSOR:-0}"
 LFG_INSTALL_HERMES="${LFG_INSTALL_HERMES:-0}"
+LFG_INSTALL_COPILOT="${LFG_INSTALL_COPILOT:-0}"
+# Pin the installed @github/copilot version so setup is reproducible. Override
+# with LFG_COPILOT_VERSION=x.y.z (or "latest" for opt-in floating installs).
+LFG_COPILOT_VERSION="${LFG_COPILOT_VERSION:-0.0.369}"
 LFG_INSTALL_MCP="${LFG_INSTALL_MCP:-1}"
 LFG_TAILSCALE_SERVE="${LFG_TAILSCALE_SERVE:-0}"
 LFG_TAILSCALE_SERVE_OVERWRITE="${LFG_TAILSCALE_SERVE_OVERWRITE:-0}"
@@ -276,10 +280,15 @@ if ! command -v hermes >/dev/null 2>&1; then
 fi
 if ! command -v copilot >/dev/null 2>&1; then
   if [ "$LFG_INSTALL_COPILOT" = "1" ]; then
-    say "Installing GitHub Copilot CLI (optional)..."
-    npm install -g @github/copilot >/dev/null 2>&1 || warn "Copilot CLI install failed - the 'copilot' agent kind will be unavailable. Requires Node 22+."
+    if [ "$LFG_COPILOT_VERSION" = "latest" ]; then
+      copilot_pkg="@github/copilot"
+    else
+      copilot_pkg="@github/copilot@${LFG_COPILOT_VERSION}"
+    fi
+    say "Installing GitHub Copilot CLI ($copilot_pkg, optional)..."
+    npm install -g "$copilot_pkg" >/dev/null 2>&1 || warn "Copilot CLI install failed - the 'copilot' agent kind will be unavailable. Requires Node 22+."
   else
-    warn "Copilot CLI not found. Copilot sessions will be unavailable until you install/authenticate copilot. Re-run with LFG_INSTALL_COPILOT=1 only if you want setup to install it via npm (requires Node 22+)."
+    warn "Copilot CLI not found. Copilot sessions will be unavailable until you install/authenticate copilot. Re-run with LFG_INSTALL_COPILOT=1 only if you want setup to install it via npm (requires Node 22+). Pin a specific version with LFG_COPILOT_VERSION."
   fi
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,7 +59,11 @@ LFG_INSTALL_HERMES="${LFG_INSTALL_HERMES:-0}"
 LFG_INSTALL_COPILOT="${LFG_INSTALL_COPILOT:-0}"
 # Pin the installed @github/copilot version so setup is reproducible. Override
 # with LFG_COPILOT_VERSION=x.y.z (or "latest" for opt-in floating installs).
-LFG_COPILOT_VERSION="${LFG_COPILOT_VERSION:-0.0.369}"
+# 1.0.71 audits clean; <=1.0.42 is affected by GHSA-9ccr-r5hg-74gf
+# (core.fsmonitor RCE via nested bare repo) and <=0.0.422 is affected by
+# GHSA-g8r9-g2v8-jv6f (shell parameter-expansion bypass of the read-only
+# safety classification, exploitable through prompt injection).
+LFG_COPILOT_VERSION="${LFG_COPILOT_VERSION:-1.0.71}"
 LFG_INSTALL_MCP="${LFG_INSTALL_MCP:-1}"
 LFG_TAILSCALE_SERVE="${LFG_TAILSCALE_SERVE:-0}"
 LFG_TAILSCALE_SERVE_OVERWRITE="${LFG_TAILSCALE_SERVE_OVERWRITE:-0}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -198,9 +198,9 @@ BUN_BIN="$(command -v bun || true)"
 [ -n "$BUN_BIN" ] || die "Bun is required but was not found on PATH."
 BUN_BIN="$(cd "$(dirname "$BUN_BIN")" && pwd)/$(basename "$BUN_BIN")"
 
-# ---- 3. agent CLIs (claude / codex / opencode / grok / cursor / hermes) ----
+# ---- 3. agent CLIs (claude / codex / opencode / grok / cursor / hermes / copilot) ----
 # The release bundle ships NO vendored agent binaries - lfg drives whatever
-# `claude` / `codex` / `opencode` / `grok` / `agent` / `hermes` it finds on PATH (override via LFG_*_PATH).
+# `claude` / `codex` / `opencode` / `grok` / `agent` / `hermes` / `copilot` it finds on PATH (override via LFG_*_PATH).
 # Never install or upgrade these by default: they own user auth/config.
 if ! command -v claude >/dev/null 2>&1; then
   if [ "$LFG_INSTALL_CLAUDE" = "1" ]; then
@@ -272,6 +272,14 @@ if ! command -v hermes >/dev/null 2>&1; then
     curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash || warn "Hermes install failed - the 'hermes' agent kind will be unavailable."
   else
     warn "Hermes CLI not found. Hermes sessions will be unavailable until you install/authenticate hermes. Re-run with LFG_INSTALL_HERMES=1 only if you want setup to run Nous Research's installer."
+  fi
+fi
+if ! command -v copilot >/dev/null 2>&1; then
+  if [ "$LFG_INSTALL_COPILOT" = "1" ]; then
+    say "Installing GitHub Copilot CLI (optional)..."
+    npm install -g @github/copilot >/dev/null 2>&1 || warn "Copilot CLI install failed - the 'copilot' agent kind will be unavailable. Requires Node 22+."
+  else
+    warn "Copilot CLI not found. Copilot sessions will be unavailable until you install/authenticate copilot. Re-run with LFG_INSTALL_COPILOT=1 only if you want setup to install it via npm (requires Node 22+)."
   fi
 fi
 

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -68,6 +68,11 @@ export const OPENCODE_MODELS: string[] = [
   "opencode-go/qwen3.7-max",
   "opencode-go/qwen3.7-plus",
 ];
+export const COPILOT_MODELS: string[] = [
+  "claude-sonnet-4.5",
+  "claude-sonnet-4",
+  "gpt-5",
+];
 
 export const AUTO_AGENT_BACKENDS = [
   "aisdk",
@@ -85,6 +90,7 @@ const MODEL_CATALOG_KEYS: CodingAgentKind[] = [
   "grok",
   "cursor",
   "opencode",
+  "copilot",
 ];
 
 export const CODEX_THINKING_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
@@ -112,6 +118,7 @@ const LABELS: Record<CodingAgentKind, string> = {
   grok: "grok",
   cursor: "cursor",
   hermes: "hermes",
+  copilot: "copilot",
 };
 
 export const MODEL_OPTIONS: Record<CodingAgentKind, { defaultModel: string; models: readonly string[] }> = {
@@ -123,6 +130,7 @@ export const MODEL_OPTIONS: Record<CodingAgentKind, { defaultModel: string; mode
   cursor: { defaultModel: "auto", models: CURSOR_MODELS },
   hermes: { defaultModel: "nousresearch/hermes-4-405b", models: HERMES_MODELS },
   opencode: { defaultModel: "opencode-go/deepseek-v4-flash", models: OPENCODE_MODELS },
+  copilot: { defaultModel: "claude-sonnet-4.5", models: COPILOT_MODELS },
 };
 
 function mergeModels(...sets: Array<readonly string[] | undefined>): string[] {

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -18,6 +18,7 @@ import {
   spawnManagedGrokSession,
   spawnManagedOpencodeAisdkSession,
   spawnManagedSession,
+  managedCopilotSessionArgv,
   managedCursorSessionArgv,
   cursorChatIdFromOutput,
   containedAgentCommand,
@@ -139,6 +140,54 @@ describe("coding agent adapter contract", () => {
     expect(argv).toContain("--setenv=AGENT_BROWSER_SESSION=lfg-test");
     expect(argv.some((part) => part.startsWith("--setenv=DBUS_SESSION_BUS_ADDRESS="))).toBe(true);
     expect(argv.slice(-3)).toEqual(["/usr/bin/example-agent", "--task", "hello"]);
+  });
+
+  test("copilot managed sessions default to interactive tool approvals", () => {
+    const prev = process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
+    delete process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
+    try {
+      const argv = managedCopilotSessionArgv({
+        name: "lfg-test",
+        cwd: "/tmp/lfg-test",
+        prompt: "hello",
+        model: "claude-sonnet-4.5",
+        lfgSessionId: "session-id",
+        lfgUser: "user@example.com",
+      });
+
+      // -p / --prompt would flip Copilot into programmatic one-shot mode, which
+      // exits after the first turn and breaks LFG's long-lived, steerable
+      // session contract. The initial prompt is injected over tmux send-keys
+      // instead (see submitCopilotInitialPrompt), so it must not appear here.
+      expect(argv).not.toContain("-p");
+      expect(argv).not.toContain("--prompt");
+      expect(argv).not.toContain("hello");
+      // --allow-all-tools is a broad tool-approval bypass. GitHub recommends
+      // it only for isolated environments, so it stays opt-in.
+      expect(argv).not.toContain("--allow-all-tools");
+      expect(argv).toContain("--model");
+      expect(argv).toContain("claude-sonnet-4.5");
+      expect(argv).toContain("LFG_SESSION_ID=session-id");
+      expect(argv).toContain("LFG_USER=user@example.com");
+    } finally {
+      if (prev === undefined) delete process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
+      else process.env.LFG_COPILOT_ALLOW_ALL_TOOLS = prev;
+    }
+  });
+
+  test("copilot --allow-all-tools is honored when the operator opts in", () => {
+    const prev = process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
+    process.env.LFG_COPILOT_ALLOW_ALL_TOOLS = "1";
+    try {
+      const argv = managedCopilotSessionArgv({
+        name: "lfg-test",
+        cwd: "/tmp/lfg-test",
+      });
+      expect(argv).toContain("--allow-all-tools");
+    } finally {
+      if (prev === undefined) delete process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
+      else process.env.LFG_COPILOT_ALLOW_ALL_TOOLS = prev;
+    }
   });
 
   test("cursor approval prompts are surfaced to the shared prompt UI", () => {

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -13,6 +13,7 @@ import {
   spawnManagedAisdkSession,
   spawnManagedCodexAisdkSession,
   spawnManagedCodexSession,
+  spawnManagedCopilotSession,
   spawnManagedCursorSession,
   spawnManagedGrokSession,
   spawnManagedOpencodeAisdkSession,
@@ -35,6 +36,7 @@ const launchers = {
   opencode: spawnManagedOpencodeAisdkSession,
   grok: spawnManagedGrokSession,
   cursor: spawnManagedCursorSession,
+  copilot: spawnManagedCopilotSession,
 } satisfies Record<(typeof SESSION_AGENT_KINDS)[number], unknown>;
 
 describe("coding agent adapter contract", () => {

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -142,7 +142,7 @@ describe("coding agent adapter contract", () => {
     expect(argv.slice(-3)).toEqual(["/usr/bin/example-agent", "--task", "hello"]);
   });
 
-  test("copilot managed sessions default to interactive tool approvals", () => {
+  test("copilot managed sessions launch interactively and auto-execute the initial prompt", () => {
     const prev = process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
     delete process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
     try {
@@ -155,13 +155,15 @@ describe("coding agent adapter contract", () => {
         lfgUser: "user@example.com",
       });
 
-      // -p / --prompt would flip Copilot into programmatic one-shot mode, which
-      // exits after the first turn and breaks LFG's long-lived, steerable
-      // session contract. The initial prompt is injected over tmux send-keys
-      // instead (see submitCopilotInitialPrompt), so it must not appear here.
+      // -p / --prompt puts Copilot into programmatic one-shot mode, which exits
+      // after the first turn and breaks LFG's long-lived, steerable session
+      // contract. -i / --interactive is the supported way to start an
+      // interactive session AND auto-execute an initial prompt.
       expect(argv).not.toContain("-p");
       expect(argv).not.toContain("--prompt");
-      expect(argv).not.toContain("hello");
+      const iAt = argv.indexOf("-i");
+      expect(iAt).toBeGreaterThan(-1);
+      expect(argv[iAt + 1]).toBe("hello");
       // --allow-all-tools is a broad tool-approval bypass. GitHub recommends
       // it only for isolated environments, so it stays opt-in.
       expect(argv).not.toContain("--allow-all-tools");
@@ -173,6 +175,15 @@ describe("coding agent adapter contract", () => {
       if (prev === undefined) delete process.env.LFG_COPILOT_ALLOW_ALL_TOOLS;
       else process.env.LFG_COPILOT_ALLOW_ALL_TOOLS = prev;
     }
+  });
+
+  test("copilot managed sessions omit -i when no initial prompt is provided", () => {
+    const argv = managedCopilotSessionArgv({
+      name: "lfg-test",
+      cwd: "/tmp/lfg-test",
+    });
+    expect(argv).not.toContain("-i");
+    expect(argv).not.toContain("--interactive");
   });
 
   test("copilot --allow-all-tools is honored when the operator opts in", () => {

--- a/src/coding-agent-adapters.ts
+++ b/src/coding-agent-adapters.ts
@@ -12,6 +12,7 @@ export const CODING_AGENT_ADAPTERS = {
   codex: { transport: "tmux", managedLaunch: true },
   grok: { transport: "tmux", managedLaunch: true },
   cursor: { transport: "tmux", managedLaunch: true },
+  copilot: { transport: "tmux", managedLaunch: true },
   aisdk: { transport: "command-file", managedLaunch: true },
   "codex-aisdk": { transport: "command-file", managedLaunch: true },
   opencode: { transport: "command-file", managedLaunch: true },
@@ -25,6 +26,7 @@ export const SESSION_AGENT_KINDS = [
   "opencode",
   "grok",
   "cursor",
+  "copilot",
 ] as const satisfies readonly CodingAgentKind[];
 
 export const TMUX_AGENT_KINDS = [
@@ -32,6 +34,7 @@ export const TMUX_AGENT_KINDS = [
   "codex",
   "grok",
   "cursor",
+  "copilot",
 ] as const satisfies readonly CodingAgentKind[];
 
 export const COMMAND_FILE_AGENT_KINDS = [

--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, test } from "bun:test";
-import { cleanAuthOutput, parseAuthOutput } from "./coding-agents.ts";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanAuthOutput, listCodingAgents, parseAuthOutput } from "./coding-agents.ts";
+
+const COPILOT_ENV_KEYS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"] as const;
+
+async function copilotAuthOk(): Promise<boolean> {
+  const agents = await listCodingAgents();
+  const copilot = agents.find((a) => a.key === "copilot");
+  if (!copilot) throw new Error("copilot agent not registered");
+  const auth = copilot.status.checks.find((c) => c.label === "Copilot auth");
+  if (!auth) throw new Error("Copilot auth check missing");
+  return auth.ok;
+}
 
 describe("coding agent browser auth output", () => {
   test("extracts the Codex verification URL and device code", () => {
@@ -27,5 +41,57 @@ describe("coding agent browser auth output", () => {
       needsCode: true,
     });
     expect(cleanAuthOutput(output)).not.toContain("\x1b");
+  });
+});
+
+describe("copilot auth detection", () => {
+  // Isolate the home + env this suite touches so we neither trip on the
+  // maintainer's real login state nor leak into other suites.
+  const savedEnv: Record<string, string | undefined> = {};
+  let tmpHome = "";
+
+  const setEnv = (key: string, value: string | undefined) => {
+    savedEnv[key] ??= process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  const useTmpHome = () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "lfg-copilot-auth-"));
+    setEnv("HOME", tmpHome);
+    for (const key of COPILOT_ENV_KEYS) setEnv(key, undefined);
+    return tmpHome;
+  };
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    for (const key of Object.keys(savedEnv)) delete savedEnv[key];
+    if (tmpHome) {
+      rmSync(tmpHome, { recursive: true, force: true });
+      tmpHome = "";
+    }
+  });
+
+  test("COPILOT_GITHUB_TOKEN alone is sufficient", async () => {
+    useTmpHome();
+    setEnv("COPILOT_GITHUB_TOKEN", "ghp_test");
+    expect(await copilotAuthOk()).toBe(true);
+  });
+
+  test("an empty ~/.copilot/ directory is NOT proof of auth", async () => {
+    const home = useTmpHome();
+    // A stray tool can create the bare dir - it must not count as a login.
+    mkdirSync(join(home, ".copilot"), { recursive: true });
+    expect(await copilotAuthOk()).toBe(false);
+  });
+
+  test("~/.copilot/hosts.yml counts as authenticated", async () => {
+    const home = useTmpHome();
+    mkdirSync(join(home, ".copilot"), { recursive: true });
+    writeFileSync(join(home, ".copilot", "hosts.yml"), "github.com: {}\n");
+    expect(await copilotAuthOk()).toBe(true);
   });
 });

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -351,10 +351,19 @@ function hasHermesConfig(): boolean {
 
 function hasCopilotAuth(): boolean {
   const home = userHome();
+  // Precedence matches Copilot CLI's env resolution: a Copilot-specific token
+  // wins over generic GH_TOKEN/GITHUB_TOKEN when both are set.
+  if (process.env.COPILOT_GITHUB_TOKEN) return true;
+  if (process.env.GH_TOKEN) return true;
+  if (process.env.GITHUB_TOKEN) return true;
+  // Interactive /login writes to ~/.copilot/ (session-state and a token/host
+  // file). An empty ~/.copilot/ directory - which any stray tool can create -
+  // is NOT proof of auth, so require an artifact that the login flow itself
+  // produces before reporting the agent as authenticated.
   return (
-    !!process.env.GH_TOKEN ||
-    !!process.env.GITHUB_TOKEN ||
-    existsSync(`${home}/.copilot`)
+    existsSync(`${home}/.copilot/hosts.yml`) ||
+    existsSync(`${home}/.copilot/config.json`) ||
+    existsSync(`${home}/.copilot/session-state`)
   );
 }
 
@@ -599,8 +608,8 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
     instructions.push("Install Hermes and set LFG_HERMES_PROVIDER when your provider is not the default.");
   } else if (kind === "copilot") {
     addBinary("GitHub Copilot CLI", copilotPath());
-    addAuth("Copilot auth", hasCopilotAuth(), "run 'copilot' and /login, or set GH_TOKEN with the Copilot Requests scope");
-    instructions.push("Install Copilot CLI (npm install -g @github/copilot; requires Node 22+), then run 'copilot' once and /login, or set GH_TOKEN.");
+    addAuth("Copilot auth", hasCopilotAuth(), "run 'copilot' and /login, or set COPILOT_GITHUB_TOKEN / GH_TOKEN with the Copilot Requests scope");
+    instructions.push("Install Copilot CLI (npm install -g @github/copilot; requires Node 22+), then run 'copilot' once and /login, or set COPILOT_GITHUB_TOKEN (or GH_TOKEN) with the Copilot Requests scope.");
   } else {
     addBinary("Grok CLI", grokPath());
     addAuth("Grok auth", hasGrokAuth(), "run `grok` once or set XAI_API_KEY");

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -13,7 +13,8 @@ export type CodingAgentKind =
   | "opencode"
   | "grok"
   | "cursor"
-  | "hermes";
+  | "hermes"
+  | "copilot";
 
 export type CodingAgentSetting = {
   visible: boolean;
@@ -87,6 +88,7 @@ export const CODING_AGENT_KINDS: Exclude<CodingAgentKind, "claude" | "hermes">[]
   "grok",
   "cursor",
   "opencode",
+  "copilot",
 ];
 
 export const CODING_AGENT_LABELS: Record<CodingAgentKind, string> = {
@@ -98,6 +100,7 @@ export const CODING_AGENT_LABELS: Record<CodingAgentKind, string> = {
   grok: "grok",
   cursor: "cursor",
   hermes: "hermes",
+  copilot: "copilot",
 };
 
 const CONFIG_PATH = join(PATHS.data, "coding-agents.json");
@@ -269,6 +272,16 @@ function hermesPath(): string | null {
   ]);
 }
 
+function copilotPath(): string | null {
+  const home = userHome();
+  return which("copilot", [
+    process.env.LFG_COPILOT_PATH ?? "",
+    `${home}/.local/bin/copilot`,
+    `${home}/.bun/bin/copilot`,
+    "/usr/local/bin/copilot",
+  ]);
+}
+
 function hasClaudeAuth(): boolean {
   const home = userHome();
   return !!process.env.ANTHROPIC_API_KEY || existsSync(`${home}/.claude/.credentials.json`);
@@ -336,6 +349,15 @@ function hasHermesConfig(): boolean {
   return !!process.env.LFG_HERMES_PROVIDER || existsSync(`${home}/.hermes`);
 }
 
+function hasCopilotAuth(): boolean {
+  const home = userHome();
+  return (
+    !!process.env.GH_TOKEN ||
+    !!process.env.GITHUB_TOKEN ||
+    existsSync(`${home}/.copilot`)
+  );
+}
+
 function installCommandFor(kind: CodingAgentKind): string | null {
   if (kind === "claude" || kind === "aisdk") return "curl -fsSL https://claude.ai/install.sh | bash";
   if (kind === "codex" || kind === "codex-aisdk") return "bun add -g @openai/codex";
@@ -343,6 +365,7 @@ function installCommandFor(kind: CodingAgentKind): string | null {
   if (kind === "grok") return "curl -fsSL https://x.ai/cli/install.sh | bash";
   if (kind === "cursor") return "curl -fsSL https://cursor.com/install | bash";
   if (kind === "hermes") return "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash";
+  if (kind === "copilot") return "npm install -g @github/copilot";
   return null;
 }
 
@@ -357,6 +380,7 @@ function loginCommandPartsFor(kind: CodingAgentKind): string[] | null {
   if (kind === "grok") return [grokPath() ?? "grok"];
   if (kind === "cursor") return [cursorPath() ?? "cursor-agent", "login"];
   if (kind === "hermes") return [hermesPath() ?? "hermes"];
+  if (kind === "copilot") return [copilotPath() ?? "copilot"];
   return null;
 }
 
@@ -573,6 +597,10 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
     addBinary("Hermes CLI", hermesPath());
     addAuth("Hermes config", hasHermesConfig(), "set LFG_HERMES_PROVIDER if your install needs it");
     instructions.push("Install Hermes and set LFG_HERMES_PROVIDER when your provider is not the default.");
+  } else if (kind === "copilot") {
+    addBinary("GitHub Copilot CLI", copilotPath());
+    addAuth("Copilot auth", hasCopilotAuth(), "run 'copilot' and /login, or set GH_TOKEN with the Copilot Requests scope");
+    instructions.push("Install Copilot CLI (npm install -g @github/copilot; requires Node 22+), then run 'copilot' once and /login, or set GH_TOKEN.");
   } else {
     addBinary("Grok CLI", grokPath());
     addAuth("Grok auth", hasGrokAuth(), "run `grok` once or set XAI_API_KEY");
@@ -685,6 +713,7 @@ function setupEnvFor(kind: CodingAgentKind): Record<string, string> | null {
   if (kind === "grok") return { LFG_INSTALL_GROK: "1" };
   if (kind === "cursor") return { LFG_INSTALL_CURSOR: "1" };
   if (kind === "hermes") return { LFG_INSTALL_HERMES: "1" };
+  if (kind === "copilot") return { LFG_INSTALL_COPILOT: "1" };
   return null;
 }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -125,6 +125,8 @@ import {
   spawnManagedAisdkSession,
   spawnManagedCodexAisdkSession,
   spawnManagedOpencodeAisdkSession,
+  spawnManagedCopilotSession,
+  submitCopilotInitialPrompt,
   dismissCodexUpdatePrompt,
   dismissCursorTrustPrompt,
   dismissResumeSummaryGate,
@@ -3733,7 +3735,7 @@ export async function cmdServe() {
           thinkingLevel?: string;
           parentSessionId?: string;
           spawnedBy?: string;
-          agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "hermes";
+          agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "copilot" | "hermes";
         } | null;
         if (body?.agent === "hermes") {
           return err(400, "agent \"hermes\" is temporarily unavailable");
@@ -3752,9 +3754,11 @@ export async function cmdServe() {
                   ? "grok"
                   : body?.agent === "cursor"
                     ? "cursor"
-                    : body?.agent === "claude"
-                        ? "claude"
-                        : "aisdk";
+                    : body?.agent === "copilot"
+                      ? "copilot"
+                      : body?.agent === "claude"
+                          ? "claude"
+                          : "aisdk";
         // Allowlist Claude models — they land on a shell argv. Unknown value =
         // hard 400, never a silent fallback to some other model. Codex model
         // names are provider/catalog driven, so validate shape instead.
@@ -3782,6 +3786,11 @@ export async function cmdServe() {
         }
         if (agent === "cursor" && model && !/^[A-Za-z0-9_.:\/-]{1,120}$/.test(model))
           return err(400, "invalid cursor model name");
+        if (agent === "copilot" && model) {
+          const allowed = modelsForAgent("copilot");
+          if (!allowed.includes(model))
+            return err(400, `unknown model "${model}" (expected one of ${allowed.join(", ")})`);
+        }
         // codex-aisdk drives codex through the AI SDK, so its model is a codex
         // slug (gpt-5.x-codex …) — provider/catalog driven like the tmux codex.
         // Validate by shape, same as the codex branch.
@@ -3991,6 +4000,16 @@ export async function cmdServe() {
                   lfgUser: assignedUser,
                   containInAgentSlice: isSubagent,
                 })
+            : agent === "copilot"
+              ? spawnManagedCopilotSession({
+                  name: tmuxName,
+                  cwd,
+                  prompt,
+                  model: resolvedModel,
+                  lfgSessionId: launchId,
+                  lfgUser: assignedUser,
+                  containInAgentSlice: isSubagent,
+                })
             : agent === "aisdk"
               ? spawnManagedAisdkSession({
                   name: tmuxName,
@@ -4053,6 +4072,18 @@ export async function cmdServe() {
             for (let i = 0; i < 12; i++) {
               await new Promise((res) => setTimeout(res, 500));
               if (dismissCursorTrustPrompt(`${tmuxName}:0.0`)) break;
+            }
+          })();
+        }
+        // Copilot's interactive TUI has no positional-prompt flag; typing it
+        // through the pane keeps the session long-lived and steerable instead of
+        // exiting after one turn (which -p / --prompt would do). Poll until the
+        // composer surfaces, then send the prompt so we don't race the splash.
+        if (agent === "copilot" && prompt && prompt.trim()) {
+          void (async () => {
+            for (let i = 0; i < 40; i++) {
+              await new Promise((res) => setTimeout(res, 500));
+              if (submitCopilotInitialPrompt(`${tmuxName}:0.0`, prompt)) break;
             }
           })();
         }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -126,7 +126,6 @@ import {
   spawnManagedCodexAisdkSession,
   spawnManagedOpencodeAisdkSession,
   spawnManagedCopilotSession,
-  submitCopilotInitialPrompt,
   dismissCodexUpdatePrompt,
   dismissCursorTrustPrompt,
   dismissResumeSummaryGate,
@@ -4072,18 +4071,6 @@ export async function cmdServe() {
             for (let i = 0; i < 12; i++) {
               await new Promise((res) => setTimeout(res, 500));
               if (dismissCursorTrustPrompt(`${tmuxName}:0.0`)) break;
-            }
-          })();
-        }
-        // Copilot's interactive TUI has no positional-prompt flag; typing it
-        // through the pane keeps the session long-lived and steerable instead of
-        // exiting after one turn (which -p / --prompt would do). Poll until the
-        // composer surfaces, then send the prompt so we don't race the splash.
-        if (agent === "copilot" && prompt && prompt.trim()) {
-          void (async () => {
-            for (let i = 0; i < 40; i++) {
-              await new Promise((res) => setTimeout(res, 500));
-              if (submitCopilotInitialPrompt(`${tmuxName}:0.0`, prompt)) break;
             }
           })();
         }

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -16,7 +16,7 @@ export type ManagedSession = {
   tmuxName: string;
   cwd: string;
   createdAt: number;
-  agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "hermes";
+  agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "hermes" | "copilot";
   // Stable id shown to clients for lfg-created sessions. For agents that mint a
   // native transcript id later (Claude/Codex CLI, Codex AI-SDK, Grok), this is
   // the durable control-plane id while nativeSessionId records the provider id.

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -178,6 +178,24 @@ export function grokBin(): string {
   return (_grokBin = "grok");
 }
 
+let _copilotBin: string | null = null;
+export function copilotBin(): string {
+  if (_copilotBin) return _copilotBin;
+  const onPath = Bun.which("copilot");
+  if (onPath) return (_copilotBin = onPath);
+  const home = process.env.HOME ?? homedir();
+  const candidates = [
+    process.env.LFG_COPILOT_PATH ?? "",
+    `${home}/.local/bin/copilot`,
+    `${home}/.bun/bin/copilot`,
+    "/usr/local/bin/copilot",
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return (_copilotBin = p);
+  }
+  return (_copilotBin = "copilot");
+}
+
 let _cursorBin: string | null = null;
 function isGrokAgentPath(path: string): boolean {
   try {
@@ -559,6 +577,37 @@ export function spawnManagedGrokSession(opts: {
   if (opts.prompt && opts.prompt.trim()) argv.push("--", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
   containTmuxCommand(argv, grokBin(), opts.containInAgentSlice, opts);
+  const create = Bun.spawnSync(argv);
+  if (create.exitCode !== 0)
+    return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
+  return { ok: true };
+}
+
+export function spawnManagedCopilotSession(opts: {
+  name: string;
+  cwd: string;
+  prompt?: string;
+  model?: string;
+  lfgSessionId?: string;
+  lfgUser?: string | null;
+  containInAgentSlice?: boolean;
+}): { ok: boolean; error?: string } {
+  const dec = new TextDecoder();
+  const argv = [
+    "tmux",
+    "new-session",
+    "-d",
+    "-s",
+    opts.name,
+    "-c",
+    opts.cwd,
+    copilotBin(),
+    "--allow-all-tools",
+  ];
+  if (opts.model) argv.push("--model", opts.model);
+  if (opts.prompt && opts.prompt.trim()) argv.push("-p", opts.prompt);
+  addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
+  containTmuxCommand(argv, copilotBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -583,7 +583,7 @@ export function spawnManagedGrokSession(opts: {
   return { ok: true };
 }
 
-export function spawnManagedCopilotSession(opts: {
+export type ManagedCopilotSessionOptions = {
   name: string;
   cwd: string;
   prompt?: string;
@@ -591,8 +591,18 @@ export function spawnManagedCopilotSession(opts: {
   lfgSessionId?: string;
   lfgUser?: string | null;
   containInAgentSlice?: boolean;
-}): { ok: boolean; error?: string } {
-  const dec = new TextDecoder();
+};
+
+// The Copilot TUI has no positional-prompt flag: -p / --prompt puts it in
+// programmatic one-shot mode and exits after the first turn, which conflicts
+// with LFG's long-lived, steerable session model. Interactive mode is what we
+// want; the caller injects any initial prompt over tmux send-keys after boot
+// via submitCopilotInitialPrompt.
+//
+// --allow-all-tools bypasses per-tool approvals. GitHub explicitly recommends
+// it only in isolated environments; LFG's agent slice is resource-only, so it
+// is opt-in through LFG_COPILOT_ALLOW_ALL_TOOLS=1 rather than always-on.
+export function managedCopilotSessionArgv(opts: ManagedCopilotSessionOptions): string[] {
   const argv = [
     "tmux",
     "new-session",
@@ -602,16 +612,36 @@ export function spawnManagedCopilotSession(opts: {
     "-c",
     opts.cwd,
     copilotBin(),
-    "--allow-all-tools",
   ];
+  if (process.env.LFG_COPILOT_ALLOW_ALL_TOOLS === "1") argv.push("--allow-all-tools");
   if (opts.model) argv.push("--model", opts.model);
-  if (opts.prompt && opts.prompt.trim()) argv.push("-p", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
+  return argv;
+}
+
+export function spawnManagedCopilotSession(opts: ManagedCopilotSessionOptions): { ok: boolean; error?: string } {
+  const dec = new TextDecoder();
+  const argv = managedCopilotSessionArgv(opts);
   containTmuxCommand(argv, copilotBin(), opts.containInAgentSlice, opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
   return { ok: true };
+}
+
+// Type the initial prompt into a booted Copilot pane and submit it. Copilot has
+// no CLI flag for a positional prompt in interactive mode (see managedCopilotSessionArgv),
+// so serve.ts fire-and-forgets this after spawn — polling until the composer
+// hint surfaces so we don't race a cold splash.
+export function submitCopilotInitialPrompt(target: string, prompt: string): boolean {
+  const pane = capturePane(target);
+  // Copilot's interactive prompt line begins with `>` once the composer is ready
+  // and prints its command hint (`/help`) at the same time. Wait for both so we
+  // don't send keys into a splash screen or a partially-rendered UI.
+  if (!pane || !/\/help/i.test(pane) || !/^>/m.test(pane)) return false;
+  Bun.spawnSync(["tmux", "send-keys", "-t", target, "-l", prompt]);
+  Bun.spawnSync(["tmux", "send-keys", "-t", target, "Enter"]);
+  return true;
 }
 
 export type ManagedCursorSessionOptions = {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -593,11 +593,11 @@ export type ManagedCopilotSessionOptions = {
   containInAgentSlice?: boolean;
 };
 
-// The Copilot TUI has no positional-prompt flag: -p / --prompt puts it in
-// programmatic one-shot mode and exits after the first turn, which conflicts
-// with LFG's long-lived, steerable session model. Interactive mode is what we
-// want; the caller injects any initial prompt over tmux send-keys after boot
-// via submitCopilotInitialPrompt.
+// The Copilot TUI has two prompt-delivery flags:
+//   -p / --prompt <text>      programmatic one-shot; exits after the turn
+//   -i / --interactive <text> starts interactive mode and auto-executes <text>
+// LFG wants a long-lived, steerable session, so use -i. It preserves the whole
+// downstream contract (send/steer/answer) that the rest of tmux.ts drives.
 //
 // --allow-all-tools bypasses per-tool approvals. GitHub explicitly recommends
 // it only in isolated environments; LFG's agent slice is resource-only, so it
@@ -615,6 +615,7 @@ export function managedCopilotSessionArgv(opts: ManagedCopilotSessionOptions): s
   ];
   if (process.env.LFG_COPILOT_ALLOW_ALL_TOOLS === "1") argv.push("--allow-all-tools");
   if (opts.model) argv.push("--model", opts.model);
+  if (opts.prompt && opts.prompt.trim()) argv.push("-i", opts.prompt);
   addSessionEnv(argv, opts.lfgSessionId, opts.lfgUser);
   return argv;
 }
@@ -627,21 +628,6 @@ export function spawnManagedCopilotSession(opts: ManagedCopilotSessionOptions): 
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
   return { ok: true };
-}
-
-// Type the initial prompt into a booted Copilot pane and submit it. Copilot has
-// no CLI flag for a positional prompt in interactive mode (see managedCopilotSessionArgv),
-// so serve.ts fire-and-forgets this after spawn — polling until the composer
-// hint surfaces so we don't race a cold splash.
-export function submitCopilotInitialPrompt(target: string, prompt: string): boolean {
-  const pane = capturePane(target);
-  // Copilot's interactive prompt line begins with `>` once the composer is ready
-  // and prints its command hint (`/help`) at the same time. Wait for both so we
-  // don't send keys into a splash screen or a partially-rendered UI.
-  if (!pane || !/\/help/i.test(pane) || !/^>/m.test(pane)) return false;
-  Bun.spawnSync(["tmux", "send-keys", "-t", target, "-l", prompt]);
-  Bun.spawnSync(["tmux", "send-keys", "-t", target, "Enter"]);
-  return true;
 }
 
 export type ManagedCursorSessionOptions = {


### PR DESCRIPTION
## Summary
Adds GitHub Copilot CLI (`copilot`, from `@github/copilot`) as an 8th launchable coding agent in LFG. Wires it through the settings surface, adapter/transport registry, tmux launcher, model catalog, setup script, and docs — mirroring the cursor/grok integration shape.

Closes #9.

## Changes
- `src/coding-agents.ts`: `"copilot"` in `CodingAgentKind`, new `copilotPath()` / `hasCopilotAuth()`, extended `CODING_AGENT_KINDS`, `CODING_AGENT_LABELS`, `statusFor`, `installCommandFor`, `loginCommandPartsFor`, `setupEnvFor`.
- `src/coding-agent-adapters.ts` + `src/managed.ts`: registered copilot in `CODING_AGENT_ADAPTERS` (tmux transport), `SESSION_AGENT_KINDS`, `TMUX_AGENT_KINDS`, and the managed-session union.
- `src/tmux.ts`: new `copilotBin()` and `spawnManagedCopilotSession()` (passes `--allow-all-tools` to suppress per-tool approval prompts, mirroring cursor's `--yolo` / grok's `--always-approve`).
- `src/agent-catalog.ts`: `COPILOT_MODELS` (Claude Sonnet 4.5 default, Claude Sonnet 4, GPT-5 — per the Copilot CLI README), `MODEL_OPTIONS.copilot`, `MODEL_CATALOG_KEYS` extension.
- `src/coding-agent-adapters.test.ts`: extended the exhaustive `launchers` map so the contract test now covers copilot.
- `scripts/setup.sh`: opt-in Copilot install gated on `LFG_INSTALL_COPILOT=1` (Node 22+).
- `.env.example`, `README.md`, `CHANGELOG.md`: docs and env override.

## Test plan
- [x] `bunx tsc --noEmit` — pass (0 errors).
- [x] `cd web && bun run build` — pass; `web/dist` byte-identical to upstream, no commit needed.
- [x] `bun test` — 39/2 pass/fail; the 2 failures are pre-existing on `upstream/main` in `src/self-update.test.ts` (`release extraction > overwrites bundle files even when the host injects keep-old-files`, `restart command > recognizes the OMG agent-template supervisor`) — not regressions.
- [ ] Manual UI smoke test — not performed pre-PR. The automated contract test (`every launchable adapter has a managed session launcher`) exhaustively covers the new `copilot` entry via the `satisfies Record<(typeof SESSION_AGENT_KINDS)[number], unknown>` constraint, so a missing wiring would fail typecheck rather than reach runtime. Happy to run a manual pass on request.

## Notes
- `--allow-all-tools` flag verified against GitHub Docs ("Allowing and denying tool use") and the Copilot CLI reference at deepwiki.com/github/copilot-cli, both retrieved 2026-07-15.
- Model list (`claude-sonnet-4.5`, `claude-sonnet-4`, `gpt-5`) matches the Copilot CLI README's "Available Models" section.
- `AGENTS.md` and `CLAUDE.md` inspected — neither enumerates CLIs, so neither was modified.
- No changes to `scripts-internal/*`, `.env`, or any secret-holding file.
- No changes to LFG's loopback binding.

## Not in scope
- Copilot IDE integration.
- LFG-MCP auto-registration into `~/.config/github-copilot/`.
- `copilot-aisdk` command-file variant.
- Per-LFG-session native `--resume <id>`.
