### PR TITLE
feat(web): connect coding agents inside embedded Computers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Recent product updates and deployment notes.
 
 ## [Unreleased]
 
+## July 28, 2026 - Embedded Computer agent connection (v0.1.82)
+
+- A fresh hosted Computer now offers Claude Code and Codex sign-in directly
+  inside LFG, using the existing provider login dialogs and without requiring
+  iMessage or showing a provisioning progress bar.
+- Starting the first session sends one origin-checked event to the omg host so
+  the $49 keep-your-Computer offer appears only after the Computer is useful.
+
 ## July 28, 2026 - Hosted animations resume reliably (v0.1.81)
 
 - Hosted Computer activity animations now resume after returning from another

--- a/docs/embed-host-protocol.md
+++ b/docs/embed-host-protocol.md
@@ -1,0 +1,81 @@
+# Embed host protocol
+
+LFG runs framed inside omg's Computer surface (`https://<box>/?embed=1`). Embed
+mode hides LFG's own header, settings, user picker and onboarding — the host
+owns account UX. This document is the contract between the two.
+
+## Detection
+
+`?embed=1` on the frame URL is the explicit signal; running inside a
+cross-origin iframe is accepted as defence in depth. See `web/src/lib/embed.ts`.
+
+## Host → frame
+
+| Message | Meaning |
+| --- | --- |
+| `{ type: "omg:computer-host-resume" }` | The host tab returned to the foreground. LFG restarts infinite CSS/WAAPI animations that WebKit left suspended (`web/src/embedded-animation-recovery.ts`). |
+
+## Frame → host: `lfg:session-created`
+
+Embedded LFG posts exactly one message, when the framed user creates a session
+from this tab:
+
+```js
+window.parent.postMessage(
+  { type: "lfg:session-created", sessionId: "<lfg session id>" },
+  hostOrigin, // never "*"
+)
+```
+
+- **Emitted from** `markCreatedSid()` in `web/src/App.tsx` — the single funnel
+  every in-tab `/api/sessions/new` call already goes through. There is no
+  second emitter and no new state owner.
+- **Emitted when** embed mode is on (`readLocationEmbedFlag()`), the frame has
+  a real parent window, and a target origin resolved. Sessions created outside
+  this tab (iMessage, CLI, subagents) do not produce the event.
+- **Payload** is the two fields above and nothing else. LFG does not read a
+  reply, keep host state, or own any billing/upgrade UI — the host decides what
+  to do with the signal (e.g. showing its upgrade prompt after the user's first
+  session).
+
+### Target origin
+
+Resolved once at document load (`web/src/lib/embed-host-signal.ts`), in order:
+
+1. `?embedOrigin=<absolute http(s) URL>` on the frame URL — an explicit opt-in
+   for hosts whose `Referrer-Policy` strips the referrer. Read straight from
+   `window.location` at boot, because the router only keeps its typed search
+   params (`session`, `embed`) in the URL.
+2. `document.referrer` — the embedding page for a framed document.
+
+Only `http:`/`https:` origins are accepted. If neither source yields one, LFG
+stays silent rather than posting to `*`.
+
+### Host side
+
+```js
+window.addEventListener("message", (event) => {
+  if (event.origin !== computerFrameOrigin) return       // the box's origin
+  if (event.source !== computerIframe.contentWindow) return
+  if (event.data?.type !== "lfg:session-created") return
+  onFirstSessionStarted(event.data.sessionId)
+})
+```
+
+## Embedded first-run gate
+
+With settings and onboarding hidden, a fresh box has no place to connect a
+coding agent. When neither Claude nor Codex is connected, embedded LFG shows a
+single card offering those two
+(`web/src/components/embedded-connect-gate.tsx`). It drives the existing
+`/api/coding-agents/:kind/auth` login and the shared auth dialog; once either
+provider reports `configured` (on the CLI kind or its ai-sdk sibling), the card
+disappears and the normal session UI renders. Standalone LFG is unchanged — it
+still uses `OnboardingFlow`.
+
+The predicate is deliberately scoped to those two providers rather than "any
+configured agent": the agent-lfg image ships pi bundled and may carry
+OpenCode/Copilot credentials, which would otherwise mark a fresh Computer as
+ready and skip the connect prompt the user still needs. A "Skip for now" link
+covers people intentionally working on one of those other providers; it is not
+persisted, so the gate returns on the next load while nothing is connected.

--- a/test/embedded-connect-gate.test.ts
+++ b/test/embedded-connect-gate.test.ts
@@ -268,6 +268,10 @@ describe("App wiring", () => {
     expect(gate.slice(0, gate.indexOf("</>"))).toContain("setupCodingAgent(kind as AgentKind)");
   });
 
+  test("a session deep link is never held behind the gate", () => {
+    expect(app).toContain("dismissed: connectGateSkipped || !!sessionDeepLinkRef.current");
+  });
+
   test("the host signal hangs off the single created-session funnel", () => {
     const funnel = app.slice(
       app.indexOf("function markCreatedSid("),

--- a/test/embedded-connect-gate.test.ts
+++ b/test/embedded-connect-gate.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ConnectAgentInfo,
+  embeddedConnectOptions,
+  hasConnectedGateProvider,
+  shouldShowEmbeddedConnectGate,
+} from "../web/src/lib/embedded-connect.ts";
+import {
+  LFG_SESSION_CREATED_MESSAGE,
+  originOf,
+  postSessionCreatedToHost,
+  resolveHostOrigin,
+  sessionCreatedMessage,
+} from "../web/src/lib/embed-host-signal.ts";
+
+function agent(
+  key: string,
+  opts: { installed?: boolean; authed?: boolean; canAutoSetup?: boolean } = {},
+): ConnectAgentInfo {
+  const installed = opts.installed !== false;
+  const authed = opts.authed === true;
+  const label = key === "codex" ? "Codex" : "Claude";
+  return {
+    key,
+    label,
+    status: {
+      configured: installed && authed,
+      canAutoSetup: opts.canAutoSetup !== false,
+      checks: [
+        { label: `${label} CLI`, ok: installed },
+        { label: `${label} auth`, ok: authed },
+      ],
+    },
+  };
+}
+
+const FRESH_BOX = [agent("claude"), agent("codex")];
+
+describe("embedded connect gate visibility", () => {
+  test("opens on a framed box with nothing authenticated", () => {
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: FRESH_BOX })).toBe(true);
+  });
+
+  test("never opens outside embed mode (standalone keeps onboarding)", () => {
+    expect(shouldShowEmbeddedConnectGate({ embedded: false, agents: FRESH_BOX })).toBe(false);
+  });
+
+  test("closes the moment Claude connects", () => {
+    const connected = [agent("claude", { authed: true }), agent("codex")];
+    expect(hasConnectedGateProvider(connected)).toBe(true);
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: connected })).toBe(false);
+  });
+
+  test("closes when Codex connects", () => {
+    const connected = [agent("claude"), agent("codex", { authed: true })];
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: connected })).toBe(false);
+  });
+
+  test("a login reported only on the ai-sdk sibling also closes it", () => {
+    // `claude auth login` configures both the CLI kind and aisdk; either
+    // reporting configured means the provider is connected.
+    const connected = [agent("claude"), agent("aisdk", { authed: true }), agent("codex")];
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: connected })).toBe(false);
+  });
+
+  test("bundled pi / OpenCode must NOT satisfy the gate on a fresh image", () => {
+    // agent-lfg ships pi bundled (file-based auth) and can carry OpenCode or
+    // Copilot creds in the image. Those report configured while the user still
+    // has no Claude/Codex login, so the connect prompt must stay up.
+    const imageDefaults = [
+      ...FRESH_BOX,
+      agent("pi", { authed: true }),
+      agent("opencode", { authed: true }),
+      agent("copilot", { authed: true }),
+    ];
+    expect(hasConnectedGateProvider(imageDefaults)).toBe(false);
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: imageDefaults })).toBe(true);
+    // …and it closes only once one of the two offered providers connects.
+    expect(
+      shouldShowEmbeddedConnectGate({
+        embedded: true,
+        agents: [...imageDefaults.slice(2), agent("claude", { authed: true }), agent("codex")],
+      }),
+    ).toBe(false);
+    // Someone deliberately using pi/OpenCode takes the skip link.
+    expect(
+      shouldShowEmbeddedConnectGate({ embedded: true, agents: imageDefaults, dismissed: true }),
+    ).toBe(false);
+  });
+
+  test("an empty roster (bootstrap failed) does not trap the user", () => {
+    expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: [] })).toBe(false);
+  });
+
+  test("skipping hides it for this app load", () => {
+    expect(
+      shouldShowEmbeddedConnectGate({ embedded: true, agents: FRESH_BOX, dismissed: true }),
+    ).toBe(false);
+  });
+});
+
+describe("embedded connect options", () => {
+  test("offers exactly Claude Code and Codex, in order", () => {
+    const options = embeddedConnectOptions(FRESH_BOX);
+    expect(options.map((o) => o.kind)).toEqual(["claude", "codex"]);
+    expect(options.map((o) => o.label)).toEqual(["Claude Code", "Codex"]);
+    expect(options.map((o) => o.provider)).toEqual(["claude", "codex"]);
+  });
+
+  test("reports a missing CLI separately from a missing login", () => {
+    const options = embeddedConnectOptions([
+      agent("claude", { installed: false }),
+      agent("codex", { installed: true, authed: false }),
+    ]);
+    expect(options[0]).toMatchObject({ installed: false, configured: false });
+    expect(options[1]).toMatchObject({ installed: true, configured: false });
+  });
+
+  test("carries canAutoSetup so an uninstallable CLI is not offered as a click", () => {
+    const options = embeddedConnectOptions([
+      agent("claude", { installed: false, canAutoSetup: false }),
+    ]);
+    expect(options[0]?.canAutoSetup).toBe(false);
+  });
+
+  test("skips providers the server does not list", () => {
+    expect(embeddedConnectOptions([agent("codex")]).map((o) => o.kind)).toEqual(["codex"]);
+    expect(embeddedConnectOptions([])).toEqual([]);
+  });
+});
+
+describe("host session-created signal", () => {
+  test("payload is the tagged message plus the session id, nothing else", () => {
+    expect(sessionCreatedMessage("s1")).toEqual({
+      type: "lfg:session-created",
+      sessionId: "s1",
+    });
+    expect(LFG_SESSION_CREATED_MESSAGE).toBe("lfg:session-created");
+  });
+
+  test("originOf keeps http(s) origins and rejects everything else", () => {
+    expect(originOf("https://sessions.omgs.app/computer/1?x=2")).toBe("https://sessions.omgs.app");
+    expect(originOf("http://localhost:5173/")).toBe("http://localhost:5173");
+    expect(originOf("javascript:alert(1)")).toBeNull();
+    expect(originOf("")).toBeNull();
+    expect(originOf(null)).toBeNull();
+    expect(originOf("not a url")).toBeNull();
+  });
+
+  test("explicit embedOrigin wins over the referrer; referrer is the fallback", () => {
+    expect(
+      resolveHostOrigin({
+        search: "?embed=1&embedOrigin=https%3A%2F%2Fsessions.omgs.app",
+        referrer: "https://evil.example/",
+      }),
+    ).toBe("https://sessions.omgs.app");
+    expect(
+      resolveHostOrigin({ search: "?embed=1", referrer: "https://sessions.omgs.app/c/9" }),
+    ).toBe("https://sessions.omgs.app");
+    expect(resolveHostOrigin({ search: "?embed=1", referrer: "" })).toBeNull();
+    expect(resolveHostOrigin({ search: null, referrer: null })).toBeNull();
+  });
+
+  test("a same-origin referrer is our own navigation, not the host", () => {
+    // The router rewrites ?embed=1 to ?embed=true with a real frame
+    // navigation; after it the referrer is LFG's own previous URL.
+    expect(
+      resolveHostOrigin({
+        search: "?embed=true",
+        referrer: "https://box.lfg.dev/?embed=1",
+        selfOrigin: "https://box.lfg.dev",
+      }),
+    ).toBeNull();
+  });
+
+  test("the cached origin survives that rewrite navigation", () => {
+    expect(
+      resolveHostOrigin({
+        search: "?embed=true",
+        referrer: "https://box.lfg.dev/?embed=1",
+        selfOrigin: "https://box.lfg.dev",
+        cached: "https://sessions.omgs.app",
+      }),
+    ).toBe("https://sessions.omgs.app");
+    // A live cross-origin referrer still wins over the cache.
+    expect(
+      resolveHostOrigin({
+        search: "",
+        referrer: "https://sessions.omgs.app/c/9",
+        selfOrigin: "https://box.lfg.dev",
+        cached: "https://stale.example",
+      }),
+    ).toBe("https://sessions.omgs.app");
+    // Garbage in the cache is ignored rather than posted to.
+    expect(
+      resolveHostOrigin({ search: "", referrer: "", cached: "not a url" }),
+    ).toBeNull();
+  });
+
+  function recorder() {
+    const sent: { message: unknown; origin: string }[] = [];
+    return {
+      sent,
+      target: {
+        postMessage: (message: unknown, origin: string) => {
+          sent.push({ message, origin });
+        },
+      },
+    };
+  }
+
+  test("posts once to the resolved host origin, never to '*'", () => {
+    const { sent, target } = recorder();
+    const posted = postSessionCreatedToHost("sess-1", {
+      embedded: true,
+      parent: target,
+      self: {},
+      origin: "https://sessions.omgs.app",
+    });
+    expect(posted).toBe(true);
+    expect(sent).toEqual([
+      {
+        message: { type: "lfg:session-created", sessionId: "sess-1" },
+        origin: "https://sessions.omgs.app",
+      },
+    ]);
+  });
+
+  test("stays silent when not embedded, unframed, id-less, or origin-less", () => {
+    const { sent, target } = recorder();
+    const base = { parent: target, self: {}, origin: "https://sessions.omgs.app" };
+    expect(postSessionCreatedToHost("s", { ...base, embedded: false })).toBe(false);
+    expect(postSessionCreatedToHost("", { ...base, embedded: true })).toBe(false);
+    expect(postSessionCreatedToHost("s", { ...base, embedded: true, origin: null })).toBe(false);
+    expect(postSessionCreatedToHost("s", { ...base, embedded: true, parent: null })).toBe(false);
+    // Top-level window: parent === self, so there is no host to notify.
+    expect(
+      postSessionCreatedToHost("s", { embedded: true, parent: target, self: target, origin: "https://x.dev" }),
+    ).toBe(false);
+    expect(sent).toEqual([]);
+  });
+
+  test("a throwing host frame degrades to a no-op", () => {
+    const posted = postSessionCreatedToHost("s", {
+      embedded: true,
+      parent: {
+        postMessage: () => {
+          throw new Error("cross-origin");
+        },
+      },
+      self: {},
+      origin: "https://sessions.omgs.app",
+    });
+    expect(posted).toBe(false);
+  });
+});
+
+describe("App wiring", () => {
+  const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
+
+  test("the gate renders the shared auth dialog rather than a second auth path", () => {
+    const gate = app.slice(app.indexOf("if (connectGateOpen) {"));
+    expect(gate).toContain("<EmbeddedConnectGate");
+    expect(gate.slice(0, gate.indexOf("</>")))
+      .toContain("<CodingAgentAuthDialog");
+    // Login/install go through the existing App handlers, not a new fetch.
+    expect(gate.slice(0, gate.indexOf("</>"))).toContain("loginCodingAgent(kind as AgentKind)");
+    expect(gate.slice(0, gate.indexOf("</>"))).toContain("setupCodingAgent(kind as AgentKind)");
+  });
+
+  test("the host signal hangs off the single created-session funnel", () => {
+    const funnel = app.slice(
+      app.indexOf("function markCreatedSid("),
+      app.indexOf("function markCreatedSid(") + 700,
+    );
+    expect(funnel).toContain("emitSessionCreatedToHost(sid, readLocationEmbedFlag())");
+    // Exactly one emit site — not one per /api/sessions/new call site.
+    expect(app.split("emitSessionCreatedToHost(").length - 1).toBe(1);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,12 @@ import {
 } from "./lib/app-search";
 import { isEmbedded, readLocationEmbedFlag } from "./lib/embed";
 import {
+  embeddedConnectOptions,
+  shouldShowEmbeddedConnectGate,
+} from "./lib/embedded-connect";
+import { emitSessionCreatedToHost } from "./lib/embed-host-signal";
+import { EmbeddedConnectGate } from "./components/embedded-connect-gate";
+import {
   isComputerHostResumeMessage,
   restartContinuousAnimations,
 } from "./embedded-animation-recovery";
@@ -3156,6 +3162,11 @@ const recentlyCreatedSids = new Set<string>();
 function markCreatedSid(sid: string): void {
   recentlyCreatedSids.add(sid);
   window.setTimeout(() => recentlyCreatedSids.delete(sid), 2000);
+  // Single funnel for "this tab just created a session", so it is also the one
+  // place the embedding host learns about it (see lib/embed-host-signal.ts).
+  // Embed intent is read from the location rather than React state to keep
+  // this module-level helper free of a second owner of that flag.
+  emitSessionCreatedToHost(sid, readLocationEmbedFlag());
 }
 
 // The set of EXPANDED session ids among `sessions`, kept in sync with the
@@ -3879,6 +3890,10 @@ export function App() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [codingAgents, setCodingAgents] = useState<CodingAgentInfo[]>([]);
   const [codingAgentAuth, setCodingAgentAuth] = useState<CodingAgentAuthSession | null>(null);
+  // Embed-only first-run gate: which provider row has an in-flight click, and
+  // whether the user chose to look past the gate for this app load.
+  const [connectPendingKind, setConnectPendingKind] = useState<AgentKind | null>(null);
+  const [connectGateSkipped, setConnectGateSkipped] = useState(false);
   const [modelCatalog, setModelCatalog] = useState<AgentModelCatalog>(() =>
     buildAgentModelCatalog(),
   );
@@ -5315,8 +5330,56 @@ export function App() {
     }
   }
 
+  // Embedded fresh box: onboarding and settings are hidden under a host, so
+  // the gate below is the only place a framed user can connect a coding agent.
+  // While it is open we re-read the roster so a finished CLI install (or an
+  // out-of-band login) reveals the app without a manual reload; the auth dialog
+  // already refreshes on its own when a browser login completes.
+  const connectGateOpen = shouldShowEmbeddedConnectGate({
+    embedded,
+    agents: codingAgents,
+    dismissed: connectGateSkipped,
+  });
+  useEffect(() => {
+    if (!connectGateOpen) return;
+    const timer = window.setInterval(() => void refreshCodingAgents(), 4000);
+    return () => window.clearInterval(timer);
+  }, [connectGateOpen, refreshCodingAgents]);
+
   if (loading) {
     return <AppShellSkeleton />;
+  }
+
+  // Reuses loginCodingAgent/setupCodingAgent and the shared auth dialog, and
+  // closes itself as soon as refreshCodingAgents reports something configured.
+  if (connectGateOpen) {
+    return (
+      <>
+        <EmbeddedConnectGate
+          options={embeddedConnectOptions(codingAgents)}
+          pendingKind={connectPendingKind}
+          onConnect={(kind) => {
+            setConnectPendingKind(kind as AgentKind);
+            void loginCodingAgent(kind as AgentKind).finally(() =>
+              setConnectPendingKind(null),
+            );
+          }}
+          onInstall={(kind) => {
+            setupCodingAgent(kind as AgentKind);
+          }}
+          onSkip={() => setConnectGateSkipped(true)}
+        />
+        <CodingAgentAuthDialog
+          session={codingAgentAuth}
+          onSessionChange={setCodingAgentAuth}
+          onComplete={async () => {
+            setCodingAgentAuth(null);
+            await refreshCodingAgents({ refreshModels: true });
+          }}
+        />
+        <Toaster position="bottom-center" />
+      </>
+    );
   }
 
   // Brand-new install (no roster, no sessions, onboarding never completed):

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5335,10 +5335,13 @@ export function App() {
   // While it is open we re-read the roster so a finished CLI install (or an
   // out-of-band login) reveals the app without a manual reload; the auth dialog
   // already refreshes on its own when a browser login completes.
+  // A `?session=` deep link is the host asking for one specific session, which
+  // only exists on a box that is past first run — never hold that behind the
+  // gate. The gate is back on the next plain load while nothing is connected.
   const connectGateOpen = shouldShowEmbeddedConnectGate({
     embedded,
     agents: codingAgents,
-    dismissed: connectGateSkipped,
+    dismissed: connectGateSkipped || !!sessionDeepLinkRef.current,
   });
   useEffect(() => {
     if (!connectGateOpen) return;

--- a/web/src/components/embedded-connect-gate.tsx
+++ b/web/src/components/embedded-connect-gate.tsx
@@ -1,0 +1,98 @@
+// Embed-only first-run gate.
+//
+// A framed LFG hides onboarding and settings (the host owns account UX), so a
+// fresh box had no surface at all for connecting a coding agent. This card is
+// that surface and nothing more: it renders the two browser-loginable
+// providers and hands the click straight back to App's existing
+// `loginCodingAgent` / `setupCodingAgent`, which drive the same
+// /api/coding-agents endpoints and the same <CodingAgentAuthDialog> the
+// Settings page uses. No credentials, no second auth path, no progress bar —
+// the card disappears the moment the agent roster reports something
+// configured.
+
+import { Loader2 } from "lucide-react";
+import { Button } from "./ui/button";
+import type { ConnectOption } from "../lib/embedded-connect";
+
+export function EmbeddedConnectGate({
+  options,
+  pendingKind,
+  onConnect,
+  onInstall,
+  onSkip,
+}: {
+  options: ConnectOption[];
+  /** Kind with an in-flight connect/install click, if any. */
+  pendingKind?: string | null;
+  onConnect: (kind: string) => void;
+  onInstall: (kind: string) => void;
+  onSkip: () => void;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center overflow-y-auto overscroll-none bg-background px-6 text-foreground"
+      style={{ height: "var(--lfg-app-height, 100dvh)" }}
+    >
+      <div className="my-auto w-full max-w-sm py-6">
+        <div className="mb-4 flex items-center gap-2">
+          <img src="/icon.svg" alt="lfg" className="size-7 shrink-0" />
+        </div>
+        <h1 className="text-xl font-semibold">Connect a coding agent</h1>
+        <p className="mb-5 mt-1 text-sm text-muted-foreground">
+          Sign in once and this Computer can start sessions. It opens the
+          provider&rsquo;s sign-in page — nothing is stored here.
+        </p>
+        <div className="flex flex-col gap-2">
+          {options.map((option) => {
+            const pending = pendingKind === option.kind;
+            const needsInstall = !option.installed;
+            const blocked = needsInstall && !option.canAutoSetup;
+            return (
+              <div
+                key={option.kind}
+                className="flex items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">{option.label}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {blocked
+                      ? "CLI not installed on this Computer"
+                      : needsInstall
+                        ? "Install first, then sign in"
+                        : `Sign in with ${option.provider === "claude" ? "Claude" : "ChatGPT"}`}
+                  </span>
+                </span>
+                <Button
+                  variant={option.provider === "claude" ? "brand" : "outline"}
+                  size="sm"
+                  disabled={pending || blocked}
+                  onClick={() =>
+                    needsInstall ? onInstall(option.kind) : onConnect(option.kind)
+                  }
+                >
+                  {pending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : needsInstall ? (
+                    "Install"
+                  ) : (
+                    "Connect"
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+        {/* Escape hatch: an expired login must never lock someone out of
+            sessions that are already running. Deliberately not persisted —
+            the gate returns on the next load while nothing is configured. */}
+        <button
+          type="button"
+          onClick={onSkip}
+          className="mt-4 w-full text-center text-xs text-muted-foreground underline-offset-2 hover:underline"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/app-search.ts
+++ b/web/src/lib/app-search.ts
@@ -73,6 +73,11 @@ export interface AppSearch {
   /** Framed-host mode (omg Computer iframe). EXTERNAL CONTRACT with omg's
    *  use-computer-session-frame mint — must stay as `embed=1`. */
   embed?: boolean;
+  /** Optional absolute origin of the embedding host, for hosts whose
+   *  Referrer-Policy strips the referrer. Kept in the typed contract so the
+   *  router's own `?embed=1` → `?embed=true` rewrite doesn't drop it. Consumed
+   *  by lib/embed-host-signal.ts, which validates the scheme. */
+  embedOrigin?: string;
 }
 
 /** Validate the search params carried on every route. */
@@ -86,6 +91,9 @@ export function validateAppSearch(search: Record<string, unknown>): AppSearch {
     search.embed === "true"
   ) {
     out.embed = true;
+  }
+  if (typeof search.embedOrigin === "string" && search.embedOrigin) {
+    out.embedOrigin = search.embedOrigin;
   }
   return out;
 }

--- a/web/src/lib/embed-host-signal.ts
+++ b/web/src/lib/embed-host-signal.ts
@@ -1,0 +1,144 @@
+// Frame → host signalling for embedded LFG (omg's Computer surface).
+//
+// The reverse direction already exists: the host posts
+// `omg:computer-host-resume` and we restart suspended animations (see
+// embedded-animation-recovery.ts). This module is the only outbound half —
+// LFG tells the host that the framed user just started a session, so the host
+// can drive its own post-first-session UX (e.g. an upgrade prompt). LFG owns
+// no host state: the payload is one id plus the message tag, and nothing is
+// read back.
+//
+// Origin safety: we never post to "*". The target origin is resolved once at
+// module load from, in order,
+//   1. `?embedOrigin=<absolute url>` on the frame URL — an explicit opt-in for
+//      hosts whose Referrer-Policy strips the referrer, and
+//   2. `document.referrer`, but only when it is cross-origin. The router
+//      normalizes `?embed=1` to `?embed=true` with a real frame navigation, so
+//      after that first hop the referrer is LFG's own previous URL, not the
+//      host's — treating that as the host would be wrong.
+//   3. the origin resolved on an earlier document of this frame, cached in
+//      sessionStorage, which is what survives that same navigation.
+// With none of the three we stay silent rather than broadcast.
+
+export const LFG_SESSION_CREATED_MESSAGE = "lfg:session-created";
+
+export type LfgSessionCreatedMessage = {
+  type: typeof LFG_SESSION_CREATED_MESSAGE;
+  /** LFG session id of the session this frame just created. */
+  sessionId: string;
+};
+
+export function sessionCreatedMessage(sessionId: string): LfgSessionCreatedMessage {
+  return { type: LFG_SESSION_CREATED_MESSAGE, sessionId };
+}
+
+/** Origin of an absolute http(s) URL, or null for anything else (relative
+ *  URLs, `null` referrers, opaque schemes). */
+export function originOf(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve the host origin we are allowed to post to. Explicit `embedOrigin`
+ *  wins, then a cross-origin referrer, then a previously cached resolution.
+ *  Null means "do not post". */
+export function resolveHostOrigin(input: {
+  search?: string | null;
+  referrer?: string | null;
+  /** This frame's own origin — a referrer matching it is our own navigation. */
+  selfOrigin?: string | null;
+  /** Origin resolved on an earlier document of this frame. */
+  cached?: string | null;
+}): string | null {
+  let explicit: string | null = null;
+  try {
+    explicit = new URLSearchParams(input.search ?? "").get("embedOrigin");
+  } catch {
+    explicit = null;
+  }
+  const fromParam = originOf(explicit);
+  if (fromParam) return fromParam;
+  const fromReferrer = originOf(input.referrer);
+  if (fromReferrer && fromReferrer !== input.selfOrigin) return fromReferrer;
+  return originOf(input.cached);
+}
+
+const HOST_ORIGIN_CACHE_KEY = "lfg_embed_host_origin";
+
+function readCachedHostOrigin(): string | null {
+  try {
+    return window.sessionStorage?.getItem(HOST_ORIGIN_CACHE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function cacheHostOrigin(origin: string): void {
+  try {
+    window.sessionStorage?.setItem(HOST_ORIGIN_CACHE_KEY, origin);
+  } catch {
+    // private mode / blocked storage: the param path still works
+  }
+}
+
+type PostTarget = { postMessage: (message: unknown, targetOrigin: string) => void };
+
+/**
+ * Post the session-created signal to the embedding host. Returns true when a
+ * message was actually sent, so callers/tests can assert the guards:
+ * embedded-only, real session id, a parent that is not us, resolved origin.
+ */
+export function postSessionCreatedToHost(
+  sessionId: string,
+  ctx: {
+    embedded: boolean;
+    parent: PostTarget | null | undefined;
+    self?: unknown;
+    origin: string | null;
+  },
+): boolean {
+  if (!ctx.embedded) return false;
+  if (!sessionId) return false;
+  if (!ctx.parent) return false;
+  if (ctx.self !== undefined && ctx.parent === ctx.self) return false;
+  if (!ctx.origin) return false;
+  try {
+    ctx.parent.postMessage(sessionCreatedMessage(sessionId), ctx.origin);
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+// Resolved once per document, then cached for the frame: the router's
+// `?embed=1` → `?embed=true` rewrite navigates the frame, which drops
+// unrecognized params and replaces the referrer with LFG's own URL.
+const bootHostOrigin: string | null = (() => {
+  if (typeof window === "undefined") return null;
+  const cached = readCachedHostOrigin();
+  const resolved = resolveHostOrigin({
+    search: window.location?.search,
+    referrer: typeof document === "undefined" ? null : document.referrer,
+    selfOrigin: window.location?.origin ?? null,
+    cached,
+  });
+  if (resolved && resolved !== cached) cacheHostOrigin(resolved);
+  return resolved;
+})();
+
+/** Browser entry point: emit the signal for a session this tab just created. */
+export function emitSessionCreatedToHost(sessionId: string, embedded: boolean): boolean {
+  if (typeof window === "undefined") return false;
+  return postSessionCreatedToHost(sessionId, {
+    embedded,
+    parent: window.parent,
+    self: window,
+    origin: bootHostOrigin,
+  });
+}

--- a/web/src/lib/embedded-connect.ts
+++ b/web/src/lib/embedded-connect.ts
@@ -1,0 +1,116 @@
+// Embedded first-run: which coding agent (if any) a framed LFG can actually
+// run work with, and what to offer when the answer is "none".
+//
+// Standalone LFG walks a fresh box through OnboardingFlow (profile → agents →
+// repo → session). Embed mode deliberately hides onboarding *and* settings —
+// the host owns account UX — which left a fresh omg Computer with no way to
+// connect a coding agent at all. This module is the shared, testable decision
+// layer for the embed-only gate that fills that hole; the auth itself still
+// runs through the existing /api/coding-agents/:kind/auth flow.
+
+/** The subset of CodingAgentInfo this module needs (kept structural so both
+ *  App.tsx's local type and the server's export satisfy it). */
+export type ConnectAgentInfo = {
+  key: string;
+  label: string;
+  status: {
+    configured: boolean;
+    canAutoSetup: boolean;
+    checks: { label: string; ok: boolean; detail?: string }[];
+  };
+};
+
+export type ConnectOption = {
+  /** Auth provider the CLI login belongs to. */
+  provider: "claude" | "codex";
+  /** Coding agent kind to drive install/login with. */
+  kind: string;
+  /** Product name shown on the card. */
+  label: string;
+  /** CLI binary is present on this box. */
+  installed: boolean;
+  /** Binary present *and* authenticated. */
+  configured: boolean;
+  /** Server says the missing CLI can be installed from the UI. */
+  canAutoSetup: boolean;
+};
+
+/** The two providers the embedded gate offers, in display order. Both reuse
+ *  the browser-login path (`claude auth login --claudeai` / `codex login
+ *  --device-auth`); every other agent kind is terminal-only, which a framed
+ *  surface cannot show. */
+const GATE_PROVIDERS: {
+  provider: "claude" | "codex";
+  /** Kind the gate drives install/login with. */
+  kind: string;
+  label: string;
+  /** Every kind that shares this provider's credentials — a login through
+   *  either CLI configures its ai-sdk sibling too. */
+  kinds: string[];
+}[] = [
+  { provider: "claude", kind: "claude", label: "Claude Code", kinds: ["claude", "aisdk"] },
+  { provider: "codex", kind: "codex", label: "Codex", kinds: ["codex", "codex-aisdk"] },
+];
+
+const GATE_PROVIDER_KINDS = new Set(GATE_PROVIDERS.flatMap((entry) => entry.kinds));
+
+/** statusFor() emits exactly one binary check per agent, always labelled
+ *  "<Product> CLI" ("Claude CLI", "Codex CLI"). Auth checks are labelled
+ *  "<Product> auth", so the CLI suffix is what separates the two. */
+function binaryInstalled(agent: ConnectAgentInfo): boolean {
+  const binary = agent.status.checks.find((check) => check.label.endsWith(" CLI"));
+  return binary ? binary.ok : agent.status.configured;
+}
+
+/**
+ * True when Claude or Codex is connected — the only two providers this gate
+ * can actually connect from a frame.
+ *
+ * Deliberately NOT "any configured agent": an agent-lfg image ships pi bundled
+ * (and can carry OpenCode/Copilot creds from the image), so `agents.some(
+ * configured)` would report a fresh Computer as ready and skip the connect
+ * prompt the user still needs. Someone genuinely working on one of those
+ * providers takes the gate's skip link instead.
+ */
+export function hasConnectedGateProvider(agents: ConnectAgentInfo[]): boolean {
+  return agents.some((agent) => GATE_PROVIDER_KINDS.has(agent.key) && agent.status.configured);
+}
+
+/**
+ * Show the embedded connect gate only when we positively know the box has
+ * neither provider connected. An empty roster means the bootstrap payload
+ * never arrived (or failed) — gating on that would trap the user behind a card
+ * we cannot resolve, so it stays closed.
+ */
+export function shouldShowEmbeddedConnectGate(input: {
+  embedded: boolean;
+  agents: ConnectAgentInfo[];
+  dismissed?: boolean;
+}): boolean {
+  if (!input.embedded || input.dismissed) return false;
+  if (!input.agents.length) return false;
+  return !hasConnectedGateProvider(input.agents);
+}
+
+/** Claude Code + Codex rows for the gate, skipping any the server doesn't
+ *  know about. */
+export function embeddedConnectOptions(agents: ConnectAgentInfo[]): ConnectOption[] {
+  const options: ConnectOption[] = [];
+  for (const entry of GATE_PROVIDERS) {
+    const agent = agents.find((item) => item.key === entry.kind);
+    if (!agent) continue;
+    options.push({
+      provider: entry.provider,
+      kind: entry.kind,
+      label: entry.label,
+      installed: binaryInstalled(agent),
+      // Credentials are per provider: the ai-sdk sibling reports the same
+      // login, so either kind being configured means this row is connected.
+      configured: agents.some(
+        (item) => entry.kinds.includes(item.key) && item.status.configured,
+      ),
+      canAutoSetup: agent.status.canAutoSetup,
+    });
+  }
+  return options;
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -31,9 +31,10 @@ const indexRoute = createRoute({
     if (search.tab) {
       // Preserve session deep-links and embed mode across the legacy ?tab=
       // redirect so framed hosts (omg) don't lose their chrome contract.
-      const nextSearch: { session?: string; embed?: boolean } = {};
+      const nextSearch: { session?: string; embed?: boolean; embedOrigin?: string } = {};
       if (search.session) nextSearch.session = search.session;
       if (search.embed) nextSearch.embed = true;
+      if (search.embedOrigin) nextSearch.embedOrigin = search.embedOrigin;
       throw redirect({
         to: tabToPath(search.tab),
         search: nextSearch,


### PR DESCRIPTION
## What changed

- Adds an embed-only first-run gate for connecting Claude Code or Codex using the existing LFG provider authentication dialogs.
- Emits one exact-origin `lfg:session-created` event from the existing session-creation funnel so omg can show the keep-your-Computer offer after first use.
- Lets explicit session deep links bypass the fresh-box gate.
- Documents the embed host protocol and adds v0.1.82 release notes.

## Why

Fresh omg cloud Computers need to become useful without iMessage or copied credentials. Provider authentication stays inside the Computer, while billing state stays owned by the omg host.

## Verification

- `bun test` — 287 passed
- root TypeScript check — clean
- web TypeScript check — clean
- production web build — clean
- cross-origin iframe contract previously verified in Chromium