### PR TITLE
fix(embed): hydrate session focus from location

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { embedSearchFlag, isEmbedded, isFramed } from "../web/src/lib/embed.ts";
 import {
+  readLocationSessionId,
   shouldNavigateToTab,
   shouldPrioritizeSession,
   validateAppSearch,
@@ -51,6 +52,12 @@ describe("session prioritization + search validation", () => {
     expect(shouldNavigateToTab("live", "live")).toBe(false);
     expect(shouldNavigateToTab("settings", "settings")).toBe(false);
     expect(shouldNavigateToTab("settings", "live")).toBe(true);
+  });
+
+  test("session deep links are available before router search hydration", () => {
+    expect(readLocationSessionId("?session=abc&embed=1")).toBe("abc");
+    expect(readLocationSessionId("?embed=1")).toBeNull();
+    expect(readLocationSessionId("?session=")).toBeNull();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 import {
   DEFAULT_TAB,
   pathnameToTab,
+  readLocationSessionId,
   shouldNavigateToTab,
   shouldPrioritizeSession,
 } from "./lib/app-search";
@@ -3821,7 +3822,8 @@ export function App() {
   const deepLinkSearch = useSearch({ strict: false });
   const sessionDeepLinkRef = useRef<string | null | undefined>(undefined);
   if (sessionDeepLinkRef.current === undefined) {
-    sessionDeepLinkRef.current = deepLinkSearch.session ?? null;
+    sessionDeepLinkRef.current =
+      deepLinkSearch.session ?? readLocationSessionId();
   }
   // Hosted inside omg (or any frame): drop LFG chrome, skip onboarding/picker,
   // default to all sessions. `?embed=1` is the explicit contract; framing alone

--- a/web/src/lib/app-search.ts
+++ b/web/src/lib/app-search.ts
@@ -49,6 +49,21 @@ export function shouldNavigateToTab(currentTab: string, nextTab: string): boolea
   return currentTab !== nextTab;
 }
 
+/** Read the session contract from the browser URL before router search state is
+ * hydrated. The location is the boot-time source of truth for external links;
+ * callers may pass a search string to test the parser without a browser. */
+export function readLocationSessionId(search?: string): string | null {
+  try {
+    const raw =
+      search ??
+      (typeof window !== "undefined" ? window.location.search : "");
+    const session = new URLSearchParams(raw).get("session");
+    return session || null;
+  } catch {
+    return null;
+  }
+}
+
 /** The typed shape of the app's search params (path aside). */
 export interface AppSearch {
   /** Deep link to focus a session on load. EXTERNAL CONTRACT: the server emits


### PR DESCRIPTION
## Summary

- read the session deep-link contract from `window.location` during boot
- avoid losing focus when router search hydration lags the first React render
- add regression coverage for the boot-time URL parser

## Verification

- `bun test` (246 passed)
- `bun run typecheck`
- `bun run --cwd web typecheck`
- `bun run --cwd web build`