### PR TITLE
Add local Computer manager round protocol

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7,6 +7,10 @@ import { marked } from "marked";
 import { PATHS, appVersion, installInfo } from "../config.ts";
 import { claudeOauthToken as sharedClaudeOauthToken } from "../claude-creds.ts";
 import {
+  ManagerRoundError,
+  createManagerRoundService,
+} from "../manager-round.ts";
+import {
   applyReleaseUpdate,
   applySourceUpdate,
   releaseUpdateStatus,
@@ -269,6 +273,7 @@ const REPOS_ROOT = reposRoot();
 const SELF_REPO = PATHS.root;
 const EVLOG_DIR = join(PATHS.data, "evlogs");
 const SERVER_INSTANCE_ID = randomBytes(8).toString("hex");
+const managerRoundService = createManagerRoundService({ dataDir: PATHS.data });
 let selfUpdateRunning = false;
 
 function evlog(event: string, fields: Record<string, unknown> = {}) {
@@ -2104,6 +2109,33 @@ export async function cmdServe() {
 
       const response = await (async () => {
       try {
+      if (path === "/api/manager/capabilities") {
+        if (req.method !== "GET") return err(405, "method not allowed");
+        return json(managerRoundService.capabilities());
+      }
+
+      if (path === "/api/manager/round") {
+        if (req.method !== "POST") return err(405, "method not allowed");
+        const declaredLength = Number(req.headers.get("content-length") ?? "0");
+        if (Number.isFinite(declaredLength) && declaredLength > 1_000_000) {
+          return err(413, "request too large");
+        }
+        const raw = await req.text();
+        if (raw.length > 1_000_000) return err(413, "request too large");
+        let body: unknown;
+        try {
+          body = JSON.parse(raw);
+        } catch {
+          return err(400, "invalid JSON");
+        }
+        try {
+          return json(await managerRoundService.run(body));
+        } catch (error) {
+          if (error instanceof ManagerRoundError) return err(error.status, error.message);
+          throw error;
+        }
+      }
+
       if (path === "/api/evlog") {
         if (req.method === "POST") {
           const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;

--- a/src/manager-round.test.ts
+++ b/src/manager-round.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MANAGER_PROTOCOL,
+  ManagerRoundError,
+  createManagerRoundService,
+  parseManagerRoundRequest,
+} from "./manager-round.ts";
+
+let tempDir = "";
+
+afterEach(async () => {
+  if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  tempDir = "";
+});
+
+function request(overrides: Record<string, unknown> = {}) {
+  return {
+    protocol: MANAGER_PROTOCOL,
+    managerId: "imsg:0123456789abcdef",
+    turnId: "12345678-abcd",
+    round: 0,
+    system: "You are helpful.",
+    messages: [{ role: "user", content: "hello" }],
+    tools: [
+      {
+        name: "search",
+        description: "Search",
+        input_schema: { type: "object", properties: {} },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("manager round protocol", () => {
+  test("rejects unknown protocols and unsafe identifiers", () => {
+    expect(() => parseManagerRoundRequest(request({ protocol: "future" }))).toThrow(
+      "unsupported manager protocol",
+    );
+    expect(() => parseManagerRoundRequest(request({ managerId: "../escape" }))).toThrow(
+      "invalid managerId",
+    );
+  });
+
+  test("reports whether the Computer has local AI credentials", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "lfg-manager-"));
+    expect(createManagerRoundService({ dataDir: tempDir, token: () => null }).capabilities()).toEqual({
+      protocol: MANAGER_PROTOCOL,
+      available: false,
+      model: "claude-haiku-4-5",
+      reason: "claude_oauth_unavailable",
+    });
+    expect(
+      createManagerRoundService({ dataDir: tempDir, token: () => "token" }).capabilities().available,
+    ).toBe(true);
+  });
+
+  test("returns one local model round without executing tools", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "lfg-manager-"));
+    const sent: Record<string, unknown>[] = [];
+    const service = createManagerRoundService({
+      dataDir: tempDir,
+      token: () => "local-token",
+      fetch: (async (_url, init) => {
+        sent.push(JSON.parse(String(init?.body)));
+        return Response.json({
+          stop_reason: "tool_use",
+          content: [{ type: "tool_use", id: "tool-1", name: "search", input: { q: "hi" } }],
+        });
+      }),
+    });
+
+    const response = await service.run(request());
+    expect(response.stopReason).toBe("tool_use");
+    expect(response.content[0]?.type).toBe("tool_use");
+    expect(sent[0]?.system).toBe("You are helpful.");
+    expect(sent[0]?.tools).toHaveLength(1);
+  });
+
+  test("deduplicates concurrent and later delivery retries", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "lfg-manager-"));
+    let calls = 0;
+    const service = createManagerRoundService({
+      dataDir: tempDir,
+      token: () => "local-token",
+      fetch: (async () => {
+        calls += 1;
+        await Bun.sleep(10);
+        return Response.json({
+          stop_reason: "end_turn",
+          content: [{ type: "text", text: "hello" }],
+        });
+      }),
+    });
+
+    const [first, concurrent] = await Promise.all([service.run(request()), service.run(request())]);
+    const later = await service.run(request());
+    expect(calls).toBe(1);
+    expect(concurrent).toEqual(first);
+    expect(later).toEqual(first);
+  });
+
+  test("fails closed when local AI is unavailable", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "lfg-manager-"));
+    const service = createManagerRoundService({ dataDir: tempDir, token: () => null });
+    await expect(service.run(request())).rejects.toEqual(
+      expect.objectContaining({ status: 503 }),
+    );
+  });
+});

--- a/src/manager-round.ts
+++ b/src/manager-round.ts
@@ -1,0 +1,282 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { claudeOauthToken } from "./claude-creds.ts";
+
+export const MANAGER_PROTOCOL = "lfg.manager.v1" as const;
+export const DEFAULT_MANAGER_MODEL = "claude-haiku-4-5";
+
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const MAX_MESSAGES = 64;
+const MAX_TOOLS = 64;
+const MAX_BODY_CHARS = 1_000_000;
+
+type JsonObject = Record<string, unknown>;
+
+export type ManagerRoundRequest = {
+  protocol: typeof MANAGER_PROTOCOL;
+  managerId: string;
+  turnId: string;
+  round: number;
+  system: string;
+  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  tools: Array<{
+    name: string;
+    description?: string;
+    input_schema: JsonObject;
+  }>;
+  maxTokens?: number;
+};
+
+export type ManagerRoundResponse = {
+  protocol: typeof MANAGER_PROTOCOL;
+  managerId: string;
+  turnId: string;
+  round: number;
+  model: string;
+  stopReason: string | null;
+  content: JsonObject[];
+};
+
+export class ManagerRoundError extends Error {
+  constructor(
+    public readonly status: 400 | 502 | 503,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ManagerRoundError";
+  }
+}
+
+type ManagerRoundDependencies = {
+  dataDir: string;
+  token?: () => string | null;
+  fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  model?: string;
+};
+
+function isObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedString(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+  pattern?: RegExp,
+): string {
+  if (
+    typeof value !== "string" ||
+    value.length < min ||
+    value.length > max ||
+    (pattern && !pattern.test(value))
+  ) {
+    throw new ManagerRoundError(400, `invalid ${field}`);
+  }
+  return value;
+}
+
+function assertJsonValue(value: unknown, field: string): void {
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw new ManagerRoundError(400, `invalid ${field}`);
+  }
+  if (encoded === undefined || encoded.length > MAX_BODY_CHARS) {
+    throw new ManagerRoundError(400, `invalid ${field}`);
+  }
+}
+
+export function parseManagerRoundRequest(value: unknown): ManagerRoundRequest {
+  if (!isObject(value)) throw new ManagerRoundError(400, "invalid request");
+  if (value.protocol !== MANAGER_PROTOCOL) {
+    throw new ManagerRoundError(400, "unsupported manager protocol");
+  }
+
+  const managerId = boundedString(
+    value.managerId,
+    "managerId",
+    1,
+    96,
+    /^[A-Za-z0-9:_-]+$/,
+  );
+  const turnId = boundedString(
+    value.turnId,
+    "turnId",
+    8,
+    128,
+    /^[A-Za-z0-9:_-]+$/,
+  );
+  if (!Number.isInteger(value.round) || (value.round as number) < 0 || (value.round as number) > 12) {
+    throw new ManagerRoundError(400, "invalid round");
+  }
+  const system = boundedString(value.system, "system", 1, 200_000);
+
+  if (!Array.isArray(value.messages) || value.messages.length > MAX_MESSAGES) {
+    throw new ManagerRoundError(400, "invalid messages");
+  }
+  const messages = value.messages.map((message, index) => {
+    if (!isObject(message) || (message.role !== "user" && message.role !== "assistant")) {
+      throw new ManagerRoundError(400, `invalid messages[${index}]`);
+    }
+    assertJsonValue(message.content, `messages[${index}].content`);
+    return {
+      role: message.role as "user" | "assistant",
+      content: message.content,
+    };
+  });
+
+  if (!Array.isArray(value.tools) || value.tools.length > MAX_TOOLS) {
+    throw new ManagerRoundError(400, "invalid tools");
+  }
+  const names = new Set<string>();
+  const tools = value.tools.map((tool, index) => {
+    if (!isObject(tool) || !isObject(tool.input_schema)) {
+      throw new ManagerRoundError(400, `invalid tools[${index}]`);
+    }
+    const name = boundedString(tool.name, `tools[${index}].name`, 1, 128, /^[A-Za-z0-9_-]+$/);
+    if (names.has(name)) throw new ManagerRoundError(400, "duplicate tool name");
+    names.add(name);
+    const description =
+      tool.description === undefined
+        ? undefined
+        : boundedString(tool.description, `tools[${index}].description`, 0, 20_000);
+    assertJsonValue(tool.input_schema, `tools[${index}].input_schema`);
+    return { name, description, input_schema: tool.input_schema };
+  });
+
+  const maxTokens =
+    value.maxTokens === undefined
+      ? undefined
+      : Number.isInteger(value.maxTokens) &&
+          (value.maxTokens as number) >= 1 &&
+          (value.maxTokens as number) <= 8192
+        ? (value.maxTokens as number)
+        : (() => {
+            throw new ManagerRoundError(400, "invalid maxTokens");
+          })();
+
+  return {
+    protocol: MANAGER_PROTOCOL,
+    managerId,
+    turnId,
+    round: value.round as number,
+    system,
+    messages,
+    tools,
+    maxTokens,
+  };
+}
+
+function cachePart(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function validResponse(value: unknown): value is ManagerRoundResponse {
+  if (!isObject(value) || value.protocol !== MANAGER_PROTOCOL || !Array.isArray(value.content)) {
+    return false;
+  }
+  return value.content.every(isObject);
+}
+
+export function createManagerRoundService(deps: ManagerRoundDependencies) {
+  const token = deps.token ?? claudeOauthToken;
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const model = deps.model ?? process.env.LFG_MANAGER_MODEL ?? DEFAULT_MANAGER_MODEL;
+  const inFlight = new Map<string, Promise<ManagerRoundResponse>>();
+
+  function capabilities() {
+    const available = Boolean(token());
+    return {
+      protocol: MANAGER_PROTOCOL,
+      available,
+      model,
+      reason: available ? null : "claude_oauth_unavailable",
+    };
+  }
+
+  async function runUncached(request: ManagerRoundRequest): Promise<ManagerRoundResponse> {
+    const oauthToken = token();
+    if (!oauthToken) {
+      throw new ManagerRoundError(503, "local AI is not signed in");
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetchImpl(ANTHROPIC_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${oauthToken}`,
+          "anthropic-beta": "oauth-2025-04-20",
+          "anthropic-version": "2023-06-01",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: request.maxTokens ?? 2048,
+          system: request.system,
+          messages: request.messages,
+          ...(request.tools.length ? { tools: request.tools } : {}),
+        }),
+      });
+    } catch {
+      throw new ManagerRoundError(502, "local AI request failed");
+    }
+    if (!upstream.ok) {
+      throw new ManagerRoundError(502, `local AI returned HTTP ${upstream.status}`);
+    }
+
+    const body = (await upstream.json().catch(() => null)) as JsonObject | null;
+    if (
+      !body ||
+      !Array.isArray(body.content) ||
+      !body.content.every(isObject) ||
+      (body.stop_reason !== null && body.stop_reason !== undefined && typeof body.stop_reason !== "string")
+    ) {
+      throw new ManagerRoundError(502, "local AI returned an invalid response");
+    }
+    return {
+      protocol: MANAGER_PROTOCOL,
+      managerId: request.managerId,
+      turnId: request.turnId,
+      round: request.round,
+      model,
+      stopReason: (body.stop_reason as string | null | undefined) ?? null,
+      content: body.content,
+    };
+  }
+
+  async function run(raw: unknown): Promise<ManagerRoundResponse> {
+    const request = parseManagerRoundRequest(raw);
+    const managerDir = join(deps.dataDir, "manager-rounds", cachePart(request.managerId));
+    const cachePath = join(managerDir, `${cachePart(`${request.turnId}:${request.round}`)}.json`);
+    const key = cachePath;
+
+    try {
+      const cached = JSON.parse(await readFile(cachePath, "utf8")) as unknown;
+      if (validResponse(cached)) return cached;
+    } catch {}
+
+    const existing = inFlight.get(key);
+    if (existing) return existing;
+
+    const promise = (async () => {
+      const response = await runUncached(request);
+      await mkdir(managerDir, { recursive: true });
+      const tempPath = `${cachePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+      await writeFile(tempPath, JSON.stringify(response), { mode: 0o600 });
+      await rename(tempPath, cachePath);
+      return response;
+    })();
+    inFlight.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      inFlight.delete(key);
+    }
+  }
+
+  return { capabilities, run };
+}


### PR DESCRIPTION
## What changed

Adds a versioned `lfg.manager.v1` API to `lfg serve` for lightweight local conversation inference:

- capability discovery for local Claude OAuth availability
- one synchronous model round returning text/tool-use blocks
- strict request validation and bounded payloads
- disk-backed and in-flight idempotency by manager/turn/round
- HTTP routes for capabilities and round execution

## Why

The iMessage gateway needs reasoning to run on the user’s Computer while privileged billing, onboarding, and platform tools remain centrally executed. A client-driven round protocol preserves that boundary and normal synchronous chat UX.

## Validation

- `bun test`: 251 passed
- `bun run typecheck`: clean
- focused manager protocol tests cover validation, capabilities, tool-use output, concurrent/later retry deduplication, and missing local auth