### PR TITLE
feat(connect): tunnel the session's live WebSocket over the relay socket

### DIFF
--- a/src/commands/connect-ws-tunnel.test.ts
+++ b/src/commands/connect-ws-tunnel.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyWsTunnelFrame,
+  isWsOpenFrame,
+  isWsTunnelFrame,
+  openLocalWsTunnel,
+  type WsTunnels,
+} from "./connect";
+
+/** Minimal EventTarget-ish stand-in for the local `lfg serve` WebSocket. */
+class FakeWs {
+  readyState = 0; // CONNECTING
+  binaryType = "";
+  sent: Array<string | Buffer> = [];
+  closed = false;
+  private listeners: Record<string, Array<(e: any) => void>> = {};
+  addEventListener(type: string, fn: (e: any) => void) {
+    (this.listeners[type] ??= []).push(fn);
+  }
+  emit(type: string, event?: any) {
+    for (const fn of this.listeners[type] ?? []) fn(event);
+  }
+  send(data: string | Buffer) {
+    this.sent.push(data);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+function setup() {
+  const tunnels: WsTunnels = new Map();
+  const out: any[] = [];
+  const fake = new FakeWs();
+  openLocalWsTunnel(
+    { type: "ws-open", id: "t1", path: "/api/live/ws" },
+    tunnels,
+    (p) => out.push(p),
+    () => fake as unknown as WebSocket,
+  );
+  return { tunnels, out, fake };
+}
+
+describe("ws tunnel frame guards", () => {
+  test("recognizes a ws-open frame", () => {
+    expect(isWsOpenFrame({ type: "ws-open", id: "a", path: "/x" })).toBe(true);
+    expect(isWsOpenFrame({ type: "ws-open", id: "a" })).toBe(false);
+    expect(isWsOpenFrame({ type: "http", id: "a", path: "/x" })).toBe(false);
+  });
+
+  test("recognizes ws-msg / ws-close but not ws-open", () => {
+    expect(isWsTunnelFrame({ type: "ws-msg", id: "a" })).toBe(true);
+    expect(isWsTunnelFrame({ type: "ws-close", id: "a" })).toBe(true);
+    expect(isWsTunnelFrame({ type: "ws-open", id: "a", path: "/x" })).toBe(false);
+  });
+});
+
+describe("openLocalWsTunnel", () => {
+  test("registers the tunnel and acks once the local socket opens", () => {
+    const { tunnels, out, fake } = setup();
+    expect(tunnels.get("t1")).toBeDefined();
+    fake.emit("open");
+    expect(out).toEqual([{ type: "ws-ack", id: "t1", ok: true }]);
+  });
+
+  test("forwards a text message from the box as base64", () => {
+    const { out, fake } = setup();
+    fake.emit("open");
+    fake.emit("message", { data: "hello" });
+    const msg = out.find((f) => f.type === "ws-msg");
+    expect(msg.binary).toBe(false);
+    expect(Buffer.from(msg.dataB64, "base64").toString("utf8")).toBe("hello");
+  });
+
+  test("forwards a binary message and flags it", () => {
+    const { out, fake } = setup();
+    fake.emit("open");
+    fake.emit("message", { data: new Uint8Array([1, 2, 3]).buffer });
+    const msg = out.find((f) => f.type === "ws-msg");
+    expect(msg.binary).toBe(true);
+    expect([...Buffer.from(msg.dataB64, "base64")]).toEqual([1, 2, 3]);
+  });
+
+  test("close removes the tunnel and reports it upstream", () => {
+    const { tunnels, out, fake } = setup();
+    fake.emit("open");
+    fake.emit("close", { code: 1006, reason: "gone" });
+    expect(tunnels.has("t1")).toBe(false);
+    expect(out.some((f) => f.type === "ws-close" && f.code === 1006)).toBe(true);
+  });
+
+  test("a failure while still CONNECTING acks the open as failed", () => {
+    const { tunnels, out, fake } = setup();
+    fake.readyState = 0; // CONNECTING
+    fake.emit("error");
+    expect(out.some((f) => f.type === "ws-ack" && f.ok === false)).toBe(true);
+    expect(tunnels.has("t1")).toBe(false);
+  });
+});
+
+describe("applyWsTunnelFrame", () => {
+  test("delivers a relayed text message to the local socket", () => {
+    const { tunnels, fake } = setup();
+    applyWsTunnelFrame(
+      { type: "ws-msg", id: "t1", dataB64: Buffer.from("ping").toString("base64"), binary: false },
+      tunnels,
+    );
+    expect(fake.sent).toEqual(["ping"]);
+  });
+
+  test("delivers binary as a Buffer", () => {
+    const { tunnels, fake } = setup();
+    applyWsTunnelFrame(
+      { type: "ws-msg", id: "t1", dataB64: Buffer.from([9, 8]).toString("base64"), binary: true },
+      tunnels,
+    );
+    expect([...(fake.sent[0] as Buffer)]).toEqual([9, 8]);
+  });
+
+  test("ws-close closes and forgets the tunnel", () => {
+    const { tunnels, fake } = setup();
+    applyWsTunnelFrame({ type: "ws-close", id: "t1" }, tunnels);
+    expect(fake.closed).toBe(true);
+    expect(tunnels.has("t1")).toBe(false);
+  });
+
+  test("an unknown id is ignored, never thrown", () => {
+    const { tunnels } = setup();
+    expect(() => applyWsTunnelFrame({ type: "ws-msg", id: "nope", dataB64: "" }, tunnels)).not.toThrow();
+  });
+});

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -246,6 +246,112 @@ export function errorFrameMessage(value: unknown): string | null {
  * reconnect loop treats this as fatal rather than backing off forever. */
 class RelayAuthError extends Error {}
 
+// ---- WebSocket tunnel (relay ⇄ this box ⇄ local `lfg serve`) ----
+//
+// The buffered `http`/`http-response` pair above can't carry the session UI's
+// live channels (`/api/live/ws`, and SSE on `/api/live/stream`). omg.dev cannot
+// reach this box directly — a tailnet host resolves to a private 100.x address
+// and Chrome's Private Network Access policy blocks a public origin from
+// loading it — so the live channel has to ride the SAME outbound socket the
+// relay already holds. Frames:
+//
+//   relay → box   {type:"ws-open",  id, path}
+//   box  → relay  {type:"ws-ack",   id, ok, error?}
+//   both          {type:"ws-msg",   id, dataB64, binary}
+//   both          {type:"ws-close", id, code?, reason?}
+
+export type WsOpenFrame = { type: "ws-open"; id: string; path: string };
+
+export function isWsOpenFrame(value: unknown): value is WsOpenFrame {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "ws-open" &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    typeof (value as { path?: unknown }).path === "string"
+  );
+}
+
+export function isWsTunnelFrame(value: unknown): value is { type: string; id: string; [k: string]: unknown } {
+  if (typeof value !== "object" || value === null) return false;
+  const type = (value as { type?: unknown }).type;
+  return (
+    (type === "ws-msg" || type === "ws-close") && typeof (value as { id?: unknown }).id === "string"
+  );
+}
+
+/** Live tunnels keyed by the relay-assigned id, so ws-msg/ws-close can route. */
+export type WsTunnels = Map<string, WebSocket>;
+
+/**
+ * Opens the local `lfg serve` WebSocket for a tunnel and wires both directions
+ * onto `send` (the relay socket). Kept exported + dependency-injected so the
+ * dispatch loop stays thin and this is unit-testable without a relay.
+ */
+export function openLocalWsTunnel(
+  frame: WsOpenFrame,
+  tunnels: WsTunnels,
+  send: (payload: unknown) => void,
+  connect: (url: string) => WebSocket = (url) => new WebSocket(url),
+): void {
+  let local: WebSocket;
+  try {
+    local = connect(`ws://${LOCAL_HOST}:${LOCAL_PORT}${frame.path}`);
+  } catch (error) {
+    send({ type: "ws-ack", id: frame.id, ok: false, error: String(error) });
+    return;
+  }
+  local.binaryType = "arraybuffer";
+  tunnels.set(frame.id, local);
+
+  local.addEventListener("open", () => send({ type: "ws-ack", id: frame.id, ok: true }));
+  local.addEventListener("message", (event: MessageEvent) => {
+    const data = event.data;
+    const binary = typeof data !== "string";
+    const buf = binary
+      ? Buffer.from(data as ArrayBuffer)
+      : Buffer.from(String(data), "utf8");
+    send({ type: "ws-msg", id: frame.id, dataB64: buf.toString("base64"), binary });
+  });
+  local.addEventListener("close", (event: CloseEvent) => {
+    tunnels.delete(frame.id);
+    send({ type: "ws-close", id: frame.id, code: event?.code, reason: event?.reason });
+  });
+  local.addEventListener("error", () => {
+    // `error` is always followed by `close`; ack a failed OPEN so the relay
+    // stops waiting, but don't double-send a close.
+    if (local.readyState === WebSocket.CONNECTING) {
+      tunnels.delete(frame.id);
+      send({ type: "ws-ack", id: frame.id, ok: false, error: "local websocket failed" });
+    }
+  });
+}
+
+/** Routes a ws-msg/ws-close frame from the relay onto the matching local socket. */
+export function applyWsTunnelFrame(
+  frame: { type: string; id: string; [k: string]: unknown },
+  tunnels: WsTunnels,
+): void {
+  const local = tunnels.get(frame.id);
+  if (!local) return;
+  if (frame.type === "ws-close") {
+    tunnels.delete(frame.id);
+    try {
+      local.close();
+    } catch {
+      /* already closing */
+    }
+    return;
+  }
+  const dataB64 = typeof frame.dataB64 === "string" ? frame.dataB64 : "";
+  const buf = Buffer.from(dataB64, "base64");
+  try {
+    local.send(frame.binary ? buf : buf.toString("utf8"));
+  } catch {
+    /* socket raced closed — the close frame will clean up */
+  }
+}
+
 /** Proxies one relayed HTTP request onto this box's own `lfg serve`. */
 export async function forwardToLocalServe(frame: HttpFrame): Promise<{
   type: "http-response";
@@ -879,6 +985,16 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
       console.log(`lfg connect: connected — proxying to local serve on ${LOCAL_HOST}:${LOCAL_PORT}`);
 
       let authRejected: string | null = null;
+      // Live WS tunnels for this relay connection. Dropped wholesale when the
+      // relay socket closes, so a reconnect never resurrects a stale tunnel.
+      const wsTunnels: WsTunnels = new Map();
+      const sendFrame = (payload: unknown) => {
+        try {
+          ws.send(JSON.stringify(payload));
+        } catch {
+          /* relay socket closing — the close handler tears the tunnels down */
+        }
+      };
       await new Promise<void>((resolveClosed) => {
         ws.addEventListener("message", (event) => {
           void (async () => {
@@ -898,12 +1014,30 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
               ws.close();
               return;
             }
+            if (isWsOpenFrame(frame)) {
+              openLocalWsTunnel(frame, wsTunnels, sendFrame);
+              return;
+            }
+            if (isWsTunnelFrame(frame)) {
+              applyWsTunnelFrame(frame, wsTunnels);
+              return;
+            }
             if (isHttpFrame(frame)) ws.send(JSON.stringify(await forwardToLocalServe(frame)));
           })();
         });
         ws.addEventListener("close", () => resolveClosed());
         ws.addEventListener("error", () => resolveClosed());
       });
+      // Tear down every tunnel with the relay socket — a half-open local
+      // socket would otherwise leak and send into a dead relay connection.
+      for (const local of wsTunnels.values()) {
+        try {
+          local.close();
+        } catch {
+          /* already closing */
+        }
+      }
+      wsTunnels.clear();
       currentWs = null;
       if (authRejected) throw new RelayAuthError(authRejected);
       console.log("lfg connect: relay connection closed — reconnecting");

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -38,11 +38,21 @@ import { PATHS } from "../config.ts";
 //                     questionId/question/options — so a relay that forwards
 //                     `event` frames verbatim needs no change to carry a new
 //                     kind.)
+//   relay  → client   {type:"ws-open",  id, path}               (open a tunnel onto local serve's WebSocket)
+//   client → relay    {type:"ws-ack",   id, ok, error?}
+//   either → other    {type:"ws-msg",   id, dataB64, binary}
+//   either → other    {type:"ws-close", id, code?, reason?}
 //   either → other    {type:"ping"} / {type:"pong"}
 //
 // This is intentionally the smallest surface that lets a relay reverse-proxy
-// HTTP semantics (incl. serve.ts's SSE/WS endpoints, tunneled as ordinary
-// request/response framing) onto a box with no inbound port open. An `error`
+// HTTP semantics onto a box with no inbound port open. Ordinary requests use
+// the buffered http/http-response pair; the ws-* frames add a real duplex
+// tunnel, because a live channel (serve.ts's /api/live/ws) genuinely cannot be
+// expressed as one request/response. That tunnel is what lets a PUBLIC origin
+// render a session hosted on this box at all: a tailnet box resolves to a
+// private 100.x address, and a browser on a public origin is forbidden from
+// loading it (Chrome Private Network Access), so the bytes have to come back
+// over this outbound socket rather than a direct connection. An `error`
 // frame during `hello` means the saved token is no longer valid (expired,
 // revoked, or unknown to the relay) — that will never resolve by retrying,
 // so the reconnect loop below treats it as fatal rather than backing off


### PR DESCRIPTION
Box side of the omg session proxy.

**Why a real tunnel is required.** omg.dev cannot reach a BYO box directly: a tailnet host resolves to a private `100.x` CGNAT address, and Chrome's Private Network Access policy forbids a *public* origin from loading a *private*-network resource. Verified live — every embed attempt died with `net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`, while the same URL opens fine as a top-level navigation. So the session bytes have to come back over the outbound socket the relay already holds.

The buffered `http`/`http-response` pair can't express a live channel (`/api/live/ws`), so this adds duplex frames:

```
relay → box   {type:"ws-open",  id, path}
box   → relay {type:"ws-ack",   id, ok, error?}
both          {type:"ws-msg",   id, dataB64, binary}
both          {type:"ws-close", id, code?, reason?}
```

Tunnels are tracked per relay connection and torn down with it, so a reconnect can never resurrect a stale one. Open/msg/close handling is dependency-injected and unit-tested without a relay (11 tests).

Next: the relay-side bridge and the authenticated control-plane proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)