### PR TITLE
Recover stale live streams after tab switching

### DIFF
--- a/src/live-visibility.test.ts
+++ b/src/live-visibility.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { visibilityRecoveryAction } from "../web/src/live-visibility.ts";
+
+describe("live socket visibility recovery", () => {
+  test("reconnects when a hidden-tab close was deferred", () => {
+    expect(visibilityRecoveryAction(null, true)).toBe("connect");
+  });
+
+  test("probes a socket that still claims to be open", () => {
+    expect(visibilityRecoveryAction(1, false)).toBe("probe");
+  });
+
+  test("does not replace a connection already in flight", () => {
+    expect(visibilityRecoveryAction(0, false)).toBe("wait");
+  });
+
+  test("reconnects sockets that are closing or closed", () => {
+    expect(visibilityRecoveryAction(2, false)).toBe("connect");
+    expect(visibilityRecoveryAction(3, false)).toBe("connect");
+  });
+});

--- a/web/src/live-visibility.ts
+++ b/web/src/live-visibility.ts
@@ -1,0 +1,11 @@
+export type VisibilityRecoveryAction = "connect" | "probe" | "wait";
+
+// WebSocket readyState values are stable browser constants:
+// CONNECTING=0, OPEN=1, CLOSING=2, CLOSED=3.
+export function visibilityRecoveryAction(
+  readyState: number | null,
+  reconnectPending: boolean,
+): VisibilityRecoveryAction {
+  if (reconnectPending || readyState == null || readyState >= 2) return "connect";
+  return readyState === 1 ? "probe" : "wait";
+}

--- a/web/src/useLiveSocket.ts
+++ b/web/src/useLiveSocket.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { visibilityRecoveryAction } from "./live-visibility";
 
 type Session = {
   agent?: string;
@@ -325,6 +326,7 @@ function reconcileSnapshotMessages(current: Message[], incoming: Message[]): Mes
 
 const BACKOFF_MIN_MS = 250;
 const BACKOFF_MAX_MS = 10_000;
+const VISIBILITY_PROBE_TIMEOUT_MS = 2_000;
 // Consecutive failed reconnect attempts after which we stop calling it a brief
 // "reconnecting" blip and surface the more alarming "offline" state instead.
 const OFFLINE_AFTER_ATTEMPTS = 5;
@@ -405,6 +407,11 @@ export function useLiveSocket(
   const pendingReconnectRef = useRef(false);
   const lastMessageFlushRef = useRef(0);
   const latencyProbeRef = useRef<{ id: string; startedAt: number } | null>(null);
+  const visibilityProbeRef = useRef<{
+    id: string;
+    ws: WebSocket;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
   const connectRef = useRef<() => void>(() => {});
 
   const [connection, setConnection] = useState<ConnectionState>(INITIAL_CONNECTION_STATE);
@@ -469,6 +476,11 @@ export function useLiveSocket(
       return;
     }
     if (payload.t === "pong") {
+      const visibilityProbe = visibilityProbeRef.current;
+      if (payload.id && visibilityProbe?.id === payload.id) {
+        clearTimeout(visibilityProbe.timer);
+        visibilityProbeRef.current = null;
+      }
       const probe = latencyProbeRef.current;
       if (!payload.id || !probe || payload.id !== probe.id) return;
       latencyProbeRef.current = null;
@@ -741,7 +753,16 @@ export function useLiveSocket(
         handleMessage(payload);
       };
       ws.onclose = (event) => {
-        if (wsRef.current === ws) wsRef.current = null;
+        const visibilityProbe = visibilityProbeRef.current;
+        if (visibilityProbe?.ws === ws) {
+          clearTimeout(visibilityProbe.timer);
+          visibilityProbeRef.current = null;
+        }
+        // A visibility recovery can replace a half-dead socket before its close
+        // event arrives. Never let that stale event tear down the replacement's
+        // subscription bookkeeping or schedule another reconnect over it.
+        if (wsRef.current !== ws) return;
+        wsRef.current = null;
         subscribedRef.current = new Set();
         subscribedChannelsRef.current = new Set();
         if (closedByHookRef.current) return;
@@ -780,7 +801,45 @@ export function useLiveSocket(
 
     const onVisible = () => {
       if (typeof document === "undefined" || document.visibilityState !== "visible") return;
-      if (pendingReconnectRef.current) connect();
+      const ws = wsRef.current;
+      const action = visibilityRecoveryAction(
+        ws?.readyState ?? null,
+        pendingReconnectRef.current,
+      );
+      if (action === "connect") {
+        pendingReconnectRef.current = false;
+        connect();
+        return;
+      }
+      if (action !== "probe" || !ws) return;
+
+      // Browsers can leave a dead connection in OPEN after a desktop/tab
+      // switch. Probe immediately instead of waiting for the TCP stack to
+      // notice; if the server does not answer, closing the stale socket runs
+      // the normal reconnect + sequence replay path.
+      const previous = visibilityProbeRef.current;
+      if (previous) clearTimeout(previous.timer);
+      const id =
+        crypto.randomUUID?.() ??
+        `visible-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+      latencyProbeRef.current = { id, startedAt: performance.now() };
+      ws.send(JSON.stringify({ t: "ping", id }));
+      const timer = setTimeout(() => {
+        const current = visibilityProbeRef.current;
+        if (!current || current.id !== id || current.ws !== ws) return;
+        visibilityProbeRef.current = null;
+        evlog("ws_client_visibility_probe_timeout", {
+          elapsedMs: VISIBILITY_PROBE_TIMEOUT_MS,
+        });
+        if (wsRef.current === ws) wsRef.current = null;
+        subscribedRef.current = new Set();
+        subscribedChannelsRef.current = new Set();
+        try {
+          ws.close(4000, "visibility probe timeout");
+        } catch {}
+        connect();
+      }, VISIBILITY_PROBE_TIMEOUT_MS);
+      visibilityProbeRef.current = { id, ws, timer };
     };
     const onOnline = () => {
       pendingReconnectRef.current = false;
@@ -796,6 +855,11 @@ export function useLiveSocket(
       window.removeEventListener("online", onOnline);
       window.clearInterval(latencyTimer);
       latencyProbeRef.current = null;
+      const visibilityProbe = visibilityProbeRef.current;
+      if (visibilityProbe) {
+        clearTimeout(visibilityProbe.timer);
+        visibilityProbeRef.current = null;
+      }
       if (reconnectTimerRef.current != null) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;


### PR DESCRIPTION
## What changed

- Probe the live WebSocket immediately when a hidden LFG tab becomes visible.
- Replace the socket within two seconds when the browser still reports `OPEN` but the server does not answer.
- Ignore delayed close events from the replaced socket so they cannot erase the new connection's subscription state.
- Add focused coverage for visibility recovery decisions.

## Why

Browsers can retain a half-dead WebSocket as `OPEN` after a desktop or tab switch. The previous visibility handler only reconnected when a close event had already fired, leaving some sessions detached until a full page refresh rebuilt the transcript.

## Impact

Returning to an existing session now restores its live transcript automatically through the existing sequence replay/snapshot path.

## Validation

- `bun test src/live-visibility.test.ts src/live-ws.test.ts`
- `bun run typecheck`
- `cd web && bun run typecheck`
- `bun test` — 241 passed