### PR TITLE
Fix stable HTML artifact ownership takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Recent product updates and deployment notes.
 
 ## [Unreleased]
 
+## July 18, 2026 - Transferable live dashboards (v0.1.42)
+
+- Re-publishing a stable HTML artifact id from a later session now updates the
+  same dashboard, transfers ownership and refresh control, and continues its
+  existing revision history.
+
 ## July 18, 2026 - Correct Pi and Copilot icons (v0.1.41)
 
 - Pi now uses its official block logo instead of a generic pi glyph, with a

--- a/docs/script-backed-html-artifacts.md
+++ b/docs/script-backed-html-artifacts.md
@@ -42,6 +42,12 @@ the artifact revision. They still emit the normal realtime artifact update, so
 an open client reloads the same card. Failures leave the prior HTML, timestamp,
 and revision intact.
 
+Stable HTML artifact ids are project-level. If a later session publishes new
+HTML with the same id, it takes ownership of the existing artifact, updates the
+same card, and continues the revision chain. The refresh configuration transfers
+with the artifact and can be rebound to an executable inside the new owner's
+cwd; the previous session can no longer refresh, reconfigure, or delete it.
+
 The Artifacts page labels scheduled dashboards with their most recent
 successful refresh time. Delete an artifact from that page with its trash
 button, or call `lfg_delete_artifact` with its stable `id`. Deletion is limited

--- a/src/artifact-refresh.test.ts
+++ b/src/artifact-refresh.test.ts
@@ -122,6 +122,32 @@ describe("script-backed HTML artifact refresh", () => {
     expect(after.updatedAt).toBeGreaterThan(before.updatedAt!);
   });
 
+  test("an old owner's in-flight refresh cannot reclaim a taken-over artifact", async () => {
+    const executable = script(
+      "takeover.sh",
+      "#!/bin/sh\nsleep 0.1\nprintf '%s' '<!doctype html><html><body>stale refresh</body></html>'\n",
+    );
+    const before = create({ scriptPath: executable });
+    const refreshes = manager();
+    const running = refreshes.refreshNow(before.id, SESSION);
+    await Bun.sleep(20);
+
+    const takeover = publishHtmlArtifact({
+      sessionId: OTHER_SESSION,
+      id: before.id,
+      html: "<!doctype html><html><body>new owner</body></html>",
+    });
+    const result = await running;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("owner changed");
+    expect(getImageArtifact(before.id)?.sessionId).toBe(OTHER_SESSION);
+    expect(getImageArtifact(before.id)?.version).toBe(2);
+    expect(readFileSync(before.filePath, "utf8")).toContain("new owner");
+    expect(takeover.refresh?.scriptPath).toBe(before.refresh?.scriptPath);
+    expect(takeover.refresh?.scopeRoot).toBe(before.refresh?.scopeRoot);
+  });
+
   test("failure and invalid output preserve the last good HTML and version", async () => {
     const executable = script("failure.sh", "#!/bin/sh\nprintf 'not a document'\n");
     const before = create({ scriptPath: executable });

--- a/src/artifacts.test.ts
+++ b/src/artifacts.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, test } from "bun:test";
-import { collapseArtifactRetryMessages } from "./artifacts.ts";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import {
+  collapseArtifactRetryMessages,
+  createImageArtifact,
+  deleteArtifact,
+  getImageArtifact,
+  publishHtmlArtifact,
+  updateHtmlArtifactRefresh,
+  type ArtifactRefreshConfig,
+} from "./artifacts.ts";
+
+const SESSION_A = "11111111-1111-4111-8111-111111111111";
+const SESSION_B = "22222222-2222-4222-8222-222222222222";
+
+function refreshConfig(scopeRoot: string): ArtifactRefreshConfig {
+  return {
+    scriptPath: join(scopeRoot, "refresh.sh"),
+    argv: [],
+    scopeRoot,
+    intervalMs: 10_000,
+    timeoutMs: 2_000,
+    enabled: true,
+    configuredAt: 1,
+    status: "idle",
+  };
+}
 
 describe("artifact display retry reconciliation", () => {
   test("collapses an identical media retry while preserving transcript order", () => {
@@ -30,5 +58,72 @@ describe("artifact display retry reconciliation", () => {
       "artifact-b",
       "artifact-c",
     ]);
+  });
+});
+
+describe("stable HTML artifact ownership", () => {
+  const originalData = PATHS.data;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "lfg-artifact-ownership-"));
+    PATHS.data = join(root, "data");
+  });
+
+  afterEach(() => {
+    PATHS.data = originalData;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a new session takes over an HTML id without breaking its version chain", () => {
+    const originalRefresh = refreshConfig(join(root, "session-a"));
+    const before = publishHtmlArtifact({
+      sessionId: SESSION_A,
+      id: "shared-dash",
+      html: "<!doctype html><html><body>session A</body></html>",
+      refresh: originalRefresh,
+    });
+
+    const after = publishHtmlArtifact({
+      sessionId: SESSION_B,
+      id: "shared-dash",
+      html: "<!doctype html><html><body>session B</body></html>",
+    });
+
+    expect(after.sessionId).toBe(SESSION_B);
+    expect(after.version).toBe(2);
+    expect(after.createdAt).toBe(before.createdAt);
+    expect(after.filePath).toBe(before.filePath);
+    expect(after.refresh).toEqual(originalRefresh);
+    expect(readFileSync(after.filePath, "utf8")).toContain("session B");
+
+    const reboundRefresh = refreshConfig(join(root, "session-b"));
+    expect(() => updateHtmlArtifactRefresh({
+      id: after.id,
+      sessionId: SESSION_A,
+      refresh: reboundRefresh,
+    })).toThrow("different session");
+    expect(() => deleteArtifact({ id: after.id, sessionId: SESSION_A })).toThrow("different session");
+
+    expect(updateHtmlArtifactRefresh({
+      id: after.id,
+      sessionId: SESSION_B,
+      refresh: reboundRefresh,
+    }).refresh).toEqual(reboundRefresh);
+    expect(deleteArtifact({ id: after.id, sessionId: SESSION_B }).id).toBe(after.id);
+    expect(getImageArtifact(after.id)).toBeNull();
+  });
+
+  test("an HTML publish cannot take over an image artifact id", () => {
+    const source = join(root, "image.png");
+    writeFileSync(source, "not-a-real-png");
+    const image = createImageArtifact({ sessionId: SESSION_A, path: source });
+
+    expect(() => publishHtmlArtifact({
+      sessionId: SESSION_B,
+      id: image.id,
+      html: "<!doctype html><html><body>collision</body></html>",
+    })).toThrow("different media kind");
+    expect(getImageArtifact(image.id)?.media).toBe("image");
   });
 });

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -268,8 +268,12 @@ export function publishHtmlArtifact(input: {
 
   const index = readIndex();
   const existing = requestedId ? index[requestedId] : null;
-  if (existing && (existing.sessionId !== sessionId || (existing.media ?? "image") !== "html")) {
-    throw new Error("artifact id belongs to a different session or media kind");
+  // Explicit HTML ids are project-level: a later session may intentionally
+  // take over the stable card. Preserve the record below so its file, creation
+  // time, refresh configuration, and version chain continue in place. Media
+  // ids remain kind-safe, so HTML can never replace an image or video.
+  if (existing && (existing.media ?? "image") !== "html") {
+    throw new Error("artifact id belongs to a different media kind");
   }
 
   const id = requestedId ?? `${Date.now().toString(36)}-${randomBytes(6).toString("hex")}`;


### PR DESCRIPTION
## What changed

Stable HTML artifact IDs can now be re-published by a later session. The existing file path, creation time, refresh configuration, and version chain are preserved while ownership transfers to the publisher. Image and video ID collisions remain rejected.

Ownership-sensitive refresh configuration and deletion continue to use the durable current owner. Regression coverage also verifies that an old owner's in-flight refresh cannot overwrite or reclaim the artifact after takeover.

## Why

Project-level dashboard IDs such as `omg-user-growth` need to survive session boundaries without creating a second card or resetting to v1.

## Validation

- `bun test` — 81 pass
- `bun run typecheck`
