### PR TITLE
fix: dial loopback when LFG_HOST is a wildcard bind address

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { PATHS } from "../config.ts";
+import { PATHS, localServeHost } from "../config.ts";
 
 // lfg connect — generic remote-access relay client.
 //
@@ -175,7 +175,7 @@ const CREDENTIALS_PATH = join(PATHS.data, "relay-credentials.json");
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 const LOCAL_PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
-const LOCAL_HOST = process.env.LFG_HOST ?? "127.0.0.1";
+const LOCAL_HOST = localServeHost();
 
 interface RelayCredentials {
   relayUrl: string;

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -6,6 +6,7 @@ import {
   listModelCatalog,
   thinkingLevelsForAgent,
 } from "../agent-catalog.ts";
+import { localServeBaseUrl } from "../config.ts";
 import {
   LFG_CAPABILITIES,
   LFG_CAPABILITY_VERSION,
@@ -85,15 +86,8 @@ type OriginDeliveryResponse = {
 
 const VERSION = "0.1.21";
 
-function baseUrl(): string {
-  if (process.env.LFG_BASE) return process.env.LFG_BASE.replace(/\/$/, "");
-  const host = process.env.LFG_HOST || "127.0.0.1";
-  const port = process.env.LFG_PORT || process.env.PORT || "8766";
-  return `http://${host}:${port}`;
-}
-
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${baseUrl()}${path}`, init);
+  const res = await fetch(`${localServeBaseUrl()}${path}`, init);
   const data = (await res.json().catch(() => ({}))) as { error?: string };
   if (!res.ok) throw new Error(data.error || `${res.status} ${res.statusText}`);
   return data as T;
@@ -1239,5 +1233,5 @@ export async function cmdMcp() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`lfg MCP server connected to ${baseUrl()}`);
+  console.error(`lfg MCP server connected to ${localServeBaseUrl()}`);
 }

--- a/src/commands/subagent.ts
+++ b/src/commands/subagent.ts
@@ -7,6 +7,7 @@ import {
   thinkingLevelsForAgent,
   type ModelCatalogItem,
 } from "../agent-catalog.ts";
+import { localServeBaseUrl } from "../config.ts";
 import { refreshModelCatalog } from "../model-discovery.ts";
 
 const HELP = `lfg subagent — spawn managed worker sessions across harnesses
@@ -87,13 +88,6 @@ export async function cmdSubagent(args: string[]) {
   }
 }
 
-function baseUrl(): string {
-  if (process.env.LFG_BASE) return process.env.LFG_BASE.replace(/\/$/, "");
-  const host = process.env.LFG_HOST || "127.0.0.1";
-  const port = process.env.LFG_PORT || process.env.PORT || "8766";
-  return `http://${host}:${port}`;
-}
-
 function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
@@ -108,7 +102,7 @@ function option(args: string[], name: string): string | undefined {
 }
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${baseUrl()}${path}`, init);
+  const res = await fetch(`${localServeBaseUrl()}${path}`, init);
   const data = (await res.json().catch(() => ({}))) as { error?: string };
   if (!res.ok) throw new Error(data.error || `${res.status} ${res.statusText}`);
   return data as T;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { localServeHost } from "./config.ts";
+
+describe("localServeHost", () => {
+  test("folds wildcard bind addresses back to loopback", () => {
+    // Every containerized deploy sets LFG_HOST to one of these. `0.0.0.0` only
+    // connects by accident on Linux; `::` does not survive URL parsing at all.
+    expect(localServeHost("0.0.0.0")).toBe("127.0.0.1");
+    expect(localServeHost("::")).toBe("[::1]");
+    expect(localServeHost("[::]")).toBe("[::1]");
+  });
+
+  test("brackets bare IPv6 literals so they parse as a URL authority", () => {
+    expect(localServeHost("::1")).toBe("[::1]");
+    expect(localServeHost("fd7a:115c:a1e0::1")).toBe("[fd7a:115c:a1e0::1]");
+    expect(() => new URL(`http://${localServeHost("::1")}:8766`)).not.toThrow();
+    expect(() => new URL(`http://${localServeHost("::")}:8766`)).not.toThrow();
+  });
+
+  test("leaves an already-bracketed literal alone", () => {
+    expect(localServeHost("[fd7a:115c:a1e0::1]")).toBe("[fd7a:115c:a1e0::1]");
+  });
+
+  test("passes through routable hosts untouched", () => {
+    expect(localServeHost("127.0.0.1")).toBe("127.0.0.1");
+    expect(localServeHost("192.168.1.10")).toBe("192.168.1.10");
+    expect(localServeHost("box.tailnet.ts.net")).toBe("box.tailnet.ts.net");
+  });
+
+  test("defaults to loopback when unset, empty, or whitespace", () => {
+    expect(localServeHost(undefined)).toBe("127.0.0.1");
+    expect(localServeHost("")).toBe("127.0.0.1");
+    expect(localServeHost("  ")).toBe("127.0.0.1");
+    expect(localServeHost("  0.0.0.0  ")).toBe("127.0.0.1");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,32 @@ export const PATHS = {
   installInfo: join(ROOT, "data", "install.json"),
 };
 
+// LFG_HOST is the server's BIND address, but the in-box clients — `lfg mcp`,
+// `lfg subagent`, `lfg connect` — read the same variable to DIAL that server.
+// A bind address is not always dialable: every containerized deploy sets
+// LFG_HOST to a wildcard (`0.0.0.0`, or `::` where the platform's private
+// network is IPv6-only). `http://0.0.0.0:8766` only connects by accident on
+// Linux, and `http://:::8766` does not parse as a URL at all. Fold wildcards
+// back to loopback and bracket bare IPv6 literals, so the result is always
+// safe to interpolate into a URL authority.
+export function localServeHost(raw: string | undefined = process.env.LFG_HOST): string {
+  const host = raw?.trim();
+  if (!host || host === "0.0.0.0") return "127.0.0.1";
+  if (host === "::" || host === "[::]") return "[::1]";
+  if (host.startsWith("[")) return host;
+  // A bare IPv6 literal has at least two colons. One colon means `host:port`,
+  // which this variable is not meant to carry — leave it alone rather than
+  // bracketing it into something even more wrong.
+  return host.split(":").length > 2 ? `[${host}]` : host;
+}
+
+// Absolute URL of the local `lfg serve`, for CLI subcommands that talk to it.
+export function localServeBaseUrl(): string {
+  if (process.env.LFG_BASE) return process.env.LFG_BASE.replace(/\/$/, "");
+  const port = process.env.LFG_PORT || process.env.PORT || "8766";
+  return `http://${localServeHost()}:${port}`;
+}
+
 export function appVersion(): string {
   try {
     const parsed = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {


### PR DESCRIPTION
Found while deploying the shared Dockerfile to Railway.

`LFG_HOST` is the server’s **bind** address ([`serve.ts`](https://github.com/BennyKok/lfg/blob/main/src/commands/serve.ts#L448)), but three in-box clients read the same variable to **dial** that server:

- `src/commands/mcp.ts` — `baseUrl()`
- `src/commands/subagent.ts` — `baseUrl()` (a byte-identical copy)
- `src/commands/connect.ts` — `LOCAL_HOST`, used for 7 `http://` and `ws://` URLs

A bind address is not always dialable, and **every** containerized deploy sets it to a wildcard — the `Dockerfile`, `render.yaml`, `fly.toml`, and `.do/app.yaml` all ship `LFG_HOST=0.0.0.0`.

### Why it has stayed latent

`http://0.0.0.0:8766` happens to connect on Linux, because the kernel treats a 0.0.0.0 destination as loopback. So the bug is invisible today.

### Where it stops being latent

On a platform whose private network is IPv6-only — Railway, and Fly private networking — a socket on `0.0.0.0` refuses those connections, so the server has to bind `::` to be reachable over `*.railway.internal` at all. Then:

```console
$ LFG_HOST=:: bun -e 'console.log(`http://${process.env.LFG_HOST}:8766`)'
http://:::8766

$ node -e 'new URL("http://:::8766")'
TypeError: Invalid URL
```

The MCP server and `lfg subagent` fail outright inside the container — and because `lfg mcp` speaks stdio to an agent, the failure surfaces as a broken tool rather than a bind error anyone would connect to networking.

### The fix

One resolver in `src/config.ts` that folds wildcards back to loopback and brackets bare IPv6 literals, so the result is always safe to interpolate into a URL authority:

| `LFG_HOST` | dialed |
|---|---|
| unset / empty | `127.0.0.1` |
| `0.0.0.0` | `127.0.0.1` |
| `::` / `[::]` | `[::1]` |
| `fd7a:115c:a1e0::1` | `[fd7a:115c:a1e0::1]` |
| `box.tailnet.ts.net` | unchanged |

`mcp.ts` and `subagent.ts` had identical copies of `baseUrl()`, so they now share it rather than each carrying the bug. `connect.ts` keeps its own `LOCAL_HOST`/`LOCAL_PORT` since it also builds `ws://` URLs.

Deliberately **not** changed here: the `Dockerfile`/`render.yaml`/`fly.toml` bind values, and the loopback-by-default security posture. This only fixes the dialing side.

### Verification

- 5 new unit tests in `src/config.test.ts`, covering wildcards, bare and pre-bracketed IPv6, routable hosts, and empty/whitespace input
- `bun run typecheck` clean
- `bun test`: the only failures are the two pre-existing ones in `src/self-update.test.ts` (`release extraction > overwrites bundle files…`, `restart command > recognizes the OMG agent-template supervisor`), identical before and after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
