### PR TITLE
perf(shipped/artifacts): cache the artifact index and stop booting every gallery iframe

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -108,12 +108,51 @@ export type ImageArtifactMessage = SessionMsg & {
   refreshStatus?: ArtifactRefreshStatus;
 };
 
+// The index is a single ~500 KB JSON blob that every artifact lookup needs, and
+// hot paths (the Shipped feed hydrating one media id at a time, each gallery
+// iframe fetching its bytes) hit it dozens of times per request. Parsing it
+// each time dominated those endpoints, so keep the parsed object and re-use it
+// while the file on disk is unchanged.
+//
+// The cache key is the file's mtime+size rather than a process-local dirty flag
+// because other processes (the MCP server, refresh jobs) write this file too —
+// a stat is ~microseconds against a multi-millisecond parse, and it means we
+// pick up their writes immediately instead of serving a stale index.
+let indexCache: { mtimeMs: number; size: number; index: Record<string, ImageArtifact> } | null = null;
+
 function readIndex(): Record<string, ImageArtifact> {
+  const path = indexPath();
+  let stat: { mtimeMs: number; size: number };
   try {
-    return JSON.parse(readFileSync(indexPath(), "utf8")) as Record<string, ImageArtifact>;
+    stat = statSync(path);
   } catch {
+    // No index yet (or it vanished): drop any cached copy and report empty.
+    indexCache = null;
     return {};
   }
+  const cached = indexCache;
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.index;
+  }
+  try {
+    const index = JSON.parse(readFileSync(path, "utf8")) as Record<string, ImageArtifact>;
+    indexCache = { mtimeMs: stat.mtimeMs, size: stat.size, index };
+    return index;
+  } catch {
+    // A torn/corrupt read must not poison the cache — fall back to empty and
+    // retry the parse on the next call.
+    indexCache = null;
+    return {};
+  }
+}
+
+// Mutators edit the index in place (`index[id] = ...`, `delete index[id]`, and
+// nested `artifact.refresh = ...`) and only persist it afterwards — and
+// `deleteArtifact` can roll its edit back if the write fails. Handing them the
+// shared cached object would publish those uncommitted edits to every reader,
+// so give writers a private copy to work on.
+function readIndexForUpdate(): Record<string, ImageArtifact> {
+  return structuredClone(readIndex());
 }
 
 function writeIndex(index: Record<string, ImageArtifact>): void {
@@ -122,6 +161,9 @@ function writeIndex(index: Record<string, ImageArtifact>): void {
   const temp = `${path}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
   writeFileSync(temp, JSON.stringify(index, null, 2));
   renameSync(temp, path);
+  // The caller still holds a mutable reference to `index`, so don't cache it
+  // here — just drop the stale entry and let the next read re-parse once.
+  indexCache = null;
 }
 
 function atomicWrite(path: string, content: string): void {
@@ -214,7 +256,7 @@ function createMediaArtifact(
     caption,
     alt,
   };
-  const index = readIndex();
+  const index = readIndexForUpdate();
   index[id] = artifact;
   writeIndex(index);
   return artifact;
@@ -266,7 +308,7 @@ export function publishHtmlArtifact(input: {
     throw new Error("artifact id must be 3-64 chars: lowercase letters, digits, dashes");
   }
 
-  const index = readIndex();
+  const index = readIndexForUpdate();
   const existing = requestedId ? index[requestedId] : null;
   // Explicit HTML ids are project-level: a later session may intentionally
   // take over the stable card. Preserve the record below so its file, creation
@@ -319,7 +361,7 @@ export function updateHtmlArtifactRefresh(input: {
   sessionId: string;
   refresh: ArtifactRefreshConfig | null;
 }): ImageArtifact {
-  const index = readIndex();
+  const index = readIndexForUpdate();
   const artifact = index[input.id];
   if (!artifact || artifact.media !== "html") throw new Error("html artifact not found");
   if (artifact.sessionId !== input.sessionId) throw new Error("artifact belongs to a different session");
@@ -333,7 +375,7 @@ export function updateHtmlArtifactRefreshStatus(input: {
   id: string;
   patch: Partial<Pick<ArtifactRefreshConfig, "status" | "lastStartedAt" | "lastSuccessAt" | "lastError">>;
 }): ImageArtifact | null {
-  const index = readIndex();
+  const index = readIndexForUpdate();
   const artifact = index[input.id];
   if (!artifact || artifact.media !== "html" || !artifact.refresh) return null;
   const refresh = { ...artifact.refresh, ...input.patch };
@@ -349,7 +391,7 @@ export function updateHtmlArtifactRefreshStatus(input: {
 // if the index write fails, the move is rolled back so a listed artifact can
 // never point at a missing file.
 export function deleteArtifact(input: { id: string; sessionId: string }): ImageArtifact {
-  const index = readIndex();
+  const index = readIndexForUpdate();
   const artifact = index[input.id];
   if (!artifact) throw new Error("artifact not found");
   if (artifact.sessionId !== input.sessionId) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -4501,10 +4501,17 @@ export async function cmdServe() {
             // (the sandboxed frame is cross-origin; postMessage is the only channel).
             const reporter =
               '<script>(function(){var last=0;var send=function(){var b=document.body;var h=Math.max(document.documentElement.scrollHeight,b?b.scrollHeight:0);if(Math.abs(h-last)>2){last=h;try{parent.postMessage({type:"lfg-artifact-height",height:h},"*")}catch(e){}}};addEventListener("load",send);setTimeout(send,60);setInterval(send,1000);try{new ResizeObserver(send).observe(document.documentElement)}catch(e){}})();</scr' + "ipt>";
+            // `?thumb=1` opts out: the Artifacts gallery renders a wall of these
+            // in fixed-height tiles that never resize to content, so the
+            // reporter there is pure overhead — one polling timer plus a forced
+            // layout every second, per tile, for as long as the page is open.
+            const wantsHeightReporter = url.searchParams.get("thumb") !== "1";
             let doc = await file.text();
-            doc = doc.includes("</body>")
-              ? doc.replace("</body>", reporter + "</body>")
-              : doc + reporter;
+            if (wantsHeightReporter) {
+              doc = doc.includes("</body>")
+                ? doc.replace("</body>", reporter + "</body>")
+                : doc + reporter;
+            }
             return new Response(doc, {
               headers: {
                 "Content-Type": "text/html; charset=utf-8",

--- a/src/shipped.ts
+++ b/src/shipped.ts
@@ -11,7 +11,7 @@
 // Image media is optimized on ingest (sharp: ≤1600px wide, webp) before it
 // lands in the durable artifact store, so agents can throw full-size
 // screenshots at lfg_ship without bloating data/artifacts.
-import { appendFileSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, extname, join } from "node:path";
 import { randomBytes } from "node:crypto";
@@ -79,11 +79,32 @@ async function optimizeImageForStore(path: string): Promise<{ path: string; temp
   }
 }
 
+// Every feed request re-read and re-parsed the whole revision log, and open
+// clients poll this endpoint every 15s. Keep the parsed rows while the file on
+// disk is unchanged; the mtime+size key means writes from any process (agents
+// ship through a separate MCP process) are picked up on the next read.
+//
+// Callers only ever copy rows out (`{ ...latest }`, `filter`, fresh per-id
+// arrays), so handing them the shared array is safe. Treat it as read-only.
+let revisionsCache: { mtimeMs: number; size: number; rows: ShipPostRevision[] } | null = null;
+
 function readRevisions(): ShipPostRevision[] {
+  let stat: { mtimeMs: number; size: number };
+  try {
+    stat = statSync(FILE);
+  } catch {
+    revisionsCache = null;
+    return [];
+  }
+  const cached = revisionsCache;
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.rows;
+  }
   let raw = "";
   try {
     raw = readFileSync(FILE, "utf8");
   } catch {
+    revisionsCache = null;
     return [];
   }
   const rows: ShipPostRevision[] = [];
@@ -93,6 +114,7 @@ function readRevisions(): ShipPostRevision[] {
       rows.push(JSON.parse(line) as ShipPostRevision);
     } catch {}
   }
+  revisionsCache = { mtimeMs: stat.mtimeMs, size: stat.size, rows };
   return rows;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16071,6 +16071,66 @@ type ShipPost = {
   mediaItems: ShipMediaItem[];
 };
 
+// An artifacts-gallery tile is a live sandboxed document, not a picture:
+// mounting the whole page's worth at once boots dozens of independent documents
+// — each with its own scripts, timers, and layout — for tiles that are mostly
+// off screen. `loading="lazy"` is only a hint and browsers largely ignore it for
+// iframes already inside the scroll container, so gate the mount ourselves.
+//
+// Once a tile has been shown it stays mounted: scrolling back should not re-run
+// a dashboard's scripts (and re-fetch it, since HTML artifacts are `no-store`).
+function GalleryTilePreview({
+  src,
+  title,
+  children,
+}: {
+  src: string;
+  title: string;
+  children?: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    const el = ref.current;
+    if (!el) return;
+    // Without IntersectionObserver, fall back to the old always-on behavior
+    // rather than showing a permanently blank tile.
+    if (typeof IntersectionObserver === "undefined") {
+      setMounted(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) setMounted(true);
+      },
+      // Start loading a little before the tile scrolls in so it is usually
+      // painted by the time it lands on screen.
+      { rootMargin: "300px" },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [mounted]);
+
+  return (
+    <div ref={ref} className="relative h-32 w-full overflow-hidden bg-background">
+      {mounted ? (
+        <iframe
+          src={src}
+          title={title}
+          sandbox="allow-scripts"
+          loading="lazy"
+          tabIndex={-1}
+          scrolling="no"
+          className="pointer-events-none h-[200%] w-[200%] origin-top-left scale-50 select-none border-0"
+        />
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
 function ShipMedia({
   item,
   onExpand,
@@ -16508,23 +16568,17 @@ function ShippedPage({
                     }
                     className="block w-full text-left active:scale-[0.99]"
                   >
-                    <div className="relative h-32 w-full overflow-hidden bg-background">
-                      <iframe
-                        src={`${a.url}?v=${a.ts}`}
-                        title={a.title || a.caption || a.name}
-                        sandbox="allow-scripts"
-                        loading="lazy"
-                        tabIndex={-1}
-                        scrolling="no"
-                        className="pointer-events-none h-[200%] w-[200%] origin-top-left scale-50 select-none border-0"
-                      />
+                    <GalleryTilePreview
+                      src={`${a.url}?v=${a.ts}&thumb=1`}
+                      title={a.title || a.caption || a.name}
+                    >
                       {(a.version ?? 1) > 1 ? (
                         <span className="absolute left-1.5 top-1.5 flex items-center gap-1 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 backdrop-blur dark:text-emerald-400">
                           <span className="size-1.5 rounded-full bg-emerald-500" />
                           live · v{a.version}
                         </span>
                       ) : null}
-                    </div>
+                    </GalleryTilePreview>
                     <div className="px-2.5 py-2 pr-9">
                       <div className="truncate text-xs font-medium">{a.title || a.caption || a.name}</div>
                       <div className="mt-0.5 truncate text-[10px] text-muted-foreground">


### PR DESCRIPTION
Shipped and Artifacts were both slow to load. Neither endpoint was slow to *respond* — the cost was elsewhere.

## What was wrong

**1. The artifact index was re-parsed on every lookup.** `data/artifacts/index.json` is a single ~470 KB blob holding all 790 artifact records. Hydrating the Shipped feed calls `getImageArtifact()` once per media item, so one `/api/shipped` request re-read and re-parsed that file **~19 times** (~8.9 MB of I/O), and open clients poll it every 15s. It got worse as you paged.

**2. The Artifacts gallery booted all 24 tiles at once.** Each tile is a live sandboxed document with its own scripts, served `no-store` so nothing caches, and the server injected a height reporter running `setInterval(…, 1000)` into every one — dozens of timers each forcing a layout every second, mostly for tiles that aren't on screen.

## Changes

- Cache the parsed index, keyed on the file's **mtime+size** rather than a process-local dirty flag — agents publish artifacts from a separate MCP process, so a stat (microseconds, against a multi-ms parse) is what keeps cross-process writes visible immediately.
- Index mutators edit the object in place and only persist afterwards, and `deleteArtifact` rolls its edit back if the write fails — so they take a private copy via `readIndexForUpdate()`. Only the read path shares the cache.
- Same caching for `data/shipped.jsonl`; its callers already copy rows out, so the shared array is safe to hand over.
- Gallery tiles mount via `IntersectionObserver` as they scroll in, and stay mounted so scrolling back doesn't re-run a dashboard. They request `?thumb=1` to skip the height reporter that fixed-height tiles never needed.

## Results

| | before | after |
|---|---|---|
| `/api/shipped?limit=15` | 72 ms | **1.8 ms** |
| `/api/shipped?limit=50` | 150 ms | **2.8 ms** |
| `/api/artifacts` gallery | 6 ms | **1.2 ms** |

## Verification

179 tests pass, typecheck and web build clean off `main`. Drove a real browser through both views: tiles render, scrolling mounts the remaining 9 (15 → 24, no blanks), the full-size artifact viewer still receives its height reporter, Shipped renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)