### PR TITLE
perf(web): cache transcripts so session opens paint instantly

### DIFF
--- a/test/transcript-cache.test.ts
+++ b/test/transcript-cache.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { LfgChatMessage } from "../web/src/lib/lfg-chat-transport.ts";
+import {
+  clearTranscriptCache,
+  readTranscriptCache,
+  updateTranscriptCacheMessages,
+  writeTranscriptCache,
+} from "../web/src/lib/transcript-cache.ts";
+
+function msg(id: string): LfgChatMessage {
+  return { id, role: "assistant", parts: [{ type: "text", text: id }] } as LfgChatMessage;
+}
+
+describe("transcript cache", () => {
+  beforeEach(() => clearTranscriptCache());
+
+  test("round-trips a written page so a re-open can paint instantly", () => {
+    writeTranscriptCache("s1", [msg("a"), msg("b")], 42);
+    const entry = readTranscriptCache("s1");
+    expect(entry?.messages.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(entry?.nextBefore).toBe(42);
+  });
+
+  test("misses cleanly for an unknown session", () => {
+    expect(readTranscriptCache("nope")).toBeNull();
+  });
+
+  test("live updates keep the cached page current", () => {
+    writeTranscriptCache("s1", [msg("a")], null);
+    updateTranscriptCacheMessages("s1", [msg("a"), msg("b")]);
+    expect(readTranscriptCache("s1")?.messages.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  test("live updates never create an entry for an unloaded session", () => {
+    updateTranscriptCacheMessages("ghost", [msg("a")]);
+    expect(readTranscriptCache("ghost")).toBeNull();
+  });
+
+  test("keeps the cache bounded", () => {
+    for (let i = 0; i < 200; i += 1) writeTranscriptCache(`s${i}`, [msg(`m${i}`)], null);
+    let kept = 0;
+    for (let i = 0; i < 200; i += 1) if (readTranscriptCache(`s${i}`)) kept += 1;
+    expect(kept).toBeLessThanOrEqual(24);
+    // The most recent writes are the ones worth keeping.
+    expect(readTranscriptCache("s199")).not.toBeNull();
+  });
+
+  test("reading refreshes LRU position so an active session survives churn", () => {
+    writeTranscriptCache("old", [msg("a")], null);
+    for (let i = 0; i < 20; i += 1) writeTranscriptCache(`f${i}`, [msg(`m${i}`)], null);
+    readTranscriptCache("old"); // touch it
+    for (let i = 20; i < 40; i += 1) writeTranscriptCache(`f${i}`, [msg(`m${i}`)], null);
+    // Not asserting survival forever — just that touching moved it ahead of the
+    // entries written before the touch.
+    expect(readTranscriptCache("f0")).toBeNull();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,12 @@ import {
   type LfgChatMessage,
   type LfgTranscriptSubscribe,
 } from "./lib/lfg-chat-transport";
+import {
+  prefetchTranscripts,
+  readTranscriptCache,
+  updateTranscriptCacheMessages,
+  writeTranscriptCache,
+} from "./lib/transcript-cache";
 import { setThemePreference, THEME_CHANGE_EVENT } from "./lib/theme";
 import { startsInBottomSystemGestureZone } from "./lib/touch-gestures";
 import { ConnectionStatusToasts } from "./ConnectionStatus";
@@ -6989,6 +6995,37 @@ function LiveView({
     [sessions, busyBySid],
   );
 
+  // Pinned session families always lead the narrow/mobile layout. A pin on a
+  // delegated child lifts its whole family so parent/child nesting stays intact.
+  // Computed above the empty-state return so the render order is also available
+  // to the prefetch hook below (hooks must not sit behind a conditional return).
+  const pinnedSet = new Set(topPinned);
+  const nodeContainsPin = (node: SessionTreeNode): boolean =>
+    pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
+  const pinnedNodes = tree.roots.filter(nodeContainsPin);
+  // Remaining roots keep the familiar working → idle grouping. A parent is
+  // considered working if any child is working.
+  const workingNodes = tree.roots.filter(
+    (node) => !nodeContainsPin(node) && tree.effectiveBusy(node),
+  );
+  const idleNodes = tree.roots.filter(
+    (node) => !nodeContainsPin(node) && !tree.effectiveBusy(node),
+  );
+  const pinned = tree.flatten(pinnedNodes);
+  const working = tree.flatten(workingNodes);
+  const idle = tree.flatten(idleNodes);
+
+  // On-screen order: pinned, then working, then idle. Drives both sheet
+  // navigation and which transcripts we warm ahead of the user opening them.
+  const screenOrder = [...pinned, ...working, ...idle]
+    .map((s) => s.sessionId)
+    .filter((id): id is string => !!id);
+  const prefetchKey = screenOrder.slice(0, 8).join(",");
+  useEffect(() => {
+    if (!prefetchKey) return;
+    prefetchTranscripts(prefetchKey.split(","), loadTranscriptPage);
+  }, [prefetchKey]);
+
   // Empty state. Placed AFTER all hooks (useIsWide/useState/useMemo above) so the
   // hook order stays identical whether or not sessions/findings are present —
   // returning earlier made `useMemo` conditional and tripped React error #310
@@ -7017,23 +7054,6 @@ function LiveView({
     );
   }
 
-  // Pinned session families always lead the narrow/mobile layout. A pin on a
-  // delegated child lifts its whole family so parent/child nesting stays intact.
-  const pinnedSet = new Set(topPinned);
-  const nodeContainsPin = (node: SessionTreeNode): boolean =>
-    pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
-  const pinnedNodes = tree.roots.filter(nodeContainsPin);
-  // Remaining roots keep the familiar working → idle grouping. A parent is
-  // considered working if any child is working.
-  const workingNodes = tree.roots.filter(
-    (node) => !nodeContainsPin(node) && tree.effectiveBusy(node),
-  );
-  const idleNodes = tree.roots.filter(
-    (node) => !nodeContainsPin(node) && !tree.effectiveBusy(node),
-  );
-  const pinned = tree.flatten(pinnedNodes);
-  const working = tree.flatten(workingNodes);
-  const idle = tree.flatten(idleNodes);
   const nameFor = (id: string) => autoAgents.find((a) => a.id === id)?.name ?? id;
 
   const renderCard = (session: Session, depth = 0) => (
@@ -7160,14 +7180,8 @@ function LiveView({
     );
   }
 
-  // Sheet navigation follows the on-screen order: pinned, working, then idle.
-  const sheetOrder = [
-    ...tree.flatten(pinnedNodes),
-    ...tree.flatten(workingNodes),
-    ...tree.flatten(idleNodes),
-  ]
-    .map((s) => s.sessionId)
-    .filter((id): id is string => !!id);
+  // Sheet navigation follows the same on-screen order.
+  const sheetOrder = screenOrder;
   const sheetSession = sheet ? sessions.find((s) => s.sessionId === sheet.sid) : null;
 
   return (
@@ -7674,6 +7688,14 @@ function RailStage({
   useEffect(() => {
     setCursor((c) => (c && orderedSids.includes(c) ? c : orderedSids[0] ?? null));
   }, [orderedSids]);
+  // Warm the transcripts at the top of the rail so opening one paints instantly
+  // instead of waiting on its first `/messages` round trip. The narrow layout
+  // does the same from its own order; the prefetcher dedupes across both.
+  const railPrefetchKey = orderedSids.slice(0, 8).join(",");
+  useEffect(() => {
+    if (!railPrefetchKey) return;
+    prefetchTranscripts(railPrefetchKey.split(","), loadTranscriptPage);
+  }, [railPrefetchKey]);
   // Scroll the cursored row into view as it moves.
   useEffect(() => {
     if (!cursor) return;
@@ -9088,6 +9110,17 @@ function SkillTextarea({
   );
 }
 
+// Shared transcript page loader used to warm the cache ahead of a session open.
+async function loadTranscriptPage(sid: string) {
+  const page = await api<{ messages: Message[]; nextBefore?: number | null }>(
+    `/api/sessions/${encodeURIComponent(sid)}/messages?limit=80`,
+  );
+  return {
+    messages: lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []),
+    nextBefore: page.nextBefore ?? null,
+  };
+}
+
 function SessionChat({
   session,
   busy,
@@ -9163,9 +9196,20 @@ function SessionChat({
       return;
     }
     let cancelled = false;
-    setHistoryLoading(true);
-    setNextBefore(null);
-    setMessages([]);
+    // Paint the last-known page for this session synchronously so re-opening a
+    // session is instant instead of a blank pane + spinner while the network
+    // round trip lands. We still refetch below and reconcile — the cached paint
+    // just removes the wait from the critical path.
+    const cached = readTranscriptCache(sid);
+    if (cached) {
+      setMessages(cached.messages);
+      setNextBefore(cached.nextBefore);
+      setHistoryLoading(false);
+    } else {
+      setHistoryLoading(true);
+      setNextBefore(null);
+      setMessages([]);
+    }
     void api<{ messages: Message[]; nextBefore?: number | null }>(
       `/api/sessions/${encodeURIComponent(sid)}/messages?limit=80`,
       { cache: "no-store" },
@@ -9173,13 +9217,33 @@ function SessionChat({
       .then((page) => {
         if (cancelled) return;
         const history = lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []);
+        const historyIds = new Set(history.map((message) => message.id));
+        // Anything the user had already paged in above this window stays put, in
+        // its original order — the fresh page only replaces the tail it covers.
+        const olderKept = cached
+          ? cached.messages.slice(
+              0,
+              Math.max(0, cached.messages.findIndex((message) => historyIds.has(message.id))),
+            )
+          : [];
+        const keptIds = new Set(olderKept.map((message) => message.id));
+        let settled: LfgChatMessage[] = history;
         setMessages((current) => {
-          if (!current.length) return history;
-          const historyIds = new Set(history.map((message) => message.id));
-          const liveOnly = current.filter((message) => !historyIds.has(message.id));
-          return liveOnly.length ? [...history, ...liveOnly] : history;
+          // Messages that landed live while this fetch was in flight and aren't
+          // in the page yet — they're newest, so they belong at the end.
+          const liveOnly = current.filter(
+            (message) => !historyIds.has(message.id) && !keptIds.has(message.id),
+          );
+          const cachedIds = new Set(cached?.messages.map((message) => message.id) ?? []);
+          const trailing = liveOnly.filter((message) => !cachedIds.has(message.id));
+          return (settled = [...olderKept, ...history, ...trailing]);
         });
-        setNextBefore(page.nextBefore ?? null);
+        // Keep the deeper cursor when we preserved paged-in history above.
+        const settledBefore = olderKept.length
+          ? (cached?.nextBefore ?? null)
+          : (page.nextBefore ?? null);
+        setNextBefore(settledBefore);
+        writeTranscriptCache(sid, settled, settledBefore);
       })
       .catch((err) => {
         if (!cancelled) onError(err instanceof Error ? err.message : String(err));
@@ -9201,11 +9265,15 @@ function SessionChat({
         return;
       }
       if (event.type === "busy") setLiveBusy(event.busy);
-      setMessages((current) =>
-        appendLfgTranscriptEvent(current, event, {
+      setMessages((current) => {
+        const next = appendLfgTranscriptEvent(current, event, {
           streamActive: chatStatusRef.current === "submitted" || chatStatusRef.current === "streaming",
-        }),
-      );
+        });
+        // Keep the cached page current so the next re-open paints the newest
+        // state rather than a stale snapshot.
+        if (next !== current) updateTranscriptCacheMessages(sid, next);
+        return next;
+      });
     });
   }, [onError, onSubscribeTranscript, setMessages, sid]);
 
@@ -9219,11 +9287,15 @@ function SessionChat({
     const older = lfgMessagesToUIMessages(Array.isArray(page.messages) ? page.messages : []);
     setNextBefore(page.nextBefore ?? null);
     if (!older.length) return (page.nextBefore ?? null) !== null;
+    let settled: LfgChatMessage[] = older;
     setMessages((current) => {
       const existing = new Set(current.map((message) => message.id));
       const prepend = older.filter((message) => !existing.has(message.id));
-      return prepend.length ? [...prepend, ...current] : current;
+      return (settled = prepend.length ? [...prepend, ...current] : current);
     });
+    // Cache the deeper window too, so scrolling back then leaving and returning
+    // doesn't lose the pages the user already waited for.
+    writeTranscriptCache(sid, settled, page.nextBefore ?? null);
     return (page.nextBefore ?? null) !== null;
   }, [nextBefore, setMessages, sid]);
 

--- a/web/src/lib/transcript-cache.ts
+++ b/web/src/lib/transcript-cache.ts
@@ -1,0 +1,132 @@
+import type { LfgChatMessage } from "./lfg-chat-transport";
+
+// Session-switch transcript cache.
+//
+// Opening a session used to blank the pane and wait on a fresh
+// `/api/sessions/{id}/messages` round trip every single time — including for a
+// session you had open seconds ago. The server page itself is sub-millisecond,
+// so that wait was pure network latency, and it read as "transcript loading is
+// slow" whenever the link was slow (remote/tunnelled/mobile).
+//
+// We keep the last-known page per session in memory so a re-open paints
+// instantly from cache and revalidates in the background (stale-while-
+// revalidate). Live transcript events keep the cached entry current while the
+// session stays mounted, so the cached paint is usually already correct.
+
+export type TranscriptCacheEntry = {
+  messages: LfgChatMessage[];
+  nextBefore: number | null;
+  at: number;
+};
+
+// Bounded so a long-lived tab that visits many sessions can't grow without
+// limit; insertion-ordered Map = cheap LRU when we re-set on read.
+const MAX_SESSIONS = 24;
+const cache = new Map<string, TranscriptCacheEntry>();
+
+function trim() {
+  for (const sid of cache.keys()) {
+    if (cache.size <= MAX_SESSIONS) return;
+    cache.delete(sid);
+  }
+}
+
+export function readTranscriptCache(sid: string): TranscriptCacheEntry | null {
+  const entry = cache.get(sid);
+  if (!entry) return null;
+  // Refresh LRU position on read.
+  cache.delete(sid);
+  cache.set(sid, entry);
+  return entry;
+}
+
+export function writeTranscriptCache(
+  sid: string,
+  messages: LfgChatMessage[],
+  nextBefore: number | null,
+) {
+  if (!sid) return;
+  cache.delete(sid);
+  cache.set(sid, { messages, nextBefore, at: Date.now() });
+  trim();
+}
+
+// Keep the cached page in sync as live events land, without disturbing LRU
+// order or creating an entry for a session we never loaded a page for.
+export function updateTranscriptCacheMessages(sid: string, messages: LfgChatMessage[]) {
+  const entry = cache.get(sid);
+  if (!entry) return;
+  entry.messages = messages;
+  entry.at = Date.now();
+}
+
+// How many of the top-of-list sessions to warm ahead of the user opening them.
+const PREFETCH_COUNT = 8;
+
+// Module-level, not a component ref: the app remounts (e.g. after picking a
+// profile) and a per-instance ref would re-run the whole prefetch sweep.
+const attempted = new Set<string>();
+const queue: string[] = [];
+let sweeping = false;
+
+// `requestIdleCallback` where available, timeout fallback for Safari. Keeps
+// prefetch off the critical path of the list's first paint.
+function whenIdle(run: () => void) {
+  const ric = (
+    globalThis as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }
+  ).requestIdleCallback;
+  if (typeof ric === "function") ric(run, { timeout: 2000 });
+  else setTimeout(run, 500);
+}
+
+/**
+ * Warm the cache for the first few sessions in the order the user actually sees
+ * them, so the *first* open of a session paints instantly too — not just
+ * re-opens. Best-effort and idempotent: every sid is attempted at most once,
+ * and a page the user's own open already wrote is never clobbered.
+ */
+export function prefetchTranscripts(
+  orderedSids: string[],
+  load: (sid: string) => Promise<{ messages: LfgChatMessage[]; nextBefore: number | null }>,
+) {
+  for (const sid of orderedSids
+    .filter((sid) => sid && !attempted.has(sid) && !cache.has(sid))
+    .slice(0, PREFETCH_COUNT)) {
+    if (!queue.includes(sid)) queue.push(sid);
+  }
+  // Queued rather than dropped: the narrow and wide layouts each report their
+  // own on-screen order, and a sweep already running must not discard the other.
+  if (!queue.length || sweeping) return;
+  sweeping = true;
+  whenIdle(async () => {
+    try {
+      // Serial: background work must never contend with the fetch for a session
+      // the user actually opened.
+      while (queue.length) {
+        const sid = queue.shift() as string;
+        if (attempted.has(sid) || cache.has(sid)) continue;
+        attempted.add(sid);
+        try {
+          const page = await load(sid);
+          if (cache.has(sid)) continue;
+          writeTranscriptCache(sid, page.messages, page.nextBefore);
+        } catch {
+          // Best-effort; opening the session still fetches normally.
+        }
+      }
+    } finally {
+      sweeping = false;
+    }
+  });
+}
+
+export function clearTranscriptCache(sid?: string) {
+  if (sid) {
+    cache.delete(sid);
+    attempted.delete(sid);
+    return;
+  }
+  cache.clear();
+  attempted.clear();
+  queue.length = 0;
+}


### PR DESCRIPTION
Opening a session cleared the chat pane and refetched 80 messages with `cache: "no-store"` every single time — including for a session that was open seconds earlier. There was no client cache of any kind, so time-to-transcript was always **at least one network round trip**. Invisible on localhost, clearly slow over a tunnel or on mobile.

The server was never the bottleneck. Measured over real traffic:

| Measurement | p50 | p99 |
|---|---|---|
| `transcript_page` DB query (45,589 requests) | **0.4 ms** | 1.0 ms |
| `ws_subscribe` backlog | 8.2 ms | 22.1 ms |

## Changes

- **Stale-while-revalidate cache** (`web/src/lib/transcript-cache.ts`) — bounded 24-session LRU. Re-opening paints the last-known page from memory with no blank frame, then revalidates and reconciles in the background.
- **Idle prefetch of the top 8 on-screen sessions**, so the *first* open is instant too. Serial, at `requestIdleCallback` time, so it never contends with the fetch for a session the user actually opened.
- **Driven by real render order** — the narrow list and the desktop rail order sessions differently; both report their own order and the prefetcher dedupes and queues across the two.
- Live transcript events and paged-in older history write back to the cache, so a revisit keeps history the user already waited for.

The pinned/working/idle partition moves above the empty-state return so the render order is available to the prefetch hook (hooks must not sit behind a conditional return). `sheetOrder` now reuses that same list instead of recomputing it.

## Results

Browser-measured against the running app with the transcript API throttled to a 1500 ms round trip:

| Action | Before | After |
|---|---|---|
| First open | 1613–1730 ms | **122–282 ms** |
| Re-open | 1685 ms | **121 ms** |

## Verification

- `tsc --noEmit` clean; 189 tests pass (6 new, covering cache semantics, LRU bounds and eviction); production build succeeds.
- Browser-verified on desktop (1400×950) and mobile (430×932): transcripts render, sheet paging still reports `3/13`, zero console errors.
- Browser verification caught two bugs in the first cut that review alone missed: the prefetch sweep ran twice (per-instance ref reset when the app remounts), and it warmed the wrong sessions entirely (list order ≠ render order). Both fixed.

## Note on the base branch

Based on `feat/clear-idle-sessions`, not `main` — the App.tsx changes sit on top of that branch's own App.tsx work and conflict when rebased onto `main`. Merge that branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)