### PR TITLE
docs: README refresh + media/transcript join fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ LFG_COPILOT_ALLOW_ALL_TOOLS=
 LFG_COPILOT_VERSION=
 # Optional Hermes provider override. Empty uses Hermes' configured/default provider.
 LFG_HERMES_PROVIDER=
+# Pi ships bundled with LFG (@mariozechner/pi-coding-agent). Override only if
+# you want a different CLI path than the package under node_modules.
+LFG_PI_PATH=
 # Optional custom agent profile for the `pi` backend: a directory with
 # system-prompt.md, a skills/ folder, and a `name` file. Layers extra
 # system-prompt text, skills, and a display-name override on top of pi's own

--- a/README.md
+++ b/README.md
@@ -9,32 +9,37 @@ Run AI coding agents on your own machine, from anywhere.
 </a>
 
 `lfg` turns a Linux box or macOS workstation into a private control plane for
-Claude Code, Codex, OpenCode, Cursor, Grok, Hermes, and GitHub Copilot. It starts each agent in a long-lived `tmux`
-session, streams the transcript to a web UI, and lets you answer prompts or steer
-work from your phone or laptop.
+Claude Code, Codex, OpenCode, Cursor, Grok, Hermes, Pi, and GitHub Copilot. It
+starts each agent in a long-lived `tmux` session, streams the transcript to a
+web UI, and lets you answer prompts or steer work from your phone or laptop.
 
 **Website:** [lfg.apps.omg.dev](https://lfg.apps.omg.dev)
 
 ## Why lfg?
 
 - **Run agents where your code lives.** Sessions execute on your machine, in your
-  repos, with your local CLIs and credentials.
-- **Use a real web UI.** Launch sessions, watch output, answer permission
-  prompts, switch projects, and resume work from an installable PWA.
+  repos, with your local CLIs and credentials — not a remote sandbox you have to
+  keep in sync.
+- **One UI for every harness.** Switch agents and models per session, resume
+  work, answer permission prompts, and manage projects from an installable PWA.
 - **Keep it private.** The server binds to loopback by default and is designed to
   be exposed through Tailscale, not the public internet.
-- **Automate repo checks.** Optional markdown-defined agents can collect git,
-  repo, GitHub, model, or security context and produce reports.
+- **Show the work.** Agents can display verification media, publish updatable
+  HTML dashboards, and post finished results to the Shipped feed.
+- **Delegate with lineage.** LFG MCP tools spawn subagents that stay visible in
+  the UI, inherit parent context, and report progress back.
+- **Automate repo checks.** Optional markdown-defined agents collect git, repo,
+  GitHub, model, or security context and produce scheduled reports.
 
 ## Screenshots
 
 <p>
   <img src="https://raw.githubusercontent.com/BennyKok/lfg/main/docs/images/lfg-screenshot-1.jpg" alt="lfg web UI screenshot" width="31%" />
-  <img src="https://raw.githubusercontent.com/BennyKok/lfg/main/docs/images/lfg-screenshot-2.jpg" alt="lfg session view screenshot" width="31%" />
-  <img src="https://raw.githubusercontent.com/BennyKok/lfg/main/docs/images/lfg-screenshot-3.jpg" alt="lfg mobile control screenshot" width="31%" />
+  <img src="https://raw.githubusercontent.com/BennyKok/lfg/main/docs/images/lfg-screenshot-2.jpg" alt="lfg scheduled agents screenshot" width="31%" />
+  <img src="https://raw.githubusercontent.com/BennyKok/lfg/main/docs/images/lfg-screenshot-3.jpg" alt="lfg usage limits screenshot" width="31%" />
 </p>
 
-The images are stored in this repo instead of hotlinked, so the README renders
+Images live in this repo (not hotlinked from elsewhere) so the README renders
 reliably on GitHub.
 
 ## Requirements
@@ -42,14 +47,16 @@ reliably on GitHub.
 - [Bun](https://bun.sh)
 - `tmux`
 - `git`
-- At least one supported agent CLI on `PATH`:
-  - `claude`
-  - `codex`
-  - `opencode`
-  - `cursor-agent` (Cursor CLI)
-  - `grok`
-  - `hermes`
-  - `copilot` (GitHub Copilot CLI, requires Node 22+)
+- At least one supported coding agent:
+  - `claude` — Claude Code CLI
+  - `codex` — OpenAI Codex CLI
+  - `opencode` — OpenCode CLI
+  - `cursor-agent` — Cursor CLI
+  - `grok` — Grok CLI
+  - `hermes` — Hermes Agent
+  - `copilot` — GitHub Copilot CLI (Node 22+)
+  - **Pi** — ships bundled with LFG (`@mariozechner/pi-coding-agent`); no
+    separate CLI install. Auth via `ANTHROPIC_API_KEY` or `~/.pi/agent/auth.json`
 - Optional: [Tailscale](https://tailscale.com) for private remote access
 
 ## Quick Start
@@ -60,7 +67,7 @@ Install on an Ubuntu/Debian VPS or macOS workstation:
 curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh | bash
 ```
 
-For a non-interactive Tailscale setup:
+For a non-interactive Tailscale join:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh \
@@ -68,88 +75,56 @@ curl -fsSL https://raw.githubusercontent.com/BennyKok/lfg/main/scripts/setup.sh 
 ```
 
 The setup script downloads the latest release, installs production dependencies,
-writes `.env`, and starts the server as a user service bound to loopback.
-When Claude or Codex is already installed, setup also registers the local LFG
-MCP server with that CLI. **Settings → Coding agents → Install MCP** verifies
-and registers every installed supported harness: Claude, Codex, OpenCode, Grok,
-and Cursor.
+writes `.env`, and starts the server as a user service bound to loopback. When
+Claude or Codex is already installed, setup also registers the local LFG MCP
+server with that CLI. **Settings → Coding agents → Install MCP** verifies and
+registers LFG MCP with Claude, Codex, OpenCode, Grok, and Cursor when those
+CLIs are present (Hermes, Copilot, and Pi have no MCP registration surface).
 
-To expose the UI over your private tailnet, opt in to Tailscale Serve:
+To expose the UI over your private tailnet:
 
 ```bash
 LFG_TAILSCALE_SERVE=1 lfg setup
 ```
 
-## One-click Launch
+Open **Settings → Coding agents** to install or check CLIs. OAuth-based agents
+still need a one-time terminal/browser login; API-key providers can use env vars
+such as `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`.
+
+## One-click & cloud deploy
 
 [![Deploy on omg](https://omg.dev/deploy-badge.svg?v=2)](https://omg.dev/sandbox/templates/lfg)
 
-OMG is the fastest hosted workspace path for `lfg`. The button opens the LFG
-template, signs you in if needed, creates a sandbox from its prebuilt image,
-starts `lfg serve` on port `8766`, and opens the workspace URL.
-
-On a fresh workspace, open **Settings → Coding agents** in LFG. That screen
-checks whether Claude, Codex, OpenCode, Cursor, Grok, Hermes, or GitHub Copilot
-is installed and signed in, and it can run the installer for supported CLIs. OAuth-based CLIs still need
-you to complete their normal terminal/browser login once, or you can configure
-API-key based providers with environment variables such as `ANTHROPIC_API_KEY`
-or `OPENAI_API_KEY`.
+**[OMG](https://omg.dev/sandbox/templates/lfg)** is the fastest hosted workspace
+path: it creates a sandbox from the LFG template, starts `lfg serve` on port
+`8766`, and opens the workspace URL. Fresh workspaces start with no personal
+agent sessions — use **Settings → Coding agents** to install and sign in.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/BennyKok/lfg)
 
-Railway is useful for a hosted demo, but `lfg` works best on the machine that
-has your repos, `tmux`, and authenticated agent CLIs. See
-[deploy/railway](./deploy/railway/README.md) for details.
+The shared [Dockerfile](./Dockerfile) also works for
+[Railway](./deploy/railway/README.md), [Fly.io](./deploy/fly/README.md),
+[Render](./deploy/render/README.md), [DigitalOcean](./deploy/digitalocean/README.md),
+and [Koyeb](./deploy/koyeb/README.md). For Hetzner, use the cloud-init template in
+[deploy/hetzner](./deploy/hetzner/README.md).
 
-The shared [Dockerfile](./Dockerfile) also works as the base for
-[Fly.io](./deploy/fly/README.md), [Render](./deploy/render/README.md),
-[DigitalOcean](./deploy/digitalocean/README.md), and
-[Koyeb](./deploy/koyeb/README.md). These PaaS targets are best for demos or
-private-network deployments; a VPS remains the cleanest production-style target.
-Because the Vibes SDK path is not live for source installs yet, the Dockerfile
-installs the published bundled release (`lfg-bundle.tar.gz`) instead of building
-from the GitHub source tree. Publish a bundle with `scripts/release.sh <tag>`
-before relying on one-click cloud deploys.
+These PaaS targets are best for demos or private-network deployments. Day-to-day
+agent work is happiest on the machine that already has your repos, `tmux`, and
+authenticated CLIs. A VPS remains the cleanest production-style target.
 
-Maintainer convention: when asking an agent to "deploy", that means make the
-current changes visible in the running/dev instance, including rebuilds or
-service restarts as needed. Say "release" when you want a new tag and published
+The Dockerfile installs the published bundle (`lfg-bundle.tar.gz`) rather than
+building from the GitHub source tree (the Vibes SDK path is not live for source
+installs yet). Publish a bundle with `scripts/release.sh <tag>` before relying
+on one-click cloud deploys.
+
+**Maintainer note:** “deploy” means make current changes visible in the running
+instance (rebuild/restart as needed). “release” means cut a tag and publish
 `lfg-bundle.tar.gz`.
 
-For Hetzner, use the cloud-init template in
-[deploy/hetzner](./deploy/hetzner/README.md). Hetzner's official deploy button
-only preselects Hetzner App images, so the repo ships a first-boot installer
-instead.
-
-OMG user requirements:
-
-- OMG account. The generic deploy route prompts for sign-in before it creates
-  anything.
-- During the preview, this deploy path is available on free accounts. Billing
-  gates may change later.
-- The hosted LFG workspace starts with no personal agent CLI sessions. Use LFG's
-  Coding agents settings to install/check CLIs, then finish the provider login
-  inside the workspace.
-- Keep secrets scoped to that workspace. Prefer provider OAuth where available,
-  or set API keys only when you intend the hosted workspace to use them.
-
-Railway user requirements:
-
-- Railway account and GitHub access to this repo.
-- Keep Public Networking disabled unless you put auth in front of `lfg`.
-- For Tailscale access, add Railway's Tailscale router as a second service and
-  put `TS_AUTHKEY` on that router service.
-- Optional provider keys in Railway variables, such as `ANTHROPIC_API_KEY`,
-  `OPENAI_API_KEY`, or `ELEVENLABS_API_KEY`.
-
-Hetzner user requirements:
-
-- Hetzner Cloud account, SSH public key, and either the `hcloud` CLI or Console.
-- Tailscale account plus an ephemeral/preauthorized auth key for unattended
-  setup. The installer joins the server with `tailscale up --authkey ...` and
-  exposes the loopback-only UI through `tailscale serve`.
-- After boot, authenticate `claude`, `codex`, `opencode`, Cursor CLI, `hermes`, or GitHub Copilot CLI on the server, or
-  configure API-key based providers in `.env`.
+Platform-specific account, networking, and secret requirements live in each
+`deploy/*/README.md`. In short: keep public networking off unless you put auth
+in front of `lfg`, prefer Tailscale for remote access, and scope provider keys
+to that environment only.
 
 ## Local Development
 
@@ -163,14 +138,20 @@ bun run serve
 
 Open `http://127.0.0.1:8766`.
 
-Authenticate the agent CLI you want to use, for example by running `claude` once
-and completing OAuth, or by setting the required API key in `.env`.
+For UI hot reload (proxies `/api` to the Bun server):
+
+```bash
+cd web && bun install && bun run dev
+```
+
+Authenticate the agent CLI you want to use (for example run `claude` once and
+complete OAuth), or set the required API key in `.env`.
 
 ## Commands
 
 ```bash
 bun run serve                  # web UI + control server
-bun run agents -- list         # list markdown-defined agents
+bun run agents -- list         # list markdown-defined insight agents
 bun run agents -- run <name>   # run an insight agent
 bun run subagent -- models     # list runtime sub-agent providers/models
 bun run subagent -- create --prompt "..." --agent codex-aisdk
@@ -179,35 +160,38 @@ bun run whatsapp -- run        # optional WhatsApp sidecar
 bun run setup                  # rerun provisioning/update flow
 ```
 
-Installed release builds expose the same commands through `lfg`.
+Installed release builds expose the same surface as `lfg <command>`.
 
-The MCP server talks to the local `lfg serve` API and exposes tools such as
-`lfg_capabilities`, `lfg_list_sessions`, `lfg_get_session_messages`,
-`lfg_send_session_message`, `lfg_create_subagent`, and `lfg_list_subagents`. Use it from an MCP client with
-`lfg mcp` or `bun run mcp`. When an MCP client also exposes its own generic
-sub-agent/delegation tool, prefer the `lfg_*subagent*` and `lfg_delegate_*`
-tools so child sessions stay visible in LFG, inherit parent/user context, and
-can run on any configured harness. LFG-managed subagents may nest up to four
-levels deep. Each child is launched with an operating contract that tells it to
-use LFG MCP for any further delegation and to send `[subagent progress]` updates
-plus one terminal `[subagent complete]`, `[subagent blocked]`, or
-`[subagent failed]` message back to its parent session.
+### MCP tools
 
-Every managed session launched with an initial task also receives a versioned
-LFG runtime contract describing when to display verification media, publish an
-artifact, ask the user, delegate, or post completed work to Shipped. The UI
-marks sessions launched with an older contract so they can be closed and
-resumed to load the current tool catalog and guidance.
+`lfg mcp` (or `bun run mcp`) talks to the local `lfg serve` API. Prefer LFG’s
+own subagent tools over a client’s generic “spawn agent” helper so children stay
+visible, inherit parent/user context, and can run on any configured harness.
 
-Backend trace diagnostics are appended to `data/logs/trace-YYYY-MM-DD.jsonl`.
-The stream includes API timings, transcript indexing/page reads, live stream
-stalls, session sends, and send queue delivery state.
+| Area | Tools |
+| --- | --- |
+| Sessions | `lfg_list_sessions`, `lfg_get_session_tree`, `lfg_get_session_messages`, `lfg_send_session_message` |
+| Presentation | `lfg_display_image`, `lfg_display_video`, `lfg_publish_artifact`, `lfg_refresh_artifact`, `lfg_ship` |
+| Delegation | `lfg_create_subagent`, `lfg_delegate_to_agent`, `lfg_delegate_design_task`, `lfg_delegate_backend_task`, `lfg_list_subagents`, `lfg_reparent_session` |
+| Human / advisor | `lfg_ask_user`, `lfg_ask_question` |
+| Catalog | `lfg_capabilities`, `lfg_list_repos`, `lfg_list_models` |
+
+Managed sessions launched with an initial task receive a versioned **LFG runtime
+contract** (when to show media, publish artifacts, ask the user, delegate, or
+ship). Sessions started on an older contract are marked in the UI so they can be
+closed and resumed to pick up the current tool catalog.
+
+Subagents may nest up to four levels. Each child is expected to send
+`[subagent progress]` updates and one terminal
+`[subagent complete]` / `[subagent blocked]` / `[subagent failed]` message to
+its parent.
+
+Backend diagnostics append to `data/logs/trace-YYYY-MM-DD.jsonl` (API timings,
+transcript indexing, live stream stalls, send queue state).
 
 ## Configuration
 
 Configuration lives in `.env`; see [`.env.example`](./.env.example).
-
-Common settings:
 
 | Variable | Purpose |
 | --- | --- |
@@ -217,36 +201,38 @@ Common settings:
 | `LFG_CLAUDE_PATH` | Override the `claude` binary path. |
 | `LFG_CODEX_PATH` | Override the `codex` binary path. |
 | `LFG_OPENCODE_PATH` | Override the `opencode` binary path. |
-| `LFG_CURSOR_PATH` | Override the Cursor CLI binary path (`cursor-agent`, or a non-Grok `agent`). |
+| `LFG_CURSOR_PATH` | Override the Cursor CLI path (`cursor-agent`, or a non-Grok `agent`). |
 | `LFG_HERMES_PATH` | Override the `hermes` binary path. |
-| `LFG_HERMES_PROVIDER` | Optional provider override passed to `hermes chat --provider`; empty uses Hermes' configured/default provider. |
-| `LFG_PI_PROFILE_DIR` | Optional [custom agent profile](./docs/custom-agent-profiles.md) directory for the `pi` backend: layers extra system-prompt text, skills, and a display-name override on top of pi's defaults. Empty = unchanged. |
-| `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` (device flow) or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` with the *Copilot Requests* scope. |
-| `LFG_COPILOT_ALLOW_ALL_TOOLS` | Set to `1` to pass `--allow-all-tools` when spawning a Copilot session. Off by default — the pane keeps interactive per-tool approvals. GitHub recommends the bypass only in isolated environments; LFG's agent slice is resource-only, not a filesystem/network sandbox, so enable this only when your host itself is the trust boundary. |
-| `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version installed by `scripts/setup.sh` when `LFG_INSTALL_COPILOT=1`. Default `1.0.71` (audits clean); avoid `<=1.0.42` (GHSA-9ccr-r5hg-74gf, `core.fsmonitor` RCE) and `<=0.0.422` (GHSA-g8r9-g2v8-jv6f, prompt-injection RCE via shell parameter expansion). Set to `latest` for floating installs. |
-| `ANTHROPIC_API_KEY` | Optional API key for Claude SDK-backed flows. |
+| `LFG_HERMES_PROVIDER` | Optional provider override for `hermes chat --provider`. |
+| `LFG_PI_PATH` | Override the bundled Pi CLI path. |
+| `LFG_PI_PROFILE_DIR` | Optional [custom agent profile](./docs/custom-agent-profiles.md) for Pi (extra system prompt, skills, display name). |
+| `LFG_COPILOT_PATH` | Override the `copilot` binary path. Auth via interactive `/login` or `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` (Copilot Requests scope). |
+| `LFG_COPILOT_ALLOW_ALL_TOOLS` | Set to `1` to pass `--allow-all-tools` when spawning Copilot. Off by default; enable only when the host is the trust boundary. |
+| `LFG_COPILOT_VERSION` | Pinned `@github/copilot` version for `LFG_INSTALL_COPILOT=1` (default `1.0.71`). Prefer a known-good pin over floating `latest`. |
+| `ANTHROPIC_API_KEY` | Optional API key for Claude / Pi flows. |
 | `LFG_WHATSAPP_*` | Optional WhatsApp bridge settings. |
-| `LFG_INSTALL_CHANNEL` | Optional install-channel override: `source`, `release`, or `container`. Normally written by setup/container deploys. |
+| `LFG_INSTALL_CHANNEL` | Install channel: `source`, `release`, or `container`. Usually set by setup/deploy. |
 
 ## Security
 
 `lfg` launches AI agents with shell access on your machine. The control API is
-unauthenticated by design because it is meant to run on loopback and be accessed
+unauthenticated by design because it is meant to run on loopback and be reached
 privately through Tailscale.
 
-Do not expose `lfg` directly to the public internet. Read
+**Do not expose `lfg` directly to the public internet.** Read
 [SECURITY.md](./SECURITY.md) before sharing access.
 
 ## Project Layout
 
 ```text
-src/                 CLI, server, sessions, tmux, agents, integrations
+src/                 CLI, server, sessions, tmux, agents, MCP, integrations
 web/                 React/Vite PWA
 agents/              Example markdown-defined insight agents
-scripts/setup.sh     Installer/provisioning script
+scripts/setup.sh     Installer / provisioning
+scripts/             Release, fleet, and smoke helpers
 scripts-internal/    Operator-only helpers (gitignored — see CONTRIBUTING.md)
-deploy/              Optional voice, STT, Modal, and ops deployments
-docs/                Notes, designs, and future public images
+deploy/              Cloud, voice, STT, and ops deployments
+docs/                Design notes, agent profiles, README images
 ```
 
 ## Contributing

--- a/src/artifact-refresh.ts
+++ b/src/artifact-refresh.ts
@@ -12,6 +12,7 @@ import {
   type ArtifactRefreshConfig,
   type ImageArtifact,
 } from "./artifacts.ts";
+import { syncArtifactIndex } from "./transcript-index.ts";
 
 export const MIN_ARTIFACT_REFRESH_INTERVAL_MS = 10_000;
 export const MAX_ARTIFACT_REFRESH_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -304,6 +305,13 @@ export class ArtifactRefreshManager {
         id,
         patch: { status: "success", lastSuccessAt: Date.now(), lastError: undefined },
       }) ?? artifact;
+      // Keep the joined transcript/artifacts row in lockstep with the file store
+      // so page reads never need a second poller to learn the new content time.
+      try {
+        syncArtifactIndex(artifact);
+      } catch {
+        // Live poll will backfill; the HTML file is already durable.
+      }
       return { ok: true, started: true, artifact };
     } catch (error) {
       const message = cleanError(error);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -95,8 +95,10 @@ import {
   enqueueTranscriptIndex,
   indexedRecentMessages,
   indexedMessagePage,
+  indexArtifactMessage,
   indexSessionArtifactMessages,
   indexTranscript,
+  removeIndexedArtifact,
   sessionIndexKey,
   searchAllTranscriptIndexes,
   searchTranscriptIndex,
@@ -4414,6 +4416,11 @@ export async function cmdServe() {
             const deleted = artifact.media === "html"
               ? artifactRefreshManager.delete(artifact.id, m[1])
               : deleteArtifact({ id: artifact.id, sessionId: m[1] });
+            try {
+              removeIndexedArtifact(deleted.id);
+            } catch {
+              // best-effort; durable file already gone
+            }
             await deleteImagePreview(deleted.id);
             return json({ ok: true, artifact: deleted });
           } catch (e) {
@@ -4442,13 +4449,13 @@ export async function cmdServe() {
             const indexPath = transcriptPath ?? sessionIndexKey(m[1]);
             let indexed = true;
             try {
-              indexSessionArtifactMessages(indexPath, m[1]);
+              // One ordered append + joined artifacts row — same source the
+              // transcript page reads via JOIN.
+              indexArtifactMessage(indexPath, m[1], artifact);
             } catch (indexError) {
               // The file and artifact record are already durable. Reporting the
               // whole request as failed makes agents retry and creates duplicate
-              // images. Return success and let the existing artifact poller show
-              // it immediately; subsequent transcript catch-up indexes it into
-              // the one ordered message stream.
+              // images. Return success; live notify + later page reads backfill.
               indexed = false;
               console.warn("artifact transcript indexing deferred", artifact.id, indexError);
             }
@@ -4479,7 +4486,7 @@ export async function cmdServe() {
             const indexPath = transcriptPath ?? sessionIndexKey(m[1]);
             let indexed = true;
             try {
-              indexSessionArtifactMessages(indexPath, m[1]);
+              indexArtifactMessage(indexPath, m[1], artifact);
             } catch (indexError) {
               indexed = false;
               console.warn("artifact transcript indexing deferred", artifact.id, indexError);
@@ -4559,7 +4566,7 @@ export async function cmdServe() {
                 refresh: hasRefreshChanges ? refresh : undefined,
               });
               const transcriptPath = await resolveTranscript(m[1]);
-              indexSessionArtifactMessages(transcriptPath ?? sessionIndexKey(m[1]), m[1]);
+              indexArtifactMessage(transcriptPath ?? sessionIndexKey(m[1]), m[1], artifact);
             } else {
               const scopeRoot = typeof body.refreshScriptPath === "string"
                 ? await artifactOwnerCwd(m[1]) ?? undefined
@@ -5321,12 +5328,20 @@ export async function cmdServe() {
                 idleMs,
               });
             };
-            const artifactOne = (sid: string) => {
+            const artifactOne = (sid: string, tp: string | null = null) => {
               if (closed) return;
               const after = lastArtifactAt.get(sid) ?? 0;
               const messages = imageArtifactMessagesSince(sid, after);
               for (const message of messages) {
                 lastArtifactAt.set(sid, Math.max(lastArtifactAt.get(sid) ?? 0, message.ts ?? 0));
+                if (tp && message.artifactId) {
+                  try {
+                    const artifact = getImageArtifact(message.artifactId);
+                    if (artifact) indexArtifactMessage(tp, sid, artifact);
+                  } catch {
+                    // best-effort; message still carries full media fields
+                  }
+                }
                 markMessage(sid);
                 send(`event: msg\ndata: ${JSON.stringify({ sid, m: msgWithHtml(message) })}\n\n`);
               }
@@ -5477,7 +5492,7 @@ export async function cmdServe() {
                     lastBusy.set(p.sid, "?");
                     lastArtifactAt.set(p.sid, 0);
                     lastMessageAt.set(p.sid, Date.now());
-                    artifactOne(p.sid);
+                    artifactOne(p.sid, p.tp);
                     pollOne(p);
                     queueOne(p);
                     return;
@@ -5535,7 +5550,7 @@ export async function cmdServe() {
               void hydrateTargets().then(() => {
                 for (const p of panes) {
                   pollOne(p);
-                  artifactOne(p.sid);
+                  artifactOne(p.sid, p.tp);
                   queueOne(p);
                 }
               });
@@ -5545,7 +5560,7 @@ export async function cmdServe() {
               pi = setInterval(() => {
                 for (const p of panes) {
                   pollOne(p);
-                  artifactOne(p.sid);
+                  artifactOne(p.sid, p.tp);
                   queueOne(p);
                   void reconcileQueued(p.sid).then((c) => c && queueOne(p));
                 }
@@ -5621,6 +5636,14 @@ export async function cmdServe() {
                 const messages = imageArtifactMessagesSince(sid, lastArtifactAt);
                 for (const message of messages) {
                   lastArtifactAt = Math.max(lastArtifactAt, message.ts ?? 0);
+                  if (message.artifactId) {
+                    try {
+                      const artifact = getImageArtifact(message.artifactId);
+                      if (artifact) indexArtifactMessage(tp, sid, artifact);
+                    } catch {
+                      // best-effort
+                    }
+                  }
                   lastMessageAt = Date.now();
                   send(`event: msg\ndata: ${JSON.stringify(msgWithHtml(message))}\n\n`);
                 }

--- a/src/live-ws.ts
+++ b/src/live-ws.ts
@@ -10,7 +10,12 @@ import {
   type Session,
 } from "./sessions.ts";
 import { listSessionsCached, noteListSessionsClientActivity } from "./session-cache.ts";
-import { indexedMessagePage, indexedMessagesAfterRowid, isSessionIndexKey } from "./transcript-index.ts";
+import {
+  indexArtifactMessage,
+  indexedMessagePage,
+  indexedMessagesAfterRowid,
+  isSessionIndexKey,
+} from "./transcript-index.ts";
 import { ensureChatTranscriptCaughtUp, subscribeChatTranscript } from "./chat-ingest.ts";
 import {
   capturePane,
@@ -24,6 +29,7 @@ import {
 } from "./aisdk-registry.ts";
 import {
   collapseArtifactRetryMessages,
+  getImageArtifact,
   hydrateImageArtifactMessage,
   imageArtifactMessagesSince,
   type ImageArtifactMessage,
@@ -505,7 +511,9 @@ export function createLiveWsSupport(opts: {
     tail.transcriptDbPolling = true;
     try {
       const page = indexedMessagesAfterRowid(tp, sessionId, afterRowid, LIVE_DB_POLL_LIMIT);
-      const messages = visibleTranscriptMessages(page.messages);
+      // Same join-hydrated messages as backlog snapshots — do not re-fetch media
+      // from a second store on the live path.
+      const messages = withImageArtifacts(sessionId, visibleTranscriptMessages(page.messages));
       if (messages.length) {
         tail.lastMessageAt = Date.now();
         evlog("ws_db_poll_publish", {
@@ -529,12 +537,27 @@ export function createLiveWsSupport(opts: {
     }
   };
 
+  // Live notify for artifact rows that the file-tail path cannot see (media is
+  // not written into agent JSONL). The durable order still lives in the
+  // transcript index: we index first, then emit the same joined message shape
+  // a page read would return. Clients upsert by artifact id and must not
+  // re-sort by timestamp.
   const pollArtifacts = (tail: SidTail) => {
-    const messages = imageArtifactMessagesSince(tail.sid, tail.lastArtifactAt)
+    const recent = imageArtifactMessagesSince(tail.sid, tail.lastArtifactAt)
       .map((message) => normalizeMediaIdentity(message))
       .sort((a, b) => (a.ts ?? 0) - (b.ts ?? 0) || String(mediaIdentity(a) ?? "").localeCompare(String(mediaIdentity(b) ?? "")));
-    for (const message of messages) {
+    if (!recent.length) return;
+    const tp = tail.pane.tp;
+    for (const message of recent) {
       tail.lastArtifactAt = Math.max(tail.lastArtifactAt, message.ts ?? 0);
+      if (tp && message.artifactId) {
+        try {
+          const artifact = getImageArtifact(message.artifactId);
+          if (artifact) indexArtifactMessage(tp, tail.sid, artifact);
+        } catch {
+          // Index is best-effort here; the message still carries full media fields.
+        }
+      }
       publishSid(tail.sid, "msg", { message: msgWithHtml(message) });
     }
   };

--- a/src/transcript-artifact-join.test.ts
+++ b/src/transcript-artifact-join.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import { createImageArtifact, deleteArtifact, publishHtmlArtifact } from "./artifacts.ts";
+import {
+  indexArtifactMessage,
+  indexedMessagePage,
+  removeIndexedArtifact,
+  resetTranscriptIndexConnectionForTests,
+  sessionIndexKey,
+  syncArtifactIndex,
+} from "./transcript-index.ts";
+
+const SESSION = "33333333-3333-4333-8333-333333333333";
+
+describe("joined artifact + transcript reads", () => {
+  const originalData = PATHS.data;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "lfg-artifact-join-"));
+    PATHS.data = join(root, "data");
+    resetTranscriptIndexConnectionForTests();
+  });
+
+  afterEach(() => {
+    resetTranscriptIndexConnectionForTests();
+    PATHS.data = originalData;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("page reads return full media fields via JOIN (not a second hydrate pass)", async () => {
+    const source = join(root, "shot.png");
+    writeFileSync(source, "fake-png-bytes");
+    const artifact = createImageArtifact({
+      sessionId: SESSION,
+      path: source,
+      caption: "Join me",
+      alt: "alt text",
+    });
+    const path = sessionIndexKey(SESSION);
+    expect(indexArtifactMessage(path, SESSION, artifact)).toBe(1);
+
+    // Second index of the same artifact updates in place — no duplicate row.
+    expect(indexArtifactMessage(path, SESSION, artifact)).toBe(0);
+
+    const page = await indexedMessagePage(path, SESSION, { limit: 20 });
+    expect(page.messages).toHaveLength(1);
+    const msg = page.messages[0] as {
+      kind: string;
+      artifactId?: string;
+      url?: string;
+      name?: string;
+      mimeType?: string;
+      size?: number;
+      caption?: string;
+      alt?: string;
+    };
+    expect(msg.kind).toBe("image");
+    expect(msg.artifactId).toBe(artifact.id);
+    expect(msg.url).toBe(`/api/artifacts/${encodeURIComponent(artifact.id)}`);
+    expect(msg.name).toBe("shot.png");
+    expect(msg.mimeType).toBe("image/png");
+    expect(msg.size).toBe(artifact.size);
+    expect(msg.caption).toBe("Join me");
+    expect(msg.alt).toBe("alt text");
+  });
+
+  test("append order is sequential (no fractional timestamp offsets)", async () => {
+    const path = sessionIndexKey(SESSION);
+    const ids: string[] = [];
+    for (const name of ["a.png", "b.png", "c.png"]) {
+      const source = join(root, name);
+      writeFileSync(source, `bytes-${name}`);
+      const artifact = createImageArtifact({ sessionId: SESSION, path: source, caption: name });
+      ids.push(artifact.id);
+      indexArtifactMessage(path, SESSION, artifact);
+    }
+
+    const page = await indexedMessagePage(path, SESSION, { limit: 20 });
+    expect(page.messages.map((m) => (m as { artifactId?: string }).artifactId)).toEqual(ids);
+
+    // Offsets must be plain ascending integers for new rows.
+    // Re-read via a second page call after sync keeps order.
+    const again = await indexedMessagePage(path, SESSION, { limit: 20 });
+    expect(again.messages.map((m) => m.id)).toEqual(ids.map((id) => `artifact-${id}`));
+  });
+
+  test("html re-publish updates the same ordered row", async () => {
+    const path = sessionIndexKey(SESSION);
+    const first = publishHtmlArtifact({
+      sessionId: SESSION,
+      id: "dash-join",
+      html: "<!doctype html><html><body>v1</body></html>",
+      title: "Dash",
+    });
+    indexArtifactMessage(path, SESSION, first);
+
+    const second = publishHtmlArtifact({
+      sessionId: SESSION,
+      id: "dash-join",
+      html: "<!doctype html><html><body>v2</body></html>",
+      title: "Dash",
+    });
+    expect(syncArtifactIndex(second)).toBe(0);
+
+    const page = await indexedMessagePage(path, SESSION, { limit: 20 });
+    expect(page.messages).toHaveLength(1);
+    const msg = page.messages[0] as { kind: string; version?: number; artifactId?: string };
+    expect(msg.kind).toBe("html");
+    expect(msg.artifactId).toBe("dash-join");
+    expect(msg.version).toBe(2);
+  });
+
+  test("removeIndexedArtifact drops both joined tables", async () => {
+    const source = join(root, "gone.png");
+    writeFileSync(source, "x");
+    const artifact = createImageArtifact({ sessionId: SESSION, path: source });
+    const path = sessionIndexKey(SESSION);
+    indexArtifactMessage(path, SESSION, artifact);
+    // Durable store + index must both go, or the next page read would backfill.
+    deleteArtifact({ id: artifact.id, sessionId: SESSION });
+    removeIndexedArtifact(artifact.id);
+    const page = await indexedMessagePage(path, SESSION, { limit: 20 });
+    expect(page.messages).toHaveLength(0);
+  });
+});

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -4,7 +4,14 @@ import { Database } from "bun:sqlite";
 import { PATHS } from "./config.ts";
 import { isCursorTurnEndedLine, normalizeLineMessages, type Session, type SessionMsg } from "./sessions.ts";
 import { traceLog } from "./trace-log.ts";
-import { imageArtifactToMessage, listImageArtifacts } from "./artifacts.ts";
+import {
+  getImageArtifact,
+  imageArtifactToMessage,
+  listAllArtifacts,
+  listImageArtifacts,
+  type ImageArtifact,
+  type ImageArtifactMessage,
+} from "./artifacts.ts";
 
 export type IndexedTranscriptMatch = {
   sessionId: string;
@@ -24,6 +31,18 @@ type IndexedMessageRow = {
   ts: number | null;
   text: string;
   byte_offset: number;
+  // Joined from the artifacts table when present (same SQLite DB).
+  artifact_id?: string | null;
+  artifact_media?: string | null;
+  artifact_name?: string | null;
+  artifact_mime_type?: string | null;
+  artifact_size?: number | null;
+  artifact_caption?: string | null;
+  artifact_alt?: string | null;
+  artifact_title?: string | null;
+  artifact_version?: number | null;
+  artifact_updated_at?: number | null;
+  artifact_refresh_json?: string | null;
 };
 
 type IndexedMessageRowidRow = IndexedMessageRow & {
@@ -39,13 +58,16 @@ export type TranscriptIndexCursor = {
   indexedAt: number;
 };
 
-const DB_PATH = join(PATHS.data, "transcript-index.sqlite");
+function dbPath(): string {
+  return join(PATHS.data, "transcript-index.sqlite");
+}
 const INDEX_TEXT_MAX = 12_000;
 const INDEX_CHUNK_BYTES = 1024 * 1024;
 const BACKGROUND_LIMIT = 8;
 const WAL_CHECKPOINT_INTERVAL_MS = 30_000;
 
 let db: Database | null = null;
+let dbOpenedPath: string | null = null;
 let initialized = false;
 let backgroundRunning = false;
 let monitorStarted = false;
@@ -56,61 +78,159 @@ const enqueued = new Set<string>();
 const imports = new Map<string, Promise<{ indexed: number; offset: number; size: number }>>();
 const directNextOffset = new Map<string, number>();
 
-// Media files live in the artifact store, but their message identity and order
-// belong in the transcript index.  Keeping the row here makes media obey the
-// same pagination boundary as prose instead of appending every session image to
-// whichever transcript page happened to be requested.
+// Media files stay on disk, but artifact *metadata* and transcript *order* both
+// live in this SQLite DB. Reads JOIN the two tables so image/video/html cards
+// come from the same query path as prose — never a second poll stream that
+// re-sorts by timestamp and lands media out of place.
+const ARTIFACT_MESSAGE_SELECT = `
+  m.id, m.message_id, m.role, m.kind, m.ts, m.text, m.byte_offset,
+  a.id AS artifact_id,
+  a.media AS artifact_media,
+  a.name AS artifact_name,
+  a.mime_type AS artifact_mime_type,
+  a.size AS artifact_size,
+  a.caption AS artifact_caption,
+  a.alt AS artifact_alt,
+  a.title AS artifact_title,
+  a.version AS artifact_version,
+  a.updated_at AS artifact_updated_at,
+  a.refresh_json AS artifact_refresh_json
+`;
+
+function upsertArtifactRow(d: Database, artifact: ImageArtifact): void {
+  d.query(`
+    INSERT INTO artifacts (
+      id, session_id, media, created_at, updated_at, file_path, name, mime_type,
+      size, caption, alt, title, version, source_path, source_mtime_ms, refresh_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      session_id = excluded.session_id,
+      media = excluded.media,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at,
+      file_path = excluded.file_path,
+      name = excluded.name,
+      mime_type = excluded.mime_type,
+      size = excluded.size,
+      caption = excluded.caption,
+      alt = excluded.alt,
+      title = excluded.title,
+      version = excluded.version,
+      source_path = excluded.source_path,
+      source_mtime_ms = excluded.source_mtime_ms,
+      refresh_json = excluded.refresh_json
+  `).run(
+    artifact.id,
+    artifact.sessionId,
+    artifact.media ?? "image",
+    artifact.createdAt,
+    artifact.updatedAt ?? null,
+    artifact.filePath,
+    artifact.name,
+    artifact.mimeType,
+    artifact.size,
+    artifact.caption ?? null,
+    artifact.alt ?? null,
+    artifact.title ?? null,
+    artifact.version ?? null,
+    artifact.sourcePath,
+    artifact.sourceMtimeMs ?? null,
+    artifact.refresh ? JSON.stringify(artifact.refresh) : null,
+  );
+}
+
+function deleteArtifactRow(d: Database, artifactId: string): void {
+  d.query("DELETE FROM artifacts WHERE id = ?").run(artifactId);
+  d.query(
+    "DELETE FROM transcript_messages_fts WHERE id IN (SELECT id FROM transcript_messages WHERE message_id = ?)",
+  ).run(`artifact-${artifactId}`);
+  d.query("DELETE FROM transcript_messages WHERE message_id = ?").run(`artifact-${artifactId}`);
+}
+
+/** Mirror one durable artifact into the joined artifacts table + ordered transcript row. */
+export function indexArtifactMessage(path: string, sessionId: string, artifact: ImageArtifact): number {
+  init();
+  const d = database();
+  const message = imageArtifactToMessage(artifact);
+  const messageId = message.id!;
+  const rowId = `${path}\0artifact\0${artifact.id}`;
+  const text = clippedText(message);
+  // Identity is global (artifact-<id>). If the row already lives under any
+  // path for this session, update in place rather than inventing a second
+  // ordered position.
+  const existing = d
+    .query<{ id: string; path: string; byte_offset: number }, [string]>(
+      "SELECT id, path, byte_offset FROM transcript_messages WHERE message_id = ? LIMIT 1",
+    )
+    .get(messageId);
+
+  return d.transaction(() => {
+    upsertArtifactRow(d, artifact);
+    if (existing) {
+      // Stable HTML cards re-publish under the same message id. Update the
+      // existing ordered row in place so live clients refresh without a second
+      // stream inventing a new position.
+      d.query(`
+        UPDATE transcript_messages
+           SET ts = ?, role = ?, kind = ?, text = ?
+         WHERE id = ?
+      `).run(message.ts, message.role, message.kind, text, existing.id);
+      d.query("DELETE FROM transcript_messages_fts WHERE id = ?").run(existing.id);
+      d.query(`
+        INSERT INTO transcript_messages_fts (id, session_id, text)
+        VALUES (?, ?, ?)
+      `).run(existing.id, sessionId, text);
+      pageTotalCache.delete(existing.path);
+      pageTotalCache.delete(path);
+      return 0;
+    }
+
+    const offset = nextDirectOffset(d, path);
+    directNextOffset.set(path, offset + 1);
+    const result = d.query(`
+      INSERT OR IGNORE INTO transcript_messages
+        (id, session_id, path, message_id, byte_offset, ts, role, kind, text)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      rowId,
+      sessionId,
+      path,
+      messageId,
+      offset,
+      message.ts,
+      message.role,
+      message.kind,
+      text,
+    );
+    const inserted = Number(result.changes ?? 0);
+    if (inserted) {
+      d.query(`
+        INSERT INTO transcript_messages_fts (id, session_id, text)
+        SELECT ?, ?, ?
+        WHERE NOT EXISTS (SELECT 1 FROM transcript_messages_fts WHERE id = ?)
+      `).run(rowId, sessionId, text, rowId);
+      pageTotalCache.delete(path);
+    }
+    return inserted;
+  })();
+}
+
+export function removeIndexedArtifact(artifactId: string): void {
+  init();
+  deleteArtifactRow(database(), artifactId);
+  pageTotalCache.clear();
+}
+
+// Backfill any durable artifacts still missing a transcript row. New publishes
+// append at the tail (conversation order at create time). We no longer invent
+// fractional byte_offsets from timestamps — that second ordering model is what
+// put images out of place relative to the rest of the chat.
 function indexMissingArtifactMessages(path: string, sessionId: string): number {
   const artifacts = listImageArtifacts(sessionId);
   if (!artifacts.length) return 0;
-  const d = database();
-  const exists = d.query<{ one: number }, [string]>(
-    "SELECT 1 AS one FROM transcript_messages WHERE message_id = ? LIMIT 1",
-  );
-  const nextRow = d.query<{ byte_offset: number }, [string, number]>(`
-    SELECT byte_offset FROM transcript_messages
-    WHERE path = ? AND ts > ? AND kind NOT IN ('image', 'video')
-    ORDER BY ts ASC, byte_offset ASC LIMIT 1
-  `);
-  const maxRow = d.query<{ byte_offset: number | null }, [string]>(
-    "SELECT max(byte_offset) AS byte_offset FROM transcript_messages WHERE path = ?",
-  );
-  const msgStmt = d.query(`
-    INSERT OR IGNORE INTO transcript_messages
-      (id, session_id, path, message_id, byte_offset, ts, role, kind, text)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `);
-  const ftsStmt = d.query(`
-    INSERT INTO transcript_messages_fts (id, session_id, text)
-    SELECT ?, ?, ? WHERE NOT EXISTS (SELECT 1 FROM transcript_messages_fts WHERE id = ?)
-  `);
   let inserted = 0;
-  let suffix = 0;
-  d.transaction(() => {
-    for (const artifact of artifacts) {
-      const message = imageArtifactToMessage(artifact);
-      if (exists.get(message.id!)) continue;
-      const next = nextRow.get(path, artifact.createdAt)?.byte_offset;
-      const end = maxRow.get(path)?.byte_offset ?? -1;
-      // SQLite accepts REAL values in this INTEGER-affinity column. A media row
-      // sits immediately before the next timestamped transcript row, or just
-      // after the current tail. Tiny increments preserve multiple-image order.
-      const offset = (next == null ? end + 0.5 : next - 0.5) + (suffix++ * 0.000001);
-      const id = `${path}\0artifact\0${artifact.id}`;
-      const result = msgStmt.run(
-        id, sessionId, path, message.id, offset, message.ts,
-        message.role, message.kind, clippedText(message),
-      );
-      inserted += Number(result.changes ?? 0);
-      ftsStmt.run(id, sessionId, clippedText(message), id);
-    }
-  })();
-  if (inserted) {
-    pageTotalCache.delete(path);
-    if (isSessionIndexKey(path)) {
-      const next = Math.floor((maxRow.get(path)?.byte_offset ?? -1) + 1);
-      directNextOffset.set(path, Math.max(directNextOffset.get(path) ?? 0, next));
-    }
+  for (const artifact of artifacts) {
+    inserted += indexArtifactMessage(path, sessionId, artifact);
   }
   return inserted;
 }
@@ -118,6 +238,18 @@ function indexMissingArtifactMessages(path: string, sessionId: string): number {
 export function indexSessionArtifactMessages(path: string, sessionId: string): number {
   init();
   return indexMissingArtifactMessages(path, sessionId);
+}
+
+/** Update the joined artifacts row (and existing transcript row if any) without inventing a path. */
+export function syncArtifactIndex(artifact: ImageArtifact): number {
+  init();
+  const existing = database()
+    .query<{ path: string }, [string]>(
+      "SELECT path FROM transcript_messages WHERE message_id = ? LIMIT 1",
+    )
+    .get(`artifact-${artifact.id}`);
+  const path = existing?.path ?? sessionIndexKey(artifact.sessionId);
+  return indexArtifactMessage(path, artifact.sessionId, artifact);
 }
 
 export function sessionIndexKey(sessionId: string): string {
@@ -161,9 +293,20 @@ function startWalCheckpointTimer(): void {
 }
 
 function database(): Database {
-  if (db) return db;
-  mkdirSync(dirname(DB_PATH), { recursive: true });
-  db = new Database(DB_PATH, { create: true });
+  const path = dbPath();
+  if (db && dbOpenedPath === path) return db;
+  if (db) {
+    try {
+      db.close();
+    } catch {
+      // ignore close errors when rebinding after PATHS.data changes (tests)
+    }
+    db = null;
+    initialized = false;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  db = new Database(path, { create: true });
+  dbOpenedPath = path;
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA synchronous = NORMAL");
   // The index has multiple process writers (serve plus managed harnesses).
@@ -174,6 +317,24 @@ function database(): Database {
   db.exec("PRAGMA wal_autocheckpoint = 1000");
   startWalCheckpointTimer();
   return db;
+}
+
+/** Test helper: drop the open connection so the next call rebinds to PATHS.data. */
+export function resetTranscriptIndexConnectionForTests(): void {
+  if (db) {
+    try {
+      db.close();
+    } catch {
+      // ignore
+    }
+  }
+  db = null;
+  dbOpenedPath = null;
+  initialized = false;
+  directNextOffset.clear();
+  pageTotalCache.clear();
+  enqueued.clear();
+  imports.clear();
 }
 
 function init() {
@@ -244,6 +405,61 @@ function init() {
       PRAGMA user_version = 4;
     `);
   }
+  if (version < 5) {
+    // Version 5 co-locates artifact metadata with transcript order so media
+    // cards are read via JOIN — one data source, one rendering path.
+    d.exec(`
+      CREATE TABLE IF NOT EXISTS artifacts (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        media TEXT NOT NULL DEFAULT 'image',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER,
+        file_path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size INTEGER NOT NULL,
+        caption TEXT,
+        alt TEXT,
+        title TEXT,
+        version INTEGER,
+        source_path TEXT,
+        source_mtime_ms REAL,
+        refresh_json TEXT
+      );
+      CREATE INDEX IF NOT EXISTS artifacts_session_created
+        ON artifacts(session_id, created_at);
+      PRAGMA user_version = 5;
+    `);
+    // Seed from the durable JSON index so existing sessions JOIN correctly
+    // without waiting for the next publish.
+    for (const artifact of listAllArtifacts()) {
+      upsertArtifactRow(d, artifact);
+    }
+  } else {
+    d.exec(`
+      CREATE TABLE IF NOT EXISTS artifacts (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        media TEXT NOT NULL DEFAULT 'image',
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER,
+        file_path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size INTEGER NOT NULL,
+        caption TEXT,
+        alt TEXT,
+        title TEXT,
+        version INTEGER,
+        source_path TEXT,
+        source_mtime_ms REAL,
+        refresh_json TEXT
+      );
+      CREATE INDEX IF NOT EXISTS artifacts_session_created
+        ON artifacts(session_id, created_at);
+    `);
+  }
   initialized = true;
 }
 
@@ -282,14 +498,59 @@ function clippedText(message: SessionMsg): string {
   return text.length > INDEX_TEXT_MAX ? `${text.slice(0, INDEX_TEXT_MAX)}...` : text;
 }
 
-function rowMessage(row: IndexedMessageRow): SessionMsg {
-  return {
+function rowMessage(row: IndexedMessageRow): SessionMsg | ImageArtifactMessage {
+  const base: SessionMsg = {
     id: row.message_id || row.id,
     role: row.role,
     kind: row.kind,
     text: row.text,
     ts: row.ts,
   };
+  if (row.kind !== "image" && row.kind !== "video" && row.kind !== "html") return base;
+
+  // Prefer the JOIN payload so the page/live stream never needs a second
+  // artifact-store pass to learn url/size/caption.
+  if (row.artifact_id) {
+    let refreshStatus: ImageArtifactMessage["refreshStatus"];
+    let lastRefreshedAt: number | undefined;
+    if (row.artifact_refresh_json) {
+      try {
+        const refresh = JSON.parse(row.artifact_refresh_json) as {
+          status?: ImageArtifactMessage["refreshStatus"];
+          lastSuccessAt?: number;
+        };
+        refreshStatus = refresh.status;
+        lastRefreshedAt = refresh.lastSuccessAt;
+      } catch {
+        // ignore corrupt refresh blob; media still renders
+      }
+    }
+    return {
+      ...base,
+      kind: (row.artifact_media as ImageArtifactMessage["kind"]) || row.kind,
+      artifactId: row.artifact_id,
+      url: `/api/artifacts/${encodeURIComponent(row.artifact_id)}`,
+      name: row.artifact_name || row.text,
+      mimeType: row.artifact_mime_type || "application/octet-stream",
+      size: row.artifact_size ?? 0,
+      caption: row.artifact_caption ?? undefined,
+      alt: row.artifact_alt ?? undefined,
+      title: row.artifact_title ?? undefined,
+      version: row.artifact_version ?? undefined,
+      // Updatable HTML cards surface at last content write.
+      ts: row.artifact_updated_at ?? row.ts,
+      lastRefreshedAt,
+      refreshStatus,
+    };
+  }
+
+  // Legacy rows written before the artifacts table existed: fall back to the
+  // durable file-store record once, so old transcripts still hydrate.
+  if (base.id?.startsWith("artifact-")) {
+    const artifact = getImageArtifact(base.id.slice("artifact-".length));
+    if (artifact) return imageArtifactToMessage(artifact);
+  }
+  return base;
 }
 
 function updateCursorInDb(
@@ -820,10 +1081,15 @@ export async function indexedMessagePage(
   const before = Math.max(0, opts.before ?? Number.MAX_SAFE_INTEGER);
   const rows = d
     .query<IndexedMessageRow, [string, number, number]>(`
-        SELECT id, message_id, role, kind, ts, text, byte_offset
-        FROM transcript_messages
-        WHERE path = ? AND byte_offset < ?
-        ORDER BY byte_offset DESC, id DESC
+        SELECT ${ARTIFACT_MESSAGE_SELECT}
+        FROM transcript_messages m
+        LEFT JOIN artifacts a
+          ON a.id = CASE
+            WHEN m.message_id LIKE 'artifact-%' THEN substr(m.message_id, 10)
+            ELSE NULL
+          END
+        WHERE m.path = ? AND m.byte_offset < ?
+        ORDER BY m.byte_offset DESC, m.id DESC
         LIMIT ?
       `)
     .all(path, before, limit);
@@ -905,10 +1171,15 @@ export function indexedMessagesAfterRowid(
   const rows = bounded
     ? d
         .query<IndexedMessageRowidRow, [string, number, number]>(`
-          SELECT rowid, id, message_id, role, kind, ts, text, byte_offset
-          FROM transcript_messages
-          WHERE path = ? AND rowid > ?
-          ORDER BY rowid ASC
+          SELECT m.rowid AS rowid, ${ARTIFACT_MESSAGE_SELECT}
+          FROM transcript_messages m
+          LEFT JOIN artifacts a
+            ON a.id = CASE
+              WHEN m.message_id LIKE 'artifact-%' THEN substr(m.message_id, 10)
+              ELSE NULL
+            END
+          WHERE m.path = ? AND m.rowid > ?
+          ORDER BY m.rowid ASC
           LIMIT ?
         `)
         .all(path, cursor, bounded)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -747,8 +747,11 @@ function ArtifactViewerPage({
   const src = artifact.kind === "html"
     ? `${artifact.url}?v=${artifact.cacheKey ?? artifact.version ?? 0}`
     : artifact.url;
+  // z-[100] sits above the mobile bottom composer (z-55), ask-center (z-60),
+  // and floating audio chrome (z-75) so the full-page viewer is not clipped
+  // by home-shell overlays. Dialogs/drawers remain higher (z-150+).
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-background">
+    <div className="fixed inset-0 z-[100] flex flex-col bg-background">
       <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-2 pt-[calc(0.5rem+env(safe-area-inset-top))]">
         <button
           type="button"
@@ -769,7 +772,7 @@ function ArtifactViewerPage({
           ) : null}
         </div>
       </header>
-      <div className="min-h-0 flex-1">
+      <div className="min-h-0 flex-1 pb-[env(safe-area-inset-bottom)]">
         {artifact.kind === "html" ? (
           <iframe
             src={src}
@@ -1200,7 +1203,9 @@ function latestLine(messages: Message[]): string {
   const items = buildChatRenderItems(messages);
   const last = items[items.length - 1];
   if (!last) return "";
-  return last.type === "tools" ? toolGroupLabel(last.items) : normText(last.message.text);
+  return last.type === "tools"
+    ? toolGroupLabel(last.items)
+    : plainPreviewText(last.message.text);
 }
 
 function isDraftAssistantMessage(message: Message) {
@@ -1224,13 +1229,10 @@ function collapseThinkingRuns(messages: Message[]) {
   return out;
 }
 
-function insertMediaByTimestamp(messages: Message[], message: Message): Message[] {
-  if ((message.kind !== "image" && message.kind !== "video" && message.kind !== "html") || message.ts == null) {
-    return [...messages, message];
-  }
-  const insertAt = messages.findIndex((item) => item.ts != null && item.ts > message.ts!);
-  if (insertAt < 0) return [...messages, message];
-  return [...messages.slice(0, insertAt), message, ...messages.slice(insertAt)];
+// Media order is owned by the server transcript index. Append live media at the
+// tail; never re-sort by timestamp (that raced a second artifact poll stream).
+function appendLiveMessage(messages: Message[], message: Message): Message[] {
+  return [...messages, message];
 }
 
 function reconcileSnapshotMessages(current: Message[], incoming: Message[]): Message[] {
@@ -1267,6 +1269,22 @@ function escapeHtml(value: string) {
 
 function normText(value?: string) {
   return (value || "").replace(/\s+/g, " ").trim();
+}
+
+// Collapse common markdown markers so one-line previews (collapsed cards,
+// rail subtitles) don't show raw `**bold**` / `` `code` `` / [links](...).
+function plainPreviewText(value?: string) {
+  return normText(value)
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    // Single-marker emphasis only at word boundaries (avoid snake_case).
+    .replace(/(^|[\s(])\*([^*]+)\*([\s).,!?:;]|$)/g, "$1$2$3")
+    .replace(/(^|[\s(])_([^_]+)_([\s).,!?:;]|$)/g, "$1$2$3")
+    .replace(/^#{1,6}\s+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function messageNeedle(value?: string) {
@@ -2779,7 +2797,7 @@ function useLiveSessionStream(sessions: Session[], streamIds: string[]) {
                 }
                 return true;
               });
-          next = insertMediaByTimestamp(next, message);
+          next = appendLiveMessage(next, message);
         }
         return { ...prev, [sid]: next.slice(-80) };
       });
@@ -4776,12 +4794,16 @@ export function App() {
 
       {!callOpen ? (
         <>
-          {isMobile && (tab === "live" || tab === "shipped" || tab === "artifacts") ? (
+          {isMobile &&
+          !viewerArtifact &&
+          (tab === "live" || tab === "shipped" || tab === "artifacts") ? (
             // Mobile bottom composer: the create flow lives inline, anchored at
             // the bottom (same component as the desktop drawer,
             // `variant="inline"`). It persists across the swipeable pages
             // (Live / Shipped / Artifacts) so you can kick off a session — and
-            // swipe between pages — from anywhere. The orb lives in the top nav.
+            // swipe between pages — from anywhere. Hidden while the full-page
+            // artifact viewer is open so it cannot stack above the content.
+            // The orb lives in the top nav.
             <NewSessionDialog
               variant="inline"
               open
@@ -6454,6 +6476,9 @@ function TreeConnector({
   continueAfter?: boolean;
   subtle?: boolean;
 }) {
+  // Branch geometry is always relative to this element's box. Callers must size
+  // the connector to the *card/row* only — not the card plus nested children —
+  // otherwise `top-1/2` / `bottom-1/2` lands in the gap under the card.
   // Solid (fully opaque) color so any segment overlap can't composite darker.
   const lineClass = "bg-current";
   const borderClass = "border-current";
@@ -6701,12 +6726,27 @@ function LiveView({
     isLast = true,
   ): ReactNode[] => [
     <div key={`child-${sessionStableId(node.session)}`} className="relative">
-      <TreeConnector
-        className="-left-4 -top-2 h-[calc(100%+1rem)] w-4"
-        colorClassName="text-zinc-500"
-        continueAfter={!isLast}
-      />
-      {renderCard(node.session, depth)}
+      {/* Spine through this whole subtree when more siblings follow. Kept
+          outside the card-sized connector so the branch still hits mid-card
+          even when this node has its own nested children. */}
+      {!isLast ? (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -left-4 -top-2 bottom-0 w-[1.5px] bg-zinc-500"
+        />
+      ) : null}
+      {/* Connector is sized to the card only so elbow/T-junction midpoints
+          land on the card center, not the midpoint of card+descendants.
+          `-top-2` + `h-[calc(100%+1rem)]` keeps the 50% branch on the card
+          midline (8px above + half of height+16px = mid-card). */}
+      <div className="relative">
+        <TreeConnector
+          className="-left-4 -top-2 h-[calc(100%+1rem)] w-4"
+          colorClassName="text-zinc-500"
+          continueAfter={!isLast}
+        />
+        {renderCard(node.session, depth)}
+      </div>
       {node.children.length ? (
         <div className="relative ml-5 mt-1 flex flex-col gap-1.5 pb-1 pl-4 pt-1">
           {node.children.flatMap((child, index) =>
@@ -6986,16 +7026,18 @@ function RailStage({
     }
   }, [railCollapsed, railCollapsedStorageKey]);
 
-  // Desktop trackpad gesture: a two-finger horizontal swipe (macOS delivers
-  // these as `wheel` events with deltaX) cycles the project folder selection —
-  // swipe left for the next folder, right for the previous (mirrors the mobile
-  // page swipe). Listens on the whole document so it works wherever the cursor
-  // hovers — no click/focus needed — but yields to content that genuinely
-  // scrolls horizontally (terminals, code blocks, tables) and to text inputs.
-  // Attached as a non-passive native listener so we can preventDefault and
-  // keep Chrome/Safari from treating the swipe as history back/forward
-  // navigation. Handler context lives in a ref so the listener attaches once
-  // instead of re-attaching every render.
+  // Desktop trackpad / mouse gesture: a two-finger horizontal swipe (macOS
+  // delivers these as `wheel` events with deltaX) cycles the project folder
+  // selection — swipe left for the next folder, right for the previous
+  // (mirrors the mobile page swipe). One continuous gesture commits at most
+  // one page; re-arm only after a silence gap so inertia / a long swipe cannot
+  // skip multiple folders. Listens on the whole document so it works wherever
+  // the cursor hovers — no click/focus needed — but yields to content that
+  // genuinely scrolls horizontally (terminals, code blocks, tables) and to
+  // text inputs. Attached as a non-passive native listener so we can
+  // preventDefault and keep Chrome/Safari from treating the swipe as history
+  // back/forward navigation. Handler context lives in a ref so the listener
+  // attaches once instead of re-attaching every render.
   const railSwipeCtx = useRef({ projectFilter, projectOptions, onProjectChange });
   railSwipeCtx.current = { projectFilter, projectOptions, onProjectChange };
   const workspaceRef = useRef<HTMLDivElement | null>(null);
@@ -7004,7 +7046,6 @@ function RailStage({
     const GESTURE_GAP_MS = 250; // silence longer than this = new gesture
     let acc = 0;
     let lastTs = 0;
-    let lastMag = 0;
     let committed = false;
     let settleTimer = 0;
     let swapAnim = false;
@@ -7077,22 +7118,18 @@ function RailStage({
       if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
       if (yieldsToTarget(e.target)) return;
       e.preventDefault();
-      const mag = Math.abs(e.deltaX);
       // A committed swipe keeps emitting wheel events while trackpad inertia
-      // decays — without these checks the momentum tail keeps the gesture
-      // "alive" and swallows the next real swipe. Re-arm on: silence gap,
-      // direction flip, or a fresh finger push (delta spikes against the
-      // decaying tail).
+      // decays. Only re-arm after a real silence gap so one continuous gesture
+      // (or its momentum tail) can never advance more than one page. Mid-stream
+      // "fresh push" / direction-flip re-arm was jumping multiple folders on a
+      // single long mouse/trackpad swipe.
       const gapReset = e.timeStamp - lastTs > GESTURE_GAP_MS;
-      const dirFlip = committed && acc !== 0 && Math.sign(e.deltaX) !== Math.sign(acc);
-      const freshPush = committed && mag > lastMag * 1.5 + 4;
-      if (gapReset || dirFlip || freshPush) {
+      if (gapReset) {
         acc = 0;
         committed = false;
       }
       lastTs = e.timeStamp;
-      lastMag = mag;
-      if (committed) return; // inertia tail of an already-committed swipe
+      if (committed) return; // inertia tail / rest of an already-committed swipe
       acc += e.deltaX;
       // Follow the fingers (damped) so the swipe has physical feedback.
       setTx(-acc * 0.45);
@@ -7107,7 +7144,7 @@ function RailStage({
       }, GESTURE_GAP_MS);
       if (Math.abs(acc) < COMMIT) return;
       // Natural scrolling: fingers left → deltaX > 0 → next folder; fingers
-      // right → deltaX < 0 → previous.
+      // right → deltaX < 0 → previous. Max 1 page per gesture.
       const dir: 1 | -1 = acc > 0 ? 1 : -1;
       committed = true;
       window.clearTimeout(settleTimer);
@@ -7483,7 +7520,7 @@ function RailStage({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  const renderRailItem = (session: Session, depth = 0, isLast = true) => {
+  const renderRailItem = (session: Session) => {
     const sid = session.sessionId ?? "";
     return (
       <RailItem
@@ -7495,19 +7532,72 @@ function RailStage({
         cursored={cursor === sid}
         pinned={validPinned.includes(sid)}
         collapsed={railCollapsed}
-        depth={depth}
-        isLast={isLast}
         onActivate={(shift) => activate(sid, shift)}
         onTogglePin={() => togglePin(sid)}
       />
     );
   };
-  const renderRailNode = (node: SessionTreeNode, depth = 0, isLast = true): ReactNode[] => [
-    renderRailItem(node.session, depth, isLast),
-    ...node.children.flatMap((child, index) =>
-      renderRailNode(child, depth + 1, index === node.children.length - 1),
-    ),
-  ];
+  // Nest children in the DOM (same model as the mobile session tree) so
+  // depth-2+ grandchildren indent further and tree elbows hit mid-row.
+  // Collapsed rail stays a flat icon strip — no indent/connectors.
+  const renderRailNode = (
+    node: SessionTreeNode,
+    depth = 0,
+    isLast = true,
+  ): ReactNode => {
+    const id = sessionStableId(node.session);
+    if (railCollapsed) {
+      return (
+        <div key={id} className="contents">
+          {renderRailItem(node.session)}
+          {node.children.map((child, index) =>
+            renderRailNode(child, depth + 1, index === node.children.length - 1),
+          )}
+        </div>
+      );
+    }
+    if (depth === 0) {
+      if (!node.children.length) return renderRailItem(node.session);
+      return (
+        <div key={id} className="flex flex-col gap-0.5">
+          {renderRailItem(node.session)}
+          <div className="relative ml-3 flex flex-col gap-0.5 pl-3">
+            {node.children.map((child, index) =>
+              renderRailNode(child, 1, index === node.children.length - 1),
+            )}
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div key={id} className="relative">
+        {/* Spine through card+descendants when more siblings follow. */}
+        {!isLast ? (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute -left-3 -top-1 bottom-0 w-[1.5px] bg-zinc-500"
+          />
+        ) : null}
+        {/* Connector sized to the row only so the branch hits mid-row. */}
+        <div className="relative">
+          <TreeConnector
+            className="-left-3 -top-1 h-[calc(100%+0.5rem)] w-3"
+            colorClassName="text-zinc-500"
+            continueAfter={!isLast}
+            subtle
+          />
+          {renderRailItem(node.session)}
+        </div>
+        {node.children.length ? (
+          <div className="relative ml-3 mt-0.5 flex flex-col gap-0.5 pl-3">
+            {node.children.map((child, index) =>
+              renderRailNode(child, depth + 1, index === node.children.length - 1),
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  };
 
   const stageColumns = useMemo(() => {
     return columnIds
@@ -7708,7 +7798,7 @@ function RailStage({
                   count={group.count}
                   collapsed={railCollapsed}
                 >
-                  {group.nodes.flatMap((node) => renderRailNode(node))}
+                  {group.nodes.map((node) => renderRailNode(node))}
                 </RailGroup>
               ))}
               {autoRailGroup}
@@ -7717,13 +7807,13 @@ function RailStage({
             <>
               {working.length ? (
                 <RailGroup label="Working" count={working.length} collapsed={railCollapsed}>
-                  {workingNodes.flatMap((node) => renderRailNode(node))}
+                  {workingNodes.map((node) => renderRailNode(node))}
                 </RailGroup>
               ) : null}
               {autoRailGroup}
               {idle.length ? (
                 <RailGroup label="Idle" count={idle.length} collapsed={railCollapsed}>
-                  {idleNodes.flatMap((node) => renderRailNode(node))}
+                  {idleNodes.map((node) => renderRailNode(node))}
                 </RailGroup>
               ) : null}
             </>
@@ -7873,8 +7963,6 @@ const RailItem = memo(function RailItem({
   cursored,
   pinned,
   collapsed,
-  depth = 0,
-  isLast = true,
   onActivate,
   onTogglePin,
 }: {
@@ -7885,8 +7973,6 @@ const RailItem = memo(function RailItem({
   cursored: boolean;
   pinned: boolean;
   collapsed: boolean;
-  depth?: number;
-  isLast?: boolean;
   onActivate: (shiftKey: boolean) => void;
   onTogglePin: () => void;
 }) {
@@ -7950,17 +8036,8 @@ const RailItem = memo(function RailItem({
         "lfg-rail-in relative rounded-xl",
         swiping ? "overflow-hidden" : "overflow-visible",
         cursored && "ring-2 ring-inset ring-primary/60",
-        depth > 0 && !collapsed && "ml-6 pl-4",
       )}
     >
-      {depth > 0 && !collapsed ? (
-        <TreeConnector
-          className="-top-1 left-0 h-[calc(100%+0.5rem)] w-4"
-          colorClassName="text-zinc-500"
-          continueAfter={!isLast}
-          subtle
-        />
-      ) : null}
       {swiping ? (
         <div
           aria-hidden
@@ -10156,7 +10233,7 @@ const SessionCard = memo(function SessionCard({
   const isMobile = useIsMobile();
   // Fall back to the list payload's last message when we aren't streaming this
   // card (collapsed) so the collapsed preview line still shows something.
-  const latest = latestLine(messages) || normText(session.last?.text ?? "");
+  const latest = latestLine(messages) || plainPreviewText(session.last?.text ?? "");
   const sectionRef = useRef<HTMLElement>(null);
   // True while voice dictation is recording in this card's composer — glows the
   // card border so it's clear which session is listening.

--- a/web/src/useLiveSocket.ts
+++ b/web/src/useLiveSocket.ts
@@ -274,15 +274,10 @@ function normalizeMessageList(messages: Message[]): Message[] {
   return messages.map(normalizeMessageIdentity);
 }
 
-function insertMediaByTimestamp(messages: Message[], message: Message): Message[] {
-  if ((message.kind !== "image" && message.kind !== "video" && message.kind !== "html") || message.ts == null) {
-    return [...messages, message];
-  }
-  const insertAt = messages.findIndex((item) => item.ts != null && item.ts > message.ts!);
-  if (insertAt < 0) return [...messages, message];
-  return [...messages.slice(0, insertAt), message, ...messages.slice(insertAt)];
-}
-
+// Media order is owned by the server transcript index (joined artifact rows).
+// Live upserts must keep an existing card's position and append brand-new media
+// at the tail — never re-sort by timestamp, which put images out of place when
+// a second poll stream raced the ordered transcript.
 function upsertMessageById(current: Message[], message: Message): Message[] {
   const normalized = normalizeMessageIdentity(message);
   const id = mediaIdentity(normalized);
@@ -301,7 +296,7 @@ function upsertMessageById(current: Message[], message: Message): Message[] {
     const insertAt = Math.min(existingIndex, withoutTransient.length);
     return [...withoutTransient.slice(0, insertAt), normalized, ...withoutTransient.slice(insertAt)];
   }
-  return insertMediaByTimestamp(withoutTransient, normalized);
+  return [...withoutTransient, normalized];
 }
 
 function reconcileSnapshotMessages(current: Message[], incoming: Message[]): Message[] {


### PR DESCRIPTION
## Summary

Lands two local commits from `byo-computer-connect-skeleton` onto a clean `main`-based branch (cherry-picked; no connect WIP):

1. **docs: refresh README and env for Pi, Shipped, and MCP** — README matches current agents/product (Pi bundled, Shipped/artifacts/MCP), slims deploy boilerplate, documents `LFG_PI_PATH` in `.env.example`.
2. **fix media/transcript join, artifact viewer stacking, and live order** — product fixes already stacked with the docs commit (transcript/media join, artifact viewer stacking, live order).

## Test plan

- [x] `bun test` — 85/85 pass (including `transcript-artifact-join` coverage)
- [x] `bunx tsc -p tsconfig.json --noEmit` — clean
- [ ] CI green on this PR

## Notes

- Does **not** include `lfg connect` skeleton/finish work (still on separate connect branches/PR #17).
- Cherry-picks of `079bea5` + `6100570`; no double-land of connect stack.