### PR TITLE
feat(sessions): add token usage inspector

### DIFF
--- a/src/agents/backends/aisdk-session.ts
+++ b/src/agents/backends/aisdk-session.ts
@@ -38,6 +38,11 @@ import {
 } from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
 import { readFileSync, statSync } from "node:fs";
+import {
+  readStoredSessionTokenUsage,
+  writeStoredSessionTokenUsage,
+  type ClaudeContextUsageSnapshot,
+} from "../../session-token-usage.ts";
 
 function arg(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
@@ -198,6 +203,63 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   let closing = false;
   let draft = "";
   let busy = false;
+  const previousUsage = readStoredSessionTokenUsage(sessionId);
+  let sessionTotals = previousUsage?.totals ?? {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    reasoning: 0,
+    total: 0,
+    costUsd: 0,
+  };
+  let contextUsage = previousUsage?.context ?? null;
+  let usageRefresh = 0;
+
+  const persistUsage = () => {
+    writeStoredSessionTokenUsage(sessionId, {
+      updatedAt: Date.now(),
+      model,
+      context: contextUsage,
+      totals: sessionTotals,
+    });
+  };
+
+  const refreshUsageSnapshot = () => {
+    const request = ++usageRefresh;
+    void Promise.allSettled([
+      q.getContextUsage(),
+      q.usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET(),
+    ])
+      .then(([contextResult, totalsResult]) => {
+        if (request !== usageRefresh) return;
+        if (contextResult.status === "fulfilled") {
+          contextUsage = contextResult.value as ClaudeContextUsageSnapshot;
+        }
+        if (totalsResult.status === "fulfilled") {
+          const reported = totalsResult.value.session;
+          const modelTotals = Object.values(reported.model_usage);
+          const input = modelTotals.reduce((sum, row) => sum + row.inputTokens, 0);
+          const output = modelTotals.reduce((sum, row) => sum + row.outputTokens, 0);
+          const cacheRead = modelTotals.reduce((sum, row) => sum + row.cacheReadInputTokens, 0);
+          const cacheWrite = modelTotals.reduce(
+            (sum, row) => sum + row.cacheCreationInputTokens,
+            0,
+          );
+          sessionTotals = {
+            input,
+            output,
+            cacheRead,
+            cacheWrite,
+            reasoning: 0,
+            total: input + output + cacheRead + cacheWrite,
+            costUsd: reported.total_cost_usd,
+          };
+        }
+        persistUsage();
+      })
+      .catch(() => {});
+  };
 
   // Busy is ACTIVITY-DRIVEN, not turn-counted. The SDK's streaming input may
   // merge a queued/steering send into the running turn, so `result` events do
@@ -276,6 +338,25 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
       return;
     }
     if (type === "result") {
+      const result = msg as {
+        usage?: Record<string, unknown>;
+        total_cost_usd?: number;
+      };
+      const usage = result.usage;
+      if (usage) {
+        const input = Number(usage.input_tokens) || 0;
+        const output = Number(usage.output_tokens) || 0;
+        const cacheRead = Number(usage.cache_read_input_tokens) || 0;
+        const cacheWrite = Number(usage.cache_creation_input_tokens) || 0;
+        sessionTotals.input += input;
+        sessionTotals.output += output;
+        sessionTotals.cacheRead += cacheRead;
+        sessionTotals.cacheWrite += cacheWrite;
+        sessionTotals.total += input + output + cacheRead + cacheWrite;
+        sessionTotals.costUsd = (sessionTotals.costUsd ?? 0) + (Number(result.total_cost_usd) || 0);
+        persistUsage();
+        refreshUsageSnapshot();
+      }
       const errText =
         (msg as { subtype?: string }).subtype !== "success"
           ? String((msg as { result?: unknown }).result ?? (msg as { subtype?: string }).subtype)

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -55,6 +55,7 @@ import {
 } from "../session-diff.ts";
 import { reportClientError, listClientErrors } from "../client-errors.ts";
 import { getAllUsage } from "../usage.ts";
+import { sessionTokenUsage } from "../session-token-usage.ts";
 import {
   vapidPublicKey,
   saveSubscription,
@@ -86,6 +87,7 @@ import {
   refreshResumableCache,
   cwdForTranscript,
   cwdForCodexTranscript,
+  findCodexTranscriptById,
   type PendingPrompt,
   type Session,
   type SessionMsg,
@@ -5157,6 +5159,29 @@ export async function cmdServe() {
 
       // Non-streaming transcript read — lets an orchestrator or LFG MCP client
       // inspect what another session is doing without holding an SSE connection.
+      {
+        const m = path.match(/^\/api\/sessions\/([0-9a-fA-F-]{36})\/token-usage$/);
+        if (m && req.method === "GET") {
+          let transcriptPath = await resolveTranscript(m[1]);
+          // Direct-indexed SDK sessions render from their synthetic lfg://
+          // conversation key, while Codex's authoritative token_count events
+          // remain in the native rollout transcript. Follow the native id only
+          // for usage accounting; chat ordering still belongs to the index.
+          if (transcriptPath?.startsWith("lfg://")) {
+            const session = (await listSessionsCached()).find(
+              (candidate) =>
+                candidate.sessionId === m[1] || candidate.nativeSessionId === m[1],
+            );
+            if (session?.nativeSessionId && session.nativeSessionId !== m[1]) {
+              transcriptPath =
+                (await findCodexTranscriptById(session.nativeSessionId).catch(() => null)) ??
+                transcriptPath;
+            }
+          }
+          return json(await sessionTokenUsage(m[1], transcriptPath));
+        }
+      }
+
       {
         const m = path.match(/^\/api\/sessions\/([0-9a-fA-F-]{36})\/messages$/);
         if (m && req.method === "GET") {

--- a/src/session-token-usage.test.ts
+++ b/src/session-token-usage.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { sessionTokenUsage } from "./session-token-usage.ts";
+
+const roots: string[] = [];
+
+function fixturePath(provider: "codex" | "claude", rows: unknown[]): string {
+  const root = join(tmpdir(), `lfg-session-usage-${crypto.randomUUID()}`);
+  roots.push(root);
+  const dir = provider === "codex" ? join(root, ".codex", "sessions") : join(root, ".claude", "projects");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "session.jsonl");
+  writeFileSync(path, rows.map((row) => JSON.stringify(row)).join("\n"));
+  return path;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("sessionTokenUsage", () => {
+  test("reads authoritative Codex counters and estimates prompt categories", async () => {
+    const path = fixturePath("codex", [
+      {
+        type: "session_meta",
+        payload: { base_instructions: { text: "fallback base instructions" } },
+      },
+      {
+        type: "turn_context",
+        payload: { model: "gpt-test", summary: "A compacted conversation summary." },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "developer",
+          content: [
+            { type: "input_text", text: "General system rules." },
+            {
+              type: "input_text",
+              text: "<skills_instructions>## Skills\n- imagegen</skills_instructions>",
+            },
+          ],
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "=== USER TASK ===\nBuild the usage view." }],
+        },
+      },
+      {
+        type: "response_item",
+        payload: { type: "function_call", arguments: "{\"cmd\":\"pwd\"}" },
+      },
+      {
+        type: "response_item",
+        payload: { type: "function_call_output", output: "/work" },
+      },
+      {
+        type: "event_msg",
+        timestamp: "2026-07-28T00:00:00Z",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 12_000,
+              cached_input_tokens: 8_000,
+              output_tokens: 900,
+              reasoning_output_tokens: 300,
+              total_tokens: 12_900,
+            },
+            last_token_usage: { input_tokens: 4_000, output_tokens: 200 },
+            model_context_window: 10_000,
+          },
+        },
+      },
+    ]);
+
+    const usage = await sessionTokenUsage(crypto.randomUUID(), path);
+
+    expect(usage.source).toBe("codex-transcript");
+    expect(usage.context).toEqual({ used: 4_200, max: 10_000, free: 5_800, percent: 42 });
+    expect(usage.totals).toMatchObject({
+      input: 4_000,
+      output: 900,
+      cacheRead: 8_000,
+      reasoning: 300,
+      total: 12_900,
+    });
+    expect(usage.categories.map((category) => category.name)).toEqual(
+      expect.arrayContaining([
+        "System prompt",
+        "Skills",
+        "User messages",
+        "Tool calls",
+        "Tool results",
+        "Compaction summary",
+        "Other context",
+      ]),
+    );
+    expect(usage.categories.every((category) => category.accuracy === "estimated")).toBe(true);
+  });
+
+  test("deduplicates repeated Claude transcript envelopes by request id", async () => {
+    const usage = {
+      input_tokens: 10,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 40,
+    };
+    const path = fixturePath("claude", [
+      {
+        type: "assistant",
+        requestId: "request-1",
+        timestamp: "2026-07-28T00:00:00Z",
+        message: { id: "message-1", model: "claude-test", usage },
+      },
+      {
+        type: "assistant",
+        requestId: "request-1",
+        timestamp: "2026-07-28T00:00:01Z",
+        message: { id: "message-1", model: "claude-test", usage },
+      },
+    ]);
+
+    const result = await sessionTokenUsage(crypto.randomUUID(), path);
+
+    expect(result.source).toBe("claude-transcript");
+    expect(result.context.used).toBe(100);
+    expect(result.totals).toMatchObject({
+      input: 10,
+      output: 20,
+      cacheRead: 30,
+      cacheWrite: 40,
+      total: 100,
+    });
+  });
+});

--- a/src/session-token-usage.ts
+++ b/src/session-token-usage.ts
@@ -1,0 +1,486 @@
+import {
+  createReadStream,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createInterface } from "node:readline";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+
+export type SessionTokenCategory = {
+  name: string;
+  tokens: number;
+  color?: string;
+  accuracy: "reported" | "estimated";
+};
+
+export type SessionTokenUsage = {
+  available: boolean;
+  source: "claude-context" | "codex-transcript" | "claude-transcript" | "unavailable";
+  accuracy: "reported" | "mixed" | "unavailable";
+  updatedAt: number;
+  model: string | null;
+  context: {
+    used: number | null;
+    max: number | null;
+    free: number | null;
+    percent: number | null;
+  };
+  totals: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    reasoning: number;
+    total: number;
+    costUsd: number | null;
+  } | null;
+  categories: SessionTokenCategory[];
+  details?: {
+    memoryFiles?: Array<{ path: string; type: string; tokens: number }>;
+    mcpTools?: Array<{ name: string; serverName: string; tokens: number; isLoaded?: boolean }>;
+    systemTools?: Array<{ name: string; tokens: number }>;
+    systemPromptSections?: Array<{ name: string; tokens: number }>;
+    skills?: {
+      totalSkills: number;
+      includedSkills: number;
+      tokens: number;
+      items: Array<{ name: string; source: string; tokens: number }>;
+    };
+    messageBreakdown?: {
+      toolCallTokens: number;
+      toolResultTokens: number;
+      attachmentTokens: number;
+      assistantMessageTokens: number;
+      userMessageTokens: number;
+      redirectedContextTokens: number;
+      unattributedTokens: number;
+      toolCallsByType: Array<{ name: string; callTokens: number; resultTokens: number }>;
+    };
+  };
+  note: string;
+};
+
+export type ClaudeContextUsageSnapshot = {
+  categories: Array<{ name: string; tokens: number; color: string; isDeferred?: boolean }>;
+  totalTokens: number;
+  maxTokens: number;
+  rawMaxTokens: number;
+  percentage: number;
+  model: string;
+  memoryFiles?: Array<{ path: string; type: string; tokens: number }>;
+  mcpTools?: Array<{ name: string; serverName: string; tokens: number; isLoaded?: boolean }>;
+  systemTools?: Array<{ name: string; tokens: number }>;
+  systemPromptSections?: Array<{ name: string; tokens: number }>;
+  skills?: {
+    totalSkills: number;
+    includedSkills: number;
+    tokens: number;
+    skillFrontmatter: Array<{ name: string; source: string; tokens: number }>;
+  };
+  messageBreakdown?: {
+    toolCallTokens: number;
+    toolResultTokens: number;
+    attachmentTokens: number;
+    assistantMessageTokens: number;
+    userMessageTokens: number;
+    redirectedContextTokens: number;
+    unattributedTokens: number;
+    toolCallsByType: Array<{ name: string; callTokens: number; resultTokens: number }>;
+  };
+};
+
+export type StoredSessionTokenUsage = {
+  updatedAt: number;
+  model: string | null;
+  context: ClaudeContextUsageSnapshot | null;
+  totals: NonNullable<SessionTokenUsage["totals"]>;
+};
+
+const COLORS = [
+  "#a78bfa",
+  "#60a5fa",
+  "#34d399",
+  "#fbbf24",
+  "#fb7185",
+  "#22d3ee",
+  "#c084fc",
+  "#94a3b8",
+];
+const transcriptCache = new Map<
+  string,
+  { mtimeMs: number; size: number; usage: SessionTokenUsage }
+>();
+
+function usageDir(): string {
+  return join(PATHS.data, "session-usage");
+}
+
+function usagePath(sessionId: string): string {
+  return join(usageDir(), `${sessionId}.json`);
+}
+
+export function readStoredSessionTokenUsage(sessionId: string): StoredSessionTokenUsage | null {
+  try {
+    return JSON.parse(readFileSync(usagePath(sessionId), "utf8")) as StoredSessionTokenUsage;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredSessionTokenUsage(
+  sessionId: string,
+  snapshot: StoredSessionTokenUsage,
+): void {
+  mkdirSync(usageDir(), { recursive: true });
+  const target = usagePath(sessionId);
+  const temp = `${target}.${process.pid}.tmp`;
+  writeFileSync(temp, JSON.stringify(snapshot));
+  renameSync(temp, target);
+}
+
+function fromStored(stored: StoredSessionTokenUsage): SessionTokenUsage {
+  const rich = stored.context;
+  const used = rich?.totalTokens ?? null;
+  const max = rich?.maxTokens ?? null;
+  return {
+    available: true,
+    source: "claude-context",
+    accuracy: rich ? "reported" : "mixed",
+    updatedAt: stored.updatedAt,
+    model: rich?.model ?? stored.model,
+    context: {
+      used,
+      max,
+      free: used != null && max != null ? Math.max(0, max - used) : null,
+      percent: rich?.percentage ?? (used != null && max ? (used / max) * 100 : null),
+    },
+    totals: stored.totals,
+    categories: (rich?.categories ?? []).map((category) => ({
+      name: category.name,
+      tokens: category.tokens,
+      color: category.color,
+      accuracy: "reported",
+    })),
+    details: rich
+      ? {
+          memoryFiles: rich.memoryFiles,
+          mcpTools: rich.mcpTools,
+          systemTools: rich.systemTools,
+          systemPromptSections: rich.systemPromptSections,
+          skills: rich.skills
+            ? {
+                totalSkills: rich.skills.totalSkills,
+                includedSkills: rich.skills.includedSkills,
+                tokens: rich.skills.tokens,
+                items: rich.skills.skillFrontmatter,
+              }
+            : undefined,
+          messageBreakdown: rich.messageBreakdown,
+        }
+      : undefined,
+    note: rich
+      ? "Context categories and token counts are reported by Claude for this session."
+      : "Session totals are reported by Claude; a context-category snapshot is not available yet.",
+  };
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function estimateTokens(value: unknown): number {
+  const text = typeof value === "string" ? value : JSON.stringify(value ?? "");
+  if (!text) return 0;
+  // A deliberately conservative display estimate for source attribution. The
+  // authoritative context and session totals always come from the provider.
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function addCategory(map: Map<string, number>, name: string, value: unknown): void {
+  const tokens = estimateTokens(value);
+  if (tokens) map.set(name, (map.get(name) ?? 0) + tokens);
+}
+
+function consumeTagged(
+  text: string,
+  map: Map<string, number>,
+  name: string,
+  pattern: RegExp,
+): string {
+  return text.replace(pattern, (match) => {
+    addCategory(map, name, match);
+    return "";
+  });
+}
+
+function classifyPromptText(
+  raw: string,
+  role: "developer" | "user",
+  map: Map<string, number>,
+): void {
+  let text = raw;
+  text = consumeTagged(text, map, "Skills", /<skills_instructions>[\s\S]*?<\/skills_instructions>/gi);
+  text = consumeTagged(text, map, "Plugins", /<apps_instructions>[\s\S]*?<\/apps_instructions>/gi);
+  text = consumeTagged(text, map, "Plugins", /<recommended_plugins>[\s\S]*?<\/recommended_plugins>/gi);
+  text = consumeTagged(
+    text,
+    map,
+    "Project instructions",
+    /# AGENTS\.md instructions[\s\S]*?(?=\n(?:<environment_context>|=== LFG RUNTIME CONTRACT|=== USER TASK ===)|$)/gi,
+  );
+  text = consumeTagged(
+    text,
+    map,
+    "Runtime instructions",
+    /=== LFG RUNTIME CONTRACT[\s\S]*?=== END LFG RUNTIME CONTRACT ===/gi,
+  );
+  if (role === "user") {
+    const marker = text.indexOf("=== USER TASK ===");
+    if (marker >= 0) {
+      addCategory(map, "Runtime instructions", text.slice(0, marker));
+      text = text.slice(marker + "=== USER TASK ===".length);
+    }
+  }
+  addCategory(map, role === "developer" ? "System prompt" : "User messages", text);
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const row = part as Record<string, unknown>;
+      return typeof row.text === "string" ? row.text : typeof row.content === "string" ? row.content : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+async function parseCodexTranscript(path: string): Promise<SessionTokenUsage | null> {
+  let latestTokenCount: Record<string, unknown> | null = null;
+  let model: string | null = null;
+  let updatedAt = 0;
+  let sawDeveloperMessage = false;
+  let baseInstructions = "";
+  const categories = new Map<string, number>();
+
+  const lines = createInterface({ input: createReadStream(path), crlfDelay: Infinity });
+  for await (const line of lines) {
+    let row: Record<string, unknown>;
+    try {
+      row = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const payload = row.payload as Record<string, unknown> | undefined;
+    if (row.type === "session_meta") {
+      const base = payload?.base_instructions as Record<string, unknown> | undefined;
+      if (typeof base?.text === "string") baseInstructions = base.text;
+    }
+    if (row.type === "turn_context") {
+      if (typeof payload?.model === "string") model = payload.model;
+      const summary = payload?.summary;
+      if (typeof summary === "string" && summary !== "auto") {
+        addCategory(categories, "Compaction summary", summary);
+      }
+    }
+    if (row.type === "event_msg" && payload?.type === "token_count" && payload.info) {
+      latestTokenCount = payload.info as Record<string, unknown>;
+      const timestamp = Date.parse(String(row.timestamp ?? ""));
+      if (Number.isFinite(timestamp)) updatedAt = timestamp;
+    }
+    if (row.type !== "response_item" || !payload) continue;
+    if (payload.type === "message") {
+      const role = String(payload.role ?? "");
+      const text = contentText(payload.content);
+      if (role === "developer") {
+        sawDeveloperMessage = true;
+        classifyPromptText(text, "developer", categories);
+      } else if (role === "user") {
+        classifyPromptText(text, "user", categories);
+      } else if (role === "assistant") {
+        addCategory(categories, "Assistant messages", text);
+      }
+    } else if (payload.type === "function_call" || payload.type === "custom_tool_call") {
+      addCategory(categories, "Tool calls", payload.arguments ?? payload.input ?? "");
+    } else if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
+      addCategory(categories, "Tool results", payload.output ?? "");
+    } else if (payload.type === "reasoning") {
+      addCategory(categories, "Reasoning", payload.summary ?? "");
+    } else if (payload.type === "tool_search_output") {
+      addCategory(categories, "Tool definitions", payload.tools ?? "");
+    }
+  }
+
+  if (!latestTokenCount) return null;
+  // base_instructions is also serialized as a developer response item in newer
+  // Codex rollouts. Use it only as a fallback for older transcript versions.
+  if (!sawDeveloperMessage && baseInstructions) {
+    addCategory(categories, "System prompt", baseInstructions);
+  }
+  const total = latestTokenCount.total_token_usage as Record<string, unknown> | undefined;
+  const last = latestTokenCount.last_token_usage as Record<string, unknown> | undefined;
+  const cacheRead = num(total?.cached_input_tokens);
+  // Codex reports cached input as a subset of input_tokens. Normalize the
+  // cross-provider display so "Input" means newly processed input and the
+  // cache row is additive instead of appearing to double-count.
+  const input = Math.max(0, num(total?.input_tokens) - cacheRead);
+  const output = num(total?.output_tokens);
+  const reasoning = num(total?.reasoning_output_tokens);
+  const currentInput = num(last?.input_tokens);
+  const currentOutput = num(last?.output_tokens);
+  const max = num(latestTokenCount.model_context_window) || null;
+  const used = currentInput + currentOutput || null;
+  const attributed = [...categories.values()].reduce((sum, value) => sum + value, 0);
+  if (used != null && attributed > used) {
+    // A rollout retains historical items that may have been compacted out of
+    // the active prompt. Normalize recorded-source estimates back to the
+    // provider-reported current context instead of showing categories whose
+    // sum can exceed the window.
+    const scale = used / attributed;
+    for (const [name, tokens] of categories) {
+      categories.set(name, Math.max(1, Math.round(tokens * scale)));
+    }
+  } else if (used != null && used > attributed) {
+    categories.set("Other context", used - attributed);
+  }
+
+  return {
+    available: true,
+    source: "codex-transcript",
+    accuracy: "mixed",
+    updatedAt: updatedAt || Date.now(),
+    model,
+    context: {
+      used,
+      max,
+      free: used != null && max != null ? Math.max(0, max - used) : null,
+      percent: used != null && max != null ? (used / max) * 100 : null,
+    },
+    totals: {
+      input,
+      output,
+      cacheRead,
+      cacheWrite: 0,
+      reasoning,
+      total: num(total?.total_tokens) || input + output,
+      costUsd: null,
+    },
+    categories: [...categories.entries()]
+      .filter(([, tokens]) => tokens > 0)
+      .map(([name, tokens], index) => ({
+        name,
+        tokens,
+        color: COLORS[index % COLORS.length],
+        accuracy: "estimated" as const,
+      })),
+    note:
+      "Totals and context size are reported by Codex. Category attribution is estimated from recorded prompt structure and normalized to the current context.",
+  };
+}
+
+async function parseClaudeTranscript(path: string): Promise<SessionTokenUsage | null> {
+  const seen = new Set<string>();
+  let latest: Record<string, unknown> | null = null;
+  let model: string | null = null;
+  let updatedAt = 0;
+  const totals = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  const lines = createInterface({ input: createReadStream(path), crlfDelay: Infinity });
+  for await (const line of lines) {
+    let row: Record<string, unknown>;
+    try {
+      row = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    const message = row.message as Record<string, unknown> | undefined;
+    const usage = message?.usage as Record<string, unknown> | undefined;
+    if (!usage) continue;
+    const key = String(row.requestId ?? message?.id ?? row.uuid ?? "");
+    if (key && seen.has(key)) continue;
+    if (key) seen.add(key);
+    totals.input += num(usage.input_tokens);
+    totals.output += num(usage.output_tokens);
+    totals.cacheRead += num(usage.cache_read_input_tokens);
+    totals.cacheWrite += num(usage.cache_creation_input_tokens);
+    latest = usage;
+    if (typeof message?.model === "string") model = message.model;
+    const timestamp = Date.parse(String(row.timestamp ?? ""));
+    if (Number.isFinite(timestamp)) updatedAt = timestamp;
+  }
+  if (!latest) return null;
+  const currentInput =
+    num(latest.input_tokens) +
+    num(latest.cache_read_input_tokens) +
+    num(latest.cache_creation_input_tokens);
+  const currentOutput = num(latest.output_tokens);
+  return {
+    available: true,
+    source: "claude-transcript",
+    accuracy: "mixed",
+    updatedAt: updatedAt || Date.now(),
+    model,
+    context: { used: currentInput + currentOutput, max: null, free: null, percent: null },
+    totals: {
+      ...totals,
+      reasoning: 0,
+      total: totals.input + totals.output + totals.cacheRead + totals.cacheWrite,
+      costUsd: null,
+    },
+    categories: [],
+    note:
+      "Token totals are reported by Claude. Detailed context categories are available for LFG-managed Claude SDK sessions.",
+  };
+}
+
+export async function sessionTokenUsage(
+  sessionId: string,
+  transcriptPath: string | null,
+): Promise<SessionTokenUsage> {
+  const stored = readStoredSessionTokenUsage(sessionId);
+  if (stored) return fromStored(stored);
+  if (transcriptPath && !transcriptPath.startsWith("lfg://")) {
+    let fingerprint: { mtimeMs: number; size: number } | null = null;
+    try {
+      const stat = statSync(transcriptPath);
+      fingerprint = { mtimeMs: stat.mtimeMs, size: stat.size };
+      const cached = transcriptCache.get(transcriptPath);
+      if (
+        cached &&
+        cached.mtimeMs === fingerprint.mtimeMs &&
+        cached.size === fingerprint.size
+      ) {
+        return cached.usage;
+      }
+    } catch {}
+    const parsed = transcriptPath.includes("/.codex/")
+      ? await parseCodexTranscript(transcriptPath)
+      : await parseClaudeTranscript(transcriptPath);
+    if (parsed) {
+      if (fingerprint) {
+        if (transcriptCache.size >= 100) {
+          const oldest = transcriptCache.keys().next().value;
+          if (oldest) transcriptCache.delete(oldest);
+        }
+        transcriptCache.set(transcriptPath, { ...fingerprint, usage: parsed });
+      }
+      return parsed;
+    }
+  }
+  return {
+    available: false,
+    source: "unavailable",
+    accuracy: "unavailable",
+    updatedAt: Date.now(),
+    model: null,
+    context: { used: null, max: null, free: null, percent: null },
+    totals: null,
+    categories: [],
+    note: "This agent does not record token usage in a format LFG can read yet.",
+  };
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -803,7 +803,7 @@ async function scanCodexRolloutFiles(): Promise<string[]> {
   return out;
 }
 
-async function findCodexTranscriptById(id: string): Promise<string | null> {
+export async function findCodexTranscriptById(id: string): Promise<string | null> {
   if (!UUID.test(id)) return null;
   const hit = codexPathById.get(id);
   if (hit) return hit;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -366,6 +366,58 @@ type Session = {
   busy?: boolean;
 };
 
+type SessionTokenUsage = {
+  available: boolean;
+  source: "claude-context" | "codex-transcript" | "claude-transcript" | "unavailable";
+  accuracy: "reported" | "mixed" | "unavailable";
+  updatedAt: number;
+  model: string | null;
+  context: {
+    used: number | null;
+    max: number | null;
+    free: number | null;
+    percent: number | null;
+  };
+  totals: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    reasoning: number;
+    total: number;
+    costUsd: number | null;
+  } | null;
+  categories: Array<{
+    name: string;
+    tokens: number;
+    color?: string;
+    accuracy: "reported" | "estimated";
+  }>;
+  details?: {
+    memoryFiles?: Array<{ path: string; type: string; tokens: number }>;
+    mcpTools?: Array<{ name: string; serverName: string; tokens: number; isLoaded?: boolean }>;
+    systemTools?: Array<{ name: string; tokens: number }>;
+    systemPromptSections?: Array<{ name: string; tokens: number }>;
+    skills?: {
+      totalSkills: number;
+      includedSkills: number;
+      tokens: number;
+      items: Array<{ name: string; source: string; tokens: number }>;
+    };
+    messageBreakdown?: {
+      toolCallTokens: number;
+      toolResultTokens: number;
+      attachmentTokens: number;
+      assistantMessageTokens: number;
+      userMessageTokens: number;
+      redirectedContextTokens: number;
+      unattributedTokens: number;
+      toolCallsByType: Array<{ name: string; callTokens: number; resultTokens: number }>;
+    };
+  };
+  note: string;
+};
+
 type User = { email: string; name?: string; avatar?: string };
 type Repo = { name: string; cwd: string; project?: string; custom?: boolean };
 
@@ -10564,6 +10616,288 @@ function useSessionActions({
   };
 }
 
+function formatTokenCount(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  if (value < 1_000) return Math.round(value).toLocaleString();
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 10_000 ? 1 : 0)}k`;
+  return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}m`;
+}
+
+function TokenUsageDetailList({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{ name: string; detail?: string; tokens: number }>;
+}) {
+  if (!items.length) return null;
+  return (
+    <section className="space-y-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
+      <div className="divide-y divide-border rounded-xl border border-border bg-muted/20 px-3">
+        {items.map((item, index) => (
+          <div key={`${item.name}-${index}`} className="flex items-center gap-3 py-2.5 text-sm">
+            <div className="min-w-0 flex-1">
+              <div className="truncate font-medium">{item.name}</div>
+              {item.detail ? (
+                <div className="truncate text-xs text-muted-foreground">{item.detail}</div>
+              ) : null}
+            </div>
+            <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+              {formatTokenCount(item.tokens)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SessionTokenUsageDialog({
+  session,
+  open,
+  onOpenChange,
+}: {
+  session: Session;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const sid = session.sessionId;
+  const [usage, setUsage] = useState<SessionTokenUsage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!sid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setUsage(await api<SessionTokenUsage>(`/api/sessions/${sid}/token-usage`));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn’t load token usage");
+    } finally {
+      setLoading(false);
+    }
+  }, [sid]);
+
+  useEffect(() => {
+    if (!open || usage || loading) return;
+    void load();
+  }, [load, loading, open, usage]);
+
+  const categoryTotal = usage?.categories.reduce((sum, category) => sum + category.tokens, 0) ?? 0;
+  const categoryDenominator = Math.max(categoryTotal, usage?.context.used ?? 0, 1);
+  const contextPercent =
+    usage?.context.percent ??
+    (usage?.context.used != null && usage.context.max
+      ? (usage.context.used / usage.context.max) * 100
+      : null);
+  const detail = usage?.details;
+  const messageBreakdown = detail?.messageBreakdown;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next);
+        if (next && usage) void load();
+      }}
+    >
+        <DialogContent
+          className="max-h-[88dvh] overflow-hidden sm:max-w-xl"
+          innerClassName="flex max-h-[88dvh] flex-col gap-0 p-0"
+        >
+          <DialogHeader className="border-b border-border px-5 pb-4 pt-5 text-left">
+            <DialogTitle className="flex items-center gap-2">
+              <Gauge className="size-5" />
+              Session token usage
+            </DialogTitle>
+            <DialogDescription>
+              Current context and cumulative model traffic for {titleForSession(session)}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 pb-6">
+            {loading && !usage ? (
+              <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                Reading session usage…
+              </div>
+            ) : error && !usage ? (
+              <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                {error}
+              </div>
+            ) : usage && !usage.available ? (
+              <div className="rounded-2xl border border-border bg-muted/30 p-5">
+                <div className="font-medium">Token data isn’t available for this agent yet</div>
+                <p className="mt-1 text-sm text-muted-foreground">{usage.note}</p>
+              </div>
+            ) : usage ? (
+              <>
+                <section className="space-y-3 pt-1">
+                  <div className="flex items-end justify-between gap-4">
+                    <div>
+                      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Current context
+                      </div>
+                      <div className="mt-1 text-3xl font-semibold tracking-tight tabular-nums">
+                        {formatTokenCount(usage.context.used)}
+                        {usage.context.max != null ? (
+                          <span className="ml-1 text-base font-normal text-muted-foreground">
+                            / {formatTokenCount(usage.context.max)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                    {contextPercent != null ? (
+                      <div className="text-right">
+                        <div className="text-xl font-semibold tabular-nums">
+                          {Math.round(contextPercent)}%
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {formatTokenCount(usage.context.free)} free
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                  {usage.context.max != null && usage.context.used != null ? (
+                    <div className="h-2 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+                      <div
+                        className="h-full rounded-full bg-foreground transition-[width]"
+                        style={{ width: `${Math.min(100, Math.max(0, contextPercent ?? 0))}%` }}
+                      />
+                    </div>
+                  ) : null}
+                </section>
+
+                {usage.categories.length ? (
+                  <section className="space-y-3">
+                    <div className="flex h-3 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+                      {usage.categories.map((category, index) => (
+                        <span
+                          key={`${category.name}-${index}`}
+                          style={{
+                            width: `${(category.tokens / categoryDenominator) * 100}%`,
+                            backgroundColor: category.color || `hsl(${(index * 47) % 360} 70% 60%)`,
+                          }}
+                        />
+                      ))}
+                    </div>
+                    <div className="grid gap-1 sm:grid-cols-2">
+                      {usage.categories.map((category, index) => (
+                        <div
+                          key={`${category.name}-${index}`}
+                          className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-sm"
+                        >
+                          <span
+                            className="size-2.5 shrink-0 rounded-sm"
+                            style={{
+                              backgroundColor:
+                                category.color || `hsl(${(index * 47) % 360} 70% 60%)`,
+                            }}
+                          />
+                          <span className="min-w-0 flex-1 truncate">{category.name}</span>
+                          <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                            {formatTokenCount(category.tokens)}
+                            {category.accuracy === "estimated" ? " ~" : ""}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                ) : null}
+
+                {usage.totals ? (
+                  <section className="space-y-2">
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Session totals
+                    </h3>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                      {[
+                        ["Input", usage.totals.input],
+                        ["Output", usage.totals.output],
+                        ["Cache read", usage.totals.cacheRead],
+                        ["Cache write", usage.totals.cacheWrite],
+                        ["Reasoning", usage.totals.reasoning],
+                        ["All traffic", usage.totals.total],
+                      ].map(([label, value]) => (
+                        <div key={String(label)} className="rounded-xl border border-border bg-muted/25 p-3">
+                          <div className="text-xs text-muted-foreground">{label}</div>
+                          <div className="mt-1 font-mono text-base font-semibold tabular-nums">
+                            {formatTokenCount(value as number)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </section>
+                ) : null}
+
+                <TokenUsageDetailList
+                  title="Skills"
+                  items={(detail?.skills?.items ?? []).map((item) => ({
+                    name: item.name,
+                    detail: item.source,
+                    tokens: item.tokens,
+                  }))}
+                />
+                <TokenUsageDetailList
+                  title="System prompt"
+                  items={(detail?.systemPromptSections ?? []).map((item) => ({
+                    name: item.name,
+                    tokens: item.tokens,
+                  }))}
+                />
+                <TokenUsageDetailList
+                  title="MCP tools"
+                  items={(detail?.mcpTools ?? []).map((item) => ({
+                    name: item.name,
+                    detail: `${item.serverName}${item.isLoaded === false ? " · deferred" : ""}`,
+                    tokens: item.tokens,
+                  }))}
+                />
+                <TokenUsageDetailList
+                  title="Memory files"
+                  items={(detail?.memoryFiles ?? []).map((item) => ({
+                    name: item.path,
+                    detail: item.type,
+                    tokens: item.tokens,
+                  }))}
+                />
+                {messageBreakdown ? (
+                  <TokenUsageDetailList
+                    title="Messages"
+                    items={[
+                      { name: "User messages", tokens: messageBreakdown.userMessageTokens },
+                      { name: "Assistant messages", tokens: messageBreakdown.assistantMessageTokens },
+                      { name: "Tool calls", tokens: messageBreakdown.toolCallTokens },
+                      { name: "Tool results", tokens: messageBreakdown.toolResultTokens },
+                      { name: "Attachments", tokens: messageBreakdown.attachmentTokens },
+                    ].filter((item) => item.tokens > 0)}
+                  />
+                ) : null}
+
+                <div className="rounded-xl bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+                  <div className="mb-1 flex items-center gap-2 font-medium text-foreground">
+                    <span
+                      className={cn(
+                        "size-2 rounded-full",
+                        usage.accuracy === "reported" ? "bg-emerald-500" : "bg-amber-500",
+                      )}
+                    />
+                    {usage.accuracy === "reported"
+                      ? "Provider-reported breakdown"
+                      : "Reported totals · estimated categories"}
+                  </div>
+                  {usage.note}
+                  {usage.model ? ` Model: ${usage.model}.` : ""}
+                </div>
+              </>
+            ) : null}
+          </div>
+        </DialogContent>
+    </Dialog>
+  );
+}
+
 function SessionActionsMenu({
   session,
   users,
@@ -10585,6 +10919,7 @@ function SessionActionsMenu({
   pinned?: boolean;
   onTogglePin?: (sid: string) => void;
 }) {
+  const [tokenUsageOpen, setTokenUsageOpen] = useState(false);
   const {
     sid,
     assignee,
@@ -10598,6 +10933,11 @@ function SessionActionsMenu({
 
   return (
     <>
+      <SessionTokenUsageDialog
+        session={session}
+        open={tokenUsageOpen}
+        onOpenChange={setTokenUsageOpen}
+      />
       {forkOpen ? (
         <ForkSessionDialog
           session={session}
@@ -10686,6 +11026,10 @@ function SessionActionsMenu({
               Rename
             </DropdownMenuItem>
           ) : null}
+          <DropdownMenuItem disabled={!sid} onClick={() => setTokenUsageOpen(true)}>
+            <Gauge className="size-4" />
+            Token usage
+          </DropdownMenuItem>
           <DropdownMenuItem disabled={!sid} onClick={() => void copyReference()}>
             <Copy className="size-4" />
             Copy reference


### PR DESCRIPTION
## What changed

- adds provider-aware session token accounting for Codex transcripts and LFG-managed Claude SDK sessions
- exposes `GET /api/sessions/:id/token-usage`
- adds a responsive token-usage inspector under the existing session ⋯ menu
- reports current context, cumulative input/output/cache/reasoning traffic, and detailed estimated context categories

## Why

Session context and cumulative model traffic were not visible from an individual session, making it difficult to understand remaining context or where prompt space was being spent.

## Scope

This PR contains only the six token-usage files/hunks recovered from the mixed stash. It intentionally excludes concurrent pin-state, rename, drawer, build-script, package, and Vite changes.

## Verification

- `bun test src/session-token-usage.test.ts` — 2 passed
- `bun test` — 246 passed
- `bun run typecheck`
- `bun run --cwd web typecheck`
- `bun run --cwd web build`
- Playwright desktop verification at 1280×900
- Playwright mobile verification at 390×844
- confirmed the feature appears only under session ⋯ → Token usage, with no standalone header button

No merge, release, deployment, or production restart was performed.