### PR TITLE
fix(web): clamp desktop rail session subtitles to 2 lines

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8439,7 +8439,7 @@ const RailItem = memo(function RailItem({
                 ) : null}
               </span>
               {latest ? (
-                <span className="truncate text-[11px] leading-tight text-muted-foreground">
+                <span className="line-clamp-2 text-[11px] leading-tight text-muted-foreground">
                   {latest}
                 </span>
               ) : null}


### PR DESCRIPTION
## Summary
- Desktop sidebar (`RailItem`) session activity subtitle: `truncate` → `line-clamp-2`.
- Title stays single-line; longer latest-activity text wraps up to two lines then ellipsizes.

## Test plan
- [ ] Open desktop wide layout with the session rail expanded
- [ ] Confirm short subtitles still look like one line
- [ ] Confirm long activity previews wrap to at most two lines with ellipsis