### PR TITLE
fix: read Claude OAuth from macOS Keychain when .credentials.json is absent

### DIFF
--- a/src/claude-creds.ts
+++ b/src/claude-creds.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Claude Code stores OAuth credentials in ~/.claude/.credentials.json on
+// Linux, but in the login Keychain (service "Claude Code-credentials") on
+// macOS — same JSON blob either way. Every reader goes through here so the
+// darwin fallback exists exactly once.
+// ponytail: 60s cache so dashboard polls don't shell out to `security` each time.
+
+type ClaudeCreds = { claudeAiOauth?: { accessToken?: string } };
+
+let cached: { token: string | null; at: number } | null = null;
+const TTL_MS = 60_000;
+
+function readCredsFile(): ClaudeCreds | null {
+  try {
+    return JSON.parse(
+      readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf8"),
+    ) as ClaudeCreds;
+  } catch {
+    return null;
+  }
+}
+
+function readCredsKeychain(): ClaudeCreds | null {
+  if (process.platform !== "darwin") return null;
+  try {
+    const proc = Bun.spawnSync(
+      ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+      { stdout: "pipe", stderr: "ignore" },
+    );
+    if (proc.exitCode !== 0) return null;
+    return JSON.parse(proc.stdout.toString().trim()) as ClaudeCreds;
+  } catch {
+    return null;
+  }
+}
+
+/** Claude subscription OAuth access token, or null when not signed in. */
+export function claudeOauthToken(): string | null {
+  if (cached && Date.now() - cached.at < TTL_MS) return cached.token;
+  const creds = readCredsFile() ?? readCredsKeychain();
+  const token = creds?.claudeAiOauth?.accessToken ?? null;
+  cached = { token, at: Date.now() };
+  return token;
+}

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { PATHS } from "./config.ts";
 import { lfgCapabilityAccess } from "./lfg-capabilities.ts";
+import { claudeOauthToken } from "./claude-creds.ts";
 
 export type CodingAgentKind =
   | "claude"
@@ -300,8 +301,8 @@ function copilotPath(): string | null {
 }
 
 function hasClaudeAuth(): boolean {
-  const home = userHome();
-  return !!process.env.ANTHROPIC_API_KEY || existsSync(`${home}/.claude/.credentials.json`);
+  // claudeOauthToken covers both the Linux credentials file and macOS Keychain.
+  return !!process.env.ANTHROPIC_API_KEY || claudeOauthToken() !== null;
 }
 
 function hasCodexAuth(): boolean {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -5,6 +5,7 @@ import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 import { marked } from "marked";
 import { PATHS, appVersion, installInfo } from "../config.ts";
+import { claudeOauthToken as sharedClaudeOauthToken } from "../claude-creds.ts";
 import {
   applyReleaseUpdate,
   applySourceUpdate,
@@ -1280,13 +1281,7 @@ function sessionSummaryTimeoutMs(): number {
 }
 
 function claudeOauthToken(): string | null {
-  try {
-    const raw = readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf8");
-    const creds = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: string } };
-    return creds?.claudeAiOauth?.accessToken ?? null;
-  } catch {
-    return null;
-  }
+  return sharedClaudeOauthToken();
 }
 
 function sessionSummaryModel(): string {
@@ -3486,10 +3481,7 @@ export async function cmdServe() {
         if (usageCache && Date.now() - usageCache.at < 60_000)
           return json(usageCache.data);
         try {
-          const creds = await Bun.file(
-            join(process.env.HOME || "", ".claude", ".credentials.json"),
-          ).json();
-          const token = creds?.claudeAiOauth?.accessToken;
+          const token = claudeOauthToken();
           if (!token) return err(503, "no Claude credentials on this box");
           const r = await fetch("https://api.anthropic.com/api/oauth/usage", {
             headers: {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -18,6 +18,7 @@ import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
+import { claudeOauthToken } from "./claude-creds.ts";
 
 export type UsageWindow = {
   label: string;
@@ -67,8 +68,7 @@ function decodeJwt(token: unknown): Record<string, unknown> | null {
 async function claudeUsage(): Promise<ProviderUsage> {
   const base = { kind: "claude", label: "Claude", plan: null as string | null };
   try {
-    const creds = await Bun.file(join(HOME, ".claude", ".credentials.json")).json();
-    const token = creds?.claudeAiOauth?.accessToken;
+    const token = claudeOauthToken();
     if (!token) return { ...base, available: false, note: "Not signed in on this box" };
     const r = await fetch("https://api.anthropic.com/api/oauth/usage", {
       headers: { Authorization: `Bearer ${token}`, "anthropic-beta": "oauth-2025-04-20" },

--- a/src/voice-eleven-llm.ts
+++ b/src/voice-eleven-llm.ts
@@ -23,7 +23,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { claudeOauthToken } from "./claude-creds.ts";
 
 const PORT = Number(process.env.LFG_PORT ?? 8766);
 const LFG = `http://127.0.0.1:${PORT}`;
@@ -33,18 +33,7 @@ const MAX_TOOL_HOPS = 6;
 
 // ── Claude subscription OAuth, same source the rest of serve.ts uses ─────────
 function oauthToken(): string | null {
-  try {
-    const raw = readFileSync(
-      join(homedir(), ".claude", ".credentials.json"),
-      "utf8",
-    );
-    const creds = JSON.parse(raw) as {
-      claudeAiOauth?: { accessToken?: string };
-    };
-    return creds?.claudeAiOauth?.accessToken ?? null;
-  } catch {
-    return null;
-  }
+  return claudeOauthToken();
 }
 
 // ── system prompt — ported verbatim from agent.py VOICE_PROMPT so spoken

--- a/src/voice-intent.ts
+++ b/src/voice-intent.ts
@@ -13,9 +13,7 @@
 // confirmation, so the orb never fails to create a session because the brain hiccuped.
 // ─────────────────────────────────────────────────────────────────────────────
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
+import { claudeOauthToken } from "./claude-creds.ts";
 
 const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
 // Latency-critical voice path: reuse the same fast Haiku brain the rest of the
@@ -23,18 +21,7 @@ const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
 const INTENT_MODEL = process.env.LFG_VOICE_MODEL || "claude-haiku-4-5";
 
 function oauthToken(): string | null {
-  try {
-    const raw = readFileSync(
-      join(homedir(), ".claude", ".credentials.json"),
-      "utf8",
-    );
-    const creds = JSON.parse(raw) as {
-      claudeAiOauth?: { accessToken?: string };
-    };
-    return creds?.claudeAiOauth?.accessToken ?? null;
-  } catch {
-    return null;
-  }
+  return claudeOauthToken();
 }
 
 export type VoiceIntentBase = {


### PR DESCRIPTION
## Problem

On macOS, Claude Code stores its OAuth credentials in the login Keychain (service `"Claude Code-credentials"`), not in `~/.claude/.credentials.json`. lfg reads only the file, so on a Mac with a normal `claude` browser login:

- **Settings → Coding agents** shows Claude as *not signed in* (`hasClaudeAuth` file-existence check) even though sessions launch and work fine,
- **Settings → Usage** and `/api/claude/usage` report *"Not signed in on this box"* — the 5-hour / 7-day windows never populate,
- the voice-intent resolver and the ElevenLabs custom-LLM brain silently lose their subscription-OAuth path.

The Keychain item contains the exact same JSON blob the file would (`claudeAiOauth.accessToken` etc.), so this is purely a lookup-location gap.

## Fix

One shared helper, `src/claude-creds.ts`:

- reads `~/.claude/.credentials.json` first (Linux / unchanged behavior),
- falls back to `security find-generic-password -s "Claude Code-credentials" -w` on darwin,
- caches the token for 60s so dashboard polls don't shell out to `security` each time (Claude Code rewrites the Keychain item on token refresh, so a short TTL stays fresh).

All five existing readers now route through it: `usage.ts` (`claudeUsage`), `coding-agents.ts` (`hasClaudeAuth`), `serve.ts` (`claudeOauthToken` + the `/api/claude/usage` handler), `voice-intent.ts`, and `voice-eleven-llm.ts` — so the darwin fallback exists exactly once.

## Verified

On a macOS 26 box with Keychain-only Claude credentials (no `.credentials.json`), running under the launchd user service:

- `GET /api/coding-agents` → Claude `configured: true`, both checks green
- `GET /api/claude/usage` → real utilization windows returned
- `bunx tsc --noEmit` clean; `bun test` failures identical to the untouched tree (the two pre-existing release/restart cases)

No behavior change on Linux: the file path is still checked first, and the Keychain branch is gated on `process.platform === "darwin"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)