### PR TITLE
fix(web): stop double-padding bottom safe inset in embed PWA

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -51,13 +51,16 @@ describe("host bottom inset contract", () => {
     expect(css).toMatch(/--lfg-host-bottom-inset:\s*2\.75rem/);
   });
 
-  test("global --lfg-safe-bottom folds host inset into every clearance token", () => {
+  test("global --lfg-safe-bottom is device-only standalone, host-only in embed", () => {
     const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
-    // Single source of truth: device safe-area + host chrome.
-    expect(css).toMatch(
-      /--lfg-safe-bottom:\s*calc\(env\(safe-area-inset-bottom,\s*0px\)\s*\+\s*var\(--lfg-host-bottom-inset\)\)/,
-    );
-    // Clearance tokens derive from the global safe bottom — not raw safe-area alone.
+    // Standalone default: device home-indicator only.
+    expect(css).toMatch(/--lfg-device-safe-bottom:\s*env\(safe-area-inset-bottom,\s*0px\)/);
+    expect(css).toMatch(/--lfg-safe-bottom:\s*var\(--lfg-device-safe-bottom\)/);
+    // Embed: host pill only — do NOT stack device safe-area (host already
+    // sits the pill above the home indicator; stacking double-pads iOS PWAs).
+    const embedBlock = css.slice(css.indexOf('html[data-lfg-embed="true"]'));
+    expect(embedBlock).toMatch(/--lfg-safe-bottom:\s*var\(--lfg-host-bottom-inset\)/);
+    // Clearance tokens derive from the global safe bottom.
     expect(css).toMatch(/--lfg-composer-clear:\s*calc\(10\.5rem\s*\+\s*var\(--lfg-safe-bottom\)\)/);
     expect(css).toMatch(/--lfg-orb-bottom:\s*calc\(1\.5rem\s*\+\s*var\(--lfg-safe-bottom\)\)/);
   });
@@ -71,5 +74,13 @@ describe("host bottom inset contract", () => {
     expect(app).not.toMatch(
       /paddingBottom:\s*["']env\(safe-area-inset-bottom(?:,\s*0px)?\)["']/,
     );
+  });
+
+  test("inline home composer does not double-count host inset with shell pad", () => {
+    const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
+    // Shell already applies host-inset when embedded; the inline form keeps a
+    // tight pb-2 so Start sits just above the pill band.
+    expect(app).toMatch(/variant === "inline"[\s\S]*?overflow-visible pb-2 pt-1\.5/);
+    expect(app).toContain('embedded && "pb-[var(--lfg-host-bottom-inset)]"');
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14679,8 +14679,14 @@ function NewSessionDialog({
       onSubmit={submit}
       {...files.dropZoneProps}
       className={cn(
-        "max-h-[70dvh] overscroll-contain px-2 pb-[max(var(--lfg-safe-bottom),0.5rem)] transition-colors",
-        variant === "inline" ? "overflow-visible pt-1.5" : "overflow-y-auto pt-1",
+        // Inline home sits above the shell's host-inset band when embedded, so
+        // only a tight pad — full --lfg-safe-bottom here double-counts the pill
+        // and leaves a large empty gap under Start in the omg PWA. Drawer /
+        // dialog variants are full-bleed and need the global safe bottom.
+        "max-h-[70dvh] overscroll-contain px-2 transition-colors",
+        variant === "inline"
+          ? "overflow-visible pb-2 pt-1.5"
+          : "overflow-y-auto pb-[max(var(--lfg-safe-bottom),0.5rem)] pt-1",
         draggingFiles && "bg-primary/8",
       )}
     >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -51,14 +51,15 @@
   --text-2: #3c3c43;
   --border-strong: rgba(60, 60, 67, 0.29);
   --lfg-orb-size: 4.5rem;
-  /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed.
-     NEVER pad bottoms with env(safe-area-inset-bottom) alone — always use
-     --lfg-safe-bottom so embed host chrome is included globally. */
+  /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed. */
   --lfg-host-bottom-inset: 0px;
-  /* GLOBAL bottom safe padding = device home-indicator + host chrome.
-     Session sheet, composers, drawers, fixed pills, and clearance tokens
-     all derive from this so no surface can forget the host pill. */
-  --lfg-safe-bottom: calc(env(safe-area-inset-bottom, 0px) + var(--lfg-host-bottom-inset));
+  /* Device home-indicator only — never use this alone for embed surfaces. */
+  --lfg-device-safe-bottom: env(safe-area-inset-bottom, 0px);
+  /* GLOBAL bottom safe padding.
+     Standalone: device home-indicator.
+     Embed: host pill only — the host already sits the pill above the home
+     indicator, so stacking env(safe-area) on top double-pads (esp. iOS PWA). */
+  --lfg-safe-bottom: var(--lfg-device-safe-bottom);
   --lfg-orb-bottom: calc(1.5rem + var(--lfg-safe-bottom));
   --lfg-orb-gap: 1rem;
   --lfg-orb-visual-overflow: 3rem;
@@ -79,9 +80,11 @@
    bottom pill floats over us. Lift content by a *tight* inset so composer +
    controls clear the pill, while our background still paints full-bleed under
    it (no color band from host crop). Sized for the compact pill (~40px), not
-   the old labeled bar. --lfg-safe-bottom / clearance tokens inherit this. */
+   the old labeled bar. Safe-bottom becomes host-only so we don't re-add the
+   device home-indicator the host already cleared. */
 html[data-lfg-embed="true"] {
   --lfg-host-bottom-inset: 2.75rem;
+  --lfg-safe-bottom: var(--lfg-host-bottom-inset);
 }
 
 /* Soft keyboard up: the orb is tucked away, so toasts and the dictation pill no


### PR DESCRIPTION
## Summary
- Embed mode: `--lfg-safe-bottom` = host pill only (no stacked device safe-area — omg already places the pill above the home indicator).
- Inline home composer: tight `pb-2`; shell still owns the host-inset band so Start is not floated far above the Computer/Settings pill.
- Session portal / drawers still use `--lfg-safe-bottom` once (full-bleed).

## Why
v0.1.69 made safe padding global as `device + host`. On the omg iOS PWA that stacked with the shell's host pad and left a large empty gap under Start on the home screen.

## Test plan
- [x] `bun test test/embed.test.ts`
- [ ] omg PWA Computer tab home: Start sits just above the compact pill (no large black band)
- [ ] Session chat still clears the pill (no overlap)
- [ ] Standalone LFG PWA: home-indicator padding still correct