### PR TITLE
connect: sane event-forwarding defaults (top-level, ≥60s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,26 @@ box's own `GET /api/sessions` every `LFG_CONNECT_EVENTS_INTERVAL_MS` (default
 `4000`) and only sent while a relay connection is open — see the "Session
 lifecycle events" doc block at the top of
 [`src/commands/connect.ts`](./src/commands/connect.ts) for the exact
-transition rules and wire shape. **Privacy:** this is off by default because
-the event includes the session's title (derived from your own first prompt in
-that session) and project/agent name, which then leave this box for whatever
-relay `LFG_RELAY_URL` points at.
+transition rules and wire shape.
+
+Not every transition is forwarded, even with the flag on. Two sanity defaults
+apply client-side, for any relay operator, before a frame is ever built:
+a session with a `parentSessionId` (a subagent) never forwards — subagent
+churn on a busy box is routine and constant, and forwarding it would make
+every internal step of someone else's task look like a top-level
+notification; and a `session.completed` for a session that ran under
+`LFG_CONNECT_EVENTS_MIN_DURATION_MS` (default `60000`) is dropped — a
+one-minute-or-shorter run isn't news. `session.needs_attention` is exempt
+from that duration floor (a blocked session is actionable regardless of how
+young it is). See `isTopLevelSession`/`isReportableTransition` in
+[`src/commands/connect.ts`](./src/commands/connect.ts).
+
+**Privacy:** this is off by default because the event includes the session's
+title (derived from your own first prompt in that session) and project/agent
+name, which then leave this box for whatever relay `LFG_RELAY_URL` points at.
+The top-level/60s filter above narrows *which* transitions can trigger that,
+but doesn't change what leaves the box once one does — a forwarded event's
+title is still your own raw prompt text, verbatim.
 
 The MCP server talks to the local `lfg serve` API and exposes tools such as
 `lfg_capabilities`, `lfg_list_sessions`, `lfg_get_session_messages`,
@@ -272,6 +288,7 @@ Configuration lives in `.env`; see [`.env.example`](./.env.example).
 | `LFG_RELAY_URL` | Relay WebSocket URL for `lfg connect` (required to use it — no default). See [Commands](#commands). |
 | `LFG_CONNECT_EVENTS` | Opt-in (default off): `lfg connect` forwards session completed/needs-attention events to the relay. Session titles leave the box when on — see [Commands](#commands). |
 | `LFG_CONNECT_EVENTS_INTERVAL_MS` | Local session-poll interval in ms when `LFG_CONNECT_EVENTS` is on (default `4000`). |
+| `LFG_CONNECT_EVENTS_MIN_DURATION_MS` | Minimum session duration (ms) for a `session.completed` to be forwarded when `LFG_CONNECT_EVENTS` is on (default `60000`). Does not apply to `session.needs_attention`. |
 | `LFG_INSTALL_CHANNEL` | Install channel: `source`, `release`, or `container`. Usually set by setup/deploy. |
 
 ## Security

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -69,6 +69,22 @@ import { PATHS } from "../config.ts";
 // announcing a completion is still categorically faster than a remote poller
 // checking in every few seconds over the network.
 //
+// Not every transition is forwarded, even with the flag on — two sanity
+// defaults any relay operator gets for free, applied client-side before a
+// frame is ever built:
+//   - top-level only: a session with a parentSessionId (a subagent, spawned
+//     via `lfg subagent` — see src/commands/subagent.ts) never generates a
+//     frame. Subagent churn is routine and constant on a box running any
+//     nontrivial agent workflow; forwarding it would mean every internal
+//     step of someone else's task looks like a top-level notification.
+//   - a minimum duration floor (MIN_REPORTABLE_DURATION_MS, default 60s):
+//     a session.completed for a session that started and finished inside a
+//     minute isn't news — quick blips (a one-line question, a trivial
+//     lookup) shouldn't page anyone. session.needs_attention is exempt from
+//     this floor: a session going "blocked" is actionable no matter how
+//     young it is, unlike routine completion.
+// See isTopLevelSession/isReportableTransition below.
+//
 // PRIVACY NOTE: when enabled, session titles (and project/agent names) leave
 // this box and are sent to whatever relay LFG_RELAY_URL points at, which then
 // (per that relay's own policy) may forward them further (e.g. omg's relay
@@ -77,7 +93,9 @@ import { PATHS } from "../config.ts";
 // session (see firstPromptTitle in src/sessions.ts) and can contain whatever
 // you typed. This is why the flag defaults OFF — turning it on is an explicit
 // choice to let a completion/attention signal (and the small amount of
-// context needed to make it useful) leave the box.
+// context needed to make it useful) leave the box. The top-level/60s filter
+// above narrows WHICH transitions can trigger that, but doesn't change what
+// leaves the box once one does.
 
 const HELP = `lfg connect — pair this box to a remote-access relay (EXPERIMENTAL)
 
@@ -95,6 +113,8 @@ Env:
   LFG_CONNECT_EVENTS         Opt-in (1/true/yes, default off): forward session completed/needs-attention
                              events to the relay. PRIVACY: session titles leave this box when on.
   LFG_CONNECT_EVENTS_INTERVAL_MS  Local session-poll interval in ms when events are enabled (default 4000)
+  LFG_CONNECT_EVENTS_MIN_DURATION_MS  Minimum session duration to report a completion, in ms (default 60000).
+                             Does not apply to session.needs_attention (always reported).
 
 No relay implementation ships with LFG. This is the generic client half of a
 protocol any relay operator can implement — see the wire protocol documented
@@ -209,6 +229,7 @@ function eventsEnabled(): boolean {
 }
 
 const EVENTS_POLL_MS = Number(process.env.LFG_CONNECT_EVENTS_INTERVAL_MS ?? 4_000);
+const MIN_REPORTABLE_DURATION_MS = Number(process.env.LFG_CONNECT_EVENTS_MIN_DURATION_MS ?? 60_000);
 
 /** The subset of src/sessions.ts's `Session` this client reads off GET /api/sessions. */
 export type SessionLite = {
@@ -219,9 +240,45 @@ export type SessionLite = {
   title?: string | null;
   project?: string | null;
   agent?: string | null;
+  // Present (non-null) only for a subagent (see src/commands/subagent.ts) —
+  // absence/null means top-level. This is the only signal isTopLevelSession
+  // needs; subagentDepth is not part of this HTTP payload today, but a
+  // future depth > 0 would mean the same thing and isTopLevelSession is
+  // written to treat it identically if it ever shows up here.
+  parentSessionId?: string | null;
+  subagentDepth?: number | null;
+  // Session.startedAt off GET /api/sessions — when the session was
+  // launched. Used for the reportable-duration floor below.
+  startedAt?: number | null;
 };
 
 type SeenSession = { busy: boolean; status: "ok" | "blocked" };
+
+/** No parentSessionId and no positive subagentDepth — see the doc block at
+ * the top of this file for why subagent churn never leaves the box. */
+export function isTopLevelSession(session: SessionLite): boolean {
+  return !session.parentSessionId && !session.subagentDepth;
+}
+
+/**
+ * Whether this tick's transition is worth forwarding at all, independent of
+ * title hygiene (the gateway's job — see BYO_COMPUTER.md). needs_attention
+ * is exempt from the duration floor: a blocked session is actionable
+ * regardless of age. A session.completed with no startedAt to judge against
+ * is let through rather than silently dropped — an unknown duration isn't
+ * evidence the run was a quick blip.
+ */
+export function isReportableTransition(
+  event: SessionEventFrame["event"],
+  session: SessionLite,
+  ts: number,
+): boolean {
+  if (!isTopLevelSession(session)) return false;
+  if (event === "session.needs_attention") return true;
+  const startedAt = session.startedAt ?? null;
+  if (startedAt == null) return true;
+  return ts - startedAt >= MIN_REPORTABLE_DURATION_MS;
+}
 
 export type SessionEventFrame = {
   type: "event";
@@ -254,6 +311,9 @@ function makeEventFrame(event: SessionEventFrame["event"], session: SessionLite,
  * A session absent from `seen` (first time observed) never emits — it only
  * seeds the baseline, so restarting `lfg connect` against a box with
  * already-finished sessions doesn't fire a burst of stale notifications.
+ * A transition that fails isReportableTransition (not top-level, or a
+ * completion under the duration floor) is diffed the same as any other —
+ * `seen` is still updated — it just never becomes an event.
  */
 export function diffSessionEvents(seen: Map<string, SeenSession>, sessions: SessionLite[], ts: number): SessionEventFrame[] {
   const events: SessionEventFrame[] = [];
@@ -266,9 +326,13 @@ export function diffSessionEvents(seen: Map<string, SeenSession>, sessions: Sess
     const prior = seen.get(session.sessionId);
     if (prior) {
       if (prior.status !== "blocked" && status === "blocked") {
-        events.push(makeEventFrame("session.needs_attention", session, ts));
+        if (isReportableTransition("session.needs_attention", session, ts)) {
+          events.push(makeEventFrame("session.needs_attention", session, ts));
+        }
       } else if (prior.busy && !busy && !session.launching && status === "ok") {
-        events.push(makeEventFrame("session.completed", session, ts));
+        if (isReportableTransition("session.completed", session, ts)) {
+          events.push(makeEventFrame("session.completed", session, ts));
+        }
       }
     }
     seen.set(session.sessionId, { busy, status });

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { diffSessionEvents, errorFrameMessage, forwardToLocalServe, isHttpFrame, type SessionLite } from "../src/commands/connect.ts";
+import {
+  diffSessionEvents,
+  errorFrameMessage,
+  forwardToLocalServe,
+  isHttpFrame,
+  isReportableTransition,
+  isTopLevelSession,
+  type SessionLite,
+} from "../src/commands/connect.ts";
 
 describe("isHttpFrame", () => {
   test("accepts a well-formed http frame", () => {
@@ -173,5 +181,98 @@ describe("diffSessionEvents", () => {
     expect(events).toEqual([
       { type: "event", event: "session.completed", sessionId: "a", title: null, project: null, agent: null, ts: 1000 },
     ]);
+  });
+
+  test("a subagent's completion (parentSessionId set) never emits — subagent churn stays on the box", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(
+      seen,
+      [session({ sessionId: "a", busy: false, parentSessionId: "parent-1", startedAt: 0 })],
+      120_000,
+    );
+    expect(events).toEqual([]);
+  });
+
+  test("a subagent's needs_attention never emits either — top-level filter applies to both kinds", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(
+      seen,
+      [session({ sessionId: "a", busy: true, status: "blocked", parentSessionId: "parent-1" })],
+      1000,
+    );
+    expect(events).toEqual([]);
+  });
+
+  test("a top-level completion under the 60s duration floor is dropped", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(seen, [session({ sessionId: "a", busy: false, startedAt: 0 })], 30_000);
+    expect(events).toEqual([]);
+  });
+
+  test("a top-level completion at/over the 60s duration floor is reported", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(seen, [session({ sessionId: "a", busy: false, startedAt: 0 })], 60_000);
+    expect(events.map((e) => e.event)).toEqual(["session.completed"]);
+  });
+
+  test("needs_attention is exempt from the duration floor — reported even for a brand-new session", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(
+      seen,
+      [session({ sessionId: "a", busy: true, status: "blocked", startedAt: 0 })],
+      1_000,
+    );
+    expect(events.map((e) => e.event)).toEqual(["session.needs_attention"]);
+  });
+
+  test("a completion with no startedAt to judge is reported rather than silently dropped", () => {
+    const seen = new Map([["a", { busy: true, status: "ok" as const }]]);
+    const events = diffSessionEvents(seen, [session({ sessionId: "a", busy: false, startedAt: undefined })], 1_000);
+    expect(events.map((e) => e.event)).toEqual(["session.completed"]);
+  });
+});
+
+describe("isTopLevelSession", () => {
+  test("a session with no parentSessionId and no subagentDepth is top-level", () => {
+    expect(isTopLevelSession(session({ sessionId: "a" }))).toBe(true);
+  });
+
+  test("a session with a parentSessionId is not top-level", () => {
+    expect(isTopLevelSession(session({ sessionId: "a", parentSessionId: "parent-1" }))).toBe(false);
+  });
+
+  test("a session with a positive subagentDepth is not top-level, even with no parentSessionId", () => {
+    expect(isTopLevelSession(session({ sessionId: "a", subagentDepth: 2 }))).toBe(false);
+  });
+
+  test("subagentDepth 0/null is treated the same as absent — top-level", () => {
+    expect(isTopLevelSession(session({ sessionId: "a", subagentDepth: 0 }))).toBe(true);
+    expect(isTopLevelSession(session({ sessionId: "a", subagentDepth: null }))).toBe(true);
+  });
+});
+
+describe("isReportableTransition", () => {
+  test("a subagent is never reportable, regardless of event kind or duration", () => {
+    const sub = session({ sessionId: "a", parentSessionId: "parent-1", startedAt: 0 });
+    expect(isReportableTransition("session.completed", sub, 1_000_000)).toBe(false);
+    expect(isReportableTransition("session.needs_attention", sub, 1_000_000)).toBe(false);
+  });
+
+  test("a top-level completion under 60s is not reportable", () => {
+    expect(isReportableTransition("session.completed", session({ sessionId: "a", startedAt: 0 }), 59_999)).toBe(
+      false,
+    );
+  });
+
+  test("a top-level completion at exactly 60s is reportable", () => {
+    expect(isReportableTransition("session.completed", session({ sessionId: "a", startedAt: 0 }), 60_000)).toBe(
+      true,
+    );
+  });
+
+  test("a top-level needs_attention is reportable regardless of duration", () => {
+    expect(
+      isReportableTransition("session.needs_attention", session({ sessionId: "a", startedAt: 0 }), 1),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Generic client-side filters before any event frame leaves the box: top-level sessions only, ≥60s runtime (needs_attention exempt). Privacy docs updated. 127/127.