### PR TITLE
connect: forward auto-agent findings and open ask-user questions

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -27,11 +27,17 @@ import { PATHS } from "../config.ts";
 //   relay  → client   {type:"error", message}                  (pairing/hello rejected — relay closes right after)
 //   relay  → client   {type:"http", id, method, path, headers, bodyB64?}
 //   client → relay   {type:"http-response", id, status, headers, bodyB64?}
-//   client → relay   {type:"event", event, sessionId, title?, project?, agent?, ts}
+//   client → relay   {type:"event", event, sessionId, title?, project?, agent?, ts, …}
 //                     (opt-in, LFG_CONNECT_EVENTS=1 — see "Session lifecycle
 //                     events" below; no response frame, a relay that doesn't
 //                     understand `event` just ignores or errors it and this
-//                     client doesn't care either way)
+//                     client doesn't care either way. Every event kind shares
+//                     that envelope and only ADDS fields — ship.posted adds
+//                     summary/media, auto.finding adds
+//                     findingId/severity/reasoning/suggest, auto.question adds
+//                     questionId/question/options — so a relay that forwards
+//                     `event` frames verbatim needs no change to carry a new
+//                     kind.)
 //   either → other    {type:"ping"} / {type:"pong"}
 //
 // This is intentionally the smallest surface that lets a relay reverse-proxy
@@ -57,6 +63,29 @@ import { PATHS } from "../config.ts";
 // The very first poll after connecting only seeds a baseline (no events) so a
 // box that's had long-finished sessions sitting around doesn't fire a burst of
 // stale notifications on startup.
+//
+// Autonomous-agent events (same flag, same cadence, same first-poll seeding):
+//
+//   - "auto.finding" — a new finding produced by an auto agent (src/auto/*,
+//     read off GET /api/auto/findings?status=open). Auto agents run headless on
+//     a schedule; without this, their output only exists in this box's web UI
+//     and nobody hears about it until they open it. The frame carries the
+//     finding's title, severity, a capped slice of its reasoning, and its
+//     suggested next step, which is enough for a gateway to render something
+//     actionable without a second round-trip.
+//   - "auto.question" — an OPEN ask-user question (src/ask/*, read off
+//     GET /api/ask?status=open). An agent that needs a human decision parks a
+//     question here and ends its turn; the question sits open until somebody
+//     answers. Forwarding it lets a connected chat channel BE that somebody.
+//
+// The answer-back path needs nothing new in this file. A gateway that received
+// an auto.question answers it by proxying an ordinary HTTP request back down
+// the relay's request plane — the relay sends `{type:"http", …}` for
+// `POST /api/ask/<id>/answer`, forwardToLocalServe hands it to local serve, and
+// serve resolves the question (and, for a pushback ask, pushes the reply into
+// the asking session as a new user message). In other words the outbound event
+// and the inbound answer travel over the two planes this protocol already has;
+// `event` frames stay strictly one-way and response-free.
 //
 // This intentionally polls locally rather than opening a second WebSocket to
 // this box's own `/api/live/ws` status channel: `lfg connect` runs as a
@@ -85,7 +114,9 @@ import { PATHS } from "../config.ts";
 //     young it is, unlike routine completion.
 // See isTopLevelSession/isReportableTransition below.
 //
-// PRIVACY NOTE: when enabled, session titles (and project/agent names) leave
+// PRIVACY NOTE: when enabled, session titles (and project/agent names, ship
+// titles/summaries, auto-agent finding titles/reasoning, and the full text of
+// open ask-user questions) leave
 // this box and are sent to whatever relay LFG_RELAY_URL points at, which then
 // (per that relay's own policy) may forward them further (e.g. omg's relay
 // forwards to an operator-configured webhook — see BYO_COMPUTER.md in the
@@ -114,8 +145,9 @@ Env:
   LFG_PUBLIC_URL             Same value as --url; an absolute HTTP(S) root for this computer's web UI
   LFG_PORT / LFG_HOST        Local 'lfg serve' address to proxy requests to (default 127.0.0.1:8766)
   LFG_CONNECT_EVENTS         Opt-in (1/true/yes, default off): forward session completed/needs-attention
-                             events AND shipped-post events to the relay. PRIVACY: session titles and
-                             ship titles/summaries leave this box when on.
+                             events, shipped-post events, new auto-agent findings, and open ask-user
+                             questions to the relay. PRIVACY: session titles, ship titles/summaries,
+                             finding titles/reasoning, and question text leave this box when on.
   LFG_CONNECT_EVENTS_INTERVAL_MS  Local session-poll interval in ms when events are enabled (default 4000)
   LFG_CONNECT_EVENTS_MIN_DURATION_MS  Minimum session duration to report a completion, in ms (default 60000).
                              Does not apply to session.needs_attention (always reported).
@@ -332,6 +364,70 @@ export type ShipEventFrame = {
   ts: number;
 };
 
+/** A new auto-agent finding (src/auto/store.ts's `Finding`, read off
+ * GET /api/auto/findings?status=open). Same envelope as SessionEventFrame /
+ * ShipEventFrame so a relay that only knows how to forward `event` frames
+ * passes it through unchanged; `findingId`/`severity`/`reasoning`/`suggest`
+ * are the finding-specific extras. */
+export type AutoFindingEventFrame = {
+  type: "event";
+  event: "auto.finding";
+  /** `auto:<findingId>` — findings have no session of their own, and relays
+   * require a session-shaped id on every event frame (same trick ship.posted
+   * uses with `ship:<id>`). A finding's own sessionId is deliberately NOT
+   * used: it's set only after the human turns the finding into a session, by
+   * which point the finding is no longer `open` and was already forwarded. */
+  sessionId: string;
+  title: string | null;
+  project: string | null;
+  agent: string | null;
+  findingId: string;
+  severity: "high" | "med" | "low";
+  /** Capped at MAX_FINDING_REASONING lines — a finding's reasoning can run
+   * long, and a chat bubble truncates it anyway. */
+  reasoning: string[];
+  suggest: string | null;
+  ts: number;
+};
+
+/** An open ask-user question (src/ask/store.ts's `AskQuestion`, read off
+ * GET /api/ask?status=open). The receiving gateway answers by proxying
+ * `POST /api/ask/<id>/answer` back through the relay's request plane — see the
+ * doc block at the top of this file; nothing in this frame is a response
+ * channel. */
+export type AskEventFrame = {
+  type: "event";
+  event: "auto.question";
+  /** The question's own sessionId when it has one (so the gateway can
+   * associate the ask with a live coding session it may already be showing),
+   * else `ask:<id>` — same session-shaped-id requirement as above. */
+  sessionId: string;
+  /** Always null: the question text IS the content of this frame, and a
+   * question is not a session/ship title. Keeping title semantics honest
+   * beats duplicating `question` into a field that means something else. */
+  title: null;
+  project: string | null;
+  agent: string | null;
+  questionId: string;
+  question: string;
+  /** Suggested one-tap answers, capped at MAX_ASK_OPTIONS — a gateway
+   * rendering these as buttons has finite room. */
+  options: string[];
+  ts: number;
+};
+
+/** Per-tick emission cap, shared by both watchers below. A bulk import (an
+ * auto agent that just wrote 40 findings, or a first-ever poll on a box with a
+ * long-parked ask backlog that somehow escaped the seeding path) must not turn
+ * into 40 chat notifications. Anything over the cap is simply not forwarded —
+ * it is NOT queued for the next tick, because `seen` is updated for every row
+ * regardless: the box's own UI remains the complete record, and the relay is a
+ * best-effort notification channel (same posture as dropping a tick's events
+ * when the socket is closed). */
+const MAX_EVENTS_PER_TICK = 5;
+const MAX_FINDING_REASONING = 4;
+const MAX_ASK_OPTIONS = 4;
+
 function makeEventFrame(event: SessionEventFrame["event"], session: SessionLite, ts: number): SessionEventFrame {
   return {
     type: "event",
@@ -469,6 +565,183 @@ async function pollShipEvents(
   }
 }
 
+/** The subset of src/auto/store.ts's `Finding` this client reads off
+ * GET /api/auto/findings?status=open. */
+export type AutoFindingLite = {
+  id: string;
+  agentId?: string | null;
+  title?: string | null;
+  reasoning?: string[] | null;
+  suggest?: string | null;
+  severity?: "high" | "med" | "low" | null;
+  createdAt?: number | null;
+  status?: string | null;
+};
+
+/**
+ * Diffs one poll's open-findings list against the previously-seen id baseline
+ * (a Set, mutated in place — same contract as diffShipEvents: the caller owns
+ * it across ticks). First observation of an id only seeds the baseline, so
+ * restarting `lfg connect` on a box with a pile of unread findings never
+ * replays them as a burst of notifications.
+ *
+ * Ids that are no longer present (dismissed, read, or turned into a session —
+ * all of which drop the row out of `status=open`) are pruned from `seen` so a
+ * long-lived process can't grow the set without bound. A finding id is
+ * content-addressed and never reused (see src/auto/store.ts), so pruning can't
+ * cause a re-emit of something already reported.
+ */
+export function diffAutoFindingEvents(
+  seen: Set<string>,
+  findings: AutoFindingLite[],
+  firstPoll: boolean,
+): AutoFindingEventFrame[] {
+  const events: AutoFindingEventFrame[] = [];
+  const presentIds = new Set<string>();
+  for (const finding of findings) {
+    if (!finding.id) continue;
+    // Defensive: we ask for status=open, but an older `lfg serve` on this box
+    // may ignore the query param entirely and hand back everything. Never
+    // announce a finding the human already dealt with.
+    if ((finding.status ?? "open") !== "open") continue;
+    const title = finding.title?.trim();
+    if (!title) continue; // nothing to render on the other side
+    presentIds.add(finding.id);
+    const isNew = !seen.has(finding.id);
+    seen.add(finding.id);
+    if (firstPoll || !isNew) continue;
+    if (events.length >= MAX_EVENTS_PER_TICK) continue; // see MAX_EVENTS_PER_TICK
+    events.push({
+      type: "event",
+      event: "auto.finding",
+      sessionId: `auto:${finding.id}`,
+      title,
+      project: null,
+      agent: finding.agentId ?? null,
+      findingId: finding.id,
+      severity: finding.severity ?? "low",
+      reasoning: (finding.reasoning ?? []).filter((line) => typeof line === "string" && line.trim()).slice(0, MAX_FINDING_REASONING),
+      suggest: finding.suggest?.trim() || null,
+      ts: finding.createdAt ?? Date.now(),
+    });
+  }
+  for (const id of seen) {
+    if (!presentIds.has(id)) seen.delete(id);
+  }
+  return events;
+}
+
+/** The subset of src/ask/store.ts's `AskQuestion` this client reads off
+ * GET /api/ask?status=open. */
+export type AskLite = {
+  id: string;
+  question?: string | null;
+  options?: string[] | null;
+  agentId?: string | null;
+  sessionId?: string | null;
+  user?: string | null;
+  pushback?: boolean;
+  status?: string | null;
+  createdAt?: number | null;
+};
+
+/**
+ * Diffs one poll's open-questions list against the previously-seen id baseline
+ * (mutated in place — same contract as diffAutoFindingEvents).
+ *
+ * Answered/expired questions drop out of `status=open` and are pruned from
+ * `seen`. That prune is safe by construction: ask ids are unique per ask, so a
+ * question re-asked after being answered arrives with a NEW id and is a
+ * genuinely new event that deserves to be forwarded again.
+ */
+export function diffAskEvents(seen: Set<string>, questions: AskLite[], firstPoll: boolean): AskEventFrame[] {
+  const events: AskEventFrame[] = [];
+  const presentIds = new Set<string>();
+  for (const q of questions) {
+    if (!q.id) continue;
+    // Defensive, same reason as diffAutoFindingEvents: never surface a
+    // question that's already been answered or has expired.
+    if ((q.status ?? "open") !== "open") continue;
+    const question = q.question?.trim();
+    if (!question) continue;
+    presentIds.add(q.id);
+    const isNew = !seen.has(q.id);
+    seen.add(q.id);
+    if (firstPoll || !isNew) continue;
+    if (events.length >= MAX_EVENTS_PER_TICK) continue; // see MAX_EVENTS_PER_TICK
+    events.push({
+      type: "event",
+      event: "auto.question",
+      sessionId: q.sessionId?.trim() || `ask:${q.id}`,
+      title: null,
+      project: null,
+      agent: q.agentId ?? null,
+      questionId: q.id,
+      question,
+      options: (q.options ?? []).filter((o) => typeof o === "string" && o.trim()).slice(0, MAX_ASK_OPTIONS),
+      ts: q.createdAt ?? Date.now(),
+    });
+  }
+  for (const id of seen) {
+    if (!presentIds.has(id)) seen.delete(id);
+  }
+  return events;
+}
+
+async function pollAutoFindingEvents(
+  state: { seenFindings: Set<string>; seeded: boolean },
+  getSocket: () => WebSocket | null,
+): Promise<void> {
+  let findings: AutoFindingLite[];
+  try {
+    const response = await fetch(`http://${LOCAL_HOST}:${LOCAL_PORT}/api/auto/findings?status=open`);
+    if (!response.ok) return;
+    const body = (await response.json()) as { findings?: AutoFindingLite[] };
+    findings = body.findings ?? [];
+  } catch {
+    return; // local serve unreachable this tick — try again next tick.
+  }
+  const events = diffAutoFindingEvents(state.seenFindings, findings, !state.seeded);
+  state.seeded = true;
+  if (!events.length) return;
+  const ws = getSocket();
+  if (!ws || ws.readyState !== WebSocket.OPEN) return; // best-effort, same as sessions/ships.
+  for (const frame of events) {
+    try {
+      ws.send(JSON.stringify(frame));
+    } catch {
+      // best-effort — see pollSessionEvents.
+    }
+  }
+}
+
+async function pollAskEvents(
+  state: { seenAsks: Set<string>; seeded: boolean },
+  getSocket: () => WebSocket | null,
+): Promise<void> {
+  let questions: AskLite[];
+  try {
+    const response = await fetch(`http://${LOCAL_HOST}:${LOCAL_PORT}/api/ask?status=open`);
+    if (!response.ok) return;
+    const body = (await response.json()) as { questions?: AskLite[] };
+    questions = body.questions ?? [];
+  } catch {
+    return; // local serve unreachable this tick — try again next tick.
+  }
+  const events = diffAskEvents(state.seenAsks, questions, !state.seeded);
+  state.seeded = true;
+  if (!events.length) return;
+  const ws = getSocket();
+  if (!ws || ws.readyState !== WebSocket.OPEN) return; // best-effort, same as sessions/ships.
+  for (const frame of events) {
+    try {
+      ws.send(JSON.stringify(frame));
+    } catch {
+      // best-effort — see pollSessionEvents.
+    }
+  }
+}
+
 async function pollSessionEvents(seen: Map<string, SeenSession>, getSocket: () => WebSocket | null): Promise<void> {
   let sessions: SessionLite[];
   try {
@@ -567,7 +840,7 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
   let currentWs: WebSocket | null = null;
   if (eventsEnabled()) {
     console.log(
-      `lfg connect: forwarding session lifecycle events to the relay every ${EVENTS_POLL_MS}ms (LFG_CONNECT_EVENTS=1) — session titles will be sent to the relay.`,
+      `lfg connect: forwarding session lifecycle, shipped-post, auto-finding and ask-user events to the relay every ${EVENTS_POLL_MS}ms (LFG_CONNECT_EVENTS=1) — session titles, ship titles/summaries, finding titles/reasoning and question text will be sent to the relay.`,
     );
     const seen = new Map<string, SeenSession>();
     const timer = setInterval(() => void pollSessionEvents(seen, () => currentWs), EVENTS_POLL_MS);
@@ -578,6 +851,18 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
     const shipState = { seenShips: new Map<string, number>(), seeded: false };
     const shipTimer = setInterval(() => void pollShipEvents(shipState, () => currentWs), EVENTS_POLL_MS);
     shipTimer.unref?.();
+    // Auto-agent findings — headless agents produce these on their own
+    // schedule, so without this watcher their output never leaves the box's
+    // web UI.
+    const findingState = { seenFindings: new Set<string>(), seeded: false };
+    const findingTimer = setInterval(() => void pollAutoFindingEvents(findingState, () => currentWs), EVENTS_POLL_MS);
+    findingTimer.unref?.();
+    // Open ask-user questions — the outbound half of the human-in-the-loop
+    // path; the answer comes back as an ordinary relayed
+    // POST /api/ask/<id>/answer over the request plane (see the doc block).
+    const askState = { seenAsks: new Set<string>(), seeded: false };
+    const askTimer = setInterval(() => void pollAskEvents(askState, () => currentWs), EVENTS_POLL_MS);
+    askTimer.unref?.();
   }
 
   let backoffMs = RECONNECT_MIN_MS;

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  diffAskEvents,
+  diffAutoFindingEvents,
   diffSessionEvents,
   diffShipEvents,
   errorFrameMessage,
@@ -330,5 +332,174 @@ describe("diffShipEvents", () => {
     seen.set("seed", 1);
     const events = diffShipEvents(seen, [post({ sessionId: "sess-9" })], false);
     expect(events[0]!.sessionId).toBe("sess-9");
+  });
+});
+
+describe("diffAutoFindingEvents", () => {
+  const finding = (over: Partial<import("../src/commands/connect").AutoFindingLite>) => ({
+    id: "f1",
+    agentId: "inbox-triage",
+    title: "3 stale PRs are blocking the release branch",
+    reasoning: ["PR #12 has been open 9 days", "PR #14 conflicts with main"],
+    suggest: "rebase #14 first",
+    severity: "med" as const,
+    createdAt: 1000,
+    status: "open",
+    ...over,
+  });
+
+  test("first poll only seeds the baseline — never replays the open backlog", () => {
+    const seen = new Set<string>();
+    const events = diffAutoFindingEvents(seen, [finding({}), finding({ id: "f2" })], true);
+    expect(events).toEqual([]);
+    expect([...seen].sort()).toEqual(["f1", "f2"]);
+  });
+
+  test("a new finding after seeding emits one fully-shaped frame", () => {
+    const seen = new Set(["f1"]);
+    const events = diffAutoFindingEvents(seen, [finding({}), finding({ id: "f2", severity: "high" })], false);
+    expect(events).toEqual([
+      {
+        type: "event",
+        event: "auto.finding",
+        sessionId: "auto:f2",
+        title: "3 stale PRs are blocking the release branch",
+        project: null,
+        agent: "inbox-triage",
+        findingId: "f2",
+        severity: "high",
+        reasoning: ["PR #12 has been open 9 days", "PR #14 conflicts with main"],
+        suggest: "rebase #14 first",
+        ts: 1000,
+      },
+    ]);
+  });
+
+  test("a repeat poll of the same open findings emits nothing", () => {
+    const seen = new Set<string>();
+    expect(diffAutoFindingEvents(seen, [finding({})], false)).toHaveLength(1);
+    expect(diffAutoFindingEvents(seen, [finding({})], false)).toEqual([]);
+  });
+
+  test("findings that drop out of the open list are pruned from the baseline", () => {
+    const seen = new Set(["f1", "f2"]);
+    diffAutoFindingEvents(seen, [finding({ id: "f2" })], false);
+    expect([...seen]).toEqual(["f2"]);
+  });
+
+  test("caps emissions per tick so a bulk run can't flood the channel", () => {
+    const seen = new Set<string>();
+    const many = Array.from({ length: 9 }, (_, i) => finding({ id: `bulk-${i}` }));
+    const events = diffAutoFindingEvents(seen, many, false);
+    expect(events).toHaveLength(5);
+    // Over-cap rows are still baselined — they are dropped, not queued.
+    expect(seen.size).toBe(9);
+    expect(diffAutoFindingEvents(seen, many, false)).toEqual([]);
+  });
+
+  test("skips non-open rows (an older serve may ignore ?status=open) and empty titles", () => {
+    const seen = new Set<string>();
+    const events = diffAutoFindingEvents(
+      seen,
+      [finding({ id: "done", status: "dismissed" }), finding({ id: "blank", title: "   " }), finding({ id: "ok" })],
+      false,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]!.findingId).toBe("ok");
+    expect([...seen]).toEqual(["ok"]);
+  });
+
+  test("caps reasoning lines and normalizes missing optional fields", () => {
+    const seen = new Set<string>();
+    const events = diffAutoFindingEvents(
+      seen,
+      [finding({ reasoning: ["a", "b", "", "c", "d", "e"], suggest: undefined, severity: undefined, agentId: undefined })],
+      false,
+    );
+    expect(events[0]!.reasoning).toEqual(["a", "b", "c", "d"]);
+    expect(events[0]!.suggest).toBeNull();
+    expect(events[0]!.severity).toBe("low");
+    expect(events[0]!.agent).toBeNull();
+  });
+});
+
+describe("diffAskEvents", () => {
+  const ask = (over: Partial<import("../src/commands/connect").AskLite>) => ({
+    id: "q1",
+    question: "Ship the migration now or wait for the backup?",
+    options: ["ship", "wait"],
+    agentId: "release-bot",
+    sessionId: null,
+    status: "open",
+    createdAt: 2000,
+    ...over,
+  });
+
+  test("first poll only seeds the baseline — a parked question isn't re-asked on restart", () => {
+    const seen = new Set<string>();
+    expect(diffAskEvents(seen, [ask({}), ask({ id: "q2" })], true)).toEqual([]);
+    expect([...seen].sort()).toEqual(["q1", "q2"]);
+  });
+
+  test("a new open question emits one fully-shaped frame with the ask: fallback id", () => {
+    const seen = new Set(["q1"]);
+    const events = diffAskEvents(seen, [ask({}), ask({ id: "q2" })], false);
+    expect(events).toEqual([
+      {
+        type: "event",
+        event: "auto.question",
+        sessionId: "ask:q2",
+        title: null,
+        project: null,
+        agent: "release-bot",
+        questionId: "q2",
+        question: "Ship the migration now or wait for the backup?",
+        options: ["ship", "wait"],
+        ts: 2000,
+      },
+    ]);
+  });
+
+  test("a question bound to a live session keeps that sessionId", () => {
+    const seen = new Set<string>();
+    const events = diffAskEvents(seen, [ask({ sessionId: "sess-9" })], false);
+    expect(events[0]!.sessionId).toBe("sess-9");
+  });
+
+  test("a repeat poll of the same open question emits nothing", () => {
+    const seen = new Set<string>();
+    expect(diffAskEvents(seen, [ask({})], false)).toHaveLength(1);
+    expect(diffAskEvents(seen, [ask({})], false)).toEqual([]);
+  });
+
+  test("answered questions drop out of the open list and are pruned", () => {
+    const seen = new Set(["q1", "q2"]);
+    diffAskEvents(seen, [ask({ id: "q2" })], false);
+    expect([...seen]).toEqual(["q2"]);
+  });
+
+  test("caps emissions per tick", () => {
+    const seen = new Set<string>();
+    const many = Array.from({ length: 8 }, (_, i) => ask({ id: `q-${i}` }));
+    expect(diffAskEvents(seen, many, false)).toHaveLength(5);
+    expect(seen.size).toBe(8);
+  });
+
+  test("skips non-open rows and empty question text, and caps options", () => {
+    const seen = new Set<string>();
+    const events = diffAskEvents(
+      seen,
+      [
+        ask({ id: "answered", status: "answered" }),
+        ask({ id: "blank", question: "  " }),
+        ask({ id: "ok", options: ["a", "b", "", "c", "d", "e"], agentId: null }),
+      ],
+      false,
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]!.questionId).toBe("ok");
+    expect(events[0]!.options).toEqual(["a", "b", "c", "d"]);
+    expect(events[0]!.agent).toBeNull();
+    expect([...seen]).toEqual(["ok"]);
   });
 });


### PR DESCRIPTION
`lfg connect` already forwards `session.completed` / `session.needs_attention` / `ship.posted` to whatever gateway is on the other end of the relay. Two kinds were missing, and both are the output of agents that run with no human watching:

- **`auto.finding`** — a new finding from an auto agent (`src/auto/*`, read off `GET /api/auto/findings?status=open`). Auto agents run headless on a schedule; without this their output only exists in this box's web UI.
- **`auto.question`** — an OPEN ask-user question (`src/ask/*`, `GET /api/ask?status=open`). An agent that needs a human decision parks a question and ends its turn; forwarding it lets a connected chat channel *be* that human.

Same opt-in (`LFG_CONNECT_EVENTS=1`), same cadence, same best-effort posture, same envelope — every kind only ADDS fields, so a relay that forwards `event` frames verbatim carries these with no change.

**The answer-back path needs nothing new**: a gateway answers by proxying an ordinary `POST /api/ask/<id>/answer` down the relay's existing request plane.

Both diffs (`diffAutoFindingEvents` / `diffAskEvents`) are pure and mutate a caller-owned `Set` baseline, mirroring `diffShipEvents`: first poll only seeds, so restarting `lfg connect` never replays a backlog as a burst of notifications; ids that leave the open list are pruned so the set can't grow unbounded; non-open rows are skipped defensively (an older `serve` may ignore the `status` param); 5 frames/tick cap.

Privacy disclosure updated in all three places (startup line, `--help`, PRIVACY NOTE): finding titles/reasoning and question text leave the box when the flag is on.

`bun test test/connect.test.ts` — 52 pass (13 new); full suite 154 pass; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)