### PR TITLE
perf(mcp): short session ids + slim agent-facing payloads

### DIFF
--- a/src/agents/backends/opencode-aisdk-session.test.ts
+++ b/src/agents/backends/opencode-aisdk-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { answersForIndex, pendingToPrompt } from "./opencode-aisdk-session.ts";
+import { answersForIndex, pendingToPrompt, toolPartMessages } from "./opencode-aisdk-session.ts";
 
 describe("opencode question prompt helpers", () => {
   const pending = {
@@ -60,5 +60,61 @@ describe("opencode question prompt helpers", () => {
       ],
     };
     expect(answersForIndex(multi, 1)).toEqual([["B"], ["X"]]);
+  });
+});
+
+describe("opencode tool part streaming", () => {
+  // OpenCode mutates one part per tool call. The regression this guards: every
+  // transcript row was frozen at `read [pending]: {}` because the empty pending
+  // snapshot claimed the part id and the append-only index ignored the rest.
+  const feed = (states: Array<Record<string, unknown>>) => {
+    const emitted = new Set<string>();
+    const rows: Array<{ id: string; kind: string; text: string }> = [];
+    for (const state of states) {
+      for (const m of toolPartMessages({ id: "prt_1", type: "tool", tool: "read", state }, "fb", emitted)) {
+        rows.push({ id: m.id ?? "", kind: m.kind, text: m.text ?? "" });
+      }
+    }
+    return rows;
+  };
+
+  test("skips the empty pending snapshot", () => {
+    expect(feed([{ status: "pending", input: {} }])).toEqual([]);
+  });
+
+  test("emits the call once input is known, then the result", () => {
+    const rows = feed([
+      { status: "pending", input: {} },
+      { status: "running", input: { filePath: "/tmp/a.ts" } },
+      { status: "completed", input: { filePath: "/tmp/a.ts" }, output: "file body" },
+    ]);
+    expect(rows).toEqual([
+      { id: "prt_1", kind: "tool_use", text: 'read: {\n  "filePath": "/tmp/a.ts"\n}' },
+      { id: "prt_1:result", kind: "tool_result", text: "file body" },
+    ]);
+  });
+
+  test("does not re-emit when the same state is re-sent", () => {
+    const running = { status: "running", input: { filePath: "/tmp/a.ts" } };
+    expect(feed([running, running, running])).toHaveLength(1);
+  });
+
+  test("still emits a call that jumps straight to completed", () => {
+    const rows = feed([{ status: "completed", input: { filePath: "/a" }, output: "out" }]);
+    expect(rows.map((r) => r.kind)).toEqual(["tool_use", "tool_result"]);
+  });
+
+  test("surfaces tool errors as a result row", () => {
+    const rows = feed([
+      { status: "running", input: { filePath: "/nope" } },
+      { status: "error", input: { filePath: "/nope" }, error: "ENOENT" },
+    ]);
+    expect(rows[1]).toEqual({ id: "prt_1:result", kind: "tool_result", text: "read failed: ENOENT" });
+  });
+
+  test("clips runaway tool output", () => {
+    const rows = feed([{ status: "completed", input: { a: 1 }, output: "x".repeat(50_000) }]);
+    expect(rows[1].text.length).toBeLessThan(4_100);
+    expect(rows[1].text.endsWith("[truncated]")).toBe(true);
   });
 });

--- a/src/agents/backends/opencode-aisdk-session.ts
+++ b/src/agents/backends/opencode-aisdk-session.ts
@@ -219,25 +219,79 @@ function latestOpencodeError(opencodeSessionId: string): string | null {
   return null;
 }
 
-function toolPartMessage(part: OcPart, fallbackId: string): ReturnType<typeof normalizeLineMessages>[number] {
-  const status = part.state?.status ? ` [${part.state.status}]` : "";
-  const input = part.state?.input == null
-    ? ""
-    : (() => {
-        try {
-          return JSON.stringify(part.state.input, null, 2);
-        } catch {
-          return String(part.state.input);
-        }
-      })();
+const TOOL_TEXT_MAX = 4_000;
+
+function stringifyToolValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function clipToolText(text: string): string {
+  return text.length > TOOL_TEXT_MAX ? `${text.slice(0, TOOL_TEXT_MAX)}\n… [truncated]` : text;
+}
+
+// OpenCode streams ONE part per tool call and mutates it in place:
+//   pending {}  →  running {input}  →  completed {input, output}
+// The transcript index is append-only (`INSERT OR IGNORE` on the message id), so
+// re-indexing the same part id only ever stores the FIRST snapshot — which is
+// the empty `pending` one. That is what froze every opencode row at
+// `read [pending]: {}`. Instead of re-publishing one mutating row, emit at most
+// two immutable rows per part, each with its own stable id:
+//   - `<partId>`         the tool_use, published once the input is actually known
+//   - `<partId>:result`  the tool_result, published when the call settles
+// Both are append-only and land in the live stream exactly like every other
+// agent's tool rows.
+/** @internal exported for unit tests */
+export function toolPartMessages(
+  part: OcPart,
+  fallbackId: string,
+  emitted: Set<string>,
+): ReturnType<typeof normalizeLineMessages> {
+  const id = part.id || fallbackId;
   const name = part.tool ?? "tool";
-  return {
-    id: part.id || fallbackId,
-    role: "assistant",
-    kind: "tool_use",
-    text: input ? `${name}${status}: ${input}` : `${name}${status}`,
-    ts: Date.now(),
-  };
+  const status = part.state?.status ?? "";
+  const input = stringifyToolValue(part.state?.input);
+  const out: ReturnType<typeof normalizeLineMessages> = [];
+
+  // Nothing to show until the arguments exist — a bare `pending` row is noise
+  // and, worse, would permanently occupy the id that the real call needs.
+  const hasInput = !!input && input !== "{}";
+  const settled = status === "completed" || status === "error";
+  if ((hasInput || settled) && !emitted.has(id)) {
+    emitted.add(id);
+    out.push({
+      id,
+      role: "assistant",
+      kind: "tool_use",
+      text: clipToolText(input ? `${name}: ${input}` : name),
+      ts: Date.now(),
+    });
+  }
+
+  if (settled) {
+    const resultId = `${id}:result`;
+    if (!emitted.has(resultId)) {
+      const body = status === "error"
+        ? stringifyToolValue(part.state?.error) || "tool call failed"
+        : stringifyToolValue(part.state?.output);
+      if (body) {
+        emitted.add(resultId);
+        out.push({
+          id: resultId,
+          role: "user",
+          kind: "tool_result",
+          text: clipToolText(status === "error" ? `${name} failed: ${body}` : body),
+          ts: Date.now(),
+        });
+      }
+    }
+  }
+  return out;
 }
 
 // Auto runner has no human — reject any OpenCode question so the turn can't hang.
@@ -263,7 +317,7 @@ export async function pipeToOpencodeAiSdk(
   const { createOpencodeServer, createOpencodeClient } = await import("@opencode-ai/sdk");
 
   log(`[runner] piping ${prompt.length} chars to opencode via opencode-sdk (${model})`);
-  const server = await createOpencodeServer({});
+  const server = await createOpencodeServer({ port: 0 });
   try {
     const client = createOpencodeClient({ baseUrl: server.url });
     const created = await client.session.create({ body: {}, query: { directory: cwd } });
@@ -327,7 +381,28 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
   const { createOpencodeServer, createOpencodeClient } = await import("@opencode-ai/sdk");
 
   // One server + client per harness, reused across every turn.
-  const server = await createOpencodeServer({});
+  // `port: 0` is load-bearing: the SDK otherwise hardcodes 4096, so a SECOND
+  // opencode session on the same box died at boot with a bare `ServeError`
+  // (address in use) and never produced a single transcript row. The SDK parses
+  // the actually-bound port back out of `opencode serve`'s banner, so ephemeral
+  // ports work transparently.
+  let server: Awaited<ReturnType<typeof createOpencodeServer>>;
+  try {
+    server = await createOpencodeServer({ port: 0 });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`opencode-aisdk-session: failed to start opencode server: ${msg}`);
+    indexSessionMessagesDirect(key, [
+      {
+        id: `${key}:server-start-failed`,
+        role: "assistant",
+        kind: "text",
+        text: `OpenCode failed to start its local server: ${msg}`,
+        ts: Date.now(),
+      },
+    ]);
+    throw e;
+  }
   const serverUrl = server.url;
   const client = createOpencodeClient({ baseUrl: serverUrl });
 
@@ -550,9 +625,10 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
         (sub as { data?: AsyncIterable<unknown> }).data;
       if (!stream) return;
       let draft = "";
-      // Track last published snapshot per tool part so status transitions
-      // (running → completed) re-index without spamming identical rows.
-      const toolPartSnapshots = new Map<string, string>();
+      // Ids already published for tool parts (`<partId>` and `<partId>:result`).
+      // OpenCode re-sends the whole part on every mutation, so this is what keeps
+      // a call from being re-emitted on each tick.
+      const emittedToolIds = new Set<string>();
       for await (const raw of stream) {
         if (closing) break;
         const ev = raw as {
@@ -610,12 +686,8 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
             }
           } else if (part.type === "tool") {
             const fallbackId = `${ocSessionId}:tool:${part.id ?? part.tool ?? "tool"}`;
-            const id = part.id || fallbackId;
-            const snap = `${part.tool ?? "tool"}|${part.state?.status ?? ""}|${JSON.stringify(part.state?.input ?? {})}`;
-            if (toolPartSnapshots.get(id) !== snap) {
-              toolPartSnapshots.set(id, snap);
-              indexSessionMessagesDirect(key, [toolPartMessage(part, fallbackId)]);
-            }
+            const rows = toolPartMessages(part, fallbackId, emittedToolIds);
+            if (rows.length) indexSessionMessagesDirect(key, rows);
             // If a question tool starts, reconcile from /question (events can
             // lag behind the tool part).
             if (part.tool === "question" && part.state?.status === "running") {

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -42,6 +42,80 @@ describe("closeLfgSession", () => {
   });
 });
 
+describe("short session ids", () => {
+  const FULL = "abcd1234-1111-4111-8111-111111111111";
+
+  test("resolves an 8-char short id to the full uuid before calling the API", async () => {
+    process.env.LFG_BASE = "http://127.0.0.1:9876";
+    process.env.LFG_SESSION_ID = "caller-session";
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      if (String(url).endsWith("/api/sessions")) {
+        return Response.json({ sessions: [{ sessionId: FULL }, { sessionId: "99999999-2222-4222-8222-222222222222" }] });
+      }
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await expect(closeLfgSession("abcd1234")).resolves.toEqual({
+      closed: true,
+      sessionId: "abcd1234",
+    });
+    // The wire always carries the full uuid.
+    expect(urls).toContain(`http://127.0.0.1:9876/api/sessions/${FULL}/close`);
+  });
+
+  test("a full uuid needs no lookup round-trip", async () => {
+    process.env.LFG_BASE = "http://127.0.0.1:9876";
+    process.env.LFG_SESSION_ID = "caller-session";
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await closeLfgSession(FULL);
+    expect(urls).toEqual([`http://127.0.0.1:9876/api/sessions/${FULL}/close`]);
+  });
+
+  test("rejects an ambiguous prefix instead of guessing a session", async () => {
+    process.env.LFG_BASE = "http://127.0.0.1:9876";
+    process.env.LFG_SESSION_ID = "caller-session";
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      if (String(url).endsWith("/api/sessions")) {
+        return Response.json({
+          sessions: [
+            { sessionId: "beefbeef-1111-4111-8111-111111111111" },
+            { sessionId: "beefbeef-2222-4222-8222-222222222222" },
+          ],
+        });
+      }
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await expect(closeLfgSession("beefbeef")).rejects.toThrow("ambiguous");
+  });
+
+  test("falls back to historical sessions when nothing live matches", async () => {
+    process.env.LFG_BASE = "http://127.0.0.1:9876";
+    process.env.LFG_SESSION_ID = "caller-session";
+    const urls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      if (String(url).endsWith("/api/sessions")) return Response.json({ sessions: [] });
+      if (String(url).endsWith("/api/sessions/find")) {
+        return Response.json({ sessions: [{ sessionId: "dead1234-1111-4111-8111-111111111111" }] });
+      }
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await expect(closeLfgSession("dead1234")).resolves.toMatchObject({ closed: true });
+    expect(urls).toContain(
+      "http://127.0.0.1:9876/api/sessions/dead1234-1111-4111-8111-111111111111/close",
+    );
+  });
+});
+
 describe("findLfgSessions", () => {
   test("queries the historical session API with composable filters", async () => {
     process.env.LFG_BASE = "http://127.0.0.1:9876";
@@ -94,7 +168,10 @@ describe("sendToOrigin", () => {
       artifactIds: ["shot-1"],
     })).resolves.toMatchObject({
       delivered: true,
-      sessionId: "11111111-1111-4111-8111-111111111111",
+      // Agent-facing ids are the 8-char short form; the full uuid is still what
+      // goes over the wire (asserted on the request below).
+      sessionId: "11111111",
+      deliveryId: "delivery-1",
     });
     expect(request?.url).toEndWith(
       "/api/sessions/11111111-1111-4111-8111-111111111111/origin-deliveries",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -10,6 +10,7 @@ import {
   LFG_CAPABILITIES,
   LFG_CAPABILITY_VERSION,
   LFG_MCP_INSTRUCTIONS,
+  SHORT_SESSION_ID_LENGTH,
 } from "../lfg-capabilities.ts";
 
 type Repo = { name: string; cwd: string; project?: string };
@@ -26,6 +27,10 @@ type SessionRow = {
   spawnedBy?: string | null;
   busy?: boolean;
   tmuxTarget?: string | null;
+  cwd?: string;
+  status?: string | null;
+  assignedUser?: string | null;
+  lastActivityAt?: number | null;
 };
 type SessionCreateResponse = {
   ok?: boolean;
@@ -99,9 +104,118 @@ function result(data: unknown) {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify(data, null, 2),
+        // Compact, not pretty-printed: indentation is pure context tax on a
+        // payload only a model reads.
+        text: JSON.stringify(data),
       },
     ],
+  };
+}
+
+// ---- Short session ids ----------------------------------------------------
+// Session ids are 36-char UUIDs minted by the underlying harnesses (claude,
+// codex, ...) and are load-bearing on disk: transcript filenames, tmux command
+// lines, aisdk registry files, sqlite keys, and ~27 HTTP route regexes that
+// hard-code the 36-char shape. So we do NOT re-mint them. Instead we do what
+// git does with commit shas: agents see and pass an 8-char PREFIX, and we
+// resolve it back to the full id here, at the single boundary every
+// agent-facing session id crosses.
+//
+// Because a short id is a genuine prefix of the real UUID, it stays compatible
+// with the backend's existing prefix search and remains greppable against
+// transcripts and process lines.
+const FULL_UUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const SHORT_SID = /^[0-9a-fA-F]{6,32}$/;
+const SHORT_SID_LEN = SHORT_SESSION_ID_LENGTH;
+
+function shortSid(id: string | null | undefined): string | null {
+  if (!id) return null;
+  return FULL_UUID.test(id) ? id.slice(0, SHORT_SID_LEN) : id;
+}
+
+// Short id -> full id. Only ever grows for ids we resolved from the server, so
+// a stale entry is impossible: session ids are immutable.
+const sidCache = new Map<string, string>();
+
+function rememberSid(full: string | null | undefined): void {
+  if (!full || !FULL_UUID.test(full)) return;
+  sidCache.set(full.slice(0, SHORT_SID_LEN).toLowerCase(), full);
+}
+
+/**
+ * Accept a full UUID, an 8-char short id (or any unambiguous hex prefix), or a
+ * harness-native id of some other shape. Returns the id the HTTP API expects.
+ * Ambiguous prefixes throw rather than silently picking a session.
+ */
+async function resolveSid(input: string): Promise<string> {
+  const id = input.trim();
+  if (!id) throw new Error("sessionId required");
+  // Already full length, or not hex-prefix shaped (native codex/opencode ids):
+  // pass through untouched, no network round-trip.
+  if (FULL_UUID.test(id) || !SHORT_SID.test(id)) return id;
+
+  const lower = id.toLowerCase();
+  const cached = sidCache.get(lower);
+  if (cached) return cached;
+
+  const matches = new Set<string>();
+  // 1. Live fleet: cheap and covers the overwhelmingly common case.
+  const { sessions } = await api<{ sessions: SessionRow[] }>("/api/sessions");
+  for (const session of sessions) {
+    for (const candidate of [session.sessionId, session.nativeSessionId]) {
+      if (candidate?.toLowerCase().startsWith(lower)) {
+        matches.add(session.sessionId ?? candidate);
+      }
+    }
+  }
+  // 2. Nothing live — fall back to durable/historical sessions.
+  if (matches.size === 0) {
+    const found = await api<{ sessions: Array<{ sessionId?: string | null }> }>(
+      "/api/sessions/find",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: id, limit: 5 }),
+      },
+    );
+    for (const session of found.sessions ?? []) {
+      if (session.sessionId?.toLowerCase().startsWith(lower)) matches.add(session.sessionId);
+    }
+  }
+
+  if (matches.size === 1) {
+    const full = [...matches][0];
+    rememberSid(full);
+    return full;
+  }
+  if (matches.size > 1) {
+    throw new Error(
+      `session id "${id}" is ambiguous (matches ${matches.size} sessions); pass more characters`,
+    );
+  }
+  throw new Error(`no session matches id "${id}"`);
+}
+
+// Agent-facing session row. The raw row carries `last` and `cmd`, which on a
+// 21-session fleet are 78% of a 108KB response — full transcript tails and
+// entire spawn command lines the model never acts on.
+function slimSession(session: SessionRow) {
+  const parent = sessionParent(session);
+  rememberSid(session.sessionId);
+  rememberSid(session.nativeSessionId);
+  return {
+    id: shortSid(session.sessionId),
+    title: session.title ?? undefined,
+    agent: session.agent,
+    model: session.model ?? undefined,
+    project: session.project,
+    cwd: session.cwd,
+    busy: session.busy,
+    status: session.status ?? undefined,
+    assignedUser: session.assignedUser ?? undefined,
+    lastActivityAt: session.lastActivityAt ?? undefined,
+    parent: parent ? shortSid(parent) : undefined,
+    tmuxTarget: session.tmuxTarget ?? undefined,
   };
 }
 
@@ -122,17 +236,18 @@ function mediaKind(path: string): "image" | "video" {
   );
 }
 
-function activeSessionId(input?: string): string {
+async function activeSessionId(input?: string): Promise<string> {
   const sessionId = input?.trim() || process.env.LFG_SESSION_ID?.trim();
   if (!sessionId) {
     throw new Error("sessionId required; pass it explicitly or run inside an LFG-managed session");
   }
-  return sessionId;
+  return await resolveSid(sessionId);
 }
 
 export async function closeLfgSession(sessionIdInput: string) {
-  const sessionId = sessionIdInput.trim();
-  if (!sessionId) throw new Error("sessionId required");
+  if (!sessionIdInput.trim()) throw new Error("sessionId required");
+  // Resolve before the self-close check so a short id can't slip past it.
+  const sessionId = await resolveSid(sessionIdInput);
   const caller = process.env.LFG_SESSION_ID?.trim();
   if (caller && caller === sessionId) {
     throw new Error("lfg_close_session cannot close the calling session");
@@ -145,7 +260,7 @@ export async function closeLfgSession(sessionIdInput: string) {
       body: JSON.stringify({ source: "mcp_lfg_close_session" }),
     },
   );
-  return { closed: data.ok !== false, sessionId };
+  return { closed: data.ok !== false, sessionId: shortSid(sessionId) };
 }
 
 export type FindLfgSessionsInput = {
@@ -167,8 +282,8 @@ export async function findLfgSessions(input: FindLfgSessionsInput) {
   });
 }
 
-function ownedSessionId(input?: string): string {
-  const sessionId = activeSessionId(input);
+async function ownedSessionId(input?: string): Promise<string> {
+  const sessionId = await activeSessionId(input);
   const caller = process.env.LFG_SESSION_ID?.trim();
   if (caller && caller !== sessionId) {
     throw new Error("session-owned actions can only target their owning LFG session");
@@ -182,7 +297,7 @@ export async function sendToOrigin(input: {
   artifactIds?: string[];
   sessionId?: string;
 }) {
-  const sessionId = ownedSessionId(input.sessionId);
+  const sessionId = await ownedSessionId(input.sessionId);
   const data = await api<OriginDeliveryResponse>(
     `/api/sessions/${encodeURIComponent(sessionId)}/origin-deliveries`,
     {
@@ -195,7 +310,13 @@ export async function sendToOrigin(input: {
       }),
     },
   );
-  return { delivered: data.ok !== false, sessionId, delivery: data.delivery };
+  // Deliberately does not echo the delivery body back: it repeats the text and
+  // media the caller just passed in, and lfg_output is called continuously.
+  return {
+    delivered: data.ok !== false,
+    sessionId: shortSid(sessionId),
+    deliveryId: data.delivery?.id ?? null,
+  };
 }
 
 const SUBAGENT_INPUT_SCHEMA = {
@@ -288,7 +409,8 @@ async function createSubagent({
     }
   }
   const model = rawModel?.trim() || MODEL_OPTIONS[agent as keyof typeof MODEL_OPTIONS].defaultModel;
-  const parent = parentSessionId?.trim() || process.env.LFG_SESSION_ID?.trim() || undefined;
+  const parentInput = parentSessionId?.trim() || process.env.LFG_SESSION_ID?.trim() || undefined;
+  const parent = parentInput ? await resolveSid(parentInput) : undefined;
   // Tag the child to the same user as the calling session. LFG_USER is injected
   // at spawn (see tmux.ts addSessionEnv); without this, subagents created from
   // sessions whose parent chain has no live assigned ancestor (headless/cron
@@ -310,7 +432,11 @@ async function createSubagent({
       worktree,
     }),
   });
-  return { subagent: created, parentSessionId: parent ?? null };
+  rememberSid(created.sessionId);
+  return {
+    subagent: { ...created, sessionId: shortSid(created.sessionId) },
+    parentSessionId: parent ? shortSid(parent) : null,
+  };
 }
 
 export async function cmdMcp() {
@@ -352,16 +478,21 @@ export async function cmdMcp() {
       inputSchema: {
         parentSessionId: z.string().optional().describe("Only return children of this parent session id."),
         driveableOnly: z.boolean().optional().describe("When true, only return sessions with sessionId and tmuxTarget."),
+        verbose: z
+          .boolean()
+          .optional()
+          .describe("Return full raw session rows (transcript tail, spawn command line) instead of the compact summary. Large; only use when the summary is genuinely insufficient."),
       },
     },
-    async ({ parentSessionId, driveableOnly }) => {
+    async ({ parentSessionId, driveableOnly, verbose }) => {
+      const parent = parentSessionId ? await resolveSid(parentSessionId) : undefined;
       const { sessions } = await api<{ sessions: SessionRow[] }>("/api/sessions");
       const filtered = sessions.filter((session) => {
         if (driveableOnly && (!session.sessionId || !session.tmuxTarget)) return false;
-        if (!parentSessionId) return true;
-        return session.parentSessionId === parentSessionId || session.parentNativeSessionId === parentSessionId;
+        if (!parent) return true;
+        return session.parentSessionId === parent || session.parentNativeSessionId === parent;
       });
-      return result({ sessions: filtered });
+      return result({ sessions: verbose ? filtered : filtered.map(slimSession) });
     },
   );
 
@@ -412,7 +543,21 @@ export async function cmdMcp() {
           .describe("Maximum newest metadata candidates to transcript-search (default 200, maximum 500)."),
       },
     },
-    async (input) => result(await findLfgSessions(input)),
+    async (input) => {
+      const found = (await findLfgSessions(input)) as {
+        sessions?: Array<Record<string, unknown> & { sessionId?: string | null }>;
+      };
+      return result({
+        ...found,
+        sessions: (found.sessions ?? []).map((session) => {
+          rememberSid(session.sessionId);
+          // transcriptPath is always "lfg://session/<sessionId>" — a second
+          // copy of the id we just returned.
+          const { transcriptPath: _drop, ...rest } = session;
+          return { ...rest, sessionId: shortSid(session.sessionId) };
+        }),
+      });
+    },
   );
 
   server.registerTool(
@@ -435,10 +580,10 @@ export async function cmdMcp() {
         childrenByParent.set(parent, [...(childrenByParent.get(parent) ?? []), session]);
       }
       return result({
-        roots,
+        roots: roots.map(slimSession),
         relationships: [...childrenByParent.entries()].map(([parentSessionId, children]) => ({
-          parentSessionId,
-          children,
+          parentSessionId: shortSid(parentSessionId),
+          children: children.map(slimSession),
         })),
       });
     },
@@ -456,9 +601,15 @@ export async function cmdMcp() {
       },
     },
     async ({ sessionId, limit, full }) => {
+      const sid = await resolveSid(sessionId);
       const params = full ? "full=1" : `limit=${limit ?? 30}`;
-      const data = await api(`/api/sessions/${encodeURIComponent(sessionId)}/messages?${params}`);
-      return result(data);
+      const data = await api<{ messages?: Array<Record<string, unknown>> }>(
+        `/api/sessions/${encodeURIComponent(sid)}/messages?${params}`,
+      );
+      // Each message carries both `text` and a rendered-markdown `html` copy of
+      // the same content for the web UI; the model only needs the text.
+      const messages = (data.messages ?? []).map(({ html: _drop, ...rest }) => rest);
+      return result({ ...data, messages });
     },
   );
 
@@ -474,7 +625,8 @@ export async function cmdMcp() {
       },
     },
     async ({ sessionId, text, mode }) => {
-      const data = await api(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
+      const sid = await resolveSid(sessionId);
+      const data = await api(`/api/sessions/${encodeURIComponent(sid)}/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -529,7 +681,7 @@ export async function cmdMcp() {
       },
     },
     async ({ question, options, sessionId, user }) => {
-      const sid = activeSessionId(sessionId);
+      const sid = await activeSessionId(sessionId);
       const who = user?.trim() || process.env.LFG_USER?.trim() || null;
       const data = await api<{ id: string; status: string }>("/api/ask", {
         method: "POST",
@@ -624,7 +776,7 @@ export async function cmdMcp() {
       },
     },
     async ({ path, caption, alt, sessionId }) => {
-      const sid = activeSessionId(sessionId);
+      const sid = await activeSessionId(sessionId);
       const data = await api<ImageArtifactResponse>(
         `/api/sessions/${encodeURIComponent(sid)}/artifacts/images`,
         {
@@ -635,7 +787,7 @@ export async function cmdMcp() {
       );
       return result({
         displayed: true,
-        sessionId: sid,
+        sessionId: shortSid(sid),
         artifact: data.artifact,
       });
     },
@@ -655,7 +807,7 @@ export async function cmdMcp() {
       },
     },
     async ({ path, caption, alt, sessionId }) => {
-      const sid = activeSessionId(sessionId);
+      const sid = await activeSessionId(sessionId);
       const data = await api<ImageArtifactResponse>(
         `/api/sessions/${encodeURIComponent(sid)}/artifacts/videos`,
         {
@@ -666,7 +818,7 @@ export async function cmdMcp() {
       );
       return result({
         displayed: true,
-        sessionId: sid,
+        sessionId: shortSid(sid),
         artifact: data.artifact,
       });
     },
@@ -694,7 +846,7 @@ export async function cmdMcp() {
     async ({ html, id, title, caption, sessionId, refreshScriptPath, refreshArgv, refreshIntervalSeconds, refreshTimeoutSeconds, refreshEnabled }) => {
       const hasRefreshChanges = refreshScriptPath !== undefined || refreshArgv !== undefined ||
         refreshIntervalSeconds !== undefined || refreshTimeoutSeconds !== undefined || refreshEnabled !== undefined;
-      const sid = hasRefreshChanges ? ownedSessionId(sessionId) : activeSessionId(sessionId);
+      const sid = hasRefreshChanges ? await ownedSessionId(sessionId) : await activeSessionId(sessionId);
       const data = await api<ImageArtifactResponse>(
         `/api/sessions/${encodeURIComponent(sid)}/artifacts/html`,
         {
@@ -718,7 +870,7 @@ export async function cmdMcp() {
       );
       return result({
         published: true,
-        sessionId: sid,
+        sessionId: shortSid(sid),
         artifact: data.artifact,
       });
     },
@@ -737,7 +889,7 @@ export async function cmdMcp() {
       },
     },
     async ({ id, action, sessionId }) => {
-      const sid = ownedSessionId(sessionId);
+      const sid = await ownedSessionId(sessionId);
       const method = action === "status" ? "GET" : "POST";
       const data = await api<ImageArtifactResponse & { started?: boolean; error?: string; refresh?: unknown }>(
         `/api/sessions/${encodeURIComponent(sid)}/artifacts/html/${encodeURIComponent(id)}/refresh`,
@@ -745,7 +897,7 @@ export async function cmdMcp() {
       );
       return result({
         refreshed: method === "POST" ? data.ok === true : undefined,
-        sessionId: sid,
+        sessionId: shortSid(sid),
         artifact: data.artifact,
         refresh: data.refresh ?? data.artifact?.refresh ?? null,
         error: data.error,
@@ -765,12 +917,12 @@ export async function cmdMcp() {
       },
     },
     async ({ id, sessionId }) => {
-      const sid = ownedSessionId(sessionId);
+      const sid = await ownedSessionId(sessionId);
       const data = await api<ImageArtifactResponse>(
         `/api/sessions/${encodeURIComponent(sid)}/artifacts/${encodeURIComponent(id)}`,
         { method: "DELETE", headers: { "X-LFG-Session-ID": sid } },
       );
-      return result({ deleted: data.ok === true, sessionId: sid, artifact: data.artifact });
+      return result({ deleted: data.ok === true, sessionId: shortSid(sid), artifact: data.artifact });
     },
   );
 
@@ -799,7 +951,7 @@ export async function cmdMcp() {
       },
     },
     async ({ title, id, summary, mediaPaths, artifactIds, project, sessionId }) => {
-      const sid = activeSessionId(sessionId);
+      const sid = await activeSessionId(sessionId);
       const data = await api<{ ok: boolean; post: unknown }>("/api/shipped", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -916,7 +1068,10 @@ export async function cmdMcp() {
       const data = await api("/api/sessions/reparent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, parentSessionId: parentSessionId ?? null }),
+        body: JSON.stringify({
+          sessionId: await resolveSid(sessionId),
+          parentSessionId: parentSessionId ? await resolveSid(parentSessionId) : null,
+        }),
       });
       return result(data);
     },
@@ -932,13 +1087,17 @@ export async function cmdMcp() {
       },
     },
     async ({ parentSessionId }) => {
+      const parent = parentSessionId ? await resolveSid(parentSessionId) : undefined;
       const { sessions } = await api<{ sessions: SessionRow[] }>("/api/sessions");
       const subagents = sessions.filter((session) => {
         if (!session.parentSessionId && !session.parentNativeSessionId) return false;
-        if (!parentSessionId) return true;
-        return session.parentSessionId === parentSessionId || session.parentNativeSessionId === parentSessionId;
+        if (!parent) return true;
+        return session.parentSessionId === parent || session.parentNativeSessionId === parent;
       });
-      return result({ parentSessionId: parentSessionId ?? null, subagents });
+      return result({
+        parentSessionId: parent ? shortSid(parent) : null,
+        subagents: subagents.map(slimSession),
+      });
     },
   );
 
@@ -988,7 +1147,7 @@ export async function cmdMcp() {
         return result(await sendToOrigin({ text, mediaPaths, artifactIds, sessionId }));
       }
       if (to === "shipped") {
-        const sid = activeSessionId(sessionId);
+        const sid = await activeSessionId(sessionId);
         const data = await api<{ ok: boolean; post: unknown }>("/api/shipped", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -998,7 +1157,7 @@ export async function cmdMcp() {
       }
       // to === "session"
       if (html !== undefined) {
-        const sid = activeSessionId(sessionId);
+        const sid = await activeSessionId(sessionId);
         const data = await api<ImageArtifactResponse>(
           `/api/sessions/${encodeURIComponent(sid)}/artifacts/html`,
           {
@@ -1007,10 +1166,10 @@ export async function cmdMcp() {
             body: JSON.stringify({ html, id, title, caption }),
           },
         );
-        return result({ output: "session", sessionId: sid, artifact: data.artifact });
+        return result({ output: "session", sessionId: shortSid(sid), artifact: data.artifact });
       }
       if (mediaPaths?.length) {
-        const sid = activeSessionId(sessionId);
+        const sid = await activeSessionId(sessionId);
         const artifacts = [];
         for (const m of media ?? []) {
           const endpoint = mediaKind(m.path) === "video" ? "videos" : "images";
@@ -1024,7 +1183,7 @@ export async function cmdMcp() {
           );
           artifacts.push(data.artifact);
         }
-        return result({ output: "session", sessionId: sid, artifacts });
+        return result({ output: "session", sessionId: shortSid(sid), artifacts });
       }
       throw new Error("lfg_output to 'session' requires either `html` or `media`");
     },
@@ -1061,7 +1220,7 @@ export async function cmdMcp() {
         });
         return result({ answer: data.answer });
       }
-      const sid = activeSessionId(sessionId);
+      const sid = await activeSessionId(sessionId);
       const who = user?.trim() || process.env.LFG_USER?.trim() || null;
       const data = await api<{ id: string; status: string }>("/api/ask", {
         method: "POST",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -13,6 +13,7 @@ import {
   sourceUpdateStatus,
 } from "../self-update.ts";
 import { compressedAssetResponse, maybeCompressResponse } from "../http-compress.ts";
+import { shortSessionId } from "../lfg-capabilities.ts";
 import {
   getCachedResumableSession,
   updateResumableUser,
@@ -1205,8 +1206,10 @@ function withLfgSubagentContract(
   opts: { parentSessionId?: string; depth?: number | null },
 ): string {
   const depthText = opts.depth ? ` Current child depth: ${opts.depth}/${MAX_LFG_SUBAGENT_DEPTH}.` : "";
+  // Short (8-char) id: LFG's MCP layer resolves any unambiguous id prefix back
+  // to the full session id, so the child never needs the whole uuid.
   const parentLine = opts.parentSessionId
-    ? `- Parent session id: ${opts.parentSessionId}. Send progress and terminal-state updates there with MCP tool \`lfg_send_session_message\`.`
+    ? `- Parent session id: ${shortSessionId(opts.parentSessionId)}. Send progress and terminal-state updates there with MCP tool \`lfg_send_session_message\`.`
     : "- No parent session id was supplied. If one becomes available, send progress and terminal-state updates there.";
   const reportLines = opts.parentSessionId
     ? [

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1080,6 +1080,97 @@ function err(status: number, message: string) {
   return json({ error: message }, { status });
 }
 
+type CloseOutcome = { ok: true; mode: string } | { ok: false; status: number; reason: string };
+
+// Tear down one live session. Shared by the single-session /close route and the
+// bulk /api/sessions/close-all sweep so both take the exact same path (harness
+// shutdown command, tmux teardown, pid tombstone, registry cleanup).
+async function closeLiveSession(
+  sess: Session,
+  id: string,
+  closeLog: Record<string, unknown>,
+): Promise<CloseOutcome> {
+  persistManagedResume(sess);
+  if (isCommandFileAgent(sess.agent)) {
+    // Ask the harness to shut down, then tear down its supervisor pane and
+    // control-plane files. markClosed tombstones the harness pid so the
+    // session drops out of the list immediately. For codex-aisdk the
+    // live-view id is the threadId — map it back to the key the command
+    // file and registry entry are named by.
+    const key = findAisdkEntryByAnyId(id)?.sessionId ?? id;
+    appendAisdkCmd(key, { type: "close" });
+    if (sess.tmuxName) tmuxKillSession(sess.tmuxName);
+    markClosed(sess.pid);
+    removeAisdkEntry(key);
+    if (sess.tmuxName) {
+      removeManaged(sess.tmuxName);
+      assignUser(sess.tmuxName, null);
+    }
+    clearResolved(id);
+    invalidateListSessionsCache();
+    evlog("session_close_done", {
+      ...closeLog,
+      agent: sess.agent,
+      tmuxName: sess.tmuxName,
+      managed: sess.managed,
+      mode: "harness",
+    });
+    return { ok: true, mode: "harness" };
+  }
+  if (!sess.tmuxTarget) {
+    evlog("session_close_rejected", {
+      ...closeLog,
+      agent: sess.agent,
+      tmuxName: sess.tmuxName,
+      managed: sess.managed,
+      reason: "no_tmux_target",
+    });
+    return { ok: false, status: 409, reason: "session is not in a tmux pane — cannot close" };
+  }
+  // A session lfg started owns its whole tmux session (one managed
+  // claude, no sibling panes) — kill the session and deregister it.
+  // Attached sessions might share a tmux session with the user's other
+  // panes, so only kill the one pane.
+  const killed =
+    sess.managed && sess.tmuxName ? tmuxKillSession(sess.tmuxName) : tmuxKillPane(sess.tmuxTarget);
+  if (!killed) {
+    evlog("session_close_failed", {
+      ...closeLog,
+      agent: sess.agent,
+      tmuxName: sess.tmuxName,
+      managed: sess.managed,
+    });
+    return { ok: false, status: 502, reason: "close failed" };
+  }
+  // Tombstone the pid so the session drops out of listSessions() at once
+  // — the process lingers briefly after the SIGHUP and would otherwise
+  // flicker back for a poll or two before pgrep stops seeing it.
+  markClosed(sess.pid);
+  if (sess.managed && sess.tmuxName) {
+    if (sess.agent === "codex") {
+      const tp = await resolveTranscript(id).catch(() => null);
+      const nativeSessionId =
+        sess.nativeSessionId ??
+        tp?.match(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/)?.[0];
+      patchManaged(sess.tmuxName, { launchState: "running", nativeSessionId });
+    } else {
+      removeManaged(sess.tmuxName);
+    }
+    assignUser(sess.tmuxName, null); // a managed name is unique + now gone
+  }
+  clearResolved(id);
+  invalidateListSessionsCache();
+  const mode = sess.managed && sess.tmuxName ? "tmux_session" : "tmux_pane";
+  evlog("session_close_done", {
+    ...closeLog,
+    agent: sess.agent,
+    tmuxName: sess.tmuxName,
+    managed: sess.managed,
+    mode,
+  });
+  return { ok: true, mode };
+}
+
 type ParentableSession = {
   sessionId?: string | null;
   nativeSessionId?: string | null;
@@ -5320,90 +5411,85 @@ export async function cmdServe() {
             managed: sess?.managed,
           });
           if (!sess) return err(404, "session not found");
-          persistManagedResume(sess);
-          if (isCommandFileAgent(sess.agent)) {
-            // Ask the harness to shut down, then tear down its supervisor pane and
-            // control-plane files. markClosed tombstones the harness pid so the
-            // session drops out of the list immediately. For codex-aisdk the
-            // live-view id is the threadId — map it back to the key the command
-            // file and registry entry are named by.
-            const key = findAisdkEntryByAnyId(m[1])?.sessionId ?? m[1];
-            appendAisdkCmd(key, { type: "close" });
-            if (sess.tmuxName) tmuxKillSession(sess.tmuxName);
-            markClosed(sess.pid);
-            removeAisdkEntry(key);
-            if (sess.tmuxName) {
-              removeManaged(sess.tmuxName);
-              assignUser(sess.tmuxName, null);
-            }
-            clearResolved(m[1]);
-            invalidateListSessionsCache();
-            evlog("session_close_done", {
-              ...closeLog,
-              agent: sess.agent,
-              tmuxName: sess.tmuxName,
-              managed: sess.managed,
-              mode: "harness",
-            });
-            return json({ ok: true });
-          }
-          if (!sess.tmuxTarget) {
-            evlog("session_close_rejected", {
-              ...closeLog,
-              agent: sess.agent,
-              tmuxName: sess.tmuxName,
-              managed: sess.managed,
-              reason: "no_tmux_target",
-            });
-            return err(409, "session is not in a tmux pane — cannot close");
-          }
-          // A session lfg started owns its whole tmux session (one managed
-          // claude, no sibling panes) — kill the session and deregister it.
-          // Attached sessions might share a tmux session with the user's other
-          // panes, so only kill the one pane.
-          const ok =
-            sess.managed && sess.tmuxName
-              ? tmuxKillSession(sess.tmuxName)
-              : tmuxKillPane(sess.tmuxTarget);
-          if (!ok) {
-            evlog("session_close_failed", {
-              ...closeLog,
-              agent: sess.agent,
-              tmuxName: sess.tmuxName,
-              managed: sess.managed,
-            });
-            return err(502, "close failed");
-          }
-          // Tombstone the pid so the session drops out of listSessions() at once
-          // — the process lingers briefly after the SIGHUP and would otherwise
-          // flicker back for a poll or two before pgrep stops seeing it.
-          markClosed(sess.pid);
-          if (sess.managed && sess.tmuxName) {
-            if (sess.agent === "codex") {
-              const tp = await resolveTranscript(m[1]).catch(() => null);
-              const nativeSessionId =
-                sess.nativeSessionId ??
-                tp?.match(/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/)?.[0];
-              patchManaged(sess.tmuxName, {
-                launchState: "running",
-                nativeSessionId,
-              });
-            } else {
-              removeManaged(sess.tmuxName);
-            }
-            assignUser(sess.tmuxName, null); // a managed name is unique + now gone
-          }
-          clearResolved(m[1]);
-          invalidateListSessionsCache();
-          evlog("session_close_done", {
-            ...closeLog,
-            agent: sess.agent,
-            tmuxName: sess.tmuxName,
-            managed: sess.managed,
-            mode: sess.managed && sess.tmuxName ? "tmux_session" : "tmux_pane",
-          });
+          const outcome = await closeLiveSession(sess, m[1], closeLog);
+          if (!outcome.ok) return err(outcome.status, outcome.reason);
           return json({ ok: true });
         }
+      }
+
+      // Bulk teardown: end every session that isn't mid-turn, in one request.
+      // Deliberately plumbing-only (no agent, no model) — the fleet view calls
+      // this directly so cleaning up a pile of finished sessions is one click.
+      if (path === "/api/sessions/close-all" && req.method === "POST") {
+        const body = (await req.json().catch(() => null)) as {
+          source?: unknown;
+          scope?: unknown;
+          exclude?: unknown;
+          sessionIds?: unknown;
+        } | null;
+        const rawSource = typeof body?.source === "string" ? body.source.trim() : "";
+        const source = rawSource ? rawSource.slice(0, 80) : "unknown";
+        // "idle" (default) spares sessions that are currently running a turn;
+        // "all" ends those too.
+        const scope = body?.scope === "all" ? "all" : "idle";
+        const exclude = new Set(
+          (Array.isArray(body?.exclude) ? body.exclude : [])
+            .filter((v): v is string => typeof v === "string")
+            .slice(0, 200),
+        );
+        // Optional allowlist: the caller (the fleet view) passes exactly the
+        // sessions currently in scope for its project/user filters, so the
+        // sweep never reaches past what the user can see.
+        const only = Array.isArray(body?.sessionIds)
+          ? new Set(body.sessionIds.filter((v): v is string => typeof v === "string").slice(0, 500))
+          : null;
+        const href = req.headers.get("referer") ?? undefined;
+        const all = await listSessions();
+        const inScope = only ? all.filter((s) => s.sessionId && only.has(s.sessionId)) : all;
+        const targets = inScope.filter(
+          (s) => s.sessionId && !exclude.has(s.sessionId) && (scope === "all" || !s.busy),
+        );
+        evlog("sessions_close_all_request", {
+          source,
+          href,
+          scope,
+          total: all.length,
+          inScope: inScope.length,
+          targets: targets.length,
+          skippedBusy: inScope.length - targets.length,
+        });
+        const closed: string[] = [];
+        const failed: { sessionId: string; reason: string }[] = [];
+        // Sequential: each close kills tmux panes and rewrites registry files,
+        // and the list is small (tens at most).
+        for (const sess of targets) {
+          const sid = sess.sessionId as string;
+          const outcome = await closeLiveSession(sess, sid, {
+            sessionId: sid,
+            source,
+            href,
+          }).catch((e) => ({
+            ok: false as const,
+            status: 500,
+            reason: e instanceof Error ? e.message : String(e),
+          }));
+          if (outcome.ok) closed.push(sid);
+          else failed.push({ sessionId: sid, reason: outcome.reason });
+        }
+        invalidateListSessionsCache();
+        evlog("sessions_close_all_done", {
+          source,
+          scope,
+          closed: closed.length,
+          failed: failed.length,
+        });
+        return json({
+          ok: true,
+          scope,
+          closed,
+          failed,
+          skipped: inScope.length - targets.length,
+        });
       }
 
       if (path === "/api/live/status") {

--- a/src/lfg-capabilities.ts
+++ b/src/lfg-capabilities.ts
@@ -35,11 +35,23 @@ export const LFG_CAPABILITIES = [
   },
 ] as const;
 
+// Session ids are 36-char uuids minted by the underlying harness and are
+// load-bearing on disk, so they are never re-minted. Agent-facing surfaces show
+// this 8-char prefix instead; LFG's MCP layer resolves any unambiguous prefix
+// back to the full id, git-short-sha style.
+const SESSION_UUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+export const SHORT_SESSION_ID_LENGTH = 8;
+
+export function shortSessionId(id: string): string {
+  return SESSION_UUID.test(id) ? id.slice(0, SHORT_SESSION_ID_LENGTH) : id;
+}
+
 export const LFG_MCP_INSTRUCTIONS = [
   `This is LFG's agent capability server (capability version ${LFG_CAPABILITY_VERSION}).`,
   "The agent<->human channel is two verbs: lfg_output (tell) and lfg_input (ask).",
   "Narrate your decisions and progress continuously through lfg_output so the session never goes dark; show verification media and verified completions the same way.",
   "Decide autonomously and keep moving — use lfg_input only for a genuinely irreversible decision (non-blocking) or to consult the advisor. Use lfg_capabilities to detect a stale long-lived session, and LFG-managed delegation when delegation is explicitly requested.",
+  `Session ids are returned in short form (${SHORT_SESSION_ID_LENGTH}-char prefix, like a git short sha). Pass them back exactly as given — any unambiguous prefix resolves to the full id.`,
 ].join(" ");
 
 export function lfgRuntimeContract(): string {
@@ -55,6 +67,7 @@ export function lfgRuntimeContract(): string {
     "- Use `lfg_find_sessions` to locate ended or historical sessions by id, owner, project, text, or last-activity range; use `lfg_list_sessions` for the live fleet.",
     "- When the user or governing instructions explicitly request delegation, prefer `lfg_create_subagent` or `lfg_delegate_*` so children remain visible and linked in LFG.",
     "- Use `lfg_close_session` only after resolving another session's exact id with `lfg_list_sessions`; never close your own session.",
+    `- Session ids are shown in short form (${SHORT_SESSION_ID_LENGTH}-char prefix, like a git short sha). Pass them back exactly as given; any unambiguous prefix resolves to the full id, and an ambiguous one is rejected rather than guessed.`,
     "- If an exact LFG tool is unavailable, call `lfg_capabilities`. Report that the session needs a capability refresh only when it returns `stale: true`; otherwise report that the capability is unsupported. Do not reverse-engineer or call LFG's private HTTP endpoints as a substitute.",
     "=== END LFG RUNTIME CONTRACT ===",
   ].join("\n");

--- a/test/transcript-cache.test.ts
+++ b/test/transcript-cache.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { LfgChatMessage } from "../web/src/lib/lfg-chat-transport.ts";
+import {
+  clearTranscriptCache,
+  readTranscriptCache,
+  updateTranscriptCacheMessages,
+  writeTranscriptCache,
+} from "../web/src/lib/transcript-cache.ts";
+
+function msg(id: string): LfgChatMessage {
+  return { id, role: "assistant", parts: [{ type: "text", text: id }] } as LfgChatMessage;
+}
+
+describe("transcript cache", () => {
+  beforeEach(() => clearTranscriptCache());
+
+  test("round-trips a written page so a re-open can paint instantly", () => {
+    writeTranscriptCache("s1", [msg("a"), msg("b")], 42);
+    const entry = readTranscriptCache("s1");
+    expect(entry?.messages.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(entry?.nextBefore).toBe(42);
+  });
+
+  test("misses cleanly for an unknown session", () => {
+    expect(readTranscriptCache("nope")).toBeNull();
+  });
+
+  test("live updates keep the cached page current", () => {
+    writeTranscriptCache("s1", [msg("a")], null);
+    updateTranscriptCacheMessages("s1", [msg("a"), msg("b")]);
+    expect(readTranscriptCache("s1")?.messages.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  test("live updates never create an entry for an unloaded session", () => {
+    updateTranscriptCacheMessages("ghost", [msg("a")]);
+    expect(readTranscriptCache("ghost")).toBeNull();
+  });
+
+  test("keeps the cache bounded", () => {
+    for (let i = 0; i < 200; i += 1) writeTranscriptCache(`s${i}`, [msg(`m${i}`)], null);
+    let kept = 0;
+    for (let i = 0; i < 200; i += 1) if (readTranscriptCache(`s${i}`)) kept += 1;
+    expect(kept).toBeLessThanOrEqual(24);
+    // The most recent writes are the ones worth keeping.
+    expect(readTranscriptCache("s199")).not.toBeNull();
+  });
+
+  test("reading refreshes LRU position so an active session survives churn", () => {
+    writeTranscriptCache("old", [msg("a")], null);
+    for (let i = 0; i < 20; i += 1) writeTranscriptCache(`f${i}`, [msg(`m${i}`)], null);
+    readTranscriptCache("old"); // touch it
+    for (let i = 20; i < 40; i += 1) writeTranscriptCache(`f${i}`, [msg(`m${i}`)], null);
+    // Not asserting survival forever — just that touching moved it ahead of the
+    // entries written before the touch.
+    expect(readTranscriptCache("f0")).toBeNull();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -950,6 +950,23 @@ function closeSessionRequest(sid: string, source: string) {
   });
 }
 
+type CloseAllResult = {
+  closed?: string[];
+  failed?: { sessionId: string; reason: string }[];
+  skipped?: number;
+};
+
+// Bulk close, straight to the server — no agent, no model in the loop. The
+// explicit id list scopes the sweep to exactly the cards visible under the
+// current project/user filters.
+function closeAllSessionsRequest(sessionIds: string[], source: string) {
+  return api<CloseAllResult>("/api/sessions/close-all", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source, scope: "idle", sessionIds }),
+  });
+}
+
 let skillCatalogPromise: Promise<SkillCatalogItem[]> | null = null;
 let skillCatalogLoadedAt = 0;
 let skillCatalogSnapshot: SkillCatalogItem[] = [];
@@ -3344,6 +3361,7 @@ function PushBell({ user }: { user?: string | null }) {
 }
 
 export function App() {
+  const appDialog = useAppDialog();
   const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
   useEffect(() => {
     const syncTheme = () => {
@@ -4539,6 +4557,42 @@ export function App() {
     }
   }
 
+  // Direct bulk clear: ends every idle in-scope session in one request. The
+  // Manage Sessions templates below spawn an agent to exercise judgement; this
+  // is the plumbing version for "just clear them" — no LLM involved.
+  async function clearIdleSessions() {
+    const targets = liveSessions.filter((s) => s.sessionId && !s.busy);
+    const busyCount = liveSessions.length - targets.length;
+    if (!targets.length) {
+      toast.info(busyCount ? "Every session in scope is still working" : "No sessions to clear");
+      return;
+    }
+    const confirmed = await appDialog.confirm({
+      title: `End ${targets.length} idle session${targets.length === 1 ? "" : "s"}?`,
+      description: busyCount
+        ? `${busyCount} session${busyCount === 1 ? " is" : "s are"} still working and will be left running.`
+        : "They stop immediately and disappear from the live view.",
+      confirmLabel: "End sessions",
+      destructive: true,
+    });
+    if (!confirmed) return;
+    const ids = targets.map((s) => s.sessionId as string);
+    // Drop the cards now; the server tombstones the pids so the next poll
+    // agrees (same optimistic path as a single close).
+    ids.forEach((sid) => removeSession(sid));
+    try {
+      const res = await closeAllSessionsRequest(ids, "live_clear_idle");
+      const closed = res.closed?.length ?? 0;
+      const failed = res.failed?.length ?? 0;
+      if (failed) toast.warning(`Ended ${closed}, ${failed} could not be closed`);
+      else toast.success(`Ended ${closed} session${closed === 1 ? "" : "s"}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not clear sessions");
+    } finally {
+      await refreshSessions().catch(() => {});
+    }
+  }
+
   async function launchManageSessions(template: ManageSessionPromptTemplate) {
     const scopedRepo =
       projectFilter !== "__all"
@@ -4845,6 +4899,7 @@ export function App() {
                   <ManageSessionsMenu
                     projectFilter={projectFilter}
                     onSelect={(template) => void launchManageSessions(template)}
+                    onClearIdle={() => void clearIdleSessions()}
                   />
                 ) : null}
                 <UserFilterMenu
@@ -4904,6 +4959,7 @@ export function App() {
               isMobile ? setComposerFocusNonce((n) => n + 1) : setNewOpen(true)
             }
             onManageSessions={(template) => void launchManageSessions(template)}
+            onClearIdle={() => void clearIdleSessions()}
             findings={projectScopedFindings}
             autoAgents={projectScopedAutoAgents}
             onOpenFinding={setOpenFinding}
@@ -5665,10 +5721,12 @@ function UsageRingsButton({
 function ManageSessionsMenu({
   projectFilter,
   onSelect,
+  onClearIdle,
   compact = false,
 }: {
   projectFilter: string;
   onSelect: (template: ManageSessionPromptTemplate) => void;
+  onClearIdle?: () => void;
   compact?: boolean;
 }) {
   const scopeLabel = projectFilter === "__all" ? "All projects" : shortProject(projectFilter);
@@ -5705,6 +5763,24 @@ function ManageSessionsMenu({
           </DropdownMenuLabel>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
+        {onClearIdle ? (
+          <>
+            {/* Direct action — runs against the API, no agent spawned. Kept
+                above the agent-driven templates because it's the one people
+                reach for most: "just clear the finished ones". */}
+            <DropdownMenuItem
+              variant="destructive"
+              className="flex cursor-pointer flex-col items-start gap-0.5 py-2"
+              onClick={onClearIdle}
+            >
+              <span className="text-sm font-medium text-destructive">Clear idle sessions</span>
+              <span className="text-xs text-muted-foreground">
+                Ends every non-working session now. No agent.
+              </span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : null}
         {MANAGE_SESSION_PROMPTS.map((template) => (
           <DropdownMenuItem
             key={template.id}
@@ -6825,6 +6901,7 @@ function LiveView({
   onOpenAsk,
   onOpenShipped,
   onManageSessions,
+  onClearIdle,
   focus,
 }: {
   sessions: Session[];
@@ -6838,6 +6915,7 @@ function LiveView({
   onOpenAsk?: () => void;
   onOpenShipped?: () => void;
   onManageSessions: (template: ManageSessionPromptTemplate) => void;
+  onClearIdle: () => void;
   messagesBySid: Record<string, Message[]>;
   busyBySid: Record<string, boolean>;
   promptsBySid: Record<string, SessionPrompt | null>;
@@ -7073,6 +7151,8 @@ function LiveView({
         onOpenSettings={onOpenSettings}
         onOpenAsk={onOpenAsk}
         onOpenShipped={onOpenShipped}
+        onManageSessions={onManageSessions}
+        onClearIdle={onClearIdle}
         focus={focus}
         topPinned={topPinned}
         onToggleTopPin={toggleTopPin}
@@ -7140,6 +7220,7 @@ function LiveView({
                 compact
                 projectFilter={projectFilter}
                 onSelect={onManageSessions}
+                onClearIdle={onClearIdle}
               />
             }
           />
@@ -7198,6 +7279,8 @@ function RailStage({
   onOpenSettings,
   onOpenAsk,
   onOpenShipped,
+  onManageSessions,
+  onClearIdle,
   focus,
   topPinned,
   onToggleTopPin,
@@ -7212,6 +7295,8 @@ function RailStage({
   onOpenSettings?: () => void;
   onOpenAsk?: () => void;
   onOpenShipped?: () => void;
+  onManageSessions?: (template: ManageSessionPromptTemplate) => void;
+  onClearIdle?: () => void;
   focus?: { sid: string; n: number } | null;
   topPinned: string[];
   onToggleTopPin: (sid: string) => void;
@@ -8075,6 +8160,13 @@ function RailStage({
                     value={userFilter}
                     users={users}
                     onChange={onUserChange}
+                  />
+                ) : null}
+                {onManageSessions ? (
+                  <ManageSessionsMenu
+                    projectFilter={projectFilter}
+                    onSelect={onManageSessions}
+                    onClearIdle={onClearIdle}
                   />
                 ) : null}
               </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,12 @@ import {
   type LfgChatMessage,
   type LfgTranscriptSubscribe,
 } from "./lib/lfg-chat-transport";
+import {
+  prefetchTranscripts,
+  readTranscriptCache,
+  updateTranscriptCacheMessages,
+  writeTranscriptCache,
+} from "./lib/transcript-cache";
 import { setThemePreference, THEME_CHANGE_EVENT } from "./lib/theme";
 import { startsInBottomSystemGestureZone } from "./lib/touch-gestures";
 import { ConnectionStatusToasts } from "./ConnectionStatus";
@@ -6989,6 +6995,37 @@ function LiveView({
     [sessions, busyBySid],
   );
 
+  // Pinned session families always lead the narrow/mobile layout. A pin on a
+  // delegated child lifts its whole family so parent/child nesting stays intact.
+  // Computed above the empty-state return so the render order is also available
+  // to the prefetch hook below (hooks must not sit behind a conditional return).
+  const pinnedSet = new Set(topPinned);
+  const nodeContainsPin = (node: SessionTreeNode): boolean =>
+    pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
+  const pinnedNodes = tree.roots.filter(nodeContainsPin);
+  // Remaining roots keep the familiar working → idle grouping. A parent is
+  // considered working if any child is working.
+  const workingNodes = tree.roots.filter(
+    (node) => !nodeContainsPin(node) && tree.effectiveBusy(node),
+  );
+  const idleNodes = tree.roots.filter(
+    (node) => !nodeContainsPin(node) && !tree.effectiveBusy(node),
+  );
+  const pinned = tree.flatten(pinnedNodes);
+  const working = tree.flatten(workingNodes);
+  const idle = tree.flatten(idleNodes);
+
+  // On-screen order: pinned, then working, then idle. Drives both sheet
+  // navigation and which transcripts we warm ahead of the user opening them.
+  const screenOrder = [...pinned, ...working, ...idle]
+    .map((s) => s.sessionId)
+    .filter((id): id is string => !!id);
+  const prefetchKey = screenOrder.slice(0, 8).join(",");
+  useEffect(() => {
+    if (!prefetchKey) return;
+    prefetchTranscripts(prefetchKey.split(","), loadTranscriptPage);
+  }, [prefetchKey]);
+
   // Empty state. Placed AFTER all hooks (useIsWide/useState/useMemo above) so the
   // hook order stays identical whether or not sessions/findings are present —
   // returning earlier made `useMemo` conditional and tripped React error #310
@@ -7017,23 +7054,6 @@ function LiveView({
     );
   }
 
-  // Pinned session families always lead the narrow/mobile layout. A pin on a
-  // delegated child lifts its whole family so parent/child nesting stays intact.
-  const pinnedSet = new Set(topPinned);
-  const nodeContainsPin = (node: SessionTreeNode): boolean =>
-    pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
-  const pinnedNodes = tree.roots.filter(nodeContainsPin);
-  // Remaining roots keep the familiar working → idle grouping. A parent is
-  // considered working if any child is working.
-  const workingNodes = tree.roots.filter(
-    (node) => !nodeContainsPin(node) && tree.effectiveBusy(node),
-  );
-  const idleNodes = tree.roots.filter(
-    (node) => !nodeContainsPin(node) && !tree.effectiveBusy(node),
-  );
-  const pinned = tree.flatten(pinnedNodes);
-  const working = tree.flatten(workingNodes);
-  const idle = tree.flatten(idleNodes);
   const nameFor = (id: string) => autoAgents.find((a) => a.id === id)?.name ?? id;
 
   const renderCard = (session: Session, depth = 0) => (
@@ -7160,14 +7180,8 @@ function LiveView({
     );
   }
 
-  // Sheet navigation follows the on-screen order: pinned, working, then idle.
-  const sheetOrder = [
-    ...tree.flatten(pinnedNodes),
-    ...tree.flatten(workingNodes),
-    ...tree.flatten(idleNodes),
-  ]
-    .map((s) => s.sessionId)
-    .filter((id): id is string => !!id);
+  // Sheet navigation follows the same on-screen order.
+  const sheetOrder = screenOrder;
   const sheetSession = sheet ? sessions.find((s) => s.sessionId === sheet.sid) : null;
 
   return (
@@ -7674,6 +7688,14 @@ function RailStage({
   useEffect(() => {
     setCursor((c) => (c && orderedSids.includes(c) ? c : orderedSids[0] ?? null));
   }, [orderedSids]);
+  // Warm the transcripts at the top of the rail so opening one paints instantly
+  // instead of waiting on its first `/messages` round trip. The narrow layout
+  // does the same from its own order; the prefetcher dedupes across both.
+  const railPrefetchKey = orderedSids.slice(0, 8).join(",");
+  useEffect(() => {
+    if (!railPrefetchKey) return;
+    prefetchTranscripts(railPrefetchKey.split(","), loadTranscriptPage);
+  }, [railPrefetchKey]);
   // Scroll the cursored row into view as it moves.
   useEffect(() => {
     if (!cursor) return;
@@ -9088,6 +9110,17 @@ function SkillTextarea({
   );
 }
 
+// Shared transcript page loader used to warm the cache ahead of a session open.
+async function loadTranscriptPage(sid: string) {
+  const page = await api<{ messages: Message[]; nextBefore?: number | null }>(
+    `/api/sessions/${encodeURIComponent(sid)}/messages?limit=80`,
+  );
+  return {
+    messages: lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []),
+    nextBefore: page.nextBefore ?? null,
+  };
+}
+
 function SessionChat({
   session,
   busy,
@@ -9163,9 +9196,20 @@ function SessionChat({
       return;
     }
     let cancelled = false;
-    setHistoryLoading(true);
-    setNextBefore(null);
-    setMessages([]);
+    // Paint the last-known page for this session synchronously so re-opening a
+    // session is instant instead of a blank pane + spinner while the network
+    // round trip lands. We still refetch below and reconcile — the cached paint
+    // just removes the wait from the critical path.
+    const cached = readTranscriptCache(sid);
+    if (cached) {
+      setMessages(cached.messages);
+      setNextBefore(cached.nextBefore);
+      setHistoryLoading(false);
+    } else {
+      setHistoryLoading(true);
+      setNextBefore(null);
+      setMessages([]);
+    }
     void api<{ messages: Message[]; nextBefore?: number | null }>(
       `/api/sessions/${encodeURIComponent(sid)}/messages?limit=80`,
       { cache: "no-store" },
@@ -9173,13 +9217,33 @@ function SessionChat({
       .then((page) => {
         if (cancelled) return;
         const history = lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []);
+        const historyIds = new Set(history.map((message) => message.id));
+        // Anything the user had already paged in above this window stays put, in
+        // its original order — the fresh page only replaces the tail it covers.
+        const olderKept = cached
+          ? cached.messages.slice(
+              0,
+              Math.max(0, cached.messages.findIndex((message) => historyIds.has(message.id))),
+            )
+          : [];
+        const keptIds = new Set(olderKept.map((message) => message.id));
+        let settled: LfgChatMessage[] = history;
         setMessages((current) => {
-          if (!current.length) return history;
-          const historyIds = new Set(history.map((message) => message.id));
-          const liveOnly = current.filter((message) => !historyIds.has(message.id));
-          return liveOnly.length ? [...history, ...liveOnly] : history;
+          // Messages that landed live while this fetch was in flight and aren't
+          // in the page yet — they're newest, so they belong at the end.
+          const liveOnly = current.filter(
+            (message) => !historyIds.has(message.id) && !keptIds.has(message.id),
+          );
+          const cachedIds = new Set(cached?.messages.map((message) => message.id) ?? []);
+          const trailing = liveOnly.filter((message) => !cachedIds.has(message.id));
+          return (settled = [...olderKept, ...history, ...trailing]);
         });
-        setNextBefore(page.nextBefore ?? null);
+        // Keep the deeper cursor when we preserved paged-in history above.
+        const settledBefore = olderKept.length
+          ? (cached?.nextBefore ?? null)
+          : (page.nextBefore ?? null);
+        setNextBefore(settledBefore);
+        writeTranscriptCache(sid, settled, settledBefore);
       })
       .catch((err) => {
         if (!cancelled) onError(err instanceof Error ? err.message : String(err));
@@ -9201,11 +9265,15 @@ function SessionChat({
         return;
       }
       if (event.type === "busy") setLiveBusy(event.busy);
-      setMessages((current) =>
-        appendLfgTranscriptEvent(current, event, {
+      setMessages((current) => {
+        const next = appendLfgTranscriptEvent(current, event, {
           streamActive: chatStatusRef.current === "submitted" || chatStatusRef.current === "streaming",
-        }),
-      );
+        });
+        // Keep the cached page current so the next re-open paints the newest
+        // state rather than a stale snapshot.
+        if (next !== current) updateTranscriptCacheMessages(sid, next);
+        return next;
+      });
     });
   }, [onError, onSubscribeTranscript, setMessages, sid]);
 
@@ -9219,11 +9287,15 @@ function SessionChat({
     const older = lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []);
     setNextBefore(page.nextBefore ?? null);
     if (!older.length) return (page.nextBefore ?? null) !== null;
+    let settled: LfgChatMessage[] = older;
     setMessages((current) => {
       const existing = new Set(current.map((message) => message.id));
       const prepend = older.filter((message) => !existing.has(message.id));
-      return prepend.length ? [...prepend, ...current] : current;
+      return (settled = prepend.length ? [...prepend, ...current] : current);
     });
+    // Cache the deeper window too, so scrolling back then leaving and returning
+    // doesn't lose the pages the user already waited for.
+    writeTranscriptCache(sid, settled, page.nextBefore ?? null);
     return (page.nextBefore ?? null) !== null;
   }, [nextBefore, setMessages, sid]);
 

--- a/web/src/lib/transcript-cache.ts
+++ b/web/src/lib/transcript-cache.ts
@@ -1,0 +1,132 @@
+import type { LfgChatMessage } from "./lfg-chat-transport";
+
+// Session-switch transcript cache.
+//
+// Opening a session used to blank the pane and wait on a fresh
+// `/api/sessions/{id}/messages` round trip every single time — including for a
+// session you had open seconds ago. The server page itself is sub-millisecond,
+// so that wait was pure network latency, and it read as "transcript loading is
+// slow" whenever the link was slow (remote/tunnelled/mobile).
+//
+// We keep the last-known page per session in memory so a re-open paints
+// instantly from cache and revalidates in the background (stale-while-
+// revalidate). Live transcript events keep the cached entry current while the
+// session stays mounted, so the cached paint is usually already correct.
+
+export type TranscriptCacheEntry = {
+  messages: LfgChatMessage[];
+  nextBefore: number | null;
+  at: number;
+};
+
+// Bounded so a long-lived tab that visits many sessions can't grow without
+// limit; insertion-ordered Map = cheap LRU when we re-set on read.
+const MAX_SESSIONS = 24;
+const cache = new Map<string, TranscriptCacheEntry>();
+
+function trim() {
+  for (const sid of cache.keys()) {
+    if (cache.size <= MAX_SESSIONS) return;
+    cache.delete(sid);
+  }
+}
+
+export function readTranscriptCache(sid: string): TranscriptCacheEntry | null {
+  const entry = cache.get(sid);
+  if (!entry) return null;
+  // Refresh LRU position on read.
+  cache.delete(sid);
+  cache.set(sid, entry);
+  return entry;
+}
+
+export function writeTranscriptCache(
+  sid: string,
+  messages: LfgChatMessage[],
+  nextBefore: number | null,
+) {
+  if (!sid) return;
+  cache.delete(sid);
+  cache.set(sid, { messages, nextBefore, at: Date.now() });
+  trim();
+}
+
+// Keep the cached page in sync as live events land, without disturbing LRU
+// order or creating an entry for a session we never loaded a page for.
+export function updateTranscriptCacheMessages(sid: string, messages: LfgChatMessage[]) {
+  const entry = cache.get(sid);
+  if (!entry) return;
+  entry.messages = messages;
+  entry.at = Date.now();
+}
+
+// How many of the top-of-list sessions to warm ahead of the user opening them.
+const PREFETCH_COUNT = 8;
+
+// Module-level, not a component ref: the app remounts (e.g. after picking a
+// profile) and a per-instance ref would re-run the whole prefetch sweep.
+const attempted = new Set<string>();
+const queue: string[] = [];
+let sweeping = false;
+
+// `requestIdleCallback` where available, timeout fallback for Safari. Keeps
+// prefetch off the critical path of the list's first paint.
+function whenIdle(run: () => void) {
+  const ric = (
+    globalThis as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }
+  ).requestIdleCallback;
+  if (typeof ric === "function") ric(run, { timeout: 2000 });
+  else setTimeout(run, 500);
+}
+
+/**
+ * Warm the cache for the first few sessions in the order the user actually sees
+ * them, so the *first* open of a session paints instantly too — not just
+ * re-opens. Best-effort and idempotent: every sid is attempted at most once,
+ * and a page the user's own open already wrote is never clobbered.
+ */
+export function prefetchTranscripts(
+  orderedSids: string[],
+  load: (sid: string) => Promise<{ messages: LfgChatMessage[]; nextBefore: number | null }>,
+) {
+  for (const sid of orderedSids
+    .filter((sid) => sid && !attempted.has(sid) && !cache.has(sid))
+    .slice(0, PREFETCH_COUNT)) {
+    if (!queue.includes(sid)) queue.push(sid);
+  }
+  // Queued rather than dropped: the narrow and wide layouts each report their
+  // own on-screen order, and a sweep already running must not discard the other.
+  if (!queue.length || sweeping) return;
+  sweeping = true;
+  whenIdle(async () => {
+    try {
+      // Serial: background work must never contend with the fetch for a session
+      // the user actually opened.
+      while (queue.length) {
+        const sid = queue.shift() as string;
+        if (attempted.has(sid) || cache.has(sid)) continue;
+        attempted.add(sid);
+        try {
+          const page = await load(sid);
+          if (cache.has(sid)) continue;
+          writeTranscriptCache(sid, page.messages, page.nextBefore);
+        } catch {
+          // Best-effort; opening the session still fetches normally.
+        }
+      }
+    } finally {
+      sweeping = false;
+    }
+  });
+}
+
+export function clearTranscriptCache(sid?: string) {
+  if (sid) {
+    cache.delete(sid);
+    attempted.delete(sid);
+    return;
+  }
+  cache.clear();
+  attempted.clear();
+  queue.length = 0;
+}


### PR DESCRIPTION
## Why

`lfg_list_sessions` returned the full raw session row for every live session: **103KB (~26k tokens)** on a 21-session fleet, on every call. Measured breakdown on a live box:

| field | bytes | |
|---|---|---|
| `last` (transcript tails) | 56KB | |
| `cmd` (full spawn command lines) | 28KB | **78% combined** |
| all 88 UUIDs | 3.2KB | 3% |

So the UUIDs were never the problem — the unprojected rows were.

## What changed

Both changes are confined to `src/commands/mcp.ts`, the single boundary every agent-facing session id crosses.

**Short session ids, git-short-sha style.** Session ids are 36-char UUIDs minted by the underlying harness (claude, codex) and are load-bearing on disk — transcript filenames, tmux command lines, aisdk registry files, sqlite keys, and ~27 route regexes that hard-code the 36-char shape. So they are *not* re-minted. Instead the MCP layer emits an 8-char prefix and resolves any unambiguous prefix back to the full id (live fleet first, then historical sessions). Because it's a genuine prefix it stays compatible with the backend's existing prefix search and remains greppable against transcripts and process lines. An ambiguous prefix is rejected rather than guessed. Storage, routes and transcripts are untouched.

**Slim payloads.** Project session rows to the fields a model acts on; drop `transcriptPath` (a byte-for-byte duplicate of the id — `lfg://session/<id>`); drop the rendered-markdown `html` copy from session messages; stop echoing the delivery body back from `lfg_output`; emit compact JSON.

## Result

`lfg_list_sessions`: **102,695 → 6,002 bytes (94% smaller)**. `verbose: true` returns raw rows when genuinely needed.

## Verification

Drove the real MCP server over stdio:
- round-tripped `lfg_get_session_messages` using only a short id
- bogus prefix correctly returned `no session matches id "ffffffff"`
- confirmed the `html` field is gone from message payloads

183 tests pass and typecheck is clean **when rebased onto current `main`** (verified in a scratch worktree).

## Note on scope

This branch also carries two commits that predate this work and were not verified here: `171c38b` (bulk clear for idle sessions) and `ef0eb78` (opencode tool streaming).

## Known ceiling

At 8 hex chars, collision odds reach ~1.2% past ~10k sessions (currently 844 claude transcripts + 2,185 codex rollouts). It fails loudly rather than silently, and `SHORT_SESSION_ID_LENGTH` in `src/lfg-capabilities.ts` is a one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)