### PR TITLE
docs: the container image builds from source, it does not install a bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ These PaaS targets are best for demos or private-network deployments. Day-to-day
 agent work is happiest on the machine that already has your repos, `tmux`, and
 authenticated CLIs. A VPS remains the cleanest production-style target.
 
-The Dockerfile installs the published bundle (`lfg-bundle.tar.gz`) rather than
-building from the GitHub source tree (the Vibes SDK path is not live for source
-installs yet). Publish a bundle with `scripts/release.sh <tag>` before relying
-on one-click cloud deploys.
+The Dockerfile builds from the source tree it is given: it installs dependencies
+with Bun, builds the web UI, and runs `bun run serve`. Nothing has to be
+published first — a one-click deploy builds whatever commit the platform checks
+out.
 
 **Maintainer note:** “deploy” means make current changes visible in the running
 instance (rebuild/restart as needed). “release” means cut a tag and publish

--- a/deploy/digitalocean/README.md
+++ b/deploy/digitalocean/README.md
@@ -8,13 +8,8 @@ DigitalOcean has two useful paths for `lfg`:
 ## App Platform
 
 The `.do/app.yaml` spec builds the shared Dockerfile and starts `lfg` on port
-`8766`. The Dockerfile installs the published bundled release, which is required
-while the Vibes SDK path is not live for source installs. Publish the bundle
-first:
-
-```bash
-scripts/release.sh v0.1.0
-```
+`8766`. The Dockerfile builds from the source tree App Platform checks out —
+there is no bundle to publish first.
 
 Add a Deploy to DigitalOcean button once the app spec is published from the
 target repo/account:

--- a/deploy/fly/README.md
+++ b/deploy/fly/README.md
@@ -8,14 +8,6 @@ control plane.
 
 ## Deploy
 
-Publish the bundled release first:
-
-```bash
-scripts/release.sh v0.1.0
-```
-
-Then deploy:
-
 ```bash
 fly apps create lfg
 fly volumes create lfg_data --size 1 --region sjc
@@ -33,7 +25,7 @@ Then open `http://127.0.0.1:8766`.
 ## Notes
 
 - Set provider keys as Fly secrets, for example `fly secrets set ANTHROPIC_API_KEY=...`.
-- The Dockerfile installs the published bundled release, which is required while
-  the Vibes SDK path is not live for source installs.
+- The Dockerfile builds from the source tree `fly deploy` uploads — there is no
+  bundle to publish first.
 - Authenticate agent CLIs inside the machine if you need CLI-backed sessions.
 - Keep public services disabled unless you add authentication in front of `lfg`.

--- a/deploy/koyeb/README.md
+++ b/deploy/koyeb/README.md
@@ -3,12 +3,8 @@
 Koyeb can deploy `lfg` from the shared Dockerfile. This is best for a hosted
 demo unless you add authentication and a private access path.
 
-The Dockerfile installs the published bundled release, which is required while
-the Vibes SDK path is not live for source installs. Publish the bundle first:
-
-```bash
-scripts/release.sh v0.1.0
-```
+The Dockerfile builds from the source tree Koyeb checks out — there is no bundle
+to publish first.
 
 ## Deploy Button
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -21,10 +21,8 @@ Use Railway for a quick hosted preview. For day-to-day agent work, install
 The Dockerfile binds the app to `0.0.0.0` and maps Railway's injected `$PORT`
 to `LFG_PORT`.
 
-The Dockerfile installs the published bundled release from GitHub, not a live
-source build. This is intentional while the Vibes SDK path is not live for users.
-Publish `lfg-bundle.tar.gz` with `scripts/release.sh <tag>` before using this as
-a public one-click template.
+The Dockerfile builds from the source tree Railway checks out — there is no
+bundle to publish first.
 
 ## Private Tailscale Access
 

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -5,14 +5,6 @@ or private-network deployment unless you add authentication in front of `lfg`.
 
 ## Deploy
 
-Publish the bundled release first:
-
-```bash
-scripts/release.sh v0.1.0
-```
-
-Then:
-
 1. Create a new Blueprint from this repository.
 2. Render will read `render.yaml`.
 3. Add optional secrets such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or
@@ -22,5 +14,5 @@ Then:
 
 The service mounts `/data` for `lfg` data and scanned repos.
 
-The Dockerfile installs the published bundled release, which is required while
-the Vibes SDK path is not live for source installs.
+The Dockerfile builds from the source tree Render checks out — there is no
+bundle to publish first.

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,7 @@ export type InstallInfo = {
 
 function updateCommand(channel: InstallChannel): string {
   if (channel === "source") return "git pull --ff-only && bun install && (cd web && bun install && bun run build)";
-  if (channel === "container") return "redeploy the container after publishing a new lfg-bundle.tar.gz";
+  if (channel === "container") return "redeploy the container to rebuild the image from the current source";
   if (channel === "release") return "lfg setup";
   return "check the install method, then update from the latest GitHub release or source checkout";
 }


### PR DESCRIPTION
The README and every `deploy/*/README.md` say the shared Dockerfile installs the published `lfg-bundle.tar.gz`, and tell people to run `scripts/release.sh <tag>` before deploying:

> The Dockerfile installs the published bundle (`lfg-bundle.tar.gz`) rather than building from the GitHub source tree […] Publish a bundle with `scripts/release.sh <tag>` before relying on one-click cloud deploys.

The Dockerfile on `main` does neither. It copies the tree, installs with Bun, builds the web UI, and runs `bun run serve`:

```dockerfile
COPY . .

RUN set -eux; \
  cd web; \
  bun run build; \
```

**Why it matters:** publishing a bundle reads as a prerequisite for the one-click Deploy buttons, so someone self-hosting for the first time concludes the buttons are blocked on a maintainer release. They are not — the platform builds whatever commit it checks out.

This corrects the claim in `README.md` and the five `deploy/*/README.md` files, and drops the now-unnecessary `scripts/release.sh` step from the Render / Fly / DigitalOcean / Koyeb instructions.

One non-doc line is included because it is the same claim and it is user-visible in the app: the `container` install channel’s update command in `src/config.ts` also told people to publish a bundle.

The “release means publish `lfg-bundle.tar.gz`” maintainer note is untouched — that is still accurate for the `scripts/setup.sh` install path.

Typechecks clean; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)