### PR TITLE
connect: finish lfg connect relay client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,11 @@ LFG_WHATSAPP_TRIGGER=lfg
 LFG_WHATSAPP_ALWAYS_ON=false
 LFG_WHATSAPP_AUTH_DIR=
 
+# ---- optional: reach this box through a relay (`lfg connect`) ----
+# No relay implementation ships with LFG — point this at an operator-run one.
+# See `lfg connect help` / README.md's "lfg connect" section.
+# LFG_RELAY_URL=wss://your-relay.example/connect
+
 # ---- optional: internal auto-agent bridges (scripts-internal/, gitignored) ----
 # Control-plane read-only SQLite over SSH (cp-sql.sh). Required for DB-triage agents.
 # TWCLI_CP_SSH=root@your-controlplane-host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Recent product updates and deployment notes.
 
 ## [Unreleased]
 
+- `lfg connect` — a new generic remote-access relay client. Lets a
+  self-hosted box be reached through an operator-run relay without opening
+  any inbound port: the box dials out over a WebSocket, authenticates with a
+  one-time pairing code (then a persisted bearer token), and proxies HTTP
+  traffic onto its own local `lfg serve`. No relay implementation ships with
+  LFG — `LFG_RELAY_URL` is a required, provider-agnostic setting (see the
+  README's "lfg connect" section and the wire protocol documented in
+  `src/commands/connect.ts`).
+
 ## July 18, 2026 - Transferable live dashboards (v0.1.42)
 
 - Re-publishing a stable HTML artifact id from a later session now updates the

--- a/README.md
+++ b/README.md
@@ -176,10 +176,35 @@ bun run subagent -- models     # list runtime sub-agent providers/models
 bun run subagent -- create --prompt "..." --agent codex-aisdk
 bun run mcp                    # stdio MCP server for LFG session tools
 bun run whatsapp -- run        # optional WhatsApp sidecar
+bun run connect -- <code>      # pair this box to a remote-access relay (see below)
 bun run setup                  # rerun provisioning/update flow
 ```
 
 Installed release builds expose the same commands through `lfg`.
+
+### `lfg connect` — reach this box through a relay
+
+`lfg serve`'s control API has no application-layer auth of its own (see
+[Security](#security)) — it trusts loopback + your tailnet. `lfg connect`
+lets an *operator-run relay* reach this box instead, without opening any
+inbound port: the box dials **out** to the relay over a WebSocket and holds
+it open, and the relay's own auth (a pairing code, then a persisted bearer
+token) is the boundary. No relay implementation ships with LFG — this is the
+generic client half of a documented protocol any relay operator can
+implement (see the wire protocol at the top of
+[`src/commands/connect.ts`](./src/commands/connect.ts)).
+
+```bash
+LFG_RELAY_URL=wss://your-relay.example/connect lfg connect ABC123   # redeem a one-time code, then stay connected
+lfg connect status                                                  # show the current binding, if any
+lfg connect disconnect                                              # drop the saved binding locally
+```
+
+`LFG_RELAY_URL` is required (no default — this file must never hardcode a
+specific operator's relay). The saved binding token lives in
+`data/relay-credentials.json` (mode `0600`); if the relay reports the token
+invalid, expired, or revoked, reconnecting stops and asks you to re-pair with
+a fresh code rather than retrying forever.
 
 The MCP server talks to the local `lfg serve` API and exposes tools such as
 `lfg_capabilities`, `lfg_list_sessions`, `lfg_get_session_messages`,
@@ -226,6 +251,7 @@ Common settings:
 | `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Default `1.0.71` (audits clean); avoid `<=1.0.42` (GHSA-9ccr-r5hg-74gf, `core.fsmonitor` RCE) and `<=0.0.422` (GHSA-g8r9-g2v8-jv6f, prompt-injection RCE via shell parameter expansion). Set to `latest` for floating installs. |
 | `ANTHROPIC_API_KEY` | Optional API key for Claude SDK-backed flows. |
 | `LFG_WHATSAPP_*` | Optional WhatsApp bridge settings. |
+| `LFG_RELAY_URL` | Relay WebSocket URL for `lfg connect` (required to use it — no default). See [Commands](#commands). |
 | `LFG_INSTALL_CHANNEL` | Optional install-channel override: `source`, `release`, or `container`. Normally written by setup/container deploys. |
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -196,9 +196,14 @@ implement (see the wire protocol at the top of
 
 ```bash
 LFG_RELAY_URL=wss://your-relay.example/connect lfg connect ABC123   # redeem a one-time code, then stay connected
+LFG_RELAY_URL=wss://your-relay.example/connect lfg connect          # resume the saved binding (e.g. after a restart) — no code needed
 lfg connect status                                                  # show the current binding, if any
 lfg connect disconnect                                              # drop the saved binding locally
 ```
+
+Run it under a process supervisor (systemd, `pm2`, etc. — not bundled) for a
+box that should stay connected: a bare `lfg connect` re-invocation resumes the
+saved binding on its own, so a crash/reboot recovers without operator action.
 
 `LFG_RELAY_URL` is required (no default — this file must never hardcode a
 specific operator's relay). The saved binding token lives in

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "subagent": "bun run src/cli.ts subagent",
     "mcp": "bun run src/cli.ts mcp",
     "whatsapp": "bun run src/cli.ts whatsapp",
+    "connect": "bun run src/cli.ts connect",
     "setup": "bun run src/cli.ts setup",
     "test": "bun test",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ Usage:
   lfg subagent [create|models]      Spawn a managed worker session on any harness
   lfg mcp                          Run the LFG MCP stdio server
   lfg whatsapp [run|sessions]      Run the optional WhatsApp control sidecar
+  lfg connect <code>               Pair this box to a remote-access relay (EXPERIMENTAL)
   lfg setup                        Provision this box (Bun, tmux, Tailscale, service)
 
 Env (read from process env / .env, see .env.example):
@@ -36,6 +37,10 @@ async function main() {
     case "whatsapp": {
       const { cmdWhatsapp } = await import("./commands/whatsapp.ts");
       return await cmdWhatsapp(rest);
+    }
+    case "connect": {
+      const { cmdConnect } = await import("./commands/connect.ts");
+      return await cmdConnect(rest);
     }
     case "setup": {
       const { cmdSetup } = await import("./commands/setup.ts");

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,0 +1,269 @@
+import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { PATHS } from "../config.ts";
+
+// lfg connect — generic remote-access relay client SKELETON.
+//
+// Lets a self-hosted `lfg serve` box be reached through a WebSocket relay
+// instead of exposing an inbound port. Deliberately provider-agnostic: this
+// file must never hardcode a specific relay's URL, branding, or account
+// model — LFG_RELAY_URL is a required argument, not a default, so any
+// operator can point it at their own relay implementation. (omg's dashboard
+// supplies its own relay URL as the *value* of that env var — see
+// apps/imsg/BYO_COMPUTER.md in the vibes repo for that integration; nothing
+// omg-specific belongs in this file.)
+//
+// `lfg serve`'s own HTTP API has no application-layer auth (see
+// live-ws.ts's liveWsUpgradeAuthenticated) — it always trusted its network
+// perimeter (localhost bind, or whatever put it there). A relay is a new
+// perimeter, so this client authenticates to the RELAY (pairing code once,
+// then a persisted bearer token) — it does not change `serve` itself.
+//
+// Wire protocol (JSON frames over one WebSocket to LFG_RELAY_URL):
+//   client → relay   {type:"pair", code}                     (first connect only)
+//   relay  → client   {type:"paired", token, boxId}           (persist token; reconnect with it instead of a code)
+//   client → relay   {type:"hello", token}                    (subsequent connects)
+//   relay  → client   {type:"http", id, method, path, headers, bodyB64?}
+//   client → relay   {type:"http-response", id, status, headers, bodyB64?}
+//   either → other    {type:"ping"} / {type:"pong"}
+//
+// This is intentionally the smallest surface that lets a relay reverse-proxy
+// HTTP semantics (incl. serve.ts's SSE/WS endpoints, tunneled as ordinary
+// request/response framing) onto a box with no inbound port open. No relay
+// implementing this protocol exists yet anywhere — this command has not been
+// exercised against a live one.
+
+const HELP = `lfg connect — pair this box to a remote-access relay (EXPERIMENTAL)
+
+Usage:
+  lfg connect <code>       Redeem a one-time pairing code from a relay, then stay connected
+  lfg connect status       Show the current relay binding, if any
+  lfg connect disconnect   Drop the saved binding and stop
+  lfg connect help         Show this help
+
+Env:
+  LFG_RELAY_URL       Relay WebSocket URL (required — no default, this file is provider-agnostic)
+  LFG_PORT / LFG_HOST Local 'lfg serve' address to proxy requests to (default 127.0.0.1:8766)
+
+No relay implementation ships with LFG. This is the generic client half of a
+protocol any relay operator can implement — see the wire protocol documented
+at the top of src/commands/connect.ts.
+`;
+
+const CREDENTIALS_PATH = join(PATHS.data, "relay-credentials.json");
+const RECONNECT_MIN_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const LOCAL_PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
+const LOCAL_HOST = process.env.LFG_HOST ?? "127.0.0.1";
+
+interface RelayCredentials {
+  relayUrl: string;
+  token: string;
+  boxId: string;
+  pairedAt: number;
+}
+
+async function readCredentials(): Promise<RelayCredentials | null> {
+  try {
+    return JSON.parse(await readFile(CREDENTIALS_PATH, "utf8")) as RelayCredentials;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCredentials(creds: RelayCredentials): Promise<void> {
+  await mkdir(PATHS.data, { recursive: true });
+  await writeFile(CREDENTIALS_PATH, JSON.stringify(creds, null, 2), { mode: 0o600 });
+}
+
+function requireRelayUrl(): string {
+  const url = process.env.LFG_RELAY_URL?.trim();
+  if (!url) {
+    console.error("lfg connect: LFG_RELAY_URL is not set — point it at your relay's WebSocket URL.\n");
+    console.log(HELP);
+    process.exit(1);
+  }
+  return url;
+}
+
+type HttpFrame = {
+  type: "http";
+  id: string;
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  bodyB64?: string;
+};
+
+function isHttpFrame(value: unknown): value is HttpFrame {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "http" &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    typeof (value as { method?: unknown }).method === "string" &&
+    typeof (value as { path?: unknown }).path === "string"
+  );
+}
+
+/** Proxies one relayed HTTP request onto this box's own `lfg serve`. */
+async function forwardToLocalServe(frame: HttpFrame): Promise<{
+  type: "http-response";
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  bodyB64: string;
+}> {
+  try {
+    const response = await fetch(`http://${LOCAL_HOST}:${LOCAL_PORT}${frame.path}`, {
+      method: frame.method,
+      headers: frame.headers,
+      body: frame.bodyB64 ? Buffer.from(frame.bodyB64, "base64") : undefined,
+    });
+    const bodyB64 = Buffer.from(await response.arrayBuffer()).toString("base64");
+    return {
+      type: "http-response",
+      id: frame.id,
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      bodyB64,
+    };
+  } catch (error) {
+    return {
+      type: "http-response",
+      id: frame.id,
+      status: 502,
+      headers: { "content-type": "text/plain" },
+      bodyB64: Buffer.from(`lfg connect: local serve unreachable — ${String(error)}`).toString("base64"),
+    };
+  }
+}
+
+function connectSocket(relayUrl: string, hello: { type: "pair"; code: string } | { type: "hello"; token: string }): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(relayUrl);
+    ws.addEventListener("open", () => {
+      ws.send(JSON.stringify(hello));
+      resolve(ws);
+    });
+    ws.addEventListener("error", (event) => reject(new Error(`relay connection failed: ${String(event)}`)));
+  });
+}
+
+/** Redeems a one-time pairing code, persists the returned token, then falls through to the persistent connect loop. */
+async function pair(code: string): Promise<void> {
+  const relayUrl = requireRelayUrl();
+  console.log(`lfg connect: redeeming pairing code against ${relayUrl} …`);
+  const ws = await connectSocket(relayUrl, { type: "pair", code });
+
+  const paired = await new Promise<{ token: string; boxId: string }>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("timed out waiting for relay to confirm pairing")), 15_000);
+    ws.addEventListener("message", (event) => {
+      try {
+        const msg = JSON.parse(String(event.data)) as { type?: string; token?: string; boxId?: string };
+        if (msg.type === "paired" && msg.token && msg.boxId) {
+          clearTimeout(timeout);
+          resolve({ token: msg.token, boxId: msg.boxId });
+        }
+      } catch {
+        // ignore malformed frames while waiting for the pairing ack
+      }
+    });
+    ws.addEventListener("close", () => {
+      clearTimeout(timeout);
+      reject(new Error("relay closed the connection before confirming pairing"));
+    });
+  });
+
+  await writeCredentials({ relayUrl, token: paired.token, boxId: paired.boxId, pairedAt: Date.now() });
+  console.log(`lfg connect: paired as ${paired.boxId} — credentials saved to ${CREDENTIALS_PATH}`);
+  ws.close();
+  await runConnectLoop();
+}
+
+/** Long-running: reconnects with backoff and proxies relayed HTTP frames onto local serve, forever. */
+async function runConnectLoop(): Promise<void> {
+  const creds = await readCredentials();
+  if (!creds) {
+    console.error("lfg connect: no saved binding — run `lfg connect <code>` first.");
+    process.exit(1);
+  }
+
+  let backoffMs = RECONNECT_MIN_MS;
+  for (;;) {
+    try {
+      console.log(`lfg connect: dialing ${creds.relayUrl} as ${creds.boxId} …`);
+      const ws = await connectSocket(creds.relayUrl, { type: "hello", token: creds.token });
+      backoffMs = RECONNECT_MIN_MS;
+      console.log(`lfg connect: connected — proxying to local serve on ${LOCAL_HOST}:${LOCAL_PORT}`);
+
+      await new Promise<void>((resolveClosed) => {
+        ws.addEventListener("message", (event) => {
+          void (async () => {
+            let frame: unknown;
+            try {
+              frame = JSON.parse(String(event.data));
+            } catch {
+              return;
+            }
+            if (frame && typeof frame === "object" && (frame as { type?: unknown }).type === "ping") {
+              ws.send(JSON.stringify({ type: "pong" }));
+              return;
+            }
+            if (isHttpFrame(frame)) ws.send(JSON.stringify(await forwardToLocalServe(frame)));
+          })();
+        });
+        ws.addEventListener("close", () => resolveClosed());
+        ws.addEventListener("error", () => resolveClosed());
+      });
+      console.log("lfg connect: relay connection closed — reconnecting");
+    } catch (error) {
+      console.error(`lfg connect: ${String(error)}`);
+    }
+    await new Promise((r) => setTimeout(r, backoffMs));
+    backoffMs = Math.min(RECONNECT_MAX_MS, backoffMs * 2);
+  }
+}
+
+async function printStatus(): Promise<void> {
+  const creds = await readCredentials();
+  if (!creds) {
+    console.log("lfg connect: not paired with any relay.");
+    return;
+  }
+  console.log(`lfg connect: paired as ${creds.boxId} via ${creds.relayUrl} (since ${new Date(creds.pairedAt).toISOString()})`);
+}
+
+async function disconnect(): Promise<void> {
+  const creds = await readCredentials();
+  if (!creds) {
+    console.log("lfg connect: nothing to disconnect.");
+    return;
+  }
+  await rm(CREDENTIALS_PATH, { force: true });
+  console.log(`lfg connect: cleared local binding to ${creds.relayUrl}. (The relay may still hold a stale token until it expires — this command only clears this box's side.)`);
+}
+
+export async function cmdConnect(args: string[]): Promise<void> {
+  const [sub, ...rest] = args;
+  switch (sub) {
+    case "status":
+      return printStatus();
+    case "disconnect":
+      return disconnect();
+    case "help":
+    case "-h":
+    case "--help":
+    case undefined:
+      console.log(HELP);
+      return;
+    default:
+      if (rest.length > 0 || sub.startsWith("-")) {
+        console.error(`Unknown connect subcommand: ${sub}\n`);
+        console.log(HELP);
+        process.exit(1);
+      }
+      // Anything else is treated as a pairing code.
+      return pair(sub);
+  }
+}

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { PATHS } from "../config.ts";
 
-// lfg connect — generic remote-access relay client SKELETON.
+// lfg connect — generic remote-access relay client.
 //
 // Lets a self-hosted `lfg serve` box be reached through a WebSocket relay
 // instead of exposing an inbound port. Deliberately provider-agnostic: this
@@ -23,15 +23,19 @@ import { PATHS } from "../config.ts";
 //   client → relay   {type:"pair", code}                     (first connect only)
 //   relay  → client   {type:"paired", token, boxId}           (persist token; reconnect with it instead of a code)
 //   client → relay   {type:"hello", token}                    (subsequent connects)
+//   relay  → client   {type:"hello-ok"}                        (optional; unknown frame types are ignored anyway)
+//   relay  → client   {type:"error", message}                  (pairing/hello rejected — relay closes right after)
 //   relay  → client   {type:"http", id, method, path, headers, bodyB64?}
 //   client → relay   {type:"http-response", id, status, headers, bodyB64?}
 //   either → other    {type:"ping"} / {type:"pong"}
 //
 // This is intentionally the smallest surface that lets a relay reverse-proxy
 // HTTP semantics (incl. serve.ts's SSE/WS endpoints, tunneled as ordinary
-// request/response framing) onto a box with no inbound port open. No relay
-// implementing this protocol exists yet anywhere — this command has not been
-// exercised against a live one.
+// request/response framing) onto a box with no inbound port open. An `error`
+// frame during `hello` means the saved token is no longer valid (expired,
+// revoked, or unknown to the relay) — that will never resolve by retrying,
+// so the reconnect loop below treats it as fatal rather than backing off
+// forever against a token that can't work.
 
 const HELP = `lfg connect — pair this box to a remote-access relay (EXPERIMENTAL)
 
@@ -95,7 +99,7 @@ type HttpFrame = {
   bodyB64?: string;
 };
 
-function isHttpFrame(value: unknown): value is HttpFrame {
+export function isHttpFrame(value: unknown): value is HttpFrame {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -106,8 +110,20 @@ function isHttpFrame(value: unknown): value is HttpFrame {
   );
 }
 
+export function errorFrameMessage(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  if ((value as { type?: unknown }).type !== "error") return null;
+  const message = (value as { message?: unknown }).message;
+  return typeof message === "string" && message ? message : "the relay rejected this connection";
+}
+
+/** A `{type:"error"}` frame the relay sent for `hello` — the saved token is
+ * dead (expired/revoked/unknown); re-pairing is the only fix, so the
+ * reconnect loop treats this as fatal rather than backing off forever. */
+class RelayAuthError extends Error {}
+
 /** Proxies one relayed HTTP request onto this box's own `lfg serve`. */
-async function forwardToLocalServe(frame: HttpFrame): Promise<{
+export async function forwardToLocalServe(frame: HttpFrame): Promise<{
   type: "http-response";
   id: string;
   status: number;
@@ -164,6 +180,12 @@ async function pair(code: string): Promise<void> {
         if (msg.type === "paired" && msg.token && msg.boxId) {
           clearTimeout(timeout);
           resolve({ token: msg.token, boxId: msg.boxId });
+          return;
+        }
+        const errorMessage = errorFrameMessage(msg);
+        if (errorMessage) {
+          clearTimeout(timeout);
+          reject(new Error(errorMessage));
         }
       } catch {
         // ignore malformed frames while waiting for the pairing ack
@@ -197,6 +219,7 @@ async function runConnectLoop(): Promise<void> {
       backoffMs = RECONNECT_MIN_MS;
       console.log(`lfg connect: connected — proxying to local serve on ${LOCAL_HOST}:${LOCAL_PORT}`);
 
+      let authRejected: string | null = null;
       await new Promise<void>((resolveClosed) => {
         ws.addEventListener("message", (event) => {
           void (async () => {
@@ -210,14 +233,26 @@ async function runConnectLoop(): Promise<void> {
               ws.send(JSON.stringify({ type: "pong" }));
               return;
             }
+            const errorMessage = errorFrameMessage(frame);
+            if (errorMessage) {
+              authRejected = errorMessage;
+              ws.close();
+              return;
+            }
             if (isHttpFrame(frame)) ws.send(JSON.stringify(await forwardToLocalServe(frame)));
           })();
         });
         ws.addEventListener("close", () => resolveClosed());
         ws.addEventListener("error", () => resolveClosed());
       });
+      if (authRejected) throw new RelayAuthError(authRejected);
       console.log("lfg connect: relay connection closed — reconnecting");
     } catch (error) {
+      if (error instanceof RelayAuthError) {
+        console.error(`lfg connect: ${error.message}`);
+        console.error("lfg connect: run `lfg connect <code>` with a fresh pairing code to reconnect.");
+        process.exit(1);
+      }
       console.error(`lfg connect: ${String(error)}`);
     }
     await new Promise((r) => setTimeout(r, backoffMs));

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -41,6 +41,8 @@ const HELP = `lfg connect — pair this box to a remote-access relay (EXPERIMENT
 
 Usage:
   lfg connect <code>       Redeem a one-time pairing code from a relay, then stay connected
+  lfg connect              Resume the saved binding, if any (safe to re-invoke, e.g. from a
+                           process manager after a restart); shows this help if never paired
   lfg connect status       Show the current relay binding, if any
   lfg connect disconnect   Drop the saved binding and stop
   lfg connect help         Show this help
@@ -289,9 +291,19 @@ export async function cmdConnect(args: string[]): Promise<void> {
     case "help":
     case "-h":
     case "--help":
-    case undefined:
       console.log(HELP);
       return;
+    case undefined: {
+      // A process manager (systemd `Restart=always`, etc.) re-invokes `lfg
+      // connect` with no arguments on every restart — it doesn't have a fresh
+      // pairing code to hand it, and shouldn't need one: the saved token is
+      // still good. Resume the connect loop from it; only fall back to HELP
+      // when there's genuinely nothing paired yet.
+      const creds = await readCredentials();
+      if (creds) return runConnectLoop();
+      console.log(HELP);
+      return;
+    }
     default:
       if (rest.length > 0 || sub.startsWith("-")) {
         console.error(`Unknown connect subcommand: ${sub}\n`);

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { errorFrameMessage, forwardToLocalServe, isHttpFrame } from "../src/commands/connect.ts";
+
+describe("isHttpFrame", () => {
+  test("accepts a well-formed http frame", () => {
+    expect(isHttpFrame({ type: "http", id: "1", method: "GET", path: "/api/sessions" })).toBe(true);
+  });
+
+  test("rejects frames missing required fields or of a different type", () => {
+    expect(isHttpFrame({ type: "ping" })).toBe(false);
+    expect(isHttpFrame({ type: "http", id: "1", method: "GET" })).toBe(false); // no path
+    expect(isHttpFrame(null)).toBe(false);
+    expect(isHttpFrame("http")).toBe(false);
+  });
+});
+
+describe("errorFrameMessage", () => {
+  test("extracts the message from a well-formed error frame", () => {
+    expect(errorFrameMessage({ type: "error", message: "pairing code invalid or expired" })).toBe(
+      "pairing code invalid or expired",
+    );
+  });
+
+  test("falls back to a generic message when the frame omits one", () => {
+    expect(errorFrameMessage({ type: "error" })).toBe("the relay rejected this connection");
+  });
+
+  test("returns null for anything that isn't an error frame", () => {
+    expect(errorFrameMessage({ type: "paired", token: "x", boxId: "y" })).toBeNull();
+    expect(errorFrameMessage({ type: "ping" })).toBeNull();
+    expect(errorFrameMessage(null)).toBeNull();
+    expect(errorFrameMessage("error")).toBeNull();
+  });
+});
+
+describe("forwardToLocalServe", () => {
+  test("forwards method/path/body to local serve and base64-encodes the response", async () => {
+    const originalFetch = globalThis.fetch;
+    let seenUrl = "";
+    let seenInit: RequestInit | undefined;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenInit = init;
+      return new Response(JSON.stringify({ sessionId: "abc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    try {
+      const response = await forwardToLocalServe({
+        type: "http",
+        id: "req-1",
+        method: "POST",
+        path: "/api/sessions/new",
+        headers: { "content-type": "application/json" },
+        bodyB64: Buffer.from(JSON.stringify({ prompt: "hi" })).toString("base64"),
+      });
+      expect(seenUrl).toContain("/api/sessions/new");
+      expect(seenInit?.method).toBe("POST");
+      expect(Buffer.from(String(seenInit?.body)).toString("utf8")).toBe(JSON.stringify({ prompt: "hi" }));
+      expect(response.id).toBe("req-1");
+      expect(response.status).toBe(200);
+      expect(Buffer.from(response.bodyB64, "base64").toString("utf8")).toBe(JSON.stringify({ sessionId: "abc" }));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("answers 502 (not a thrown error) when local serve is unreachable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("connection refused");
+    }) as typeof fetch;
+    try {
+      const response = await forwardToLocalServe({ type: "http", id: "req-2", method: "GET", path: "/api/sessions" });
+      expect(response.status).toBe(502);
+      expect(Buffer.from(response.bodyB64, "base64").toString("utf8")).toContain("connection refused");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Finishes the `byo-computer-connect-skeleton` branch's generic remote-access relay client (`lfg connect`) so it's merge-ready.
- Handles a relay `{type:"error"}` frame both during pairing (fails fast instead of waiting out the 15s timeout) and during reconnect (an expired/revoked token is now fatal — re-pairing is the only fix, so the loop stops with a clear message instead of backing off forever against a token that can never work).
- Documents `lfg connect` in the README (new "lfg connect" subsection) and `.env.example`, adds a `bun run connect` package.json script.
- Adds unit tests for the pure frame-parsing/local-forward helpers (`isHttpFrame`, `errorFrameMessage`, `forwardToLocalServe`).

Still fully generic: `LFG_RELAY_URL`/args only, no omg endpoints, branding, or account concepts. omg's own relay implementation (the counterparty this client talks to) lives in a separate closed-source repo (`vibes`, `apps/relay` + `apps/imsg/BYO_COMPUTER.md`) — nothing here references it beyond a doc-comment pointer.

Per this repo's house rules: no release tag, no version bump — that's the parent's call whenever this merges.

## Test plan
- [x] `bun test` — 88/88 pass (including 7 new tests in `test/connect.test.ts`)
- [x] `bunx tsc -p tsconfig.json --noEmit` — clean
- [x] Manual smoke: paired against a real relay implementation (omg's `apps/relay`) end-to-end — pair → token persist → reconnect/hello → proxied HTTP round-trip → offline detection on relay 503 → revoke drops the connection. (Done in a sibling verification pass, not part of this repo's own test suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)