### PR TITLE
fix(web): restore standalone device pad; cancel when embedded

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -53,12 +53,13 @@ describe("host bottom inset contract", () => {
 
   test("global --lfg-safe-bottom is device-only standalone, host-only in embed", () => {
     const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
-    // Standalone default: device home-indicator only.
+    // Standalone default: original device home-indicator.
     expect(css).toMatch(/--lfg-device-safe-bottom:\s*env\(safe-area-inset-bottom,\s*0px\)/);
     expect(css).toMatch(/--lfg-safe-bottom:\s*var\(--lfg-device-safe-bottom\)/);
-    // Embed: host pill only — do NOT stack device safe-area (host already
-    // sits the pill above the home indicator; stacking double-pads iOS PWAs).
+    // Embed: cancel device pad + host pill only (host already owns the
+    // home-indicator zone; stacking it double-pads iOS PWAs).
     const embedBlock = css.slice(css.indexOf('html[data-lfg-embed="true"]'));
+    expect(embedBlock).toMatch(/--lfg-device-safe-bottom:\s*0px/);
     expect(embedBlock).toMatch(/--lfg-safe-bottom:\s*var\(--lfg-host-bottom-inset\)/);
     // Clearance tokens derive from the global safe bottom.
     expect(css).toMatch(/--lfg-composer-clear:\s*calc\(10\.5rem\s*\+\s*var\(--lfg-safe-bottom\)\)/);
@@ -76,11 +77,11 @@ describe("host bottom inset contract", () => {
     );
   });
 
-  test("inline home composer does not double-count host inset with shell pad", () => {
+  test("inline home uses device pad (standalone) and cancels under embed", () => {
     const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
-    // Shell already applies host-inset when embedded; the inline form keeps a
-    // tight pb-2 so Start sits just above the pill band.
-    expect(app).toMatch(/variant === "inline"[\s\S]*?overflow-visible pb-2 pt-1\.5/);
+    // Standalone: original home-indicator via --lfg-device-safe-bottom.
+    // Embed: that token is cancelled to 0; shell host-inset clears the pill.
+    expect(app).toContain("pb-[max(var(--lfg-device-safe-bottom),0.5rem)]");
     expect(app).toContain('embedded && "pb-[var(--lfg-host-bottom-inset)]"');
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14679,13 +14679,13 @@ function NewSessionDialog({
       onSubmit={submit}
       {...files.dropZoneProps}
       className={cn(
-        // Inline home sits above the shell's host-inset band when embedded, so
-        // only a tight pad — full --lfg-safe-bottom here double-counts the pill
-        // and leaves a large empty gap under Start in the omg PWA. Drawer /
-        // dialog variants are full-bleed and need the global safe bottom.
+        // Inline home: original device home-indicator pad when standalone.
+        // Embed cancels --lfg-device-safe-bottom to 0 (host owns that zone) and
+        // the shell still applies host-inset, so Start clears the pill without
+        // a double gap. Drawer / dialog are full-bleed → global safe bottom.
         "max-h-[70dvh] overscroll-contain px-2 transition-colors",
         variant === "inline"
-          ? "overflow-visible pb-2 pt-1.5"
+          ? "overflow-visible pb-[max(var(--lfg-device-safe-bottom),0.5rem)] pt-1.5"
           : "overflow-y-auto pb-[max(var(--lfg-safe-bottom),0.5rem)] pt-1",
         draggingFiles && "bg-primary/8",
       )}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -53,12 +53,12 @@
   --lfg-orb-size: 4.5rem;
   /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed. */
   --lfg-host-bottom-inset: 0px;
-  /* Device home-indicator only — never use this alone for embed surfaces. */
+  /* Device home-indicator. Standalone uses the real inset; embed cancels it
+     (host already places chrome above the home indicator). */
   --lfg-device-safe-bottom: env(safe-area-inset-bottom, 0px);
   /* GLOBAL bottom safe padding.
-     Standalone: device home-indicator.
-     Embed: host pill only — the host already sits the pill above the home
-     indicator, so stacking env(safe-area) on top double-pads (esp. iOS PWA). */
+     Standalone: original device home-indicator pad.
+     Embed: host pill only (device pad cancelled — see data-lfg-embed). */
   --lfg-safe-bottom: var(--lfg-device-safe-bottom);
   --lfg-orb-bottom: calc(1.5rem + var(--lfg-safe-bottom));
   --lfg-orb-gap: 1rem;
@@ -76,13 +76,11 @@
   --lfg-above-orb: var(--lfg-composer-clear);
 }
 
-/* Framed inside omg Computer (`?embed=1` / iframe): the host's icon-only
-   bottom pill floats over us. Lift content by a *tight* inset so composer +
-   controls clear the pill, while our background still paints full-bleed under
-   it (no color band from host crop). Sized for the compact pill (~40px), not
-   the old labeled bar. Safe-bottom becomes host-only so we don't re-add the
-   device home-indicator the host already cleared. */
+/* Framed inside omg Computer (`?embed=1` / iframe): cancel the device
+   home-indicator pad (host already owns that zone) and lift content by a
+   tight host-pill inset so composer + controls clear the floating nav. */
 html[data-lfg-embed="true"] {
+  --lfg-device-safe-bottom: 0px;
   --lfg-host-bottom-inset: 2.75rem;
   --lfg-safe-bottom: var(--lfg-host-bottom-inset);
 }


### PR DESCRIPTION
## Summary
- **Standalone:** restore original device home-indicator pad on the home composer via `--lfg-device-safe-bottom`.
- **Embed:** cancel device pad to `0` (host owns that zone) and keep host-pill inset only.

## Why
v0.1.70 set the inline form to `pb-2`, which fixed the omg PWA double-gap but left standalone LFG flush against the home indicator.

## Test plan
- [x] `bun test test/embed.test.ts`
- [ ] Standalone LFG PWA: Start sits above the home indicator (original feel)
- [ ] omg Computer embed: no large empty band under Start; session Message still clears the pill