### PR TITLE
fix(web): zero embed host-bottom-inset on desktop

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -101,4 +101,12 @@ describe("host bottom inset contract", () => {
     expect(app).toContain("pb-[max(var(--lfg-device-safe-bottom),0.5rem)]");
     expect(app).toContain('embedded && "pb-[var(--lfg-host-bottom-inset)]"');
   });
+
+  test("desktop embed zeroes host-bottom-inset (omg nav is top-middle)", () => {
+    const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
+    // Match omg useIsDesktop (lg = 1024). Mobile keeps the 2.75rem bottom pill.
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*1024px\)\s*\{[\s\S]*?html\[data-lfg-embed="true"\]\s*\{[\s\S]*?--lfg-host-bottom-inset:\s*0px/,
+    );
+  });
 });

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -102,6 +102,15 @@ html.lfg-keyboard-open {
   }
 }
 
+/* omg desktop (lg = 1024): global nav docks top-middle, not bottom. Cancel
+   host-bottom-inset so embed doesn't leave a ghost band under the composer. */
+@media (min-width: 1024px) {
+  html[data-lfg-embed="true"] {
+    --lfg-host-bottom-inset: 0px;
+    --lfg-safe-bottom: 0px;
+  }
+}
+
 .dark {
   color-scheme: dark;
   --background: #000000;


### PR DESCRIPTION
## Summary
- At \`min-width: 1024px\` (omg desktop), embed mode zeroes \`--lfg-host-bottom-inset\` / \`--lfg-safe-bottom\`.
- Mobile embed still uses the 2.75rem host pill inset.

## Why
Desktop omg no longer has a bottom capsule (nav moves top-middle). LFG still reserved bottom host chrome and looked like extra empty padding.

## Test plan
- [x] \`bun test test/embed.test.ts\`
- [ ] Desktop app.omg.dev Computer: no empty band under LFG composer
- [ ] Mobile embed: Message / Start still clear the bottom pill