### PR TITLE
feat: add lfg_find_sessions (historical/ended session lookup)

### DIFF
--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { closeLfgSession, sendToOrigin } from "./mcp.ts";
+import { closeLfgSession, findLfgSessions, sendToOrigin } from "./mcp.ts";
 
 const originalFetch = globalThis.fetch;
 const originalBase = process.env.LFG_BASE;
@@ -39,6 +39,43 @@ describe("closeLfgSession", () => {
     await expect(closeLfgSession("same-session")).rejects.toThrow(
       "lfg_close_session cannot close the calling session",
     );
+  });
+});
+
+describe("findLfgSessions", () => {
+  test("queries the historical session API with composable filters", async () => {
+    process.env.LFG_BASE = "http://127.0.0.1:9876";
+    let request: { url: string; init?: RequestInit } | undefined;
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      request = { url: String(url), init };
+      return Response.json({ sessions: [], candidateTotal: 0, scanned: 0, truncated: false });
+    }) as typeof fetch;
+
+    await expect(findLfgSessions({
+      sessionId: "abcd",
+      user: "dev@example.com",
+      project: "/repos/lfg",
+      text: "historical finder",
+      activeAfter: "2026-07-01T00:00:00Z",
+      activeBefore: "2026-07-24T00:00:00Z",
+      limit: 20,
+      scanLimit: 100,
+    })).resolves.toMatchObject({ sessions: [], candidateTotal: 0 });
+    expect(request?.url).toBe("http://127.0.0.1:9876/api/sessions/find");
+    expect(request?.init).toMatchObject({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "abcd",
+        user: "dev@example.com",
+        project: "/repos/lfg",
+        text: "historical finder",
+        activeAfter: "2026-07-01T00:00:00Z",
+        activeBefore: "2026-07-24T00:00:00Z",
+        limit: 20,
+        scanLimit: 100,
+      }),
+    });
   });
 });
 

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -135,6 +135,25 @@ export async function closeLfgSession(sessionIdInput: string) {
   return { closed: data.ok !== false, sessionId };
 }
 
+export type FindLfgSessionsInput = {
+  sessionId?: string;
+  user?: string;
+  project?: string;
+  text?: string;
+  activeAfter?: string;
+  activeBefore?: string;
+  limit?: number;
+  scanLimit?: number;
+};
+
+export async function findLfgSessions(input: FindLfgSessionsInput) {
+  return api("/api/sessions/find", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
 function ownedSessionId(input?: string): string {
   const sessionId = activeSessionId(input);
   const caller = process.env.LFG_SESSION_ID?.trim();
@@ -331,6 +350,56 @@ export async function cmdMcp() {
       });
       return result({ sessions: filtered });
     },
+  );
+
+  server.registerTool(
+    "lfg_find_sessions",
+    {
+      title: "Find Historical LFG Sessions",
+      description:
+        "Find durable LFG sessions, including ended sessions no longer present in tmux or the process table. Filters compose, results are newest-first, and text searches titles plus normalized transcript content.",
+      inputSchema: {
+        sessionId: z
+          .string()
+          .optional()
+          .describe("Exact session id or id prefix."),
+        user: z
+          .string()
+          .optional()
+          .describe("Exact assigned user email."),
+        project: z
+          .string()
+          .optional()
+          .describe("Case-insensitive substring of the project label or cwd."),
+        text: z
+          .string()
+          .optional()
+          .describe("All-term text match against the title or normalized transcript content."),
+        activeAfter: z
+          .string()
+          .optional()
+          .describe("Only sessions active at or after this ISO 8601 timestamp."),
+        activeBefore: z
+          .string()
+          .optional()
+          .describe("Only sessions active at or before this ISO 8601 timestamp."),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Maximum results (default 30, maximum 100)."),
+        scanLimit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Maximum newest metadata candidates to transcript-search (default 200, maximum 500)."),
+      },
+    },
+    async (input) => result(await findLfgSessions(input)),
   );
 
   server.registerTool(

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -77,6 +77,7 @@ import {
   sessionIdForPid,
   pendingToolPrompt,
   listResumable,
+  findSessions,
   queryResumable,
   refreshResumableCache,
   cwdForTranscript,
@@ -741,22 +742,40 @@ function persistManagedResume(session: Session): void {
         : session.agent === "pi"
           ? "pi"
           : null;
-  if (!backend) return;
+  if (!backend && !session.transcriptPath) return;
+  const fileBackedId =
+    session.nativeSessionId ??
+    session.transcriptPath?.match(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/)?.[0] ??
+    session.sessionId;
+  const sessionId = backend ? session.sessionId : fileBackedId;
+  const agent =
+    backend === "codex-aisdk" || session.agent === "codex"
+      ? "codex"
+      : backend === "opencode"
+        ? "opencode"
+        : backend === "pi"
+          ? "pi"
+          : session.agent === "grok"
+            ? "grok"
+            : session.agent === "cursor"
+              ? "cursor"
+              : "claude";
   upsertResumableRows([{
-    sessionId: session.sessionId,
+    sessionId,
     cwd: session.cwd,
     project: session.project,
     title: session.title,
     lastActivityAt: session.lastActivityAt ?? Date.now(),
     lastUserText: session.lastUserText,
-    agent: backend === "codex-aisdk" ? "codex" : backend === "opencode" ? "opencode" : backend === "pi" ? "pi" : "claude",
-    path: sessionIndexKey(session.sessionId),
+    agent,
+    path: backend ? sessionIndexKey(session.sessionId) : session.transcriptPath,
     mtimeMs: session.lastActivityAt ?? Date.now(),
-    backend,
-    resumeHandle: session.nativeSessionId || session.sessionId,
+    backend: backend ?? undefined,
+    resumeHandle: backend ? session.nativeSessionId || session.sessionId : undefined,
     model: session.model,
     assignedUser: session.assignedUser,
-    managed: true,
+    managed: !!backend,
+    resumable: agent !== "grok" && agent !== "cursor",
   }]);
 }
 
@@ -3583,6 +3602,45 @@ export async function cmdServe() {
         return json({ sessions, total, facets });
       }
 
+      if (path === "/api/sessions/find" && req.method === "POST") {
+        const body = (await req.json().catch(() => null)) as {
+          sessionId?: unknown;
+          user?: unknown;
+          project?: unknown;
+          text?: unknown;
+          activeAfter?: unknown;
+          activeBefore?: unknown;
+          limit?: unknown;
+          scanLimit?: unknown;
+        } | null;
+        const parseTime = (value: unknown, field: string): number | undefined => {
+          if (value === undefined || value === null || value === "") return undefined;
+          const parsed =
+            typeof value === "number"
+              ? value
+              : typeof value === "string"
+                ? Date.parse(value)
+                : Number.NaN;
+          if (!Number.isFinite(parsed)) throw new Error(`${field} must be an ISO 8601 timestamp`);
+          return parsed;
+        };
+        try {
+          const live = await listSessionsCached();
+          return json(await findSessions({
+            sessionId: typeof body?.sessionId === "string" ? body.sessionId.trim() || undefined : undefined,
+            user: typeof body?.user === "string" ? body.user.trim() || undefined : undefined,
+            project: typeof body?.project === "string" ? body.project.trim() || undefined : undefined,
+            text: typeof body?.text === "string" ? body.text.trim() || undefined : undefined,
+            activeAfter: parseTime(body?.activeAfter, "activeAfter"),
+            activeBefore: parseTime(body?.activeBefore, "activeBefore"),
+            limit: typeof body?.limit === "number" ? body.limit : undefined,
+            scanLimit: typeof body?.scanLimit === "number" ? body.scanLimit : undefined,
+          }, live));
+        } catch (error) {
+          return err(400, error instanceof Error ? error.message : String(error));
+        }
+      }
+
       // Resume a closed session in its original cwd as a fresh managed session,
       // preserving the full conversation. Two engines:
       //  - claude: relaunch `claude --resume <id>`; it continues into a NEW
@@ -5262,8 +5320,8 @@ export async function cmdServe() {
             managed: sess?.managed,
           });
           if (!sess) return err(404, "session not found");
+          persistManagedResume(sess);
           if (isCommandFileAgent(sess.agent)) {
-            persistManagedResume(sess);
             // Ask the harness to shut down, then tear down its supervisor pane and
             // control-plane files. markClosed tombstones the harness pid so the
             // session drops out of the list immediately. For codex-aisdk the

--- a/src/lfg-capabilities.test.ts
+++ b/src/lfg-capabilities.test.ts
@@ -15,6 +15,7 @@ describe("LFG runtime capabilities", () => {
     expect(prompt).toContain("lfg_publish_artifact");
     expect(prompt).toContain("lfg_ship");
     expect(prompt).toContain("lfg_ask_user");
+    expect(prompt).toContain("lfg_find_sessions");
     expect(prompt).toContain("lfg_close_session");
     expect(prompt).toEndWith("=== USER TASK ===\nFix the mobile navigation");
   });
@@ -32,6 +33,7 @@ describe("LFG runtime capabilities", () => {
   test("publishes a bootstrap entry for every promoted workflow", () => {
     expect(LFG_CAPABILITIES.map((item) => item.tool)).toEqual([
       "lfg_send_to_origin",
+      "lfg_find_sessions",
       "lfg_close_session",
       "lfg_ship",
       "lfg_display_image / lfg_display_video",

--- a/src/lfg-capabilities.ts
+++ b/src/lfg-capabilities.ts
@@ -3,13 +3,18 @@ import type { CodingAgentKind } from "./coding-agents.ts";
 // Bump whenever an agent-facing LFG capability or its operating guidance
 // changes. Managed sessions persist the value they launched with, which lets
 // the UI identify long-lived sessions whose MCP/tool catalog predates a ship.
-export const LFG_CAPABILITY_VERSION = "2026-07-23.1";
+export const LFG_CAPABILITY_VERSION = "2026-07-24.1";
 
 export const LFG_CAPABILITIES = [
   {
     tool: "lfg_send_to_origin",
     useWhen: "The agent should intentionally deliver text or visual evidence back to the channel that launched this session.",
     guidance: "Send only user-facing results. The origin adapter owns transport and identity; never request phone numbers or channel credentials.",
+  },
+  {
+    tool: "lfg_find_sessions",
+    useWhen: "An ended or historical LFG session must be located after its tmux pane or process disappeared.",
+    guidance: "Filter by id/prefix, user, project/cwd, title/transcript text, or last-activity range; use lfg_list_sessions for the current live fleet.",
   },
   {
     tool: "lfg_close_session",
@@ -56,6 +61,7 @@ export function lfgRuntimeContract(): string {
     "- You are running as an LFG-managed coding agent. LFG features are part of the product workflow, not optional implementation trivia.",
     "- After visual or interaction work, capture verification media and show the best evidence with `lfg_display_image` or `lfg_display_video`.",
     "- Use `lfg_send_to_origin` when the user wants a result intentionally delivered back to the channel that launched this session. The origin adapter owns transport identity and credentials.",
+    "- Use `lfg_find_sessions` to locate ended or historical sessions by id, owner, project, text, or last-activity range; use `lfg_list_sessions` for the live fleet.",
     "- When a report, data view, or live dashboard is materially clearer as interactive HTML than prose, publish it with `lfg_publish_artifact`; use a stable id for updates.",
     "- When material user-visible work is complete and verified, call `lfg_ship` with a concise showcase and the strongest media. Do not ship diagnosis, planning, partial, invisible, or trivial work.",
     "- Use `lfg_ask_user` only for a risky, irreversible, or genuinely ambiguous decision. It is fire-and-forget: do not poll or block waiting for the answer.",

--- a/src/migrations/resume-cache/002_historical_sessions.sql
+++ b/src/migrations/resume-cache/002_historical_sessions.sql
@@ -1,0 +1,6 @@
+ALTER TABLE resumable_sessions ADD COLUMN resumable INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS resumable_sessions_user
+  ON resumable_sessions(assigned_user);
+
+PRAGMA user_version = 2;

--- a/src/resume-cache-historical.test.ts
+++ b/src/resume-cache-historical.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import {
+  queryHistoricalCache,
+  queryResumableCache,
+  resetResumeCacheConnectionForTests,
+  upsertResumableRows,
+} from "./resume-cache.ts";
+
+const originalData = PATHS.data;
+let root = "";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lfg-historical-cache-"));
+  PATHS.data = root;
+  resetResumeCacheConnectionForTests();
+});
+
+afterEach(() => {
+  resetResumeCacheConnectionForTests();
+  PATHS.data = originalData;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("historical session cache", () => {
+  test("filters by id prefix, user, project/cwd, and activity range", () => {
+    upsertResumableRows([
+      {
+        sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        cwd: "/home/dev/repos/lfg",
+        project: "lfg",
+        title: "Historical finder",
+        lastActivityAt: 2_000,
+        lastUserText: "find the old session",
+        agent: "claude",
+        path: "/tmp/a.jsonl",
+        mtimeMs: 2_000,
+        assignedUser: "dev@example.com",
+      },
+      {
+        sessionId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        cwd: "/home/dev/repos/other",
+        project: "other",
+        title: "Other work",
+        lastActivityAt: 4_000,
+        lastUserText: null,
+        agent: "grok",
+        path: "/tmp/b.jsonl",
+        mtimeMs: 4_000,
+        assignedUser: "other@example.com",
+        resumable: false,
+      },
+    ]);
+
+    expect(queryHistoricalCache({
+      sessionId: "aaaa",
+      user: "DEV@example.com",
+      project: "repos/lfg",
+      activeAfter: 1_500,
+      activeBefore: 2_500,
+    })).toMatchObject({
+      total: 1,
+      truncated: false,
+      sessions: [{
+        sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        transcriptPath: "/tmp/a.jsonl",
+        agent: "claude",
+        assignedUser: "dev@example.com",
+      }],
+    });
+  });
+
+  test("keeps discoverable-only agents out of the resume picker", () => {
+    upsertResumableRows([
+      {
+        sessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        cwd: "/home/dev/repos/lfg",
+        project: "lfg",
+        title: "Claude session",
+        lastActivityAt: 2_000,
+        lastUserText: null,
+        agent: "claude",
+        path: "/tmp/a.jsonl",
+        mtimeMs: 2_000,
+      },
+      {
+        sessionId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        cwd: "/home/dev/repos/lfg",
+        project: "lfg",
+        title: "Cursor session",
+        lastActivityAt: 3_000,
+        lastUserText: null,
+        agent: "cursor",
+        path: "/tmp/b.jsonl",
+        mtimeMs: 3_000,
+        resumable: false,
+      },
+    ]);
+
+    expect(queryHistoricalCache().sessions.map((session) => session.agent)).toEqual([
+      "cursor",
+      "claude",
+    ]);
+    expect(queryResumableCache().sessions.map((session) => session.agent)).toEqual([
+      "claude",
+    ]);
+  });
+});

--- a/src/resume-cache-migration.test.ts
+++ b/src/resume-cache-migration.test.ts
@@ -33,6 +33,11 @@ describe("resume cache migration", () => {
       "utf8",
     );
     db.exec(sql);
+    const historicalSql = readFileSync(
+      new URL("./migrations/resume-cache/002_historical_sessions.sql", import.meta.url),
+      "utf8",
+    );
+    db.exec(historicalSql);
 
     const columns = db.query<{ name: string }, []>("PRAGMA table_info(resumable_sessions)").all();
     expect(columns.map((column) => column.name)).toEqual(expect.arrayContaining([
@@ -41,8 +46,9 @@ describe("resume cache migration", () => {
       "model",
       "assigned_user",
       "managed",
+      "resumable",
     ]));
-    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(1);
+    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(2);
     db.close();
   });
 });

--- a/src/resume-cache.ts
+++ b/src/resume-cache.ts
@@ -24,6 +24,10 @@ export type ResumableCacheRow = ResumableSession & {
   model?: string | null;
   assignedUser?: string | null;
   managed?: boolean;
+  // Some durable transcripts (currently Grok and Cursor) can be discovered
+  // and searched but not resumed by LFG. Keep them in the same derived catalog
+  // without exposing them in the existing Resume picker.
+  resumable?: boolean;
 };
 
 export type ResumableBackend = "aisdk" | "codex-aisdk" | "opencode" | "pi";
@@ -53,6 +57,32 @@ export type ResumableQueryResult = {
   facets: ResumableFacets;
 };
 
+export type HistoricalSession = {
+  sessionId: string;
+  cwd: string | null;
+  project: string;
+  title: string;
+  agent: string;
+  lastActivityAt: number | null;
+  transcriptPath: string | null;
+  assignedUser: string | null;
+};
+
+export type HistoricalQuery = {
+  sessionId?: string;
+  user?: string;
+  project?: string;
+  activeAfter?: number;
+  activeBefore?: number;
+  limit?: number;
+};
+
+export type HistoricalQueryResult = {
+  sessions: HistoricalSession[];
+  total: number;
+  truncated: boolean;
+};
+
 type Row = {
   session_id: string;
   cwd: string | null;
@@ -68,17 +98,17 @@ type Row = {
   model: string | null;
   assigned_user: string | null;
   managed: number;
+  resumable: number;
 };
-
-const DB_PATH = join(PATHS.data, "resume-cache.sqlite");
 
 let db: Database | null = null;
 let initialized = false;
 
 function database(): Database {
   if (db) return db;
-  mkdirSync(dirname(DB_PATH), { recursive: true });
-  db = new Database(DB_PATH, { create: true });
+  const dbPath = join(PATHS.data, "resume-cache.sqlite");
+  mkdirSync(dirname(dbPath), { recursive: true });
+  db = new Database(dbPath, { create: true });
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA synchronous = NORMAL");
   db.exec("PRAGMA busy_timeout = 2500");
@@ -113,6 +143,13 @@ function init(): Database {
     );
     d.exec(migration);
   }
+  if (version < 2) {
+    const migration = readFileSync(
+      new URL("./migrations/resume-cache/002_historical_sessions.sql", import.meta.url),
+      "utf8",
+    );
+    d.exec(migration);
+  }
   initialized = true;
   return d;
 }
@@ -125,7 +162,15 @@ function toSession(row: Row): ResumableSession {
     title: row.title,
     lastActivityAt: row.last_activity_at,
     lastUserText: row.last_user_text,
-    agent: (row.agent === "codex" || row.agent === "opencode" ? row.agent : "claude") as ResumableSession["agent"],
+    agent: (
+      row.agent === "codex" ||
+      row.agent === "opencode" ||
+      row.agent === "pi" ||
+      row.agent === "grok" ||
+      row.agent === "cursor"
+        ? row.agent
+        : "claude"
+    ) as ResumableSession["agent"],
     backend: (row.backend || undefined) as ResumableSession["backend"],
     resumeHandle: row.resume_handle,
     model: row.model,
@@ -153,8 +198,8 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
   const stmt = d.query(`
     INSERT INTO resumable_sessions
       (session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-       backend, resume_handle, model, assigned_user, managed)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       backend, resume_handle, model, assigned_user, managed, resumable)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(session_id) DO UPDATE SET
       cwd = excluded.cwd,
       project = excluded.project,
@@ -168,7 +213,8 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
       resume_handle = COALESCE(excluded.resume_handle, resumable_sessions.resume_handle),
       model = COALESCE(excluded.model, resumable_sessions.model),
       assigned_user = COALESCE(excluded.assigned_user, resumable_sessions.assigned_user),
-      managed = MAX(excluded.managed, resumable_sessions.managed)
+      managed = MAX(excluded.managed, resumable_sessions.managed),
+      resumable = excluded.resumable
   `);
   d.transaction((batch: ResumableCacheRow[]) => {
     for (const r of batch) {
@@ -187,6 +233,7 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
         r.model ?? null,
         r.assignedUser ?? null,
         r.managed ? 1 : 0,
+        r.resumable === false ? 0 : 1,
       );
     }
   })(rows);
@@ -212,9 +259,9 @@ export function getCachedResumableSession(sessionId: string): ResumableSession |
   const row = d
     .query<Row, [string]>(`
       SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-             backend, resume_handle, model, assigned_user, managed
+             backend, resume_handle, model, assigned_user, managed, resumable
       FROM resumable_sessions
-      WHERE session_id = ?
+      WHERE session_id = ? AND resumable = 1
     `)
     .get(sessionId);
   return row ? toSession(row) : null;
@@ -224,6 +271,13 @@ export function updateResumableUser(sessionId: string, user: string | null): boo
   const result = init()
     .query("UPDATE resumable_sessions SET assigned_user = ? WHERE session_id = ?")
     .run(user, sessionId);
+  return Number(result.changes ?? 0) > 0;
+}
+
+export function updateCachedSessionTitle(sessionId: string, title: string): boolean {
+  const result = init()
+    .query("UPDATE resumable_sessions SET title = ? WHERE session_id = ?")
+    .run(title, sessionId);
   return Number(result.changes ?? 0) > 0;
 }
 
@@ -276,6 +330,7 @@ export function queryResumableCache(opts: ResumableQuery = {}): ResumableQueryRe
     facetWhere.push(exclude.sql);
     facetParams.push(...exclude.params);
   }
+  facetWhere.push("resumable = 1");
   const facetWhereSql = facetWhere.length ? `WHERE ${facetWhere.join(" AND ")}` : "";
 
   const agentFacet = d
@@ -312,7 +367,7 @@ export function queryResumableCache(opts: ResumableQuery = {}): ResumableQueryRe
   const rows = d
     .query<Row, (string | number)[]>(`
       SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-             backend, resume_handle, model, assigned_user, managed
+             backend, resume_handle, model, assigned_user, managed, resumable
       FROM resumable_sessions
       ${whereSql}
       ORDER BY last_activity_at IS NULL, last_activity_at DESC, session_id DESC
@@ -330,4 +385,78 @@ export function queryResumableCache(opts: ResumableQuery = {}): ResumableQueryRe
         .map((r) => ({ project: r.project, count: r.count })),
     },
   };
+}
+
+function escapedLike(value: string): string {
+  return value.replace(/[%_\\]/g, (ch) => `\\${ch}`);
+}
+
+export function queryHistoricalCache(opts: HistoricalQuery = {}): HistoricalQueryResult {
+  const d = init();
+  const limit = Math.max(1, Math.min(500, opts.limit ?? 200));
+  const where: string[] = [];
+  const params: (string | number)[] = [];
+
+  if (opts.sessionId?.trim()) {
+    where.push("LOWER(session_id) LIKE ? ESCAPE '\\'");
+    params.push(`${escapedLike(opts.sessionId.trim().toLowerCase())}%`);
+  }
+  if (opts.user?.trim()) {
+    where.push("LOWER(COALESCE(assigned_user, '')) = ?");
+    params.push(opts.user.trim().toLowerCase());
+  }
+  if (opts.project?.trim()) {
+    const like = `%${escapedLike(opts.project.trim().toLowerCase())}%`;
+    where.push(
+      "(LOWER(project) LIKE ? ESCAPE '\\' OR LOWER(COALESCE(cwd, '')) LIKE ? ESCAPE '\\')",
+    );
+    params.push(like, like);
+  }
+  if (Number.isFinite(opts.activeAfter)) {
+    where.push("last_activity_at >= ?");
+    params.push(opts.activeAfter!);
+  }
+  if (Number.isFinite(opts.activeBefore)) {
+    where.push("last_activity_at <= ?");
+    params.push(opts.activeBefore!);
+  }
+
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const total =
+    d
+      .query<{ count: number }, (string | number)[]>(
+        `SELECT COUNT(*) AS count FROM resumable_sessions ${whereSql}`,
+      )
+      .get(...params)?.count ?? 0;
+  const rows = d
+    .query<Row, (string | number)[]>(`
+      SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
+             backend, resume_handle, model, assigned_user, managed, resumable
+      FROM resumable_sessions
+      ${whereSql}
+      ORDER BY last_activity_at IS NULL, last_activity_at DESC, session_id DESC
+      LIMIT ?
+    `)
+    .all(...params, limit);
+
+  return {
+    sessions: rows.map((row) => ({
+      sessionId: row.session_id,
+      cwd: row.cwd,
+      project: row.project,
+      title: row.title,
+      agent: row.agent,
+      lastActivityAt: row.last_activity_at,
+      transcriptPath: row.path,
+      assignedUser: row.assigned_user,
+    })),
+    total,
+    truncated: total > rows.length,
+  };
+}
+
+export function resetResumeCacheConnectionForTests(): void {
+  db?.close();
+  db = null;
+  initialized = false;
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -24,13 +24,17 @@ import {
   cachedFingerprints,
   upsertResumableRows,
   pruneResumableExcept,
+  queryHistoricalCache,
   queryResumableCache,
+  updateCachedSessionTitle,
+  type HistoricalSession,
   type ResumableCacheRow,
   type ResumableQuery,
   type ResumableQueryResult,
 } from "./resume-cache";
 import {
   indexedRecentMessages,
+  searchTranscriptIndex,
   sessionHasIndexedMessages,
   sessionIndexKey,
   isSessionIndexKey,
@@ -611,6 +615,7 @@ export async function setSessionTitle(
   if (t) all[sessionId] = t.slice(0, 200);
   else delete all[sessionId]; // empty title clears the override
   await Bun.write(PATHS.sessionTitles, JSON.stringify(all, null, 2));
+  if (t) updateCachedSessionTitle(sessionId, all[sessionId]);
 }
 
 // Claude's /resume picker titles a session by its first real user prompt; mirror
@@ -627,15 +632,11 @@ async function firstPromptTitle(path: string): Promise<string | null> {
       } catch {
         continue;
       }
-      const cm = normalizeCodexLine(line);
-      if (cm?.role === "user" && cm.kind === "text") {
-        const t = stripConversationPrefix(cm.text).trim().replace(/\s+/g, " ");
-        if (t && !t.startsWith("<"))
-          return t.length > TITLE_MAX ? t.slice(0, TITLE_MAX - 1) + "…" : t;
-      }
-      const gm = normalizeGrokLineMessages(line).find((msg) => msg.role === "user" && msg.kind === "text");
-      if (gm) {
-        const t = gm.text.trim().replace(/\s+/g, " ");
+      const normalized = normalizeLineMessages(line).find(
+        (msg) => msg.role === "user" && msg.kind === "text",
+      );
+      if (normalized) {
+        const t = stripConversationPrefix(normalized.text).trim().replace(/\s+/g, " ");
         if (t && !t.startsWith("<"))
           return t.length > TITLE_MAX ? t.slice(0, TITLE_MAX - 1) + "…" : t;
       }
@@ -831,8 +832,11 @@ async function findGrokTranscriptById(id: string): Promise<string | null> {
 
 async function grokSummaryById(id: string): Promise<{
   generated_title?: string;
+  session_summary?: string;
   current_model_id?: string;
   updated_at?: string;
+  last_active_at?: string;
+  info?: { cwd?: string };
 } | null> {
   if (!UUID.test(id)) return null;
   let dirs: string[];
@@ -847,12 +851,25 @@ async function grokSummaryById(id: string): Promise<{
       const f = Bun.file(p);
       if (await f.exists()) return (await f.json()) as {
         generated_title?: string;
+        session_summary?: string;
         current_model_id?: string;
         updated_at?: string;
+        last_active_at?: string;
+        info?: { cwd?: string };
       };
     } catch {}
   }
   return null;
+}
+
+async function cwdForCursorTranscript(path: string): Promise<string | null> {
+  try {
+    const text = await Bun.file(path).slice(0, 256 * 1024).text();
+    const match = text.match(/Workspace Path:\s*([^\n<]+)/);
+    return match?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 // Encode an absolute cwd the way cursor-agent names its project dir: drop the
@@ -1507,9 +1524,11 @@ async function lastUserText(path: string): Promise<string | null> {
       } catch {
         continue;
       }
-      const cm = normalizeCodexLine(lines[i]);
-      if (cm?.role === "user" && cm.kind === "text") {
-        const t = stripConversationPrefix(cm.text).trim().replace(/\s+/g, " ");
+      const normalized = normalizeLineMessages(lines[i]).find(
+        (msg) => msg.role === "user" && msg.kind === "text",
+      );
+      if (normalized) {
+        const t = stripConversationPrefix(normalized.text).trim().replace(/\s+/g, " ");
         if (t && !t.startsWith("<")) return t.length > 140 ? t.slice(0, 139) + "…" : t;
       }
       if (x.type !== "user" || x.isMeta) continue;
@@ -2441,7 +2460,7 @@ export type ResumableSession = {
   // Which engine the session was recorded with. "claude" resumes via the claude
   // CLI (`claude --resume`); "codex" resumes via a codex-aisdk harness keyed to
   // the rollout's threadId. The serve /resume endpoint branches on this.
-  agent: "claude" | "codex" | "opencode" | "pi";
+  agent: "claude" | "codex" | "opencode" | "pi" | "grok" | "cursor";
   backend?: "aisdk" | "codex-aisdk" | "opencode" | "pi";
   resumeHandle?: string | null;
   model?: string | null;
@@ -2479,11 +2498,16 @@ const RESUMABLE_REFRESH_THROTTLE_MS = 1500;
 // a usable (newest-first) page fast; the tail backfills over later refreshes.
 const RESUMABLE_ENRICH_BUDGET = 600;
 
-async function refreshResumableCacheOnce(): Promise<void> {
+async function refreshResumableCacheOnce(focusSessionId?: string): Promise<void> {
   const fingerprints = cachedFingerprints();
   const overrides = await readTitleOverrides();
   const managedSessions = listManaged();
   const managedByCwd = new Map(managedSessions.map((m) => [m.cwd, m]));
+  const managedById = new Map<string, ManagedSession>();
+  for (const managed of managedSessions) {
+    if (managed.sessionId) managedById.set(managed.sessionId, managed);
+    if (managed.nativeSessionId) managedById.set(managed.nativeSessionId, managed);
+  }
   const sdkEntries = new Map(listAisdkEntries().map((entry) => [entry.sessionId, entry]));
   const assignments = userAssignments();
   const seen = new Set<string>();
@@ -2518,15 +2542,27 @@ async function refreshResumableCacheOnce(): Promise<void> {
       candidates.push({ id, path, mtime });
     }
   }
-  candidates.sort((a, b) => b.mtime - a.mtime);
+  const focus = focusSessionId?.trim().toLowerCase() || null;
+  const byFocusThenMtime = (
+    a: { id: string; mtime: number },
+    b: { id: string; mtime: number },
+  ) => {
+    if (focus) {
+      const aFocused = a.id.toLowerCase().startsWith(focus);
+      const bFocused = b.id.toLowerCase().startsWith(focus);
+      if (aFocused !== bFocused) return aFocused ? -1 : 1;
+    }
+    return b.mtime - a.mtime;
+  };
+  candidates.sort(byFocusThenMtime);
   let budget = RESUMABLE_ENRICH_BUDGET;
   for (const c of candidates) {
     const prev = fingerprints.get(c.id);
     if (prev && prev.mtimeMs === c.mtime) continue; // unchanged -> keep cached row
     if (budget-- <= 0) break; // remainder backfills on the next refresh
     const cwd = await cwdForTranscript(c.path).catch(() => null);
-    const managedRec = cwd ? managedByCwd.get(cwd) : undefined;
-    let title = overrides[c.id] || null;
+    const managedRec = managedById.get(c.id) ?? (cwd ? managedByCwd.get(cwd) : undefined);
+    let title = managedTitle(managedRec, c.id, managedRec?.nativeSessionId, overrides);
     if (!title) title = await firstPromptTitle(c.path).catch(() => null);
     if (!title) title = cwd ? basename(cwd) : "—";
     changed.push({
@@ -2539,6 +2575,7 @@ async function refreshResumableCacheOnce(): Promise<void> {
       agent: "claude",
       path: c.path,
       mtimeMs: c.mtime,
+      assignedUser: managedRec ? assignments[managedRec.tmuxName] ?? null : null,
     });
   }
 
@@ -2549,17 +2586,147 @@ async function refreshResumableCacheOnce(): Promise<void> {
     const mtime = t.updatedAt ?? t.createdAt ?? 0;
     const prev = fingerprints.get(t.id);
     if (prev && prev.mtimeMs === mtime) continue;
-    const managedRec = t.cwd ? managedByCwd.get(t.cwd) : undefined;
+    const managedRec = managedById.get(t.id) ?? (t.cwd ? managedByCwd.get(t.cwd) : undefined);
     changed.push({
       sessionId: t.id,
       cwd: t.cwd,
       project: managedRec?.project || projectName(t.cwd, { repoRoot: managedRec?.repoRoot }),
-      title: overrides[t.id] || t.firstUserText || (t.cwd ? basename(t.cwd) : "—"),
+      title:
+        managedTitle(managedRec, t.id, managedRec?.nativeSessionId, overrides) ||
+        t.firstUserText ||
+        (t.cwd ? basename(t.cwd) : "—"),
       lastActivityAt: t.updatedAt ?? t.createdAt,
       lastUserText: t.firstUserText,
       agent: "codex",
       path: t.path,
       mtimeMs: mtime,
+      assignedUser: managedRec ? assignments[managedRec.tmuxName] ?? null : null,
+    });
+  }
+
+  // Grok sessions: each cwd-keyed directory contains one directory per native
+  // session id with chat_history.jsonl + summary.json. They are searchable and
+  // inspectable after exit, but LFG does not currently resume them.
+  let grokProjects: string[] = [];
+  try {
+    grokProjects = await readdir(GROK_SESSIONS_DIR);
+  } catch {}
+  const grokCandidates: Array<{ id: string; path: string; mtime: number }> = [];
+  for (const projectDir of grokProjects) {
+    const base = join(GROK_SESSIONS_DIR, projectDir);
+    let ids: string[] = [];
+    try {
+      ids = await readdir(base);
+    } catch {
+      continue;
+    }
+    for (const id of ids) {
+      if (!UUID.test(id)) continue;
+      const path = join(base, id, "chat_history.jsonl");
+      let mtime = 0;
+      try {
+        mtime = statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      seen.add(id);
+      grokCandidates.push({ id, path, mtime });
+    }
+  }
+  grokCandidates.sort(byFocusThenMtime);
+  let grokBudget = 200;
+  for (const { id, path, mtime } of grokCandidates) {
+    const prev = fingerprints.get(id);
+    if (prev && prev.mtimeMs === mtime) continue;
+    if (grokBudget-- <= 0) break;
+    const summary = await grokSummaryById(id).catch(() => null);
+    const cwd = summary?.info?.cwd ?? null;
+    const managedRec = managedById.get(id) ?? (cwd ? managedByCwd.get(cwd) : undefined);
+    const summaryActivity = Date.parse(summary?.last_active_at ?? summary?.updated_at ?? "");
+    const lastActivityAt = Number.isFinite(summaryActivity) ? summaryActivity : mtime;
+    changed.push({
+      sessionId: id,
+      cwd,
+      project: managedRec?.project || projectName(cwd, { repoRoot: managedRec?.repoRoot }),
+      title:
+        overrides[id] ||
+        summary?.generated_title ||
+        summary?.session_summary ||
+        (await firstPromptTitle(path).catch(() => null)) ||
+        (cwd ? basename(cwd) : "—"),
+      lastActivityAt,
+      lastUserText: await lastUserText(path).catch(() => null),
+      agent: "grok",
+      path,
+      mtimeMs: mtime,
+      model: summary?.current_model_id ?? null,
+      assignedUser: managedRec ? assignments[managedRec.tmuxName] ?? null : null,
+      resumable: false,
+    });
+  }
+
+  // Cursor sessions: one transcript directory per native chat id. The encoded
+  // project directory is not reversible when path segments contain dashes, so
+  // recover cwd from Cursor's persisted <user_info> header when no managed
+  // record remains.
+  let cursorProjects: string[] = [];
+  try {
+    cursorProjects = await readdir(CURSOR_PROJECTS_DIR);
+  } catch {}
+  const cursorCandidates: Array<{
+    id: string;
+    path: string;
+    mtime: number;
+    encodedProject: string;
+  }> = [];
+  for (const projectDir of cursorProjects) {
+    const base = join(CURSOR_PROJECTS_DIR, projectDir, "agent-transcripts");
+    let ids: string[] = [];
+    try {
+      ids = await readdir(base);
+    } catch {
+      continue;
+    }
+    for (const id of ids) {
+      if (!UUID.test(id)) continue;
+      const path = join(base, id, `${id}.jsonl`);
+      let mtime = 0;
+      try {
+        mtime = statSync(path).mtimeMs;
+      } catch {
+        continue;
+      }
+      seen.add(id);
+      cursorCandidates.push({ id, path, mtime, encodedProject: projectDir });
+    }
+  }
+  cursorCandidates.sort(byFocusThenMtime);
+  let cursorBudget = 200;
+  for (const { id, path, mtime, encodedProject } of cursorCandidates) {
+    const prev = fingerprints.get(id);
+    if (prev && prev.mtimeMs === mtime) continue;
+    if (cursorBudget-- <= 0) break;
+    const managedRec = managedById.get(id);
+    const cwd = managedRec?.cwd || (await cwdForCursorTranscript(path).catch(() => null));
+    const byCwd = !managedRec && cwd ? managedByCwd.get(cwd) : undefined;
+    const owner = managedRec ?? byCwd;
+    changed.push({
+      sessionId: id,
+      cwd,
+      project:
+        owner?.project ||
+        (cwd ? projectName(cwd, { repoRoot: owner?.repoRoot }) : encodedProject),
+      title:
+        overrides[id] ||
+        (await firstPromptTitle(path).catch(() => null)) ||
+        (cwd ? basename(cwd) : "—"),
+      lastActivityAt: mtime,
+      lastUserText: await lastUserText(path).catch(() => null),
+      agent: "cursor",
+      path,
+      mtimeMs: mtime,
+      assignedUser: owner ? assignments[owner.tmuxName] ?? null : null,
+      resumable: false,
     });
   }
 
@@ -2626,11 +2793,13 @@ async function refreshResumableCacheOnce(): Promise<void> {
 // Refresh at most once per throttle window (unless forced); concurrent callers
 // share the in-flight scan. Awaited by queryResumable so the first-ever request
 // still populates the cache before it reads.
-export async function refreshResumableCache(opts: { force?: boolean } = {}): Promise<void> {
+export async function refreshResumableCache(
+  opts: { force?: boolean; focusSessionId?: string } = {},
+): Promise<void> {
   const now = Date.now();
   if (resumableRefreshing) return resumableRefreshing;
   if (!opts.force && now - resumableRefreshAt < RESUMABLE_REFRESH_THROTTLE_MS) return;
-  resumableRefreshing = refreshResumableCacheOnce()
+  resumableRefreshing = refreshResumableCacheOnce(opts.focusSessionId)
     .catch((err) => {
       console.warn(
         `[resume-cache] refresh failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -2671,6 +2840,102 @@ export async function listResumable(
 ): Promise<ResumableSession[]> {
   const { sessions } = await queryResumable(opts);
   return sessions;
+}
+
+export type FindSessionsQuery = {
+  sessionId?: string;
+  user?: string;
+  project?: string;
+  text?: string;
+  activeAfter?: number;
+  activeBefore?: number;
+  limit?: number;
+  scanLimit?: number;
+};
+
+export type FoundSession = HistoricalSession & {
+  live: boolean;
+  textMatch: string | null;
+};
+
+function titleMatches(title: string, query: string): boolean {
+  const folded = title.toLowerCase();
+  return query
+    .toLowerCase()
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((term) => folded.includes(term));
+}
+
+// Find durable sessions independently of process/tmux lifetime. Metadata
+// filtering happens in the derived SQLite catalog; full-text matching uses the
+// existing streaming transcript index and is bounded to the newest scanLimit
+// candidates so a broad search cannot parse an unbounded history in one call.
+export async function findSessions(
+  opts: FindSessionsQuery = {},
+  liveSessions?: Session[],
+): Promise<{
+  sessions: FoundSession[];
+  candidateTotal: number;
+  scanned: number;
+  truncated: boolean;
+}> {
+  await refreshResumableCache({
+    force: !!opts.sessionId?.trim(),
+    focusSessionId: opts.sessionId,
+  });
+  const live = liveSessions ?? (await listSessions());
+  const limit = Math.max(1, Math.min(100, opts.limit ?? 30));
+  const scanLimit = Math.max(limit, Math.min(500, opts.scanLimit ?? 200));
+  const candidates = queryHistoricalCache({
+    sessionId: opts.sessionId,
+    user: opts.user,
+    project: opts.project,
+    activeAfter: opts.activeAfter,
+    activeBefore: opts.activeBefore,
+    limit: opts.text?.trim() ? scanLimit : limit,
+  });
+  const liveIds = new Set<string>();
+  for (const session of live) {
+    if (session.sessionId) liveIds.add(session.sessionId);
+    if (session.nativeSessionId) liveIds.add(session.nativeSessionId);
+  }
+  const found: FoundSession[] = [];
+  const text = opts.text?.trim() || null;
+  let scanned = 0;
+
+  for (const candidate of candidates.sessions) {
+    scanned++;
+    let textMatch: string | null = null;
+    if (text) {
+      if (titleMatches(candidate.title, text)) {
+        textMatch = candidate.title;
+      } else if (candidate.transcriptPath) {
+        const match = await searchTranscriptIndex(
+          candidate.transcriptPath,
+          candidate.sessionId,
+          text,
+          { limit: 1 },
+        ).catch(() => null);
+        textMatch = match?.results[0]?.snippet ?? null;
+      }
+      if (!textMatch) continue;
+    }
+    found.push({
+      ...candidate,
+      live: liveIds.has(candidate.sessionId),
+      textMatch,
+    });
+    if (found.length >= limit) break;
+  }
+
+  return {
+    sessions: found,
+    candidateTotal: candidates.total,
+    scanned,
+    truncated: candidates.truncated || scanned < candidates.total,
+  };
 }
 
 // A prompt read straight from the transcript's structured AskUserQuestion


### PR DESCRIPTION
Adds `lfg_find_sessions({ sessionId?, user?, project?, text?, activeAfter?, activeBefore?, limit?, scanLimit? })` to find durable/ended sessions (not just live ones surfaced by `lfg_list_sessions`). Extends the existing derived resume-cache.sqlite (discoverable-vs-resumable rows) + normalized transcript FTS across Claude/Codex/Grok/Cursor + managed SDK transcripts, newest-first, with id/user/project/text/time filters, a live overlay, and bounded scanning. typecheck ✅; bun test 173/173 ✅.

Built by a delegated codex agent (session lfg-f3c56c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)