### PR TITLE
Polish session workflows and uploads

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,5 +1,5 @@
-import { mkdir, readdir, realpath, stat } from "node:fs/promises";
-import { appendFileSync, statSync, mkdirSync, readFileSync, type Dirent } from "node:fs";
+import { mkdir, open, readdir, realpath, stat } from "node:fs/promises";
+import { appendFileSync, statfsSync, statSync, mkdirSync, readFileSync, type Dirent } from "node:fs";
 import { tmpdir, homedir, loadavg, cpus, totalmem, freemem } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -335,6 +335,48 @@ async function persistUpload(req: Request, filename: string, prefix = "upload"):
   return { path: fp, name: filename || name };
 }
 
+async function persistUploadChunk(
+  req: Request,
+  filename: string,
+  prefix: string,
+  uploadId: string,
+  offset: number,
+  total: number,
+): Promise<{ path?: string; name: string; complete: boolean }> {
+  if (!/^[0-9a-f-]{36}$/i.test(uploadId)) throw new Error("invalid upload id");
+  if (!Number.isSafeInteger(offset) || offset < 0) throw new Error("invalid upload offset");
+  if (!Number.isSafeInteger(total) || total <= 0 || offset >= total) throw new Error("invalid upload size");
+
+  const ct = (req.headers.get("content-type") || "").toLowerCase();
+  const ext = uploadExt(ct, filename);
+  const buf = new Uint8Array(await req.arrayBuffer());
+  if (!buf.length) throw new Error("empty upload chunk");
+  if (offset + buf.length > total) throw new Error("upload chunk exceeds file size");
+
+  const dir = join(tmpdir(), "lfg-uploads");
+  mkdirSync(dir, { recursive: true });
+  const safePrefix = prefix.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "upload";
+  const name = `${safePrefix}-${uploadId}-${uploadStem(filename)}.${ext}`;
+  const fp = join(dir, name);
+
+  // The browser sends a file's chunks in order. Writing at an explicit offset
+  // makes a repeated request safe if the connection drops after the server
+  // persisted a chunk but before the browser received its response.
+  if (offset > 0) {
+    const current = await stat(fp).catch(() => null);
+    if (!current || current.size < offset) throw new Error("upload chunk arrived out of order");
+  }
+  const handle = await open(fp, offset === 0 ? "w" : "r+");
+  try {
+    await handle.write(buf, 0, buf.length, offset);
+    const complete = offset + buf.length === total;
+    if (complete) await handle.truncate(total);
+    return { ...(complete ? { path: fp } : {}), name: filename || name, complete };
+  } finally {
+    await handle.close();
+  }
+}
+
 function uploadFilename(req: Request, url: URL): string {
   const rawName = url.searchParams.get("filename") || req.headers.get("x-file-name") || "";
   try {
@@ -342,6 +384,16 @@ function uploadFilename(req: Request, url: URL): string {
   } catch {
     return rawName;
   }
+}
+
+function uploadChunkParams(url: URL): { uploadId: string; offset: number; total: number } | null {
+  const uploadId = url.searchParams.get("uploadId");
+  if (!uploadId) return null;
+  return {
+    uploadId,
+    offset: Number(url.searchParams.get("offset")),
+    total: Number(url.searchParams.get("total")),
+  };
 }
 
 const GROK_DEFAULT_MODEL = "grok-4.5";
@@ -425,6 +477,23 @@ function sliceMemoryBytes(): { current: number | null; max: number | null } {
   }
 }
 
+// Capacity of the filesystem that holds LFG's durable data. Keep this
+// best-effort: Settings should still load in runtimes where statfs is not
+// available or the data directory has not been mounted yet.
+function hostDiskBytes(): { total: number | null; free: number | null } {
+  try {
+    const disk = statfsSync(PATHS.data);
+    const total = Number(disk.blocks) * Number(disk.bsize);
+    const free = Number(disk.bfree) * Number(disk.bsize);
+    if (!Number.isFinite(total) || total <= 0 || !Number.isFinite(free)) {
+      return { total: null, free: null };
+    }
+    return { total, free: Math.max(0, Math.min(total, free)) };
+  } catch {
+    return { total: null, free: null };
+  }
+}
+
 // Live server snapshot for the settings performance panel + the "working now"
 // counter. "live" = an agent process exists; "working" = it has a turn in
 // flight (Session.busy). The cap counts LIVE agents (a resident-but-idle agent
@@ -435,6 +504,7 @@ async function serverStats() {
   const working = sessions.filter((s) => s.busy).length;
   const settings = getGlobalSettingsSync();
   const slice = sliceMemoryBytes();
+  const disk = hostDiskBytes();
   const [load1, load5, load15] = loadavg();
   return {
     agents: {
@@ -449,6 +519,10 @@ async function serverStats() {
       sliceMaxBytes: slice.max,
       hostTotalBytes: totalmem(),
       hostFreeBytes: freemem(),
+    },
+    disk: {
+      totalBytes: disk.total,
+      freeBytes: disk.free,
     },
     cpu: { cores: cpus().length, load1, load5, load15 },
   };
@@ -4659,7 +4733,11 @@ export async function cmdServe() {
         // initial prompt.
         if (path === "/api/uploads" && req.method === "POST") {
           try {
-            const uploaded = await persistUpload(req, uploadFilename(req, url), "new-session");
+            const filename = uploadFilename(req, url);
+            const chunk = uploadChunkParams(url);
+            const uploaded = chunk
+              ? await persistUploadChunk(req, filename, "new-session", chunk.uploadId, chunk.offset, chunk.total)
+              : await persistUpload(req, filename, "new-session");
             return json({ ok: true, ...uploaded });
           } catch (e) {
             return err(400, e instanceof Error ? e.message : "upload failed");
@@ -4675,7 +4753,11 @@ export async function cmdServe() {
         const m = path.match(/^\/api\/sessions\/([0-9a-fA-F-]{36})\/upload$/);
         if (m && req.method === "POST") {
           try {
-            const uploaded = await persistUpload(req, uploadFilename(req, url), m[1]);
+            const filename = uploadFilename(req, url);
+            const chunk = uploadChunkParams(url);
+            const uploaded = chunk
+              ? await persistUploadChunk(req, filename, m[1], chunk.uploadId, chunk.offset, chunk.total)
+              : await persistUpload(req, filename, m[1]);
             return json({ ok: true, ...uploaded });
           } catch (e) {
             return err(400, e instanceof Error ? e.message : "upload failed");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,7 @@ import {
   ChevronLeft,
   Cpu,
   Gauge,
+  HardDrive,
   MemoryStick,
   Maximize2,
   Megaphone,
@@ -428,10 +429,12 @@ type ComposerAttachment = {
   size: number;
   type: string;
   previewUrl?: string;
-  status: "ready" | "uploading" | "failed";
+  status: "ready" | "uploading" | "uploaded" | "failed";
   progress?: number;
   error?: string;
 };
+
+type UploadedAttachment = { name: string; path: string };
 
 type SkillCatalogItem = {
   name: string;
@@ -482,6 +485,10 @@ type ServerStats = {
     sliceMaxBytes: number | null;
     hostTotalBytes: number;
     hostFreeBytes: number;
+  };
+  disk: {
+    totalBytes: number | null;
+    freeBytes: number | null;
   };
   cpu: { cores: number; load1: number; load5: number; load15: number };
 };
@@ -884,13 +891,21 @@ function uploadFile<T>(
   contentType: string,
   onProgress: (progress: number) => void,
 ): Promise<T> {
-  return new Promise((resolve, reject) => {
+  const chunkSize = 8 * 1024 * 1024;
+  const uploadId = crypto.randomUUID();
+
+  const sendChunk = (chunk: Blob, offset: number): Promise<T> => new Promise((resolve, reject) => {
+    const separator = path.includes("?") ? "&" : "?";
     const request = new XMLHttpRequest();
-    request.open("POST", path);
+    request.open(
+      "POST",
+      `${path}${separator}uploadId=${encodeURIComponent(uploadId)}&offset=${offset}&total=${file.size}`,
+    );
     request.setRequestHeader("Content-Type", contentType || "application/octet-stream");
     request.upload.addEventListener("progress", (event) => {
-      const total = event.total || file.size;
-      if (total > 0) onProgress(Math.min(100, Math.round((event.loaded / total) * 100)));
+      if (file.size > 0) {
+        onProgress(Math.min(100, Math.round(((offset + event.loaded) / file.size) * 100)));
+      }
     });
     request.addEventListener("load", () => {
       let data: unknown = {};
@@ -900,7 +915,7 @@ function uploadFile<T>(
         // Keep the HTTP status error below useful even if a proxy returns HTML.
       }
       if (request.status >= 200 && request.status < 300) {
-        onProgress(100);
+        onProgress(Math.min(100, Math.round(((offset + chunk.size) / file.size) * 100)));
         resolve(data as T);
         return;
       }
@@ -912,8 +927,16 @@ function uploadFile<T>(
     });
     request.addEventListener("error", () => reject(new Error("Upload failed due to a network error")));
     request.addEventListener("abort", () => reject(new Error("Upload cancelled")));
-    request.send(file);
+    request.send(chunk);
   });
+
+  return (async () => {
+    let response: T | undefined;
+    for (let offset = 0; offset < file.size; offset += chunkSize) {
+      response = await sendChunk(file.slice(offset, Math.min(file.size, offset + chunkSize)), offset);
+    }
+    return response as T;
+  })();
 }
 
 function closeSessionRequest(sid: string, source: string) {
@@ -1004,7 +1027,13 @@ function evlog(event: string, fields: Record<string, unknown> = {}) {
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+  }
+  if (bytes < 1024 * 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 * 1024 ? 1 : 0)} GB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024 * 1024)).toFixed(1)} TB`;
 }
 
 function composeAttachmentMessage(
@@ -1025,16 +1054,106 @@ function applyAnnotatedAttachment(
   previewUrls: MutableRefObject<string[]>,
   id: string,
   file: File,
+  onReplaced?: (att: ComposerAttachment) => void,
 ) {
   const previewUrl = URL.createObjectURL(file);
   previewUrls.current.push(previewUrl);
+  let replaced: ComposerAttachment | null = null;
   setAttachments((current) =>
     current.map((att) => {
       if (att.id !== id) return att;
       if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
-      return { ...att, file, name: file.name, size: file.size, type: file.type, previewUrl, status: "ready" as const };
+      const next = { ...att, file, name: file.name, size: file.size, type: file.type, previewUrl, status: "ready" as const };
+      delete next.progress;
+      delete next.error;
+      replaced = next;
+      return next;
     }),
   );
+  // The annotated file replaces the original bytes, so any upload already
+  // running (or finished) for this attachment is stale. Hand the new file back
+  // so the caller can restart it.
+  queueMicrotask(() => {
+    if (replaced) onReplaced?.(replaced);
+  });
+}
+
+// Attachments upload as soon as they are attached rather than on send, so the
+// bytes are usually already on the server by the time the user hits enter.
+//
+// Each attachment gets a token that identifies its current upload attempt. A
+// re-upload (retry, or an annotation replacing the file) mints a fresh token,
+// so a superseded attempt that resolves late can no longer write status or
+// progress back into the composer.
+function useEagerUploads(options: {
+  endpoint: (att: ComposerAttachment) => string | null;
+  onPatch: (id: string, patch: Partial<ComposerAttachment>) => void;
+}) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+  const inflight = useRef(new Map<string, Promise<UploadedAttachment>>());
+  const tokens = useRef(new Map<string, object>());
+
+  // Start (or restart) the upload for an attachment and cache it by id.
+  const startUpload = useCallback((att: ComposerAttachment): Promise<UploadedAttachment> => {
+    const { endpoint, onPatch } = optionsRef.current;
+    const url = endpoint(att);
+    if (!url) return Promise.reject(new Error("Upload destination is not ready"));
+    const token = {};
+    tokens.current.set(att.id, token);
+    const isCurrent = () => tokens.current.get(att.id) === token;
+    onPatch(att.id, { status: "uploading", progress: 0, error: undefined });
+    const task = uploadFile<{ path: string; name?: string }>(url, att.file, att.type, (progress) => {
+      if (isCurrent()) onPatch(att.id, { progress });
+    })
+      .then((uploaded) => {
+        const result = { name: uploaded.name || att.name, path: uploaded.path };
+        if (isCurrent()) onPatch(att.id, { status: "uploaded", progress: 100, error: undefined });
+        return result;
+      })
+      .catch((err: unknown) => {
+        if (isCurrent()) {
+          // Drop the cached failure so the next resolveUpload retries instead of
+          // replaying the same rejection.
+          inflight.current.delete(att.id);
+          onPatch(att.id, {
+            status: "failed",
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        throw err;
+      });
+    inflight.current.set(att.id, task);
+    return task;
+  }, []);
+
+  // Fire-and-forget variant for the attach path, where nothing awaits the
+  // result yet and an unhandled rejection would surface as a console error.
+  const prefetchUpload = useCallback(
+    (att: ComposerAttachment) => {
+      void startUpload(att).catch(() => {});
+    },
+    [startUpload],
+  );
+
+  // Send path: reuse the in-flight or finished upload when there is one.
+  const resolveUpload = useCallback(
+    (att: ComposerAttachment): Promise<UploadedAttachment> =>
+      inflight.current.get(att.id) ?? startUpload(att),
+    [startUpload],
+  );
+
+  const forgetUpload = useCallback((id: string) => {
+    inflight.current.delete(id);
+    tokens.current.delete(id);
+  }, []);
+
+  const forgetAllUploads = useCallback(() => {
+    inflight.current.clear();
+    tokens.current.clear();
+  }, []);
+
+  return { prefetchUpload, resolveUpload, forgetUpload, forgetAllUploads };
 }
 
 // Fire-and-forget instrumentation: record which CTA a finding graduated
@@ -1193,6 +1312,10 @@ function titleForSession(session: Session) {
     session.sessionId?.slice(0, 8) ||
     "session"
   );
+}
+
+function sessionReference(sessionId: string): string {
+  return `LFG session reference: ${sessionId}`;
 }
 
 // The most recent activity condensed to one line — used as the collapsed-card
@@ -8690,6 +8813,12 @@ function SessionChat({
   const [launching, setLaunching] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const previewUrls = useRef<string[]>([]);
+  const { prefetchUpload, resolveUpload, forgetUpload, forgetAllUploads } = useEagerUploads({
+    endpoint: (att) =>
+      sid ? `/api/sessions/${sid}/upload?filename=${encodeURIComponent(att.name)}` : null,
+    onPatch: (id, patch) =>
+      setAttachments((current) => current.map((item) => (item.id === id ? { ...item, ...patch } : item))),
+  });
   const chatStatusRef = useRef<ReturnType<typeof useChat<LfgChatMessage>>["status"]>("ready");
   const chatTransport = useMemo(
     () =>
@@ -8801,66 +8930,38 @@ function SessionChat({
   function addFiles(files: FileList | File[]) {
     const incoming = Array.from(files).filter((file) => file.size > 0);
     if (!incoming.length) return;
-    setAttachments((current) => {
-      const room = Math.max(0, 8 - current.length);
-      if (!room) {
-        toast.error("Remove an attachment before adding another.");
-        return current;
-      }
-      if (incoming.length > room) toast.error(`Added ${room} of ${incoming.length} files.`);
-      const next = incoming.slice(0, room).map((file) => {
-        const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
-        if (previewUrl) previewUrls.current.push(previewUrl);
-        return {
-          id: `${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
-          file,
-          name: file.name || "upload",
-          size: file.size,
-          type: file.type,
-          previewUrl,
-          status: "ready" as const,
-        };
-      });
-      return [...current, ...next];
+    const room = Math.max(0, 8 - attachments.length);
+    if (!room) {
+      toast.error("Remove an attachment before adding another.");
+      return;
+    }
+    if (incoming.length > room) toast.error(`Added ${room} of ${incoming.length} files.`);
+    const next: ComposerAttachment[] = incoming.slice(0, room).map((file) => {
+      const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
+      if (previewUrl) previewUrls.current.push(previewUrl);
+      return {
+        id: `${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
+        file,
+        name: file.name || "upload",
+        size: file.size,
+        type: file.type,
+        previewUrl,
+        status: "ready" as const,
+      };
     });
+    setAttachments((current) => [...current, ...next]);
+    // Push the bytes now instead of waiting for send, so the upload is normally
+    // already finished by the time the user submits.
+    next.forEach(prefetchUpload);
   }
 
   function removeAttachment(id: string) {
+    forgetUpload(id);
     setAttachments((current) => {
       const item = current.find((att) => att.id === id);
       if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl);
       return current.filter((att) => att.id !== id);
     });
-  }
-
-  async function uploadAttachment(att: ComposerAttachment): Promise<{ name: string; path: string }> {
-    if (!sid) throw new Error("session not found");
-    setAttachments((current) =>
-      current.map((item) =>
-        item.id === att.id ? { ...item, status: "uploading", progress: 0, error: undefined } : item,
-      ),
-    );
-    try {
-      const uploaded = await uploadFile<{ path: string; name?: string }>(
-        `/api/sessions/${sid}/upload?filename=${encodeURIComponent(att.name)}`,
-        att.file,
-        att.type,
-        (progress) => {
-          setAttachments((current) =>
-            current.map((item) => (item.id === att.id ? { ...item, progress } : item)),
-          );
-        },
-      );
-      return { name: uploaded.name || att.name, path: uploaded.path };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      setAttachments((current) =>
-        current.map((item) =>
-          item.id === att.id ? { ...item, status: "failed", error: message } : item,
-        ),
-      );
-      throw err;
-    }
   }
 
   async function sendMessage(
@@ -8889,7 +8990,9 @@ function SessionChat({
           }).catch(() => {});
         }
       }
-      const uploaded = files.length ? await Promise.all(files.map(uploadAttachment)) : [];
+      // Uploads started when the files were attached; this normally resolves
+      // immediately and only actually waits for bytes still in flight.
+      const uploaded = files.length ? await Promise.all(files.map(resolveUpload)) : [];
       const outgoingText = composeAttachmentMessage(text, uploaded);
       // Pulse the composer so the send visibly launches into the transcript.
       setLaunching(true);
@@ -8916,6 +9019,7 @@ function SessionChat({
         if (att.previewUrl) URL.revokeObjectURL(att.previewUrl);
       }
       setAttachments([]);
+      forgetAllUploads();
       setSending(false);
       void onRefresh().catch((err) => {
         onError(err instanceof Error ? err.message : String(err));
@@ -8923,9 +9027,6 @@ function SessionChat({
     } catch (err) {
       onError(err instanceof Error ? err.message : String(err));
       setMessageText(text);
-      setAttachments((current) =>
-        current.map((att) => (att.status === "uploading" ? { ...att, status: "ready" } : att)),
-      );
     } finally {
       setSending(false);
     }
@@ -9172,7 +9273,9 @@ function SessionChat({
           if (!next) setAnnotatingId(null);
         }}
         onSave={(file) => {
-          if (annotatingId) applyAnnotatedAttachment(setAttachments, previewUrls, annotatingId, file);
+          if (annotatingId) {
+            applyAnnotatedAttachment(setAttachments, previewUrls, annotatingId, file, prefetchUpload);
+          }
           setAnnotatingId(null);
         }}
       />
@@ -9283,6 +9386,16 @@ function SessionActionsMenu({
     }
   }
 
+  async function copyReference() {
+    if (!sid) return;
+    try {
+      await copyMessageText(sessionReference(sid));
+      toast.success("Session reference copied");
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Could not copy session reference");
+    }
+  }
+
   async function close() {
     if (!sid) return;
     const confirmed = await appDialog.confirm({
@@ -9383,6 +9496,10 @@ function SessionActionsMenu({
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          <DropdownMenuItem disabled={!sid} onClick={() => void copyReference()}>
+            <Copy className="size-4" />
+            Copy reference
+          </DropdownMenuItem>
           <DropdownMenuItem disabled={!sid} onClick={() => setForkOpen(true)}>
             <GitFork className="size-4" />
             Fork
@@ -10992,7 +11109,9 @@ function UserBubble({ html, pending }: { html: string; pending?: boolean }) {
         // sent bubbles rendered a size smaller than assistant replies.
         // text-base is also a utility, so it cleanly out-conflicts text-sm
         // via the same layer instead of fighting it on specificity.
-        "msg-text markdown user-bubble text-base w-fit max-w-[85%]",
+        // Width cap lives on MessageActions (definite parent); bubble just
+        // hugs content up to that cap so multi-line turns stay right-aligned.
+        "msg-text markdown user-bubble text-base w-fit max-w-full",
         pending && "is-pending",
       )}
     >
@@ -11154,8 +11273,14 @@ function MessageActions({
   return (
     <div
       className={cn(
-        "message-actions-wrap flex min-w-0 max-w-full flex-col",
-        isUser ? "items-end" : "items-start",
+        // Cap width on this direct child of Message (which has a definite
+        // w-full). Nested max-w-[85%] on the bubble used to resolve against a
+        // content-sized ancestor after MessageActions was introduced, so the
+        // percentage collapsed and long user turns grew full-width / looked
+        // left-aligned. Short turns still hug the trailing edge via items-end
+        // + Message's justify-end.
+        "message-actions-wrap flex min-w-0 flex-col",
+        isUser ? "max-w-[85%] items-end" : "max-w-[92%] items-start",
         selecting && "is-selecting",
       )}
       onPointerDown={onPointerDown}
@@ -12058,6 +12183,19 @@ function NewSessionDialog({
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const previewUrls = useRef<string[]>([]);
+  // An attachment can be mid-upload in either list: submit() moves it from
+  // `attachments` to `pendingUploads` so the composer clears immediately, and
+  // the chip row renders both. Patch both so its progress keeps ticking across
+  // the handoff.
+  const { prefetchUpload, resolveUpload, forgetUpload } = useEagerUploads({
+    endpoint: (att) => `/api/uploads?filename=${encodeURIComponent(att.name)}`,
+    onPatch: (id, patch) => {
+      const apply = (current: ComposerAttachment[]) =>
+        current.map((item) => (item.id === id ? { ...item, ...patch } : item));
+      setAttachments(apply);
+      setPendingUploads(apply);
+    },
+  });
   // Resumable (closed / rebooted-away) sessions. Fetched lazily when the user
   // expands the section so opening the dialog stays instant; reset on close.
   const [resumeOpen, setResumeOpen] = useState(false);
@@ -12538,61 +12676,38 @@ function NewSessionDialog({
   function addFiles(files: FileList | File[]) {
     const incoming = Array.from(files).filter((file) => file.size > 0);
     if (!incoming.length) return;
-    setAttachments((current) => {
-      const room = Math.max(0, 8 - current.length);
-      if (!room) {
-        toast.error("Remove an attachment before adding another.");
-        return current;
-      }
-      if (incoming.length > room) toast.error(`Added ${room} of ${incoming.length} files.`);
-      const next = incoming.slice(0, room).map((file) => {
-        const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
-        if (previewUrl) previewUrls.current.push(previewUrl);
-        return {
-          id: `${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
-          file,
-          name: file.name || "upload",
-          size: file.size,
-          type: file.type,
-          previewUrl,
-          status: "ready" as const,
-        };
-      });
-      return [...current, ...next];
+    const room = Math.max(0, 8 - attachments.length);
+    if (!room) {
+      toast.error("Remove an attachment before adding another.");
+      return;
+    }
+    if (incoming.length > room) toast.error(`Added ${room} of ${incoming.length} files.`);
+    const next: ComposerAttachment[] = incoming.slice(0, room).map((file) => {
+      const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined;
+      if (previewUrl) previewUrls.current.push(previewUrl);
+      return {
+        id: `${file.name}-${file.size}-${file.lastModified}-${crypto.randomUUID()}`,
+        file,
+        name: file.name || "upload",
+        size: file.size,
+        type: file.type,
+        previewUrl,
+        status: "ready" as const,
+      };
     });
+    setAttachments((current) => [...current, ...next]);
+    // Push the bytes now instead of waiting for send, so the upload is normally
+    // already finished by the time the user submits.
+    next.forEach(prefetchUpload);
   }
 
   function removeAttachment(id: string) {
+    forgetUpload(id);
     setAttachments((current) => {
       const item = current.find((att) => att.id === id);
       if (item?.previewUrl) URL.revokeObjectURL(item.previewUrl);
       return current.filter((att) => att.id !== id);
     });
-  }
-
-  async function uploadAttachment(att: ComposerAttachment): Promise<{ name: string; path: string }> {
-    const update = (patch: Partial<ComposerAttachment>) => {
-      setAttachments((current) =>
-        current.map((item) => (item.id === att.id ? { ...item, ...patch } : item)),
-      );
-      setPendingUploads((current) =>
-        current.map((item) => (item.id === att.id ? { ...item, ...patch } : item)),
-      );
-    };
-    update({ status: "uploading", progress: 0, error: undefined });
-    try {
-      const uploaded = await uploadFile<{ path: string; name?: string }>(
-        `/api/uploads?filename=${encodeURIComponent(att.name)}`,
-        att.file,
-        att.type,
-        (progress) => update({ progress }),
-      );
-      return { name: uploaded.name || att.name, path: uploaded.path };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      update({ status: "failed", error: message });
-      throw err;
-    }
   }
 
   function submit(e?: FormEvent, overrideText?: string) {
@@ -12614,9 +12729,14 @@ function NewSessionDialog({
     setError(null);
     setPrompt("");
     setAttachments([]);
+    // Carry each attachment's real upload state across. Most will already be
+    // "uploaded" because the bytes went up when the file was attached; only
+    // genuinely unstarted ones should read as uploading.
     setPendingUploads((current) => [
       ...current,
-      ...files.map((att) => ({ ...att, status: "uploading" as const, progress: 0, error: undefined })),
+      ...files.map((att) =>
+        att.status === "ready" ? { ...att, status: "uploading" as const, progress: 0, error: undefined } : att,
+      ),
     ]);
     setPendingCreates((n) => n + 1);
     localStorage.setItem("lfg_v2_agent", launchAgent);
@@ -12636,7 +12756,8 @@ function NewSessionDialog({
     }
     void (async () => {
       try {
-        const uploaded = files.length ? await Promise.all(files.map(uploadAttachment)) : [];
+        // Started at attach time; usually already resolved by now.
+        const uploaded = files.length ? await Promise.all(files.map(resolveUpload)) : [];
         const composedPrompt = composeAttachmentMessage(taskPrompt, uploaded);
         const res = await api<{ sessionId?: string }>("/api/sessions/new", {
           method: "POST",
@@ -12669,6 +12790,7 @@ function NewSessionDialog({
         );
         previewUrls.current = previewUrls.current.filter((url) => !uploadPreviewUrls.has(url));
         setPendingUploads((current) => current.filter((att) => !uploadIds.has(att.id)));
+        for (const id of uploadIds) forgetUpload(id);
         setPendingCreates((n) => Math.max(0, n - 1));
       }
     })();
@@ -12988,7 +13110,13 @@ function NewSessionDialog({
 
       {pendingUploads.length || attachments.length ? (
         <div className="mt-2 flex gap-1.5 overflow-x-auto pb-0.5">
-          {[...pendingUploads, ...attachments].map((att) => (
+          {[
+            // Chips already handed off to an in-flight session creation can no
+            // longer be edited or removed; live composer attachments always can,
+            // even while their upload is still running.
+            ...pendingUploads.map((att) => ({ att, locked: true })),
+            ...attachments.map((att) => ({ att, locked: false })),
+          ].map(({ att, locked }) => (
             <div
               key={att.id}
               className={cn(
@@ -13033,7 +13161,7 @@ function NewSessionDialog({
                   onClick={() => setAnnotatingId(att.id)}
                   aria-label={`Annotate ${att.name}`}
                   title="Annotate"
-                  disabled={att.status === "uploading"}
+                  disabled={locked}
                 >
                   <Pencil className="size-3.5" />
                 </button>
@@ -13044,7 +13172,7 @@ function NewSessionDialog({
                 onClick={() => removeAttachment(att.id)}
                 aria-label={`Remove ${att.name}`}
                 title="Remove"
-                disabled={att.status === "uploading"}
+                disabled={locked}
               >
                 <X className="size-3.5" />
               </button>
@@ -13151,7 +13279,9 @@ function NewSessionDialog({
         if (!next) setAnnotatingId(null);
       }}
       onSave={(file) => {
-        if (annotatingId) applyAnnotatedAttachment(setAttachments, previewUrls, annotatingId, file);
+        if (annotatingId) {
+          applyAnnotatedAttachment(setAttachments, previewUrls, annotatingId, file, prefetchUpload);
+        }
         setAnnotatingId(null);
       }}
     />
@@ -15025,8 +15155,14 @@ function ServerPerformancePanel({ stats }: { stats: ServerStats | null }) {
     : 0;
   const sliceCur = stats?.memory.sliceCurrentBytes ?? null;
   const sliceMax = stats?.memory.sliceMaxBytes ?? null;
+  const diskTotal = stats?.disk?.totalBytes ?? null;
+  const diskFree = stats?.disk?.freeBytes ?? null;
+  const diskUsed = diskTotal != null && diskFree != null ? Math.max(0, diskTotal - diskFree) : null;
+  const diskPct = diskUsed != null && diskTotal != null && diskTotal > 0
+    ? Math.min(100, Math.round((diskUsed / diskTotal) * 100))
+    : null;
 
-  const rows: { icon: ReactNode; label: string; value: string; sub?: string }[] = [
+  const rows: { icon: ReactNode; label: string; value: string; sub?: string; pct?: number | null }[] = [
     {
       icon: <Cpu className="size-4" />,
       label: "CPU load",
@@ -15045,6 +15181,15 @@ function ServerPerformancePanel({ stats }: { stats: ServerStats | null }) {
       value: stats ? `${hostPct}%` : "—",
       sub: stats ? `${formatBytes(hostUsed)} of ${formatBytes(stats.memory.hostTotalBytes)}` : undefined,
     },
+    {
+      icon: <HardDrive className="size-4" />,
+      label: "Host disk",
+      value: diskPct != null ? `${diskPct}%` : "—",
+      sub: diskUsed != null && diskTotal != null
+        ? `${formatBytes(diskUsed)} of ${formatBytes(diskTotal)}`
+        : "capacity unavailable",
+      pct: diskPct,
+    },
   ];
 
   return (
@@ -15062,6 +15207,24 @@ function ServerPerformancePanel({ stats }: { stats: ServerStats | null }) {
               <div className="min-w-0">
                 <div className="text-sm font-medium">{row.label}</div>
                 {row.sub ? <div className="text-xs text-muted-foreground tabular-nums">{row.sub}</div> : null}
+                {row.pct != null ? (
+                  <div
+                    className="mt-1.5 h-1.5 w-32 max-w-full overflow-hidden rounded-full bg-foreground/[0.08]"
+                    role="progressbar"
+                    aria-label={`${row.label} usage`}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={row.pct}
+                  >
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-300 ease-ios",
+                        row.pct >= 90 ? "bg-destructive" : row.pct >= 75 ? "bg-amber-500" : "bg-primary",
+                      )}
+                      style={{ width: `${row.pct}%` }}
+                    />
+                  </div>
+                ) : null}
               </div>
             </div>
             <div className="shrink-0 text-sm font-semibold tabular-nums">{row.value}</div>

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -34,7 +34,10 @@ export function MessageContent({ className, ...props }: MessageContentProps) {
   return (
     <div
       className={cn(
-        "min-w-0 max-w-[92%] text-sm leading-relaxed group-data-[role=user]/message:max-w-[85%]",
+        // Default cap for assistant content that is a direct Message child.
+        // User turns cap width on MessageActions instead (so the percentage
+        // resolves against Message's definite width and stays right-aligned).
+        "min-w-0 max-w-[92%] text-sm leading-relaxed",
         className,
       )}
       {...props}

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -125,6 +125,7 @@ function DrawerContent({
       <DialogContent
         data-slot="drawer-content"
         showCloseButton={false}
+        overlayClassName={overlayClassName}
         // Cap height so tall content scrolls inside the dialog instead of
         // overflowing the viewport; callers already carry their own inner
         // scroll containers.


### PR DESCRIPTION
## What changed

- uploads attachments eagerly and transfers large files in resumable 8 MB chunks
- adds host disk usage to the performance panel
- adds a copyable session reference action
- keeps user messages correctly right-aligned
- fixes desktop bottom-sheet layering so the fork dialog is not dimmed by its own backdrop

## Why

Attachment uploads were delayed until send and large requests were fragile, while several desktop session interactions had layout and discoverability rough edges. The fork dialog specifically inherited a lower z-index than its desktop dialog backdrop because `overlayClassName` was not forwarded by the responsive drawer adapter.

## Validation

- `bun test` — 127 passed
- `bun run typecheck`
- `bun run build` in `web/`
- desktop Playwright verification at 1920×1080, including computed panel/backdrop stacking and opacity