### PR TITLE
feat(auto): treat recurring findings as escalation, not duplicates

### DIFF
--- a/src/auto/recurrence.test.ts
+++ b/src/auto/recurrence.test.ts
@@ -1,0 +1,63 @@
+// Recurrence matching for auto-agent findings.
+//
+// These cases are not invented — they are real titles from data/auto/findings.jsonl.
+// The watch agents correctly reported the sqld WAL failure on 2026-07-12 and the
+// snapshot accumulation repeatedly through 07-20/21/22. Every one of those repeats
+// was filed as a BRAND NEW finding and the persistence signal was lost, because
+// the old dedup required an exact title match and only looked at "open"/"dismissed"
+// (302 of 396 findings were sitting in "session"). The WAL problem then caused a
+// four-day backup outage on 07-22.
+//
+// So the two properties under test are the two that actually failed in production:
+//   1. the same problem re-reported with a MOVED NUMBER must match
+//   2. genuinely different problems must NOT match
+
+import { expect, test } from "bun:test";
+import { normTitleForTest as normTitle } from "./store.ts";
+
+const same = (a: string, b: string) => normTitle(a) === normTitle(b);
+
+test("same problem with a grown number is one finding, not two", () => {
+  expect(
+    same(
+      "Orchestrator sqld WAL is 2.3 GB (600× data file) — checkpoints not truncating",
+      "Orchestrator sqld WAL is 3.1 GB (712× data file) — checkpoints not truncating",
+    ),
+  ).toBe(true);
+});
+
+test("snapshot accumulation re-reported with new counts is one finding", () => {
+  expect(
+    same(
+      "Orch user_project snapshots: 2772 unreferenced hold 1.60 TB on Tigris",
+      "Orch user_project snapshots: 2984 unreferenced hold 1.26 TB on Tigris",
+    ),
+  ).toBe(true);
+});
+
+test("unrelated findings stay separate", () => {
+  expect(
+    same(
+      "Publish button hardcodes `color: \"#FBF8F2\"`",
+      "Orchestrator sqld WAL is 2.3 GB — checkpoints not truncating",
+    ),
+  ).toBe(false);
+});
+
+test("differing units do not collapse unrelated metrics", () => {
+  expect(
+    same(
+      "tigris.upload_snapshot p95 regression: ~60s → ~450s",
+      "processedWebhooks has no GC — 59k rows, 27% of CP DB",
+    ),
+  ).toBe(false);
+});
+
+test("whitespace and punctuation noise does not create a new finding", () => {
+  expect(
+    same(
+      "Orchestrator sqld WAL is 2.3 GB  —  checkpoints not truncating",
+      "Orchestrator sqld WAL is 2.3GB - checkpoints not truncating",
+    ),
+  ).toBe(true);
+});

--- a/src/auto/runner.ts
+++ b/src/auto/runner.ts
@@ -12,7 +12,7 @@ import {
   type Severity,
   addFinding,
   clearRunning,
-  hasOpenSimilar,
+  recordRecurrence,
   listFindings,
   markRunning,
 } from "./store.ts";
@@ -235,9 +235,20 @@ async function runAutoAgentInner(
     onLog("[auto] finding had no title — skipping");
     return null;
   }
-  if (await hasOpenSimilar(agent.id, title)) {
-    onLog(`[auto] duplicate of an existing finding — skipping: ${title}`);
-    return null;
+  // Recurrence is signal, not noise. Previously a repeat observation was
+  // dropped on the floor; now it bumps the occurrence count and re-surfaces the
+  // finding, so "reported 4 times" becomes visible instead of invisible.
+  const recurred = await recordRecurrence(agent.id, title);
+  if (recurred) {
+    const n = recurred.occurrences ?? 2;
+    onLog(`[auto] recurrence #${n} of an unresolved finding: ${title}`);
+    // Re-notify on escalation thresholds rather than on every repeat: the 2nd
+    // sighting says "this is persistent", and every 5th says "this is still
+    // being ignored". Silence in between avoids retraining you to swipe it away.
+    if (n === 2 || n % 5 === 0) {
+      void notifyAll().catch(() => {});
+    }
+    return recurred;
   }
   const finding = await addFinding({
     agentId: agent.id,

--- a/src/auto/store.ts
+++ b/src/auto/store.ts
@@ -36,7 +36,25 @@ export type AutoAgent = {
   lastRunAt?: number;
 };
 
-export type FindingStatus = "open" | "dismissed" | "session" | "read";
+// "resolved" is TERMINAL and is the only status that means the underlying
+// problem is actually gone. Everything else — including "session" — only
+// records what happened to the *notification*, not to the problem. That gap is
+// why a correct, high-severity finding ("sqld WAL is 2.3 GB, checkpoints not
+// truncating", 2026-07-12) spawned a session, the session ended, nobody
+// re-checked, and the same failure caused a four-day backup outage ten days
+// later. A finding is not done because someone looked at it.
+export type FindingStatus =
+  | "open"
+  | "dismissed"
+  | "session"
+  | "read"
+  | "resolved";
+
+// Statuses where the underlying problem may still be live. Recurrence is
+// measured against these — NOT against "open"/"dismissed" alone, which was the
+// original bug: 302 of 396 findings sat in "session", so a repeat report never
+// matched and was filed as brand new instead of escalating.
+const UNRESOLVED: FindingStatus[] = ["open", "dismissed", "session", "read"];
 
 export type Finding = {
   id: string;
@@ -48,6 +66,10 @@ export type Finding = {
   createdAt: number;
   status: FindingStatus;
   sessionId?: string;
+  /** How many times an agent has independently reported this. 1 on first sight. */
+  occurrences?: number;
+  /** When it was most recently re-observed (differs from createdAt once it recurs). */
+  lastSeenAt?: number;
 };
 
 const dir = () => join(PATHS.data, "auto");
@@ -271,16 +293,66 @@ export async function logFindingAction(input: {
 // Dedup: a finding with the same normalized title for this agent that is still
 // open (or was dismissed) should not be re-added. Keeps the stream from
 // re-accumulating the same item every run.
+// Normalise a title for recurrence matching. Numbers are stripped because the
+// same problem is usually re-reported with a moved number — "sqld WAL is 2.3 GB"
+// and "sqld WAL is 3.1 GB" are one problem getting worse, not two problems.
+// Exact-title matching treated them as unrelated and filed both as new.
+export const normTitleForTest = (t: string) => normTitle(t);
+
+const normTitle = (t: string) =>
+  t
+    .toLowerCase()
+    .replace(/[\d.,]+\s*(gb|mb|kb|tb|b|ms|s|%|×|x)?/g, "#")
+    .replace(/[^a-z#\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/**
+ * Record that an agent has just observed `title` again.
+ *
+ * Returns the existing finding when this is a recurrence, after bumping its
+ * occurrence count and re-surfacing it. Returns null when it is genuinely new
+ * and the caller should file it.
+ *
+ * The old behaviour (hasOpenSimilar -> skip) SILENTLY DISCARDED repeat
+ * observations. That is the worst possible response: the signal that a problem
+ * is persistent — the single most useful thing an agent can tell you — was the
+ * one signal thrown away. A thing reported four times is not noise, it is the
+ * thing you should be doing.
+ */
+export async function recordRecurrence(
+  agentId: string,
+  title: string,
+): Promise<Finding | null> {
+  const rows = await listFindings();
+  const now = Date.now();
+  const key = normTitle(title);
+  const match = rows.find(
+    (r) =>
+      r.agentId === agentId &&
+      UNRESOLVED.includes(r.status) &&
+      normTitle(r.title) === key,
+  );
+  if (!match) return null;
+
+  const occurrences = (match.occurrences ?? 1) + 1;
+  // Re-surface it. A recurrence that stays "dismissed"/"read" is invisible
+  // again, which is how these got lost the first time. "session" is preserved
+  // so an in-flight session is not yanked out from under whoever owns it.
+  const status: FindingStatus =
+    match.status === "session" ? "session" : "open";
+
+  const next = rows.map((r) =>
+    r.id === match.id ? { ...r, occurrences, lastSeenAt: now, status } : r,
+  );
+  await writeFindings(next);
+  return { ...match, occurrences, lastSeenAt: now, status };
+}
+
+/** @deprecated use recordRecurrence — kept so existing callers keep compiling. */
 export async function hasOpenSimilar(
   agentId: string,
   title: string,
 ): Promise<boolean> {
-  const norm = (t: string) => t.toLowerCase().replace(/\s+/g, " ").trim();
-  const rows = await listFindings();
-  return rows.some(
-    (r) =>
-      r.agentId === agentId &&
-      (r.status === "open" || r.status === "dismissed") &&
-      norm(r.title) === norm(title),
-  );
+  return (await recordRecurrence(agentId, title)) !== null;
 }


### PR DESCRIPTION
## The finding that was right, and got lost

On **2026-07-12** an auto agent filed this, severity `high`:

> **"Orchestrator sqld WAL is 2.3 GB (600× data file) — checkpoints not truncating"**
> - *"bottomless frames flush to Tigris only on checkpoint — stalled checkpoints mean backup lag + disk risk"*
> - suggest: *"Force a TRUNCATE checkpoint… **alert if data-wal ≫ 1000 frames**"*

It was correct. It named the mechanism and prescribed the fix. **Ten days later that exact failure left the control-plane database with no restorable off-box backup for four days.**

Detection was never the problem. The finding was filed, a session spawned, the session ended, and nobody re-checked. Two defects made that the default outcome.

## 1. No terminal state

`FindingStatus` was `open | dismissed | session | read`. None of those means *the problem is gone* — they record what happened to the **notification**, not the **problem**. A finding was treated as handled because someone looked at it.

Adds `resolved`.

## 2. Recurrence was silently discarded

`hasOpenSimilar()` matched only `open|dismissed` — but **302 of 396 findings sit in `session`**, so a repeat report never matched and was filed as brand new. It also required an *exact* title match, so `WAL is 2.3 GB` and `WAL is 3.1 GB` were unrelated problems rather than one problem getting worse. And when it *did* match, the repeat was dropped entirely.

That's backwards. **"This is the fourth time I've told you" is the most valuable thing a watch agent can say**, and it was the one signal being thrown away. The same class was refiled on 07-12, 07-20, 07-21 and 07-22 — each time as a peer of everything else.

## What changes

`recordRecurrence()` replaces it:
- matches across **every unresolved status**, not just two
- **normalises numbers out of the title**, so a moved metric still matches
- on a repeat: bumps `occurrences`, stamps `lastSeenAt`, and **re-surfaces** the finding rather than dropping it
- re-notifies on the **2nd** sighting (*"this is persistent"*) and every **5th** after (*"this is still being ignored"*) — not every repeat, which would just retrain you to swipe it away
- leaves an in-flight `session` alone so it isn't yanked from its owner

`hasOpenSimilar` kept as a deprecated shim so existing callers compile.

## Tests

Cases are **real titles from `data/auto/findings.jsonl`**, including the two that actually recurred in production and were missed. 5 new tests; full suite 214 pass / 0 fail.

## Not in this PR

Auto-verification (re-running a finding's originating command to close it automatically) is the natural next step but wants its own design — findings don't currently record how they were derived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)