### PR TITLE
fix(web): global --lfg-safe-bottom so omg controls never cover chat

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -50,4 +50,26 @@ describe("host bottom inset contract", () => {
     expect(css).toContain('html[data-lfg-embed="true"]');
     expect(css).toMatch(/--lfg-host-bottom-inset:\s*2\.75rem/);
   });
+
+  test("global --lfg-safe-bottom folds host inset into every clearance token", () => {
+    const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
+    // Single source of truth: device safe-area + host chrome.
+    expect(css).toMatch(
+      /--lfg-safe-bottom:\s*calc\(env\(safe-area-inset-bottom,\s*0px\)\s*\+\s*var\(--lfg-host-bottom-inset\)\)/,
+    );
+    // Clearance tokens derive from the global safe bottom — not raw safe-area alone.
+    expect(css).toMatch(/--lfg-composer-clear:\s*calc\(10\.5rem\s*\+\s*var\(--lfg-safe-bottom\)\)/);
+    expect(css).toMatch(/--lfg-orb-bottom:\s*calc\(1\.5rem\s*\+\s*var\(--lfg-safe-bottom\)\)/);
+  });
+
+  test("session chat composer pads with global safe bottom (portal is full-bleed)", () => {
+    const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
+    // The session sheet portals to document.body, so shell host-pad cannot
+    // protect the composer — the form itself must use --lfg-safe-bottom.
+    expect(app).toContain("pb-[calc(0.5rem+var(--lfg-safe-bottom))]");
+    // No residual session-body pad that only knew about the device safe-area.
+    expect(app).not.toMatch(
+      /paddingBottom:\s*["']env\(safe-area-inset-bottom(?:,\s*0px)?\)["']/,
+    );
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -816,7 +816,7 @@ function ArtifactViewerPage({
           ) : null}
         </div>
       </header>
-      <div className="min-h-0 flex-1 pb-[env(safe-area-inset-bottom)]">
+      <div className="min-h-0 flex-1 pb-[var(--lfg-safe-bottom)]">
         {artifact.kind === "html" ? (
           <iframe
             src={src}
@@ -5349,7 +5349,8 @@ export function App() {
       className={cn(
         APP_SHELL_CLASS,
         // Embed: leave a blank band of our own background under the host
-        // compact pill so LFG controls sit above it without a color mismatch.
+        // compact pill so list/inline composer sit above it. Full-bleed
+        // portals (session sheet) use --lfg-safe-bottom on their own chrome.
         embedded && "pb-[var(--lfg-host-bottom-inset)]",
       )}
     >
@@ -5860,7 +5861,7 @@ function FloatingSessionAudio({
 
   return (
     <div
-      className="fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+4.75rem+var(--lfg-host-bottom-inset))] z-[75] flex justify-center px-3 md:bottom-[calc(1.25rem+var(--lfg-host-bottom-inset))]"
+      className="fixed inset-x-0 bottom-[calc(var(--lfg-safe-bottom)+4.75rem)] z-[75] flex justify-center px-3 md:bottom-[calc(1.25rem+var(--lfg-safe-bottom))]"
       role="region"
       aria-label="Session audio controls"
     >
@@ -10135,7 +10136,9 @@ function SessionChat({
             // Sit on the same surface as the chat (no card/border seam) and let
             // the transcript melt into the bar via a soft gradient fade so the
             // composer reads as part of the conversation, not a bolted-on panel.
-            "relative overflow-x-clip bg-background px-2 pb-2 pt-1.5 transition-colors",
+            // pb uses global --lfg-safe-bottom so embed host chrome never covers
+            // the input (session portal is full-bleed outside the shell pad).
+            "relative overflow-x-clip bg-background px-2 pb-[calc(0.5rem+var(--lfg-safe-bottom))] pt-1.5 transition-colors",
             "before:pointer-events-none before:absolute before:inset-x-0 before:-top-6 before:h-8 before:bg-gradient-to-t before:from-background before:to-transparent before:content-['']",
             draggingFiles && "bg-primary/8",
             launching && "lfg-composer-launching",
@@ -11399,11 +11402,7 @@ function SessionTitleSheet({
           onSaved={onRefresh}
           onError={setError}
         />
-        <div
-          ref={bodyRef}
-          className="flex min-h-0 flex-1 flex-col"
-          style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
-        >
+        <div ref={bodyRef} className="flex min-h-0 flex-1 flex-col">
           <SessionChat
             session={session}
             busy={busy}
@@ -12727,7 +12726,7 @@ function ToolGroup({ items, live }: { items: Message[]; live: boolean }) {
         <VaulDrawer.Root open={open} onOpenChange={handleOpenChange} repositionInputs={false} shouldScaleBackground={false}>
           <VaulDrawer.Portal>
             <VaulDrawer.Overlay className="fixed inset-0 z-[149] bg-black/80" />
-            <VaulDrawer.Content className="fixed inset-x-0 bottom-0 z-[150] mx-auto flex max-h-[82dvh] max-w-lg flex-col rounded-t-[2rem] border border-border bg-background p-4 pb-[max(env(safe-area-inset-bottom),1rem)] text-foreground shadow-2xl outline-none">
+            <VaulDrawer.Content className="fixed inset-x-0 bottom-0 z-[150] mx-auto flex max-h-[82dvh] max-w-lg flex-col rounded-t-[2rem] border border-border bg-background p-4 pb-[max(var(--lfg-safe-bottom),1rem)] text-foreground shadow-2xl outline-none">
               <div className="mx-auto mb-3 h-1.5 w-24 shrink-0 rounded-full bg-muted" />
               <VaulDrawer.Title className="mb-3 text-base font-semibold">Command details</VaulDrawer.Title>
               <div className="min-h-0 overflow-y-auto">{details}</div>
@@ -13657,7 +13656,7 @@ function ProjectFolderBrowser({
     <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
       <DrawerContent className="mx-auto h-[min(82dvh,42rem)] max-w-lg overflow-hidden">
         <DrawerTitle className="sr-only">Choose a project folder</DrawerTitle>
-        <div className="flex min-h-0 flex-1 flex-col px-4 pb-[max(env(safe-area-inset-bottom),1rem)]">
+        <div className="flex min-h-0 flex-1 flex-col px-4 pb-[max(var(--lfg-safe-bottom),1rem)]">
           <div className="mb-3 flex items-center justify-between">
             <div className="min-w-0">
               <h2 className="text-lg font-semibold">Choose a project</h2>
@@ -13773,7 +13772,7 @@ function ComposerProjectSheet({
     <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
       <DrawerContent className="mx-auto max-h-[78dvh] max-w-lg overflow-hidden">
         <DrawerTitle className="sr-only">Projects</DrawerTitle>
-        <div className="flex min-h-0 flex-col px-4 pb-[max(env(safe-area-inset-bottom),1rem)]">
+        <div className="flex min-h-0 flex-col px-4 pb-[max(var(--lfg-safe-bottom),1rem)]">
           <div className="mb-3 flex items-center justify-between">
             <div>
               <h2 className="text-lg font-semibold">Projects</h2>
@@ -14680,7 +14679,7 @@ function NewSessionDialog({
       onSubmit={submit}
       {...files.dropZoneProps}
       className={cn(
-        "max-h-[70dvh] overscroll-contain px-2 pb-[max(env(safe-area-inset-bottom),0.5rem)] transition-colors",
+        "max-h-[70dvh] overscroll-contain px-2 pb-[max(var(--lfg-safe-bottom),0.5rem)] transition-colors",
         variant === "inline" ? "overflow-visible pt-1.5" : "overflow-y-auto pt-1",
         draggingFiles && "bg-primary/8",
       )}
@@ -15158,7 +15157,7 @@ function ResumeSessionSheet({
 
       <div
         className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-2"
-        style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.5rem)" }}
+        style={{ paddingBottom: "calc(var(--lfg-safe-bottom) + 0.5rem)" }}
       >
         <div className="mx-auto max-w-lg">
           {showSkeleton ? (
@@ -15473,7 +15472,7 @@ function ModelPicker({
               <VaulDrawer.Overlay className="fixed inset-0 z-[179] bg-black/80" />
               <VaulDrawer.Content
                 data-slot="model-picker-drawer-content"
-                className="fixed inset-x-0 bottom-0 z-[180] mx-auto flex max-h-[82dvh] max-w-lg select-none flex-col rounded-t-[2rem] border border-border bg-background p-4 pb-[max(env(safe-area-inset-bottom),1rem)] text-foreground shadow-2xl outline-none"
+                className="fixed inset-x-0 bottom-0 z-[180] mx-auto flex max-h-[82dvh] max-w-lg select-none flex-col rounded-t-[2rem] border border-border bg-background p-4 pb-[max(var(--lfg-safe-bottom),1rem)] text-foreground shadow-2xl outline-none"
                 aria-label="Model"
               >
                 <div className="mx-auto mb-3 h-1.5 w-24 shrink-0 rounded-full bg-muted" />

--- a/web/src/components/TermView.tsx
+++ b/web/src/components/TermView.tsx
@@ -956,7 +956,7 @@ export function TermView() {
       {/* Fallback when the browser blocks clipboard reads: a real input the user
           can long-press → Paste into (always works on iOS), then send. */}
       {pasteInput ? (
-        <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-2 border-t border-white/10 bg-[#0b0b0d] p-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
+        <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-2 border-t border-white/10 bg-[#0b0b0d] p-2 pb-[calc(0.5rem+var(--lfg-safe-bottom))]">
           <input
             ref={pasteInputRef}
             autoFocus

--- a/web/src/components/ask-center.tsx
+++ b/web/src/components/ask-center.tsx
@@ -312,7 +312,7 @@ export function AskCenter({ onExpand }: { onExpand: () => void }) {
   const queued = questions.length - 1;
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-center px-3 pb-[calc(var(--lfg-orb-stack-bottom)+var(--lfg-host-bottom-inset))]">
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-[60] flex justify-center px-3 pb-[var(--lfg-orb-stack-bottom)]">
       <div className="pointer-events-auto w-full max-w-md rounded-2xl border border-primary/30 bg-background p-3.5 shadow-[0_12px_40px_rgba(0,0,0,0.28)]">
         <div className="mb-2 flex items-start gap-2">
           <div className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-lg bg-primary/15 text-primary">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -51,7 +51,15 @@
   --text-2: #3c3c43;
   --border-strong: rgba(60, 60, 67, 0.29);
   --lfg-orb-size: 4.5rem;
-  --lfg-orb-bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed.
+     NEVER pad bottoms with env(safe-area-inset-bottom) alone — always use
+     --lfg-safe-bottom so embed host chrome is included globally. */
+  --lfg-host-bottom-inset: 0px;
+  /* GLOBAL bottom safe padding = device home-indicator + host chrome.
+     Session sheet, composers, drawers, fixed pills, and clearance tokens
+     all derive from this so no surface can forget the host pill. */
+  --lfg-safe-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--lfg-host-bottom-inset));
+  --lfg-orb-bottom: calc(1.5rem + var(--lfg-safe-bottom));
   --lfg-orb-gap: 1rem;
   --lfg-orb-visual-overflow: 3rem;
   --lfg-orb-bubble-height: 2rem;
@@ -61,19 +69,17 @@
      space above that compact composer for scroll content, toasts, the dictation
      pill and the ask-center card. --lfg-composer-clear ≈ the composer's resting
      height: prompt, collapsed agent button and Start. */
-  --lfg-composer-clear: calc(10.5rem + env(safe-area-inset-bottom));
+  --lfg-composer-clear: calc(10.5rem + var(--lfg-safe-bottom));
   --lfg-inline-composer-height: var(--lfg-composer-clear);
   --lfg-orb-stack-bottom: calc(var(--lfg-composer-clear) + 0.5rem);
   --lfg-above-orb: var(--lfg-composer-clear);
-  /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed. */
-  --lfg-host-bottom-inset: 0px;
 }
 
 /* Framed inside omg Computer (`?embed=1` / iframe): the host's icon-only
    bottom pill floats over us. Lift content by a *tight* inset so composer +
    controls clear the pill, while our background still paints full-bleed under
    it (no color band from host crop). Sized for the compact pill (~40px), not
-   the old labeled bar. */
+   the old labeled bar. --lfg-safe-bottom / clearance tokens inherit this. */
 html[data-lfg-embed="true"] {
   --lfg-host-bottom-inset: 2.75rem;
 }
@@ -81,7 +87,8 @@ html[data-lfg-embed="true"] {
 /* Soft keyboard up: the orb is tucked away, so toasts and the dictation pill no
    longer need to clear the orb stack — hike them up to sit just above the
    keyboard. --lfg-keyboard-height is published live from the visualViewport
-   sync in App.tsx. */
+   sync in App.tsx. Keep host inset: the omg pill is on the parent document and
+   may still cover the iframe bottom while our soft keyboard is up. */
 html.lfg-keyboard-open {
   --lfg-orb-stack-bottom: calc(var(--lfg-keyboard-height, 0px) + 1rem);
   --lfg-above-orb: calc(var(--lfg-keyboard-height, 0px) + 1rem);

--- a/web/src/voice-call.tsx
+++ b/web/src/voice-call.tsx
@@ -450,7 +450,7 @@ export function VoiceCall({
         className="lfg-call-root fixed z-[80] flex items-center gap-2 rounded-full border bg-background/95 py-1.5 pl-1.5 pr-2 shadow-lg backdrop-blur"
         style={{
           right: "calc(env(safe-area-inset-right) + 0.75rem)",
-          bottom: "calc(env(safe-area-inset-bottom) + 0.75rem)",
+          bottom: "calc(var(--lfg-safe-bottom) + 0.75rem)",
           borderColor: "color-mix(in srgb, var(--foreground) 12%, transparent)",
         }}
       >
@@ -511,7 +511,7 @@ export function VoiceCall({
         className="lfg-call-root lfg-call-win pointer-events-auto relative flex h-[72vh] max-h-[760px] w-full flex-col overflow-hidden rounded-t-3xl border bg-background text-foreground shadow-2xl sm:h-[min(80vh,720px)] sm:w-[min(46vw,520px)] sm:min-w-[380px] sm:rounded-3xl"
         style={{
           paddingTop: "calc(env(safe-area-inset-top) + 0.5rem)",
-          paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)",
+          paddingBottom: "calc(var(--lfg-safe-bottom) + 1rem)",
           borderColor: "color-mix(in srgb, var(--foreground) 12%, transparent)",
         }}
       >


### PR DESCRIPTION
## Summary
- Introduces global `--lfg-safe-bottom` = device `safe-area-inset-bottom` + `--lfg-host-bottom-inset` (omg Computer compact pill when `?embed=1`).
- Session chat composer (full-bleed portal) pads with that token so the Message bar clears the host monitor/settings pill.
- Clearance tokens (`--lfg-composer-clear`, `--lfg-orb-bottom`, ask-center, audio bar, drawers, term input, voice call) derive from the same global safe bottom — no more one-off `env(safe-area-inset-bottom)` pads that forget host chrome.

## Why
When LFG is framed under omg Computer, the host icon-only bottom pill floats over the full-bleed iframe. The session sheet portals to `document.body` outside the shell's host pad, so only `env(safe-area-inset-bottom)` applied — and inside an iframe that is usually `0`. Result: host controls sat on the session composer.

## Test plan
- [x] `bun test test/embed.test.ts` (host inset + global safe-bottom contracts)
- [ ] Open a session on app.omg.dev (Computer tab, mobile): Message bar sits fully above the compact Computer/Settings pill
- [ ] Standalone LFG (no embed): home-indicator padding still correct on session sheet + drawers
- [ ] Soft keyboard open: composer still tracks keyboard; no regression on dictation/ask-center stack