### PR TITLE
Show a started emoji badge on newly-created session cards

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10702,6 +10702,14 @@ const onTouchStart = (e: ReactTouchEvent) => {
               ) : null}
             </div>
           </button>
+        {entering ? (
+          <span
+            className="shrink-0 rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-semibold text-success ring-1 ring-inset ring-success/30"
+            title="Session just started"
+          >
+            🚀 started
+          </span>
+        ) : null}
         {session.status === "blocked" ? (
           <span
             className="shrink-0 rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-semibold text-warning ring-1 ring-inset ring-warning/30"


### PR DESCRIPTION
## Summary
- Add a `🚀 started` pill to `SessionCard` for the ~2s window a session is flagged `entering` (just created), mirroring the existing `⏸ paused` pill shown for `session.status === "blocked"`.

## Why
Investigated where a "task/session started" event is surfaced today: the codebase has no global emoji-status vocabulary (the fleet UI mostly uses colored dots/pills + lucide icons), but there IS one existing emoji-badge precedent — the `⏸ paused` pill in `SessionCard`. There's also already state tracking "just created" sessions (`recentlyCreatedSids` / `markCreatedSid()` / the `entering` prop), used today only to trigger a CSS entrance animation. This change reuses that existing signal to add a matching textual badge instead of introducing a new convention.

## Test plan
- [x] `web`: `tsc --noEmit` passes
- [x] `web`: `npm run build` (tsc + vite build) succeeds
- [x] Rendered the exact pill markup against the compiled app CSS with `agent-browser` and visually confirmed it matches the paused pill's style (screenshot attached in the LFG session transcript)
- [ ] Not run: full `lfg serve` + live session creation (would require booting the whole backend/tmux stack in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)