### PR TITLE
fix(embed): preserve session deep links on focus

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { embedSearchFlag, isEmbedded, isFramed } from "../web/src/lib/embed.ts";
-import { shouldPrioritizeSession, validateAppSearch } from "../web/src/lib/app-search.ts";
+import {
+  shouldNavigateToTab,
+  shouldPrioritizeSession,
+  validateAppSearch,
+} from "../web/src/lib/app-search.ts";
 
 describe("embed detection", () => {
   test("accepts embed=1 / true / boolean from search", () => {
@@ -41,6 +45,12 @@ describe("session prioritization + search validation", () => {
     expect(shouldPrioritizeSession({ embed: true })).toBe(false);
     expect(shouldPrioritizeSession({})).toBe(false);
     expect(shouldPrioritizeSession(null)).toBe(false);
+  });
+
+  test("same-tab state updates do not navigate and discard deep-link search", () => {
+    expect(shouldNavigateToTab("live", "live")).toBe(false);
+    expect(shouldNavigateToTab("settings", "settings")).toBe(false);
+    expect(shouldNavigateToTab("settings", "live")).toBe(true);
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,12 @@
 import { Component, createContext, type ComponentProps, forwardRef, memo, Suspense, useCallback, useContext, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
-import { DEFAULT_TAB, pathnameToTab, shouldPrioritizeSession } from "./lib/app-search";
+import {
+  DEFAULT_TAB,
+  pathnameToTab,
+  shouldNavigateToTab,
+  shouldPrioritizeSession,
+} from "./lib/app-search";
 import { isEmbedded, readLocationEmbedFlag } from "./lib/embed";
 import { useChat } from "@ai-sdk/react";
 import {
@@ -3896,6 +3901,7 @@ export function App() {
   const setTab = useCallback(
     (next: string | ((current: string) => string)) => {
       const resolved = typeof next === "function" ? next(tabRef.current) : next;
+      if (!shouldNavigateToTab(tabRef.current, resolved)) return;
       if (resolved === DEFAULT_TAB) void navigate({ to: "/" });
       else void navigate({ to: "/$tab", params: { tab: resolved } });
     },

--- a/web/src/lib/app-search.ts
+++ b/web/src/lib/app-search.ts
@@ -42,6 +42,13 @@ export function tabToPath(tab: string): string {
   return tab === DEFAULT_TAB ? "/" : `/${encodeURIComponent(tab)}`;
 }
 
+/** Same-tab requests are state updates, not route changes. Avoiding a redundant
+ * navigation also preserves active search contracts such as `session` and
+ * `embed`, which the router would otherwise clear when no `search` is supplied. */
+export function shouldNavigateToTab(currentTab: string, nextTab: string): boolean {
+  return currentTab !== nextTab;
+}
+
 /** The typed shape of the app's search params (path aside). */
 export interface AppSearch {
   /** Deep link to focus a session on load. EXTERNAL CONTRACT: the server emits


### PR DESCRIPTION
## Summary

- make same-tab state updates a no-op instead of redundant route navigations
- preserve active `session` and `embed` search contracts while a hosted Computer deep link resolves
- add regression coverage for the navigation guard

## Verification

- `bun test` (245 passed)
- `bun run typecheck`
- `bun run --cwd web typecheck`
- `bun run --cwd web build`