### PR TITLE
feat(agents): make pi a first-class selectable coding agent

### DIFF
--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -92,6 +92,7 @@ export const CODING_AGENT_KINDS: Exclude<CodingAgentKind, "claude" | "hermes">[]
   "cursor",
   "opencode",
   "copilot",
+  "pi",
 ];
 
 export const CODING_AGENT_LABELS: Record<CodingAgentKind, string> = {
@@ -276,6 +277,18 @@ function hermesPath(): string | null {
   ]);
 }
 
+// pi has no standalone-CLI requirement: the backend drives LFG's own bundled
+// copy of @mariozechner/pi-coding-agent over its RPC protocol (see
+// agents/backends/pi-session.ts), with LFG_PI_PATH as an explicit override.
+// Detection therefore mirrors the harness's resolvePiCliPath() instead of
+// scanning PATH for a global binary.
+function piPath(): string | null {
+  const override = process.env.LFG_PI_PATH;
+  if (override && existsSync(override)) return override;
+  const bundled = join(PATHS.root, "node_modules", "@mariozechner", "pi-coding-agent", "dist", "cli.js");
+  return existsSync(bundled) ? bundled : null;
+}
+
 function copilotPath(): string | null {
   const home = userHome();
   return which("copilot", [
@@ -366,6 +379,13 @@ function hasCursorAuth(): boolean {
   return !!process.env.CURSOR_API_KEY || existsSync(`${home}/.cursor`);
 }
 
+// pi's auth is file-based (~/.pi/agent/auth.json) or the ANTHROPIC_API_KEY env
+// var — there is no interactive login step (see pi-session.ts header).
+function hasPiAuth(): boolean {
+  const home = userHome();
+  return !!process.env.ANTHROPIC_API_KEY || existsSync(`${home}/.pi/agent/auth.json`);
+}
+
 function hasHermesConfig(): boolean {
   const home = userHome();
   return !!process.env.LFG_HERMES_PROVIDER || existsSync(`${home}/.hermes`);
@@ -397,6 +417,9 @@ function installCommandFor(kind: CodingAgentKind): string | null {
   if (kind === "cursor") return "curl -fsSL https://cursor.com/install | bash";
   if (kind === "hermes") return "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash";
   if (kind === "copilot") return "npm install -g @github/copilot";
+  // pi ships bundled with LFG (node_modules/@mariozechner/pi-coding-agent) —
+  // there is nothing separate to install.
+  if (kind === "pi") return null;
   return null;
 }
 
@@ -412,6 +435,9 @@ function loginCommandPartsFor(kind: CodingAgentKind): string[] | null {
   if (kind === "cursor") return [cursorPath() ?? "cursor-agent", "login"];
   if (kind === "hermes") return [hermesPath() ?? "hermes"];
   if (kind === "copilot") return [copilotPath() ?? "copilot"];
+  // pi has no login subcommand — auth is file-based (~/.pi/agent/auth.json) or
+  // ANTHROPIC_API_KEY, so there is no terminal login to offer.
+  if (kind === "pi") return null;
   return null;
 }
 
@@ -628,6 +654,16 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
     addBinary("Hermes CLI", hermesPath());
     addAuth("Hermes config", hasHermesConfig(), "set LFG_HERMES_PROVIDER if your install needs it");
     instructions.push("Install Hermes and set LFG_HERMES_PROVIDER when your provider is not the default.");
+  } else if (kind === "pi") {
+    addBinary("pi runtime", piPath());
+    addAuth("pi auth", hasPiAuth(), "set ANTHROPIC_API_KEY or configure ~/.pi/agent/auth.json");
+    instructions.push(
+      "pi ships bundled with LFG. Set ANTHROPIC_API_KEY or configure ~/.pi/agent/auth.json — pi has no login step.",
+    );
+    // No setup.sh install path and no login subcommand: pi is ready as soon as
+    // the bundled runtime exists and its file-based auth is in place.
+    canAutoSetup = false;
+    canLoginInTerminal = false;
   } else if (kind === "copilot") {
     addBinary("GitHub Copilot CLI", copilotPath());
     addAuth("Copilot auth", hasCopilotAuth(), "run 'copilot' and /login, or set COPILOT_GITHUB_TOKEN / GH_TOKEN with the Copilot Requests scope");
@@ -693,6 +729,10 @@ export async function listSetupChecks(): Promise<SetupCheck[]> {
   } else {
     checks.push({ label: "Codex MCP", ok: true, detail: "Codex CLI not installed" });
   }
+  // No row for aisdk/codex-aisdk (they ride the Claude/Codex CLI registrations
+  // above) and none for pi: pi is an RPC backend driving LFG's bundled
+  // @mariozechner/pi-coding-agent — it has no `pi mcp` registration surface, so
+  // there is no LFG MCP to install or check for it.
   const optionalMcpAgents: Array<[string, string | null, () => boolean]> = [
     ["OpenCode", opencode, hasOpencodeLfgMcp],
     ["Grok", grok, hasGrokLfgMcp],

--- a/src/lfg-capabilities.ts
+++ b/src/lfg-capabilities.ts
@@ -62,5 +62,7 @@ export function withLfgRuntimeContract(prompt: string | undefined): string | und
 }
 
 export function lfgCapabilityAccess(agent: CodingAgentKind): "mcp" | "contract-only" {
-  return agent === "hermes" || agent === "copilot" ? "contract-only" : "mcp";
+  // pi is an RPC backend with no MCP registration surface (its harness drives
+  // the bundled pi CLI directly), so it never gets the LFG MCP toolset.
+  return agent === "hermes" || agent === "copilot" || agent === "pi" ? "contract-only" : "mcp";
 }

--- a/web/public/agent-pi.svg
+++ b/web/public/agent-pi.svg
@@ -1,0 +1,1 @@
+<svg height="1em" width="1em" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg"><title>pi</title><rect width="512" height="512" rx="96" fill="#111318"/><path d="M146 178c10-14 26-24 50-24h176M212 166v180M320 166v152c0 22 12 34 32 34 12 0 22-6 28-14" stroke="#fff" stroke-width="38" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,6 +90,7 @@ import {
   Paperclip,
   Pause,
   Pencil,
+  Pi,
   Pin,
   Play,
   Plus,
@@ -553,6 +554,10 @@ const OPENCODE_MODELS = [
   "opencode-go/qwen3.7-max",
   "opencode-go/qwen3.7-plus",
 ];
+// pi resolves the same Claude aliases as claude/aisdk plus one custom proxy
+// model id. Kept in sync with PI_MODELS in src/agent-catalog.ts (the server
+// catalog overrides this fallback at bootstrap).
+const PI_MODELS_FALLBACK = ["fable", "opus", "sonnet", "haiku", "deepseek/deepseek-v4-flash"];
 const THINKING_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 type ThinkingLevel = string;
 type AutoAgentBackend = "aisdk" | "codex-aisdk" | "grok" | "cursor" | "opencode";
@@ -568,7 +573,7 @@ function savedThinkingLevel(): ThinkingLevel {
   return value && (THINKING_LEVELS as readonly string[]).includes(value) ? value : "medium";
 }
 
-type AgentKind = "claude" | "aisdk" | "codex" | "codex-aisdk" | "opencode" | "grok" | "cursor";
+type AgentKind = "claude" | "aisdk" | "codex" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "pi";
 
 // Which agents honor a thinking/reasoning-effort level. Claude (CLI + ai-sdk)
 // takes an `effort`; Codex (CLI + ai-sdk) takes a `reasoning_effort` — both
@@ -581,7 +586,8 @@ function agentSupportsThinking(agent: AgentKind): boolean {
     agent === "grok" ||
     agent === "cursor" ||
     agent === "codex" ||
-    agent === "codex-aisdk"
+    agent === "codex-aisdk" ||
+    agent === "pi"
   );
 }
 
@@ -596,6 +602,7 @@ const AGENT_MODELS: Record<AgentKind, string[]> = {
   grok: GROK_MODELS,
   cursor: CURSOR_MODELS,
   opencode: OPENCODE_MODELS,
+  pi: PI_MODELS_FALLBACK,
 };
 const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   claude: "sonnet",
@@ -605,6 +612,7 @@ const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   grok: "grok-4.5",
   cursor: "auto",
   opencode: "opencode-go/deepseek-v4-flash",
+  pi: "sonnet",
 };
 const AGENT_THINKING_LEVELS: Record<AgentKind, string[]> = {
   claude: ["low", "medium", "high", "xhigh", "max"],
@@ -614,6 +622,7 @@ const AGENT_THINKING_LEVELS: Record<AgentKind, string[]> = {
   grok: ["low", "medium", "high", "xhigh", "max"],
   cursor: ["low", "medium", "high", "xhigh", "max"],
   opencode: [],
+  pi: ["low", "medium", "high", "xhigh", "max"],
 };
 
 type AgentModelCatalog = {
@@ -671,6 +680,7 @@ const AGENT_OPTIONS: { key: AgentKind; label: string; Icon: typeof Sparkles }[] 
   { key: "grok", label: "grok", Icon: Bot },
   { key: "cursor", label: "cursor", Icon: TerminalSquare },
   { key: "opencode", label: "opencode", Icon: Boxes },
+  { key: "pi", label: "pi", Icon: Pi },
 ];
 
 // Bump when any agent SVG's artwork changes. The version rides on every icon
@@ -810,6 +820,7 @@ function agentIconSrc(agent?: string): string {
   if (agent === "cursor") return `/agent-cursor.svg${v}`;
   if (agent === "hermes") return `/agent-hermes.svg${v}`;
   if (agent === "opencode") return `/agent-opencode.svg${v}`;
+  if (agent === "pi") return `/agent-pi.svg${v}`;
   return `/agent-claude.svg${v}`;
 }
 function agentIconAlt(agent?: string): string {
@@ -818,6 +829,7 @@ function agentIconAlt(agent?: string): string {
   if (agent === "cursor") return "Cursor";
   if (agent === "hermes") return "Hermes";
   if (agent === "opencode") return "OpenCode";
+  if (agent === "pi") return "pi";
   return "Claude";
 }
 


### PR DESCRIPTION
## What

Promotes `pi` from a registered-but-hidden backend to a first-class, selectable agent in vanilla LFG — wired exactly like the other agents in `CODING_AGENT_KINDS`.

## Changes

- **`CODING_AGENT_KINDS`**: adds `"pi"` (appended after `copilot`), so the agents settings list, setup checks, and `isCodingAgentKind` validation include it automatically.
- **`piPath()`**: detects the runtime the backend actually uses — `LFG_PI_PATH` override, else LFG's bundled `node_modules/@mariozechner/pi-coding-agent/dist/cli.js` (mirrors `resolvePiCliPath()` in `pi-session.ts`; pi never shells out to a global `pi` binary, so PATH scanning would be the wrong check).
- **`statusFor("pi")`**: `pi runtime` check (bundled CLI present) + `pi auth` check (`ANTHROPIC_API_KEY` or `~/.pi/agent/auth.json`). `canAutoSetup=false` (nothing to install — pi ships with LFG) and `canLoginInTerminal=false` (no login subcommand; auth is file-based by design).
- **`installCommandFor` / `loginCommandPartsFor`**: explicit `null` for pi, with the reasoning documented inline.
- **`listSetupChecks`**: intentionally **no** "pi MCP" row — pi is an RPC backend with no `pi mcp` registration surface. Same treatment as `aisdk` (which rides the Claude CLI row); fabricating an MCP check would always show red or lie green.
- **`lfgCapabilityAccess("pi") → "contract-only"`**: pi never receives the LFG MCP toolset, so the settings badge stops claiming "LFG tools" for it. (Note: pi's spawn helper also doesn't wrap prompts with the LFG runtime contract today, so "contract-only" is still generous — flagged below.)
- **Web picker**: adds pi to the new-session picker (`AgentKind`, `AGENT_OPTIONS`, model/default/thinking-level maps kept in sync with `PI_MODELS` / `thinkingLevelsForAgent` in `agent-catalog.ts`) plus a `agent-pi.svg` mark. `configuredAgentOptions` already filters to visible+configured agents, so pi only shows once its checks pass — same as every other agent.

## Not touched (OMG sandbox flavor)

`pi-session.ts`, the serve launch/steer/resume paths, and the `~/.pi/agent` proxy-config injection are unchanged — OMG's explicit selection of pi keeps working; this is purely additive selectability for vanilla instances.

## For owner review

- `copilot` is in `CODING_AGENT_KINDS` but absent from the web `AGENT_OPTIONS` picker (pre-existing); pi is now in both. If copilot's absence was an oversight, it can be added the same way.
- `spawnManagedPiSession` is the only spawn helper that does NOT wrap the initial prompt with `withLfgRuntimeContract` — left as-is to avoid steering pi toward LFG tools it can't call, but worth a deliberate decision.

## Verification

- `bun run typecheck` — clean
- `bun test` — 64 pass / 0 fail (includes the `coding-agent-adapters.test.ts` contract tests now enforcing pi across KINDS ↔ adapters ↔ catalog ↔ launchers)
- `web: bun run build` — clean
- Runtime: `listCodingAgents()` returns a correct pi row (runtime check green pointing at the bundled cli.js, auth check red with file-based guidance, no setup/login buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)