### PR TITLE
Recover hosted animations after foregrounding

### DIFF
--- a/test/embedded-animation-recovery.test.ts
+++ b/test/embedded-animation-recovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  COMPUTER_HOST_RESUME_MESSAGE,
+  isComputerHostResumeMessage,
+  restartContinuousAnimations,
+} from "../web/src/embedded-animation-recovery.ts";
+
+function fakeAnimation(iterations: number, currentTime: number | null = 250) {
+  const calls: string[] = [];
+  return {
+    animation: {
+      effect: { getTiming: () => ({ iterations }) },
+      currentTime,
+      cancel() {
+        calls.push("cancel");
+        this.currentTime = null;
+      },
+      play() {
+        calls.push("play");
+      },
+    },
+    calls,
+  };
+}
+
+describe("embedded animation foreground recovery", () => {
+  test("accepts only the host resume protocol message", () => {
+    expect(isComputerHostResumeMessage({ type: COMPUTER_HOST_RESUME_MESSAGE })).toBe(true);
+    expect(isComputerHostResumeMessage({ type: "other" })).toBe(false);
+    expect(isComputerHostResumeMessage(null)).toBe(false);
+  });
+
+  test("restarts infinite animations and preserves their phase", () => {
+    const spinner = fakeAnimation(Infinity, 875);
+    const transition = fakeAnimation(1, 120);
+
+    expect(
+      restartContinuousAnimations([spinner.animation, transition.animation]),
+    ).toBe(1);
+    expect(spinner.calls).toEqual(["cancel", "play"]);
+    expect(spinner.animation.currentTime).toBe(875);
+    expect(transition.calls).toEqual([]);
+    expect(transition.animation.currentTime).toBe(120);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,10 @@ import {
   shouldPrioritizeSession,
 } from "./lib/app-search";
 import { isEmbedded, readLocationEmbedFlag } from "./lib/embed";
+import {
+  isComputerHostResumeMessage,
+  restartContinuousAnimations,
+} from "./embedded-animation-recovery";
 import { useChat } from "@ai-sdk/react";
 import {
   DEFAULT_SCHED_TZ,
@@ -3839,6 +3843,34 @@ export function App() {
     document.documentElement.dataset.lfgEmbed = "true";
     return () => {
       delete document.documentElement.dataset.lfgEmbed;
+    };
+  }, [embedded]);
+  // Standalone WebKit resumes its own animation timelines. A cross-origin
+  // Computer iframe can remain suspended, so the top-level omg host forwards
+  // its authoritative foreground event and we restart infinite animations
+  // only. Finite transitions must never replay when a user returns.
+  useEffect(() => {
+    if (!embedded) return;
+    const recover = () => {
+      if (document.visibilityState !== "visible") return;
+      restartContinuousAnimations(document.getAnimations());
+    };
+    const onHostResume = (event: MessageEvent) => {
+      if (event.source !== window.parent || !isComputerHostResumeMessage(event.data)) return;
+      recover();
+    };
+    const onVisible = () => {
+      if (document.visibilityState === "visible") recover();
+    };
+    window.addEventListener("message", onHostResume);
+    window.addEventListener("pageshow", recover);
+    window.addEventListener("focus", recover);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("message", onHostResume);
+      window.removeEventListener("pageshow", recover);
+      window.removeEventListener("focus", recover);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [embedded]);
   const isMobile = useIsMobile();

--- a/web/src/embedded-animation-recovery.ts
+++ b/web/src/embedded-animation-recovery.ts
@@ -1,0 +1,40 @@
+// Foreground recovery for continuous animations inside the omg Computer frame.
+//
+// WebKit can leave a cross-origin iframe's infinite CSS animations suspended
+// after the top-level tab/window returns. The host owns foreground detection
+// and forwards this message; LFG owns which animation timelines are safe to
+// restart. Finite transitions are deliberately excluded so resume never
+// replays entrances or other one-shot motion.
+
+export const COMPUTER_HOST_RESUME_MESSAGE = "omg:computer-host-resume";
+
+type ContinuousAnimation = {
+  effect: { getTiming(): { iterations?: number } } | null;
+  currentTime: CSSNumberish | null;
+  cancel(): void;
+  play(): void;
+};
+
+export function isComputerHostResumeMessage(data: unknown): boolean {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    data.type === COMPUTER_HOST_RESUME_MESSAGE
+  );
+}
+
+export function restartContinuousAnimations(
+  animations: Iterable<ContinuousAnimation>,
+): number {
+  let restarted = 0;
+  for (const animation of animations) {
+    if (animation.effect?.getTiming().iterations !== Infinity) continue;
+    const currentTime = animation.currentTime;
+    animation.cancel();
+    animation.play();
+    if (currentTime !== null) animation.currentTime = currentTime;
+    restarted += 1;
+  }
+  return restarted;
+}


### PR DESCRIPTION
## What changed

- Listen for the omg Computer host’s foreground-resume message in embedded mode.
- Restart only infinite animation timelines and preserve their current phase.
- Keep finite transitions untouched so returning to the app does not replay entrance motion.

## Why

WebKit can leave CSS animations inside a cross-origin iframe suspended after a tab or window switch. Standalone LFG resumes normally, but the hosted Computer surface could return with a frozen coding-agent activity ring.

## Impact

Hosted LFG activity indicators resume when the user returns without reloading the iframe or interrupting the live coding session.

## Validation

- `bun test` — 264 passed
- `bun run typecheck`
- `bun run --cwd web typecheck`
- `bun run --cwd web build`