### PR TITLE
fix(ask): expire stale asks, and stop asserting a pivot is an answer

### DIFF
--- a/src/ask/store.ts
+++ b/src/ask/store.ts
@@ -185,3 +185,41 @@ export async function expireQuestion(id: string): Promise<void> {
   await writeAll(next);
   wake(found);
 }
+
+/**
+ * How long an unanswered ask stays live. Past it the question is stale: the
+ * work it was blocking has moved on, and re-surfacing it does active harm —
+ * the channel adapter can route the user's next unrelated message into it as
+ * an "answer" (see the omg imsg pending-question park), and the voice agent
+ * keeps reading it out. Chosen to match the imsg side's own park TTL so the
+ * two ends agree on what "still answerable" means.
+ */
+export const ASK_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Flip every `open` ask older than `ttlMs` to `expired`, and return them.
+ *
+ * Called from the read paths that SURFACE open questions rather than from a
+ * timer: this store is a whole-file rewrite with no locking, so a background
+ * tick racing a concurrent `addQuestion` would clobber it. Sweeping on read
+ * means the rewrite only happens on the request that would otherwise have
+ * handed out a stale question, and a no-op sweep never writes at all.
+ *
+ * Long-poll waiters are woken (an expired question resolves the poll rather
+ * than hanging it to the timeout), matching `expireQuestion`.
+ */
+export async function sweepExpiredQuestions(ttlMs: number = ASK_TTL_MS): Promise<AskQuestion[]> {
+  const rows = await listQuestions();
+  const cutoff = Date.now() - ttlMs;
+  const expired: AskQuestion[] = [];
+  const next = rows.map((r) => {
+    if (r.status !== "open" || r.createdAt > cutoff) return r;
+    const flipped: AskQuestion = { ...r, status: "expired" };
+    expired.push(flipped);
+    return flipped;
+  });
+  if (!expired.length) return [];
+  await writeAll(next);
+  for (const q of expired) wake(q);
+  return expired;
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -68,6 +68,7 @@ import {
   answerQuestion,
   markHandled,
   waitForAnswer,
+  sweepExpiredQuestions,
 } from "../ask/store.ts";
 import {
   listSessions,
@@ -1611,6 +1612,7 @@ async function voiceStatusSnapshot(user?: string | null): Promise<string> {
   // Pending agent questions for the human — the voice agent should read these
   // out and, when the user replies, answer them via POST /api/ask/<id>/answer.
   try {
+    await sweepExpiredQuestions();
     const open = await listQuestions("open");
     if (open.length) {
       lines.push("");
@@ -2998,6 +3000,7 @@ export async function cmdServe() {
       if (path === "/api/push/pending" && req.method === "GET") {
         const endpoint = url.searchParams.get("endpoint");
         const me = endpoint ? await subscriptionUser(endpoint) : null;
+        await sweepExpiredQuestions();
         const openQs = await listQuestions("open");
         const questions = me ? openQs.filter((q) => q.user === me) : openQs;
         // Findings are global (not user-private), so they pass through as-is.
@@ -3015,6 +3018,10 @@ export async function cmdServe() {
           | "expired"
           | null;
         const user = url.searchParams.get("user");
+        // Stale asks must not be handed to a consumer that will act on them:
+        // `lfg connect` turns every open row here into an `auto.question`
+        // channel event, and the omg brain can route a reply into it.
+        if (status === "open" || !status) await sweepExpiredQuestions();
         let rows = await listQuestions(status ?? undefined);
         if (user) rows = rows.filter((q) => !q.user || q.user === user);
         return json({ questions: rows });
@@ -3094,11 +3101,25 @@ export async function cmdServe() {
               const c = t.replace(/\s+/g, " ").trim();
               return c.length > n ? c.slice(0, n - 1).trimEnd() + "…" : c;
             };
+            // The text is delivered verbatim, but it is NOT guaranteed to be an
+            // answer. Channels that answer on the user's behalf can bind an
+            // unrelated message to an open ask (the omg imsg brain used to hand
+            // the next inbound message to whatever question was parked), and a
+            // user typing in the web composer can simply change the subject. So
+            // the envelope states what we actually know — the user replied while
+            // this question was open — and gives the agent an explicit branch
+            // for a reply that doesn't answer it. Asserting "act on this answer
+            // now" unconditionally is what turned a pivot into a forced merge
+            // decision in a live incident (2026-07-25).
             const text =
-              `[ask-user answer ${q.id}] The user answered the question you asked earlier.\n` +
+              `[ask-user answer ${q.id}] The user replied while this question was open.\n` +
               `Question: ${clip(q.question, 300)}\n` +
-              `Answer: ${q.answer ?? ""}\n` +
-              `Act on this answer now; it is the user's decision.`;
+              `Their reply: ${q.answer ?? ""}\n` +
+              `If it answers the question, act on it now — it is the user's decision, ` +
+              `and do not ask again. If it does not answer the question (they raised ` +
+              `something else, or changed the subject), treat it as a NEW instruction ` +
+              `and take it up instead; say in one line that you are parking the ` +
+              `original question, and re-ask it only if you still need it answered.`;
             try {
               const r = await fetch(
                 `http://127.0.0.1:${PORT}/api/sessions/${q.sessionId}/send`,

--- a/test/ask-store.test.ts
+++ b/test/ask-store.test.ts
@@ -1,0 +1,106 @@
+// Ask-store TTL sweep. The bug this pins: `expireQuestion` existed but had
+// zero callers, so an unanswered ask stayed `open` forever — it kept being
+// re-surfaced in the web feed and the voice snapshot, and (the harmful part)
+// `lfg connect` kept emitting it as an `auto.question` channel event, where the
+// omg imsg brain could bind an unrelated inbound message to it as the "answer".
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "../src/config.ts";
+import {
+  addQuestion,
+  answerQuestion,
+  listQuestions,
+  sweepExpiredQuestions,
+  waitForAnswer,
+  ASK_TTL_MS,
+} from "../src/ask/store.ts";
+
+const realData = PATHS.data;
+let dir: string;
+
+/** Backdate a stored row — `addQuestion` always stamps `Date.now()`. */
+async function backdate(id: string, createdAt: number): Promise<void> {
+  const rows = await listQuestions();
+  const next = rows.map((r) => (r.id === id ? { ...r, createdAt } : r));
+  await Bun.write(
+    join(PATHS.data, "ask", "questions.jsonl"),
+    next.map((r) => JSON.stringify(r)).join("\n") + "\n",
+  );
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "lfg-ask-"));
+  await mkdir(join(dir, "ask"), { recursive: true });
+  PATHS.data = dir;
+});
+
+afterEach(async () => {
+  PATHS.data = realData;
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("sweepExpiredQuestions", () => {
+  test("expires an open ask older than the TTL", async () => {
+    const q = await addQuestion({ question: "merge #917?", pushback: true });
+    await backdate(q.id, Date.now() - ASK_TTL_MS - 1_000);
+
+    const expired = await sweepExpiredQuestions();
+
+    expect(expired.map((r) => r.id)).toEqual([q.id]);
+    expect(await listQuestions("open")).toEqual([]);
+    expect((await listQuestions("expired")).map((r) => r.id)).toEqual([q.id]);
+  });
+
+  test("leaves an ask inside the TTL open", async () => {
+    const q = await addQuestion({ question: "merge #917?", pushback: true });
+    await backdate(q.id, Date.now() - (ASK_TTL_MS - 60_000));
+
+    expect(await sweepExpiredQuestions()).toEqual([]);
+    expect((await listQuestions("open")).map((r) => r.id)).toEqual([q.id]);
+  });
+
+  test("never touches an already-answered ask, however old", async () => {
+    const q = await addQuestion({ question: "merge #917?", pushback: true });
+    await answerQuestion(q.id, { answer: "yes", via: "web" });
+    await backdate(q.id, Date.now() - ASK_TTL_MS * 10);
+
+    expect(await sweepExpiredQuestions()).toEqual([]);
+    expect((await listQuestions("answered")).map((r) => r.id)).toEqual([q.id]);
+  });
+
+  test("a no-op sweep does not rewrite the store", async () => {
+    const q = await addQuestion({ question: "still fresh?", pushback: true });
+    const file = join(PATHS.data, "ask", "questions.jsonl");
+    const before = await Bun.file(file).text();
+
+    expect(await sweepExpiredQuestions()).toEqual([]);
+
+    expect(await Bun.file(file).text()).toBe(before);
+    expect((await listQuestions("open")).map((r) => r.id)).toEqual([q.id]);
+  });
+
+  test("expiring wakes a blocked long-poll instead of hanging it to timeout", async () => {
+    const q = await addQuestion({ question: "legacy long-poll", pushback: false });
+    await backdate(q.id, Date.now() - ASK_TTL_MS - 1_000);
+
+    const waiting = waitForAnswer(q.id, 5_000);
+    await sweepExpiredQuestions();
+
+    const resolved = await waiting;
+    expect(resolved?.status).toBe("expired");
+  });
+
+  test("sweeps only the stale rows in a mixed store", async () => {
+    const stale = await addQuestion({ question: "old", pushback: true });
+    const fresh = await addQuestion({ question: "new", pushback: true });
+    await backdate(stale.id, Date.now() - ASK_TTL_MS - 1_000);
+
+    const expired = await sweepExpiredQuestions();
+
+    expect(expired.map((r) => r.id)).toEqual([stale.id]);
+    expect((await listQuestions("open")).map((r) => r.id)).toEqual([fresh.id]);
+  });
+});


### PR DESCRIPTION
## Why

From a live incident on 2026-07-25, reproduced from the prod imsg DB.

An agent asked *"Merge PR #917 and deploy to prod?"* via `lfg_input`. The user's next message was **"Btw omg pwa got stuck"** — a pivot, not an answer. It arrived in the asking session as:

```
[ask-user answer 6146cfb130a0] The user answered the question you asked earlier.
Question: Merge PR #917 (Computer links omg.dev to app.omg.dev) and deploy to prod? ...
Answer: Btw omg pwa got stuck
Act on this answer now; it is the user's decision.
```

Two independent defects on this side made that possible. (The channel-side cause — the omg imsg brain handing the *next inbound message* to whatever question was parked, with no reply-identity check and no model in the loop — is fixed separately in the vibes repo.)

## 1. Asks never expired

`expireQuestion` existed but had **zero callers** in `src/`. An unanswered ask stayed `open` forever:

- re-surfaced in the web ask feed and the voice orchestrator's spawn snapshot,
- and re-emitted by `lfg connect`'s `pollAskEvents` as an `auto.question` channel event indefinitely — where a channel adapter can bind an unrelated message to it.

Adds `sweepExpiredQuestions(ttlMs)` and `ASK_TTL_MS` (6h, deliberately matching the imsg side's own park TTL so both ends agree on what "still answerable" means), wired into the three read paths that hand out open asks:

- `GET /api/ask` (when `status=open` or unfiltered) — the path `lfg connect` polls
- `GET /api/push/pending`
- the voice snapshot's `PENDING QUESTIONS FOR YOU` block

**Swept on read, not on a timer.** This store is a whole-file read-modify-rewrite with no locking, so a background tick racing a concurrent `addQuestion` would clobber it. Sweeping on read means the rewrite only happens on the request that would otherwise have handed out a stale question, and a no-op sweep never writes at all (pinned by a test). Long-poll waiters are woken, so an expiry resolves a blocked poll rather than hanging it to timeout.

## 2. The envelope asserted a claim it can't support

`Act on this answer now; it is the user's decision.` — but all we actually know is that the user replied *while this question was open*. Whether it answers the question is not something the answer route can determine, and both callers can get it wrong: a channel adapter can mis-bind, and a user typing in the web composer can simply change the subject.

The envelope now states what we know and gives the agent an explicit branch for a reply that doesn't answer: treat it as a new instruction, say in one line that the original question is parked, and re-ask only if still needed.

Delivery is still **verbatim** — no classifier, no interpretation. A plain "no" is still a real answer. Only the framing changed.

## Tests

`test/ask-store.test.ts`, 6 new cases: TTL boundary both sides, answered rows never swept however old, no-op sweep doesn't rewrite the file, expiry wakes a blocked long-poll, mixed store sweeps only stale rows.

`bun test` 179 pass / 0 fail. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)