### PR TITLE
feat(agents): add ultracode effort for Claude CLI

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { curateOpenCodeModels } from "./agent-catalog.ts";
+import { curateOpenCodeModels, thinkingLevelsForAgent } from "./agent-catalog.ts";
+import { claudeCliEffortFor, claudeEffortFor, claudeSupportsUltracode } from "./tmux.ts";
 
 const DISCOVERED = [
   "openai/gpt-5.3-codex-spark",
@@ -49,5 +50,35 @@ describe("curateOpenCodeModels", () => {
     expect(curateOpenCodeModels(["opencode-go/kimi-k3", "openrouter/whatever"])).toEqual([
       "opencode-go/kimi-k3",
     ]);
+  });
+});
+
+describe("ultracode thinking level", () => {
+  test("is offered on the claude CLI backend only", () => {
+    expect(thinkingLevelsForAgent("claude")).toContain("ultracode");
+    // Everything else shares the plain claude effort vocabulary: grok's CLI and
+    // the ai-sdk/pi backends reject the literal value.
+    for (const agent of ["aisdk", "grok", "pi", "codex", "codex-aisdk", "cursor"]) {
+      expect(thinkingLevelsForAgent(agent) ?? []).not.toContain("ultracode");
+    }
+  });
+
+  test("collapses to xhigh for non-claude-CLI consumers", () => {
+    // grok's `--effort` goes through claudeEffortFor; it must never see the
+    // literal "ultracode", and must not silently lose the level either.
+    expect(claudeEffortFor("ultracode")).toBe("xhigh");
+  });
+
+  test("passes through to the claude CLI only when the CLI supports it", () => {
+    const effort = claudeCliEffortFor("ultracode");
+    expect(effort).toBe(claudeSupportsUltracode() ? "ultracode" : "xhigh");
+  });
+
+  test("leaves the other levels untouched", () => {
+    expect(claudeCliEffortFor("xhigh")).toBe("xhigh");
+    expect(claudeCliEffortFor("max")).toBe("max");
+    expect(claudeCliEffortFor("minimal")).toBe("low");
+    expect(claudeCliEffortFor(undefined)).toBeUndefined();
+    expect(claudeCliEffortFor("bogus")).toBeUndefined();
   });
 });

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -104,6 +104,16 @@ const MODEL_CATALOG_KEYS: CodingAgentKind[] = [
 
 export const CODEX_THINKING_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
 export const CLAUDE_THINKING_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+// The `claude` CLI additionally accepts `--effort ultracode` (Claude Code
+// >= 2.1.203): xhigh reasoning PLUS automatic dynamic-workflow orchestration,
+// where Claude plans a multi-agent workflow for every substantive task. It is a
+// session-only level — it cannot be persisted via settings' effortLevel or
+// CLAUDE_CODE_EFFORT_LEVEL — which is exactly how lfg passes it (a per-spawn
+// flag), so the CLI path is the only backend that can offer it. NOT added to
+// CLAUDE_THINKING_LEVELS because that list is shared with grok/pi/aisdk, whose
+// CLIs and SDKs reject the value. See claudeCliEffortFor in tmux.ts for the
+// version gate and the xhigh fallback.
+export const CLAUDE_CLI_THINKING_LEVELS = [...CLAUDE_THINKING_LEVELS, "ultracode"] as const;
 export const PICKER_THINKING_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 
 export type ModelCatalogItem = {
@@ -403,7 +413,9 @@ export function resolveModelForAgent(
 }
 
 export function thinkingLevelsForAgent(agent: string): readonly string[] | null {
-  if (agent === "claude" || agent === "aisdk" || agent === "grok" || agent === "pi") return CLAUDE_THINKING_LEVELS;
+  // "claude" is the tmux CLI backend, the only one that can take `ultracode`.
+  if (agent === "claude") return CLAUDE_CLI_THINKING_LEVELS;
+  if (agent === "aisdk" || agent === "grok" || agent === "pi") return CLAUDE_THINKING_LEVELS;
   if (agent === "codex" || agent === "codex-aisdk") return CODEX_THINKING_LEVELS;
   if (agent === "cursor") return CURSOR_THINKING_LEVELS;
   return null;

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -428,8 +428,58 @@ export function spawnAgentSession(opts: {
 export function claudeEffortFor(level?: string): string | undefined {
   if (!level) return undefined;
   if (level === "none" || level === "minimal") return "low";
+  // "ultracode" is a claude-CLI-only level (xhigh + dynamic workflows). Every
+  // other consumer of this mapper (grok today) would reject the literal value,
+  // so collapse it to the effort half of what it means. This mirrors Claude
+  // Code's own documented behaviour when ultracode is unavailable: "--effort
+  // ultracode sets xhigh effort only". Callers that CAN honour the real thing
+  // go through claudeCliEffortFor below.
+  if (level === "ultracode") return "xhigh";
   if (["low", "medium", "high", "xhigh", "max"].includes(level)) return level;
   return undefined;
+}
+
+// Minimum Claude Code version that accepts `--effort ultracode`. Older CLIs
+// print `Unknown --effort value 'ultracode'` and then start the session at the
+// DEFAULT effort — silently losing the thinking level the user picked — so the
+// gate below downgrades to plain xhigh instead of risking that.
+const ULTRACODE_MIN_CLAUDE_VERSION = [2, 1, 203] as const;
+
+function parseSemver(text: string): number[] | null {
+  const m = text.match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+let _ultracodeSupported: boolean | null = null;
+
+// Whether the installed `claude` is new enough for `--effort ultracode`.
+// Cached for the life of the process: it shells out to `claude --version`, and
+// a CLI upgrade under a running lfg needs a restart to be picked up anyway.
+// Fails closed — an unparseable/erroring version means no ultracode.
+export function claudeSupportsUltracode(): boolean {
+  if (_ultracodeSupported !== null) return _ultracodeSupported;
+  let version: number[] | null = null;
+  try {
+    const r = Bun.spawnSync([claudeBin(), "--version"]);
+    if (r.exitCode === 0) version = parseSemver(new TextDecoder().decode(r.stdout));
+  } catch {
+    version = null; // claude missing/not executable — fall back to xhigh
+  }
+  if (!version) return (_ultracodeSupported = false);
+  const min = ULTRACODE_MIN_CLAUDE_VERSION;
+  const ok =
+    version[0]! !== min[0] ? version[0]! > min[0]
+    : version[1]! !== min[1] ? version[1]! > min[1]
+    : version[2]! >= min[2];
+  return (_ultracodeSupported = ok);
+}
+
+// Effort mapper for the `claude` CLI specifically: same as claudeEffortFor, but
+// passes "ultracode" through when the installed CLI supports it. Anything else
+// (including an old CLI) lands on claudeEffortFor's xhigh collapse.
+export function claudeCliEffortFor(level?: string): string | undefined {
+  if (level === "ultracode" && claudeSupportsUltracode()) return "ultracode";
+  return claudeEffortFor(level);
 }
 
 export function spawnManagedSession(opts: {
@@ -465,8 +515,9 @@ export function spawnManagedSession(opts: {
   argv.push("--model", opts.model || DEFAULT_MODEL);
   // Pin the reasoning effort when the caller asked for one (thinking mode). The
   // claude CLI exposes this as `--effort <level>`; map our shared thinking-level
-  // vocabulary onto it (see claudeEffortFor). Omitted → CLI default effort.
-  const effort = claudeEffortFor(opts.thinkingLevel);
+  // vocabulary onto it (see claudeCliEffortFor, which also handles the
+  // claude-only "ultracode" level). Omitted → CLI default effort.
+  const effort = claudeCliEffortFor(opts.thinkingLevel);
   if (effort) argv.push("--effort", effort);
   // `--` terminates option parsing so the variadic --add-dir can't swallow the
   // positional prompt as a second directory (which strands the new session at

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -677,7 +677,12 @@ const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   copilot: "claude-sonnet-4.5",
 };
 const AGENT_THINKING_LEVELS: Record<AgentKind, string[]> = {
-  claude: ["low", "medium", "high", "xhigh", "max"],
+  // "ultracode" (claude CLI only, >= 2.1.203) is xhigh effort PLUS automatic
+  // dynamic-workflow orchestration — Claude plans a multi-agent workflow for
+  // every substantive task, so runs cost meaningfully more. Kept in sync with
+  // CLAUDE_CLI_THINKING_LEVELS in src/agent-catalog.ts (the server catalog
+  // overrides this fallback at bootstrap).
+  claude: ["low", "medium", "high", "xhigh", "max", "ultracode"],
   aisdk: ["low", "medium", "high", "xhigh", "max"],
   codex: ["none", "minimal", "low", "medium", "high", "xhigh"],
   "codex-aisdk": ["none", "minimal", "low", "medium", "high", "xhigh"],


### PR DESCRIPTION
## What changed

- Adds `ultracode` to the thinking-level catalog and web picker for the Claude CLI backend only.
- Passes `--effort ultracode` to Claude Code when the installed CLI supports it (2.1.203+).
- Falls back safely to `xhigh` on older, missing, or unparseable Claude CLI versions.
- Keeps AI SDK, Pi, and Grok backends on their existing effort vocabulary so they never receive an unsupported literal value.
- Adds focused coverage for backend exposure, fallback behavior, version-gated pass-through, and unchanged existing levels.

## Why

Claude Code now supports an `ultracode` session effort that combines `xhigh` reasoning with dynamic multi-agent workflow orchestration. LFG already passes thinking level per spawn, so exposing this on the Claude CLI backend makes the supported control available without leaking it into incompatible backends. The version gate prevents older CLIs from silently dropping the requested effort.

## User impact

Users launching the `claude` backend can select `ultracode`. It is intentionally absent from other backends and may use materially more tokens because it can orchestrate multiple agents.

## Verification

- `bun test` — 248 pass, 0 fail
- `npm run typecheck`
- `npm --prefix web run build`
- Installed Claude Code 2.1.220 detected; `claudeCliEffortFor("ultracode")` resolves to `ultracode`

No deployment or release is included in this PR.