### PR TITLE
feat(web): introduce TanStack Router with path-based routing

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",
+        "@tanstack/react-router": "^1.170.18",
         "ai": "^7.0.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1892,6 +1893,89 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/history": {
+      "version": "1.162.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.162.0.tgz",
+      "integrity": "sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.170.18",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.18.tgz",
+      "integrity": "sha512-wpbGYZEp/fmz1q4bn7BD8VZ+/VZ7GBqSJv5V969pU+chP8y7dquWDmKTFMohvUegb9lg12m1uPVvD6kB2wORvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.162.0",
+        "@tanstack/react-store": "^0.9.3",
+        "@tanstack/router-core": "1.171.15",
+        "isbot": "^5.1.22"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
+      "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.9.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.171.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.15.tgz",
+      "integrity": "sha512-IILCDcLaItMZQ2jEmCABHY1Nhjjn5XUvwpQp3e4Nmu+vfg0BgYFuu/QASz2SwE2ZNbVMrvt8X/wxa+Gg5aErxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.162.0",
+        "cookie-es": "^3.0.0",
+        "seroval": "^1.5.4",
+        "seroval-plugins": "^1.5.4"
+      },
+      "engines": {
+        "node": ">=20.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
+      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "dev": true,
@@ -3193,6 +3277,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
@@ -5223,6 +5313,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isbot": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.2.1.tgz",
+      "integrity": "sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/isexe": {
@@ -7758,6 +7857,27 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.6.tgz",
+      "integrity": "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
       }
     },
     "node_modules/serve-static": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
+    "@tanstack/react-router": "^1.170.18",
     "ai": "^7.0.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,7 @@
 import { Component, createContext, type ComponentProps, forwardRef, memo, Suspense, useCallback, useContext, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import { DEFAULT_TAB, pathnameToTab } from "./lib/app-search";
 import { useChat } from "@ai-sdk/react";
 import {
   DEFAULT_SCHED_TZ,
@@ -3422,10 +3424,27 @@ export function App() {
   // Tabs are "live" | "settings" | "ask" | "term" | "browser". Auto agents and runtime
   // extension nav-tabs now render inside the Settings page rather than as their
   // own top-level tabs.
-  // ?tab=shipped|artifacts|settings|… deep-links straight to a page (also lets
-  // tooling/screenshots reach pages that are otherwise gesture-only on mobile).
-  const [tab, setTab] = useState<string>(
-    () => new URLSearchParams(window.location.search).get("tab") || "live",
+  // Routing lives in the URL now (TanStack Router). The visible page IS the
+  // path: `/settings`, `/usage`, `/<extension-tab>`, with `/` meaning the
+  // default ("live"). Shareable, back/forward-aware, and survives a hard
+  // refresh via the server's SPA fallback. App is mounted at the root route so
+  // switching pages re-renders here rather than remounting the whole app.
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const tab: string = pathnameToTab(pathname);
+  // Backwards-compatible with the old `useState` API: accepts a literal tab id
+  // (a built-in page or an extension tab) or an updater `(current) => next`, and
+  // navigates to the matching path. Kept identity-stable (reads the current tab
+  // from a ref, not a closure) so passing it to children doesn't churn them.
+  const tabRef = useRef(tab);
+  tabRef.current = tab;
+  const setTab = useCallback(
+    (next: string | ((current: string) => string)) => {
+      const resolved = typeof next === "function" ? next(tabRef.current) : next;
+      if (resolved === DEFAULT_TAB) void navigate({ to: "/" });
+      else void navigate({ to: "/$tab", params: { tab: resolved } });
+    },
+    [navigate],
   );
   const extNavTabs = useExtensionNavTabs();
   const [autoAgents, setAutoAgents] = useState<AutoAgent[]>([]);
@@ -3806,7 +3825,8 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    history.replaceState(null, "", selected === "__live" ? "#/__live" : `#/${selected}`);
+    // (The router owns the URL now; this legacy effect only resets report
+    // state. `selected` is pinned to "__live" — see its declaration.)
     if (selected === "__live") {
       setReports([]);
       setReport(null);
@@ -7327,9 +7347,10 @@ function RailStage({
   // list (session-link cards from external surfaces, e.g. a relay operator's
   // messaging bridge, land here). Consumed once — later list refreshes never
   // re-steal focus.
+  const deepLinkSearch = useSearch({ strict: false });
   const sessionDeepLinkRef = useRef<string | null | undefined>(undefined);
   if (sessionDeepLinkRef.current === undefined) {
-    sessionDeepLinkRef.current = new URLSearchParams(window.location.search).get("session");
+    sessionDeepLinkRef.current = deepLinkSearch.session ?? null;
   }
   useEffect(() => {
     const sid = sessionDeepLinkRef.current;

--- a/web/src/lib/app-search.ts
+++ b/web/src/lib/app-search.ts
@@ -1,0 +1,72 @@
+// The typed URL contract for the app, shared by the router (which validates it)
+// and App.tsx (which reads/writes it). Kept in its own module so neither has to
+// import the other — router.tsx imports <App>, so App.tsx pulling the schema
+// from router.tsx would be a cycle.
+//
+// Routing is PATH-based: the visible page is the first path segment
+// (`/settings`, `/usage`, `/my-extension-tab`), with `/` meaning the default
+// ("live"). The only search param is `session` — an external deep-link contract
+// (see below). A legacy `?tab=` param is still accepted on `/` and redirected to
+// the matching path so old links/bookmarks keep working.
+
+/** The built-in top-level pages. NOT exhaustive: runtime extensions register
+ *  their own nav tabs with arbitrary ids (see useExtensionNavTabs), so a tab is
+ *  typed as `string`, not this union. These values document the known set. */
+export const TAB_VALUES = [
+  "live",
+  "shipped",
+  "artifacts",
+  "settings",
+  "ask",
+  "auto",
+  "usage",
+  "coding-agents",
+  "changelog",
+  "term",
+  "browser",
+] as const;
+export type Tab = (typeof TAB_VALUES)[number];
+export const DEFAULT_TAB: Tab = "live";
+
+/** The visible page for a pathname — the first path segment, or the default
+ *  ("live") at the root. An id matching no built-in page and no extension tab
+ *  renders the Settings page (the app's existing catch-all). */
+export function pathnameToTab(pathname: string): string {
+  const seg = pathname.split("/").filter(Boolean)[0];
+  return seg ? decodeURIComponent(seg) : DEFAULT_TAB;
+}
+
+/** The URL path for a tab. The default tab lives at `/` (kept segment-free so
+ *  the common link stays clean); every other tab is a single path segment. */
+export function tabToPath(tab: string): string {
+  return tab === DEFAULT_TAB ? "/" : `/${encodeURIComponent(tab)}`;
+}
+
+/** The typed shape of the app's search params (path aside). */
+export interface AppSearch {
+  /** Deep link to focus a session on load. EXTERNAL CONTRACT: the server emits
+   *  `/?session=<id>` via `publicSessionUrl` into messaging bridges and Shipped
+   *  posts, so this key must never be renamed or dropped. */
+  session?: string;
+}
+
+/** Validate the search params carried on every route. */
+export function validateAppSearch(search: Record<string, unknown>): AppSearch {
+  const out: AppSearch = {};
+  if (typeof search.session === "string" && search.session) out.session = search.session;
+  return out;
+}
+
+/** The index (`/`) route additionally tolerates a legacy `?tab=` param so old
+ *  links redirect to the matching path. */
+export interface IndexSearch extends AppSearch {
+  tab?: string;
+}
+
+export function validateIndexSearch(search: Record<string, unknown>): IndexSearch {
+  const out: IndexSearch = validateAppSearch(search);
+  if (typeof search.tab === "string" && search.tab && search.tab !== DEFAULT_TAB) {
+    out.tab = search.tab;
+  }
+  return out;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,7 +5,9 @@ import { createRoot } from "react-dom/client";
 import * as ReactDOM from "react-dom";
 import "./index.css";
 import { toast } from "sonner";
-import { App, RootErrorBoundary } from "./App";
+import { RouterProvider } from "@tanstack/react-router";
+import { RootErrorBoundary } from "./App";
+import { router } from "./router";
 import { registerExtension } from "./lib/extensions";
 import { installErrorReporting } from "./lib/report-error";
 import { AppDialogProvider } from "@/components/ui/app-dialog";
@@ -55,7 +57,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <RootErrorBoundary>
       <AppDialogProvider>
-        <App />
+        <RouterProvider router={router} />
       </AppDialogProvider>
     </RootErrorBoundary>
   </StrictMode>,

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,0 +1,61 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+} from "@tanstack/react-router";
+import { App } from "./App";
+import {
+  tabToPath,
+  validateAppSearch,
+  validateIndexSearch,
+} from "./lib/app-search";
+
+// App is rendered by the ROOT route so it stays mounted across every page
+// change — the page is selected by the URL path (read inside App via
+// useRouterState), not by swapping route components. Remounting the ~16k-line
+// App on each tab switch would blow away sessions, live streams and scroll, so
+// the child routes below exist only to make each path a valid match (and to
+// hold per-route search validation); they render nothing themselves.
+const rootRoute = createRootRoute({
+  component: App,
+});
+
+// `/` → the default page ("live"). Also honors a legacy `?tab=` param by
+// redirecting to the matching path, so old links and bookmarks keep working.
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  validateSearch: validateIndexSearch,
+  beforeLoad: ({ search }) => {
+    if (search.tab) {
+      throw redirect({
+        to: tabToPath(search.tab),
+        search: search.session ? { session: search.session } : {},
+        replace: true,
+      });
+    }
+  },
+  component: () => null,
+});
+
+// `/$tab` → any single-segment page: a built-in page or an extension tab id.
+const tabRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "$tab",
+  validateSearch: validateAppSearch,
+  component: () => null,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, tabRoute]);
+
+export const router = createRouter({
+  routeTree,
+  defaultPreload: false,
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
## What

Puts the web app on a real router. Previously there was none: `?tab=` was read once on mount and never written back, so switching pages didn't change the URL, the back button didn't work across pages, and no page was shareable. A dead `#/__live` hash was written every render but never read.

Now the visible page **is the URL path** — `/settings`, `/usage`, `/coding-agents`, `/<extension-tab>`, and `/` for the default (`live`). Navigation is shareable, back/forward-aware, and survives a hard refresh.

## How

- **App mounted at the root route**, reading the current page from the path (`useRouterState`). The `/` and `/$tab` child routes render nothing. This keeps the ~16k-line `App` mounted across page changes instead of remounting it — a remount would blow away sessions, live streams, and scroll on every tab switch.
- A small identity-stable `setTab` adapter preserves every existing `useState`-style call site but navigates by path.
- Tabs are typed `string`, not a closed enum — extensions register nav tabs with arbitrary ids; an unknown id renders Settings (the existing catch-all).
- **`?session=<id>` preserved verbatim** (the server emits it via `publicSessionUrl` into external surfaces). Legacy `/?tab=X` redirects to `/X`, carrying `&session=`.

## No server/SW change needed

The server already serves `index.html` for non-`/api`, non-`/asset` HTML navigations (`serve.ts:5884`), and the service worker is already network-first with a `/` shell fallback. So this is purely 3 frontend files.

## Verified

Playwright, desktop + mobile, against the live service — in-app nav changes the path without a reload; back/forward move between pages; hard-refresh of `/settings` and `/usage` render; legacy `?tab=` redirects; `?session=` still focuses its session; artifact-viewer `history.state` coexists with the router. Zero page errors; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)