### PR TITLE
feat(pi): custom agent profile directory (LFG_PI_PROFILE_DIR)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,11 @@ LFG_COPILOT_ALLOW_ALL_TOOLS=
 LFG_COPILOT_VERSION=
 # Optional Hermes provider override. Empty uses Hermes' configured/default provider.
 LFG_HERMES_PROVIDER=
+# Optional custom agent profile for the `pi` backend: a directory with
+# system-prompt.md, a skills/ folder, and a `name` file. Layers extra
+# system-prompt text, skills, and a display-name override on top of pi's own
+# defaults. Empty = no customization. See docs/custom-agent-profiles.md.
+LFG_PI_PROFILE_DIR=
 # Optional: an API key instead of the interactive `claude` OAuth.
 ANTHROPIC_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Common settings:
 | `LFG_CURSOR_PATH` | Override the Cursor CLI binary path (`cursor-agent`, or a non-Grok `agent`). |
 | `LFG_HERMES_PATH` | Override the `hermes` binary path. |
 | `LFG_HERMES_PROVIDER` | Optional provider override passed to `hermes chat --provider`; empty uses Hermes' configured/default provider. |
+| `LFG_PI_PROFILE_DIR` | Optional [custom agent profile](./docs/custom-agent-profiles.md) directory for the `pi` backend: layers extra system-prompt text, skills, and a display-name override on top of pi's defaults. Empty = unchanged. |
 | `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
 | `LFG_COPILOT_ALLOW_ALL_TOOLS` | Set to `1` to pass `--allow-all-tools` when spawning a Copilot session. Off by default — the pane keeps interactive per-tool approvals. GitHub recommends the bypass only in isolated environments; LFG's agent slice is resource-only, not a filesystem/network sandbox, so enable this only when your host itself is the trust boundary. |
 | `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Default `1.0.71` (audits clean); avoid `<=1.0.42` (GHSA-9ccr-r5hg-74gf, `core.fsmonitor` RCE) and `<=0.0.422` (GHSA-g8r9-g2v8-jv6f, prompt-injection RCE via shell parameter expansion). Set to `latest` for floating installs. |

--- a/docs/custom-agent-profiles.md
+++ b/docs/custom-agent-profiles.md
@@ -1,0 +1,79 @@
+# Custom agent profiles
+
+A **custom agent profile** points a managed coding agent at extra system-prompt
+text, extra skills, and a display-name override, sourced from a plain local
+directory you control. Think of it like your own `~/.claude/CLAUDE.md`: a
+reusable customization that layers **on top of** an agent's built-in defaults,
+updates without an LFG code change or release (just edit the files), and is a
+complete no-op when unconfigured.
+
+It is designed to be generic. Today it is wired into the **`pi`** backend via the
+`LFG_PI_PROFILE_DIR` environment variable, because pi's own CLI already exposes
+the primitives it needs (`--append-system-prompt` and `--skill`). The mechanism
+(`src/agent-profile.ts`) is backend-agnostic and is intended to generalize to
+other backends later behind their own `LFG_<AGENT>_PROFILE_DIR` variables.
+
+## Enabling it
+
+Point the env var at a profile directory before starting `lfg`:
+
+```sh
+LFG_PI_PROFILE_DIR=/path/to/my-profile lfg serve
+```
+
+If the variable is unset — the default for every existing install — nothing
+changes. Every `pi` session behaves exactly as before.
+
+## Directory layout
+
+All parts are optional; a profile can supply any subset.
+
+```text
+my-profile/
+  system-prompt.md      Extra system-prompt text, appended to pi's own default
+                        system prompt. system-prompt.txt is also accepted; .md
+                        wins if both exist.
+  skills/               A directory of skill subfolders. Each subfolder holds a
+                        SKILL.md, e.g. skills/my-skill/SKILL.md. pi loads them
+                        all, in addition to the project's own auto-discovered
+                        .agents/skills/.
+  name                  Plain-text display name shown in the UI instead of the
+                        raw "pi" agent kind. Alternatively, a profile.json file
+                        with a { "displayName": "..." } field. The name file
+                        wins when both are present.
+```
+
+## What it does under the hood
+
+When a `pi` session starts, LFG reads the profile directory and appends the
+matching flags to the arguments it passes to pi's own CLI:
+
+- `system-prompt.md` / `system-prompt.txt` → `--append-system-prompt <path>`
+  (pi reads the file contents).
+- `skills/` → `--skill <path>` (pi recurses to load every `<name>/SKILL.md`).
+
+Both flags are **additive**. They do not replace pi's built-in system prompt or
+the project's own `.agents/skills/` discovery — your profile's text and skills
+are layered on top.
+
+The display name from `name` / `profile.json` is recorded on the session so the
+web UI can show your branded label (for example, in the session card's agent
+tooltip) instead of `pi`.
+
+## Failure handling
+
+Profile loading never crashes a session. If the directory is missing, a
+referenced file is absent, `profile.json` is malformed, or `skills/` is not a
+directory, LFG logs a `[agent-profile] …` warning and simply skips that part —
+the session still starts with whatever remains (or with no customization at
+all).
+
+## Notes and limits
+
+- **pi-only for now.** The env var is scoped to the `pi` backend. The loader is
+  written generically so other backends can adopt the same convention later.
+- **Keep it local.** The profile directory and its contents live on your
+  machine, not in this repo — nothing product- or partner-specific belongs in
+  LFG itself.
+- **No restart needed to change contents.** Editing the files takes effect on
+  the next `pi` session you start; the env var itself is read at session launch.

--- a/src/agent-profile.test.ts
+++ b/src/agent-profile.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  agentProfileCliArgs,
+  loadAgentProfile,
+  loadAgentProfileFromEnv,
+} from "./agent-profile.ts";
+
+const tempDirs: string[] = [];
+
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "lfg-profile-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// Build a profile dir with the requested conventional files.
+function makeProfile(parts: {
+  systemPromptMd?: string;
+  systemPromptTxt?: string;
+  skill?: { name: string; body: string };
+  name?: string;
+  profileJson?: string;
+  skillsAsFile?: boolean;
+}): string {
+  const dir = makeDir();
+  if (parts.systemPromptMd !== undefined) {
+    writeFileSync(join(dir, "system-prompt.md"), parts.systemPromptMd);
+  }
+  if (parts.systemPromptTxt !== undefined) {
+    writeFileSync(join(dir, "system-prompt.txt"), parts.systemPromptTxt);
+  }
+  if (parts.skillsAsFile) {
+    writeFileSync(join(dir, "skills"), "not a dir");
+  } else if (parts.skill) {
+    const skillDir = join(dir, "skills", parts.skill.name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), parts.skill.body);
+  }
+  if (parts.name !== undefined) writeFileSync(join(dir, "name"), parts.name);
+  if (parts.profileJson !== undefined) writeFileSync(join(dir, "profile.json"), parts.profileJson);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop()!;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+describe("custom agent profile loading", () => {
+  test("unset / blank env value is a no-op (null profile, no args)", () => {
+    expect(loadAgentProfile(undefined)).toBeNull();
+    expect(loadAgentProfile(null)).toBeNull();
+    expect(loadAgentProfile("")).toBeNull();
+    expect(loadAgentProfile("   ")).toBeNull();
+    expect(agentProfileCliArgs(null)).toEqual([]);
+  });
+
+  test("non-existent directory is ignored gracefully", () => {
+    expect(loadAgentProfile(join(tmpdir(), "lfg-does-not-exist-xyz-123"))).toBeNull();
+  });
+
+  test("a file path (not a directory) is ignored gracefully", () => {
+    const dir = makeDir();
+    const file = join(dir, "afile");
+    writeFileSync(file, "x");
+    expect(loadAgentProfile(file)).toBeNull();
+  });
+
+  test("a full profile resolves all three parts and builds additive CLI args", () => {
+    const dir = makeProfile({
+      systemPromptMd: "Be extra helpful.",
+      skill: { name: "greet", body: "---\nname: greet\n---\nSay hi." },
+      name: "Branded Agent",
+    });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile).not.toBeNull();
+    expect(profile.dir).toBe(dir);
+    expect(profile.systemPromptPath).toBe(join(dir, "system-prompt.md"));
+    expect(profile.skillsDir).toBe(join(dir, "skills"));
+    expect(profile.displayName).toBe("Branded Agent");
+
+    expect(agentProfileCliArgs(profile)).toEqual([
+      "--append-system-prompt",
+      join(dir, "system-prompt.md"),
+      "--skill",
+      join(dir, "skills"),
+    ]);
+  });
+
+  test("an empty directory yields a usable profile with no parts and no args", () => {
+    const dir = makeDir();
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.dir).toBe(dir);
+    expect(profile.systemPromptPath).toBeUndefined();
+    expect(profile.skillsDir).toBeUndefined();
+    expect(profile.displayName).toBeUndefined();
+    expect(agentProfileCliArgs(profile)).toEqual([]);
+  });
+
+  test("system-prompt.txt is used when the .md variant is absent", () => {
+    const dir = makeProfile({ systemPromptTxt: "plain text prompt" });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.systemPromptPath).toBe(join(dir, "system-prompt.txt"));
+  });
+
+  test("system-prompt.md is preferred over .txt when both exist", () => {
+    const dir = makeProfile({ systemPromptMd: "md", systemPromptTxt: "txt" });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.systemPromptPath).toBe(join(dir, "system-prompt.md"));
+  });
+
+  test("profile.json displayName is used when no name file exists", () => {
+    const dir = makeProfile({ profileJson: JSON.stringify({ displayName: "JSON Name" }) });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.displayName).toBe("JSON Name");
+  });
+
+  test("a plain name file wins over profile.json", () => {
+    const dir = makeProfile({
+      name: "File Name",
+      profileJson: JSON.stringify({ displayName: "JSON Name" }),
+    });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.displayName).toBe("File Name");
+  });
+
+  test("a blank name file yields no display name (and no crash)", () => {
+    const dir = makeProfile({ name: "   \n" });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.displayName).toBeUndefined();
+  });
+
+  test("malformed profile.json is ignored, not fatal", () => {
+    const dir = makeProfile({ profileJson: "{ this is not json" });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile).not.toBeNull();
+    expect(profile.displayName).toBeUndefined();
+  });
+
+  test("a skills path that is a file (not a directory) is skipped", () => {
+    const dir = makeProfile({ skillsAsFile: true });
+    const profile = loadAgentProfile(dir)!;
+    expect(profile.skillsDir).toBeUndefined();
+    expect(agentProfileCliArgs(profile)).toEqual([]);
+  });
+
+  test("the name is trimmed", () => {
+    const dir = makeProfile({ name: "  Padded Name  \n" });
+    expect(loadAgentProfile(dir)!.displayName).toBe("Padded Name");
+  });
+
+  test("loadAgentProfileFromEnv reads the named env var", () => {
+    const dir = makeProfile({ name: "Env Agent" });
+    const prev = process.env.LFG_TEST_PROFILE_DIR;
+    process.env.LFG_TEST_PROFILE_DIR = dir;
+    try {
+      expect(loadAgentProfileFromEnv("LFG_TEST_PROFILE_DIR")!.displayName).toBe("Env Agent");
+    } finally {
+      if (prev === undefined) delete process.env.LFG_TEST_PROFILE_DIR;
+      else process.env.LFG_TEST_PROFILE_DIR = prev;
+    }
+    expect(loadAgentProfileFromEnv("LFG_TEST_PROFILE_UNSET_XYZ")).toBeNull();
+  });
+});

--- a/src/agent-profile.ts
+++ b/src/agent-profile.ts
@@ -1,0 +1,169 @@
+// Custom agent profiles — a generic, opt-in seam for pointing a managed coding
+// agent at extra system-prompt text, extra skills, and a display-name override,
+// sourced from a plain local directory. Think of it like a user's own
+// `~/.claude/CLAUDE.md`: a reusable customization mechanism that layers ON TOP
+// of an agent's built-in defaults, updates without an LFG code change or
+// release, and is a complete no-op when unconfigured.
+//
+// This is intentionally backend-agnostic. It is currently wired only into the
+// "pi" backend (see agents/backends/pi-session.ts) via the LFG_PI_PROFILE_DIR
+// env var, because pi's own CLI already exposes the primitives we lean on
+// (`--append-system-prompt <path>` and `--skill <path>`). The loader/arg
+// builder below take the env-var NAME as a parameter so other backends can
+// adopt the same convention later without duplicating this logic.
+//
+// Directory layout (all parts optional — a profile can supply any subset):
+//   <profile-dir>/
+//     system-prompt.md   (or system-prompt.txt)  extra system-prompt text,
+//                                                 appended to the agent's own
+//                                                 default system prompt.
+//     skills/            a directory of <name>/SKILL.md skill subfolders,
+//                        added to the agent's discovered skills.
+//     name               (or profile.json {"displayName": "..."})  a plain-text
+//                        display name shown in the UI instead of the raw agent
+//                        kind.
+//
+// Nothing here is product- or partner-specific: the profile directory is
+// supplied by the operator, and its contents never live in this repo.
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export type AgentProfile = {
+  /** Absolute path to the resolved profile directory. */
+  dir: string;
+  /**
+   * Absolute path to the extra system-prompt file, when one exists. Passed to
+   * pi as `--append-system-prompt <path>` (pi reads file contents when the
+   * argument resolves to an existing file).
+   */
+  systemPromptPath?: string;
+  /**
+   * Absolute path to the skills directory, when one exists. Passed to pi as
+   * `--skill <path>`; pi recurses to load every `<name>/SKILL.md` under it.
+   */
+  skillsDir?: string;
+  /** Display-name override, when one is configured (non-empty after trimming). */
+  displayName?: string;
+};
+
+// Conventional filenames, checked in order. First match wins.
+const SYSTEM_PROMPT_FILES = ["system-prompt.md", "system-prompt.txt"] as const;
+const NAME_FILE = "name";
+const PROFILE_JSON = "profile.json";
+const SKILLS_DIR = "skills";
+
+function warn(message: string): void {
+  // Never throw from profile loading — a broken/partial profile must degrade to
+  // "no customization", not crash the harness. Surface the reason so an operator
+  // can see why their profile was skipped.
+  console.error(`[agent-profile] ${message}`);
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function readDisplayName(dir: string): string | undefined {
+  // Plain `name` file wins — it is the simplest thing an operator can drop in.
+  const namePath = join(dir, NAME_FILE);
+  if (isFile(namePath)) {
+    try {
+      const value = readFileSync(namePath, "utf8").trim();
+      if (value) return value;
+    } catch (e) {
+      warn(`could not read ${namePath}: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  // Fall back to profile.json { "displayName": "..." }.
+  const jsonPath = join(dir, PROFILE_JSON);
+  if (isFile(jsonPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(jsonPath, "utf8")) as { displayName?: unknown };
+      if (typeof parsed.displayName === "string" && parsed.displayName.trim()) {
+        return parsed.displayName.trim();
+      }
+    } catch (e) {
+      warn(`could not parse ${jsonPath}: ${e instanceof Error ? e.message : e}`);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Load a custom agent profile from an explicit directory path. Returns null when
+ * `dirValue` is empty/unset or does not resolve to an existing directory — both
+ * are ordinary "no profile configured" cases and are logged only when a value
+ * was given but unusable. Missing individual parts (no system prompt, no skills,
+ * no name) are skipped silently; the profile is still returned for whatever
+ * parts DO exist.
+ */
+export function loadAgentProfile(dirValue: string | undefined | null): AgentProfile | null {
+  const raw = dirValue?.trim();
+  if (!raw) return null;
+  const dir = resolve(raw);
+  if (!existsSync(dir)) {
+    warn(`profile directory does not exist, ignoring: ${dir}`);
+    return null;
+  }
+  if (!isDir(dir)) {
+    warn(`profile path is not a directory, ignoring: ${dir}`);
+    return null;
+  }
+
+  const profile: AgentProfile = { dir };
+
+  for (const candidate of SYSTEM_PROMPT_FILES) {
+    const path = join(dir, candidate);
+    if (isFile(path)) {
+      profile.systemPromptPath = path;
+      break;
+    }
+  }
+
+  const skills = join(dir, SKILLS_DIR);
+  if (existsSync(skills)) {
+    if (isDir(skills)) profile.skillsDir = skills;
+    else warn(`skills path is not a directory, skipping: ${skills}`);
+  }
+
+  const displayName = readDisplayName(dir);
+  if (displayName) profile.displayName = displayName;
+
+  return profile;
+}
+
+/**
+ * Load a profile from a named environment variable (e.g. "LFG_PI_PROFILE_DIR").
+ * Keeps the env-var name out of the loader so the same mechanism can back other
+ * backends later.
+ */
+export function loadAgentProfileFromEnv(envVar: string): AgentProfile | null {
+  return loadAgentProfile(process.env[envVar]);
+}
+
+/**
+ * Build the additive pi CLI args for a profile: `--append-system-prompt <path>`
+ * for the system prompt file and `--skill <dir>` for the skills directory. Both
+ * pi flags are additive — they do NOT replace pi's built-in system prompt or its
+ * auto-discovered project skills. Returns [] for a null profile or one with no
+ * usable parts, so callers can always spread the result unconditionally.
+ */
+export function agentProfileCliArgs(profile: AgentProfile | null): string[] {
+  if (!profile) return [];
+  const args: string[] = [];
+  if (profile.systemPromptPath) args.push("--append-system-prompt", profile.systemPromptPath);
+  if (profile.skillsDir) args.push("--skill", profile.skillsDir);
+  return args;
+}

--- a/src/agents/backends/pi-session.ts
+++ b/src/agents/backends/pi-session.ts
@@ -31,6 +31,7 @@ import {
   removeEntry,
   writeEntry,
 } from "../../aisdk-registry.ts";
+import { agentProfileCliArgs, loadAgentProfileFromEnv } from "../../agent-profile.ts";
 import type { SessionMsg } from "../../sessions.ts";
 import { indexSessionMessagesDirect } from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
@@ -44,6 +45,12 @@ function arg(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
   return i >= 0 ? argv[i + 1] : undefined;
 }
+
+// Env var pointing at a custom agent profile directory — extra system-prompt
+// text, extra skills, and a display-name override, layered on top of pi's own
+// built-in defaults. Unset (the default for every existing LFG user) means no
+// customization at all. See src/agent-profile.ts for the directory layout.
+const PI_PROFILE_DIR_ENV = "LFG_PI_PROFILE_DIR";
 
 // pi has no separately-installed global binary we can rely on being present or
 // readable (sandboxes symlink /usr/local/bin/pi into root's bun install, which
@@ -147,10 +154,25 @@ export async function cmdPiSession(argv: string[]): Promise<void> {
   } catch {}
 
   ensurePiProviderConfig();
+  // Custom agent profile (optional): append the operator's extra system-prompt
+  // and skills as additive CLI args, and pick up a display-name override for the
+  // registry entry below. loadAgentProfileFromEnv returns null (and this whole
+  // block is a no-op) when LFG_PI_PROFILE_DIR is unset or the dir is missing;
+  // missing sub-parts are skipped without failing the harness.
+  const profile = loadAgentProfileFromEnv(PI_PROFILE_DIR_ENV);
+  if (profile) {
+    console.error(
+      `[agent-profile] pi profile active: ${profile.dir}` +
+        `${profile.systemPromptPath ? " +system-prompt" : ""}` +
+        `${profile.skillsDir ? " +skills" : ""}` +
+        `${profile.displayName ? ` name=${JSON.stringify(profile.displayName)}` : ""}`,
+    );
+  }
   const { RpcClient } = await import("@mariozechner/pi-coding-agent");
   const rpcArgs: string[] = [];
   if (thinkingLevel) rpcArgs.push("--thinking", thinkingLevel);
   if (resumeSessionId) rpcArgs.push("--session", resumeSessionId);
+  rpcArgs.push(...agentProfileCliArgs(profile));
   const client = new RpcClient({
     cliPath: resolvePiCliPath(),
     cwd,
@@ -174,6 +196,10 @@ export async function cmdPiSession(argv: string[]): Promise<void> {
     model,
     busy: false,
     title: initialPrompt ? initialPrompt.slice(0, 72) : null,
+    // Display-name override from the custom agent profile, if any — lets the UI
+    // show a branded label instead of the raw "pi" agent kind. Null when no
+    // profile / no name is configured, which keeps behavior unchanged.
+    agentLabel: profile?.displayName ?? null,
     createdAt: Date.now(),
   });
 

--- a/src/aisdk-registry.ts
+++ b/src/aisdk-registry.ts
@@ -43,6 +43,11 @@ export type AisdkEntry = {
   draftText?: string | null; // transient streamed assistant text; never persisted to transcripts
   draftUpdatedAt?: number | null;
   title?: string | null; // first user prompt, for the card before a transcript exists
+  // Display-name override for this session, from a custom agent profile (see
+  // src/agent-profile.ts). When set, the UI shows this branded label instead of
+  // the raw agent kind. Absent/null on every session without a configured
+  // profile — treat a missing value as "use the agent kind".
+  agentLabel?: string | null;
   createdAt: number;
   // Which AI-SDK backend this entry drives. Absent on legacy Claude entries —
   // treat a missing value as "claude" so old entries keep working unchanged.

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -232,6 +232,10 @@ export type SessionMsg = {
 
 export type Session = {
   agent: CodingAgentKind;
+  // Display-name override from a custom agent profile (see src/agent-profile.ts),
+  // or null/absent to fall back to the agent kind. Currently only pi-backed
+  // sessions can set this.
+  agentLabel?: string | null;
   pid: number;
   cmd: string;
   cwd: string | null;
@@ -2193,6 +2197,9 @@ export async function listSessions(): Promise<Session[]> {
     } catch {}
     out.push({
       agent: isCodex ? "codex-aisdk" : isOpencode ? "opencode" : isPi ? "pi" : "aisdk",
+      // Only pi carries a profile display-name override today; other backends
+      // leave it null.
+      agentLabel: isPi ? (e.agentLabel ?? null) : null,
       pid: e.harnessPid,
       cmd: isCodex
         ? `lfg codex-aisdk-session --model ${e.model}`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -291,6 +291,9 @@ type AgentReport = {
 
 type Session = {
   agent?: "claude" | "aisdk" | "codex" | "codex-aisdk" | "opencode" | "grok" | "cursor" | string;
+  // Display-name override from a custom agent profile (server-side), when set.
+  // Prefer this over the raw agent kind for labels/tooltips.
+  agentLabel?: string | null;
   pid?: number;
   cmd?: string;
   cwd?: string;
@@ -8007,7 +8010,8 @@ const RailItem = memo(function RailItem({
         <span className="relative flex size-6 shrink-0 items-center justify-center">
           <img
             src={agentIconSrc(session.agent)}
-            alt={agentIconAlt(session.agent)}
+            alt={session.agentLabel || agentIconAlt(session.agent)}
+            title={session.agentLabel || undefined}
             className="size-6 rounded-md"
           />
           <span
@@ -9796,7 +9800,8 @@ function SessionTitleSheet({
           </Button>
           <img
             src={agentIconSrc(session.agent)}
-            alt={agentIconAlt(session.agent)}
+            alt={session.agentLabel || agentIconAlt(session.agent)}
+            title={session.agentLabel || undefined}
             className="size-7 shrink-0 rounded-lg"
           />
           <SessionTitleLine title={title} />
@@ -10452,7 +10457,8 @@ const onTouchStart = (e: ReactTouchEvent) => {
                 new-session picker keeps a distinct label to tell them apart. */}
             <img
               src={agentIconSrc(session.agent)}
-              alt={agentIconAlt(session.agent)}
+              alt={session.agentLabel || agentIconAlt(session.agent)}
+              title={session.agentLabel || undefined}
               className={cn(
                 "rounded-lg transition-all duration-300 ease-ios",
                 busy || summarizing ? "size-4" : "size-6",


### PR DESCRIPTION
## Summary

Adds a generic, opt-in **custom agent profile** seam: point a managed agent at
extra system-prompt text, extra skills, and a display-name override from a plain
local directory — updated without an LFG code change or release, and a complete
no-op when unconfigured. Think of it like a user's own `~/.claude/CLAUDE.md`: a
reusable customization mechanism, not a partner integration.

Currently wired into the **`pi`** backend via `LFG_PI_PROFILE_DIR` (pi's own CLI
already exposes `--append-system-prompt` and `--skill`). The loader
(`src/agent-profile.ts`) is backend-agnostic and designed to generalize to other
backends later.

## Directory layout

```
my-profile/
  system-prompt.md   # (or .txt) appended via --append-system-prompt <path>
  skills/            # <name>/SKILL.md subfolders, passed via --skill <path>
  name               # (or profile.json {"displayName": "..."}) display-name override
```

If `LFG_PI_PROFILE_DIR` is unset, every existing `pi` session behaves exactly as
before. Both pi flags are **additive** — they don't replace pi's built-in system
prompt or the project's own `.agents/skills/`.

## Changes

- `src/agent-profile.ts` — reusable loader + additive CLI-arg builder; fails
  gracefully (log + skip) on any missing/malformed part, never crashes.
- `src/agents/backends/pi-session.ts` — load the profile, append the flags to the
  pi `RpcClient` args, record the display name on the registry entry.
- `src/aisdk-registry.ts` / `src/sessions.ts` — new optional `agentLabel`
  display-name override on the entry and `Session`.
- `web/src/App.tsx` — prefer `agentLabel` for the session-card agent tooltip/alt.
- Docs: `docs/custom-agent-profiles.md`, README config row, `.env.example`.
- Tests: `src/agent-profile.test.ts` (14 cases: loader + arg-builder edge cases).

## Verification

- `bun test` → 78 pass / 0 fail (14 new).
- `bun run typecheck` (backend) and `tsc --noEmit` (web) both clean.
- **Live**: ran the real `pi-session` harness with `LFG_PI_PROFILE_DIR` set to a
  scratch profile; confirmed the spawned pi child argv included
  `--append-system-prompt <profile>/system-prompt.md --skill <profile>/skills`,
  and the registry entry recorded `"agentLabel": "Demo Branded Agent"`. (A full
  pi RPC turn needs Anthropic credentials, which weren't exercised — only the
  process spawn + arg wiring was verified live.)

## Release note

Not tagging a release here: `scripts/tag-release.sh` requires being **on `main`**,
clean and synced, and this repo lands changes via PR review. Leaving the release
decision to a maintainer after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)