### PR TITLE
Fix embedded account connection detection

### DIFF
--- a/src/claude-creds.test.ts
+++ b/src/claude-creds.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { claudeOauthToken } from "./claude-creds.ts";
+
+describe("Claude account credentials", () => {
+  const originalHome = process.env.HOME;
+  let testHome = "";
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (testHome) rmSync(testHome, { recursive: true, force: true });
+    testHome = "";
+  });
+
+  test("observes a browser login immediately after an initial miss", () => {
+    testHome = mkdtempSync(join(tmpdir(), "lfg-claude-creds-"));
+    process.env.HOME = testHome;
+    expect(claudeOauthToken()).toBeNull();
+
+    const credentialsDir = join(testHome, ".claude");
+    mkdirSync(credentialsDir, { recursive: true });
+    writeFileSync(
+      join(credentialsDir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "oauth-test-token" } }),
+    );
+
+    expect(claudeOauthToken()).toBe("oauth-test-token");
+  });
+});

--- a/src/claude-creds.ts
+++ b/src/claude-creds.ts
@@ -16,7 +16,10 @@ const TTL_MS = 60_000;
 function readCredsFile(): ClaudeCreds | null {
   try {
     return JSON.parse(
-      readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf8"),
+      readFileSync(
+        join(process.env.HOME ?? homedir(), ".claude", ".credentials.json"),
+        "utf8",
+      ),
     ) as ClaudeCreds;
   } catch {
     return null;
@@ -39,8 +42,15 @@ function readCredsKeychain(): ClaudeCreds | null {
 
 /** Claude subscription OAuth access token, or null when not signed in. */
 export function claudeOauthToken(): string | null {
+  // The Linux credentials file is cheap to read and can appear while LFG is
+  // running after a browser login. Read it before the Keychain cache so a
+  // completed first-run connection is visible on the very next status poll.
+  const fileToken = readCredsFile()?.claudeAiOauth?.accessToken ?? null;
+  if (fileToken) return fileToken;
+  if (process.platform !== "darwin") return null;
+
   if (cached && Date.now() - cached.at < TTL_MS) return cached.token;
-  const creds = readCredsFile() ?? readCredsKeychain();
+  const creds = readCredsKeychain();
   const token = creds?.claudeAiOauth?.accessToken ?? null;
   cached = { token, at: Date.now() };
   return token;

--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -74,7 +74,7 @@ describe("coding agent browser auth output", () => {
   });
 });
 
-describe("copilot auth detection", () => {
+describe("coding agent auth detection", () => {
   // Isolate the home + env this suite touches so we neither trip on the
   // maintainer's real login state nor leak into other suites.
   const savedEnv: Record<string, string | undefined> = {};
@@ -123,5 +123,19 @@ describe("copilot auth detection", () => {
     mkdirSync(join(home, ".copilot"), { recursive: true });
     writeFileSync(join(home, ".copilot", "hosts.yml"), "github.com: {}\n");
     expect(await copilotAuthOk()).toBe(true);
+  });
+
+  test("a platform OpenAI key makes Codex runnable without claiming the account is connected", async () => {
+    const home = useTmpHome();
+    const codex = join(home, "codex");
+    writeFileSync(codex, "#!/bin/sh\nexit 1\n");
+    chmodSync(codex, 0o755);
+    setEnv("LFG_CODEX_PATH", codex);
+    setEnv("OPENAI_API_KEY", "platform_test_key");
+
+    const agents = await listCodingAgents();
+    const codexAgent = agents.find((agent) => agent.key === "codex-aisdk");
+    expect(codexAgent?.status.configured).toBe(true);
+    expect(codexAgent?.status.accountConnected).toBe(false);
   });
 });

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -35,6 +35,9 @@ export type CodingAgentCheck = {
 
 export type CodingAgentStatus = {
   configured: boolean;
+  /** True only when the user connected this provider's account. Platform API
+   *  keys can make an agent runnable, but they are not a user login. */
+  accountConnected: boolean;
   lfgCapabilityAccess: "mcp" | "contract-only";
   checks: CodingAgentCheck[];
   instructions: string[];
@@ -300,26 +303,34 @@ function copilotPath(): string | null {
   ]);
 }
 
-function hasClaudeAuth(): boolean {
+function hasClaudeAccountAuth(): boolean {
   // claudeOauthToken covers both the Linux credentials file and macOS Keychain.
-  return !!process.env.ANTHROPIC_API_KEY || claudeOauthToken() !== null;
+  return claudeOauthToken() !== null;
 }
 
-function hasCodexAuth(): boolean {
+function hasCodexAccountAuth(): boolean {
   const home = userHome();
-  return (
-    !!process.env.OPENAI_API_KEY ||
-    existsSync(`${home}/.codex/auth.json`) ||
-    !!(codexPath() && commandOutput([codexPath()!, "login", "status"]).ok)
-  );
+  if (existsSync(`${home}/.codex/auth.json`)) return true;
+  const codex = codexPath();
+  if (!codex) return false;
+
+  // `codex login status` can treat OPENAI_API_KEY as sufficient runtime auth.
+  // Remove the platform key so this check answers the narrower question:
+  // did the user connect their ChatGPT account?
+  const env = { ...process.env };
+  delete env.OPENAI_API_KEY;
+  return commandOutput([codex, "login", "status"], env).ok;
 }
 
-function commandOutput(argv: string[]): { ok: boolean; text: string } {
+function commandOutput(
+  argv: string[],
+  env: Record<string, string | undefined> = process.env,
+): { ok: boolean; text: string } {
   try {
     const proc = Bun.spawnSync(argv, {
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env },
+      env,
     });
     const text = `${new TextDecoder().decode(proc.stdout)}${new TextDecoder().decode(proc.stderr)}`;
     return { ok: proc.exitCode === 0, text };
@@ -628,6 +639,7 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
   const instructions: string[] = [];
   let canAutoSetup = true;
   let canLoginInTerminal = true;
+  let accountConnected = false;
 
   const addBinary = (label: string, path: string | null) => {
     checks.push({ label, ok: !!path, detail: path ?? "not found" });
@@ -637,12 +649,22 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
   };
 
   if (kind === "claude" || kind === "aisdk") {
+    accountConnected = hasClaudeAccountAuth();
     addBinary("Claude CLI", claudePath());
-    addAuth("Claude auth", hasClaudeAuth(), "use Login below or set ANTHROPIC_API_KEY");
+    addAuth(
+      "Claude auth",
+      accountConnected || !!process.env.ANTHROPIC_API_KEY,
+      "use Login below or set ANTHROPIC_API_KEY",
+    );
     instructions.push("Use Login to sign in with Claude in your browser, or set ANTHROPIC_API_KEY.");
   } else if (kind === "codex" || kind === "codex-aisdk") {
+    accountConnected = hasCodexAccountAuth();
     addBinary("Codex CLI", codexPath());
-    addAuth("Codex auth", hasCodexAuth(), "use Login below or set OPENAI_API_KEY");
+    addAuth(
+      "Codex auth",
+      accountConnected || !!process.env.OPENAI_API_KEY,
+      "use Login below or set OPENAI_API_KEY",
+    );
     instructions.push("Use Login to connect ChatGPT in your browser, or set OPENAI_API_KEY.");
   } else if (kind === "opencode") {
     addBinary("OpenCode CLI", opencodePath());
@@ -677,6 +699,7 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
 
   return {
     configured: checks.every((c) => c.ok),
+    accountConnected,
     lfgCapabilityAccess: lfgCapabilityAccess(kind),
     checks,
     instructions,

--- a/test/embedded-connect-gate.test.ts
+++ b/test/embedded-connect-gate.test.ts
@@ -15,16 +15,23 @@ import {
 
 function agent(
   key: string,
-  opts: { installed?: boolean; authed?: boolean; canAutoSetup?: boolean } = {},
+  opts: {
+    installed?: boolean;
+    authed?: boolean;
+    runtimeAuthed?: boolean;
+    canAutoSetup?: boolean;
+  } = {},
 ): ConnectAgentInfo {
   const installed = opts.installed !== false;
   const authed = opts.authed === true;
-  const label = key === "codex" ? "Codex" : "Claude";
+  const runtimeAuthed = opts.runtimeAuthed ?? authed;
+  const label = key.includes("codex") ? "Codex" : "Claude";
   return {
     key,
     label,
     status: {
-      configured: installed && authed,
+      configured: installed && runtimeAuthed,
+      accountConnected: authed,
       canAutoSetup: opts.canAutoSetup !== false,
       checks: [
         { label: `${label} CLI`, ok: installed },
@@ -34,7 +41,7 @@ function agent(
   };
 }
 
-const FRESH_BOX = [agent("claude"), agent("codex")];
+const FRESH_BOX = [agent("aisdk"), agent("codex-aisdk")];
 
 describe("embedded connect gate visibility", () => {
   test("opens on a framed box with nothing authenticated", () => {
@@ -57,10 +64,22 @@ describe("embedded connect gate visibility", () => {
   });
 
   test("a login reported only on the ai-sdk sibling also closes it", () => {
-    // `claude auth login` configures both the CLI kind and aisdk; either
-    // reporting configured means the provider is connected.
+    // Production exposes the ai-sdk roster key, and its explicit account
+    // signal closes the gate after browser login.
     const connected = [agent("claude"), agent("aisdk", { authed: true }), agent("codex")];
     expect(shouldShowEmbeddedConnectGate({ embedded: true, agents: connected })).toBe(false);
+  });
+
+  test("platform API keys make agents runnable but do not impersonate a user connection", () => {
+    const platformConfigured = [
+      agent("aisdk", { runtimeAuthed: true }),
+      agent("codex-aisdk", { runtimeAuthed: true }),
+    ];
+    expect(platformConfigured.every((item) => item.status.configured)).toBe(true);
+    expect(hasConnectedGateProvider(platformConfigured)).toBe(false);
+    expect(
+      shouldShowEmbeddedConnectGate({ embedded: true, agents: platformConfigured }),
+    ).toBe(true);
   });
 
   test("bundled pi / OpenCode must NOT satisfy the gate on a fresh image", () => {
@@ -102,7 +121,7 @@ describe("embedded connect gate visibility", () => {
 describe("embedded connect options", () => {
   test("offers exactly Claude Code and Codex, in order", () => {
     const options = embeddedConnectOptions(FRESH_BOX);
-    expect(options.map((o) => o.kind)).toEqual(["claude", "codex"]);
+    expect(options.map((o) => o.kind)).toEqual(["aisdk", "codex-aisdk"]);
     expect(options.map((o) => o.label)).toEqual(["Claude Code", "Codex"]);
     expect(options.map((o) => o.provider)).toEqual(["claude", "codex"]);
   });
@@ -126,6 +145,12 @@ describe("embedded connect options", () => {
   test("skips providers the server does not list", () => {
     expect(embeddedConnectOptions([agent("codex")]).map((o) => o.kind)).toEqual(["codex"]);
     expect(embeddedConnectOptions([])).toEqual([]);
+  });
+
+  test("uses the installed ai-sdk roster key to drive the existing login endpoint", () => {
+    expect(embeddedConnectOptions([agent("aisdk")])).toEqual([
+      expect.objectContaining({ provider: "claude", kind: "aisdk" }),
+    ]);
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -266,6 +266,7 @@ type CodingAgentInfo = {
   visible: boolean;
   status: {
     configured: boolean;
+    accountConnected: boolean;
     lfgCapabilityAccess: "mcp" | "contract-only";
     setupRunning: boolean;
     setupProgress?: { percent: number; label: string };

--- a/web/src/lib/embedded-connect.ts
+++ b/web/src/lib/embedded-connect.ts
@@ -15,6 +15,8 @@ export type ConnectAgentInfo = {
   label: string;
   status: {
     configured: boolean;
+    /** User-owned browser/CLI login. Runtime API keys do not satisfy this. */
+    accountConnected?: boolean;
     canAutoSetup: boolean;
     checks: { label: string; ok: boolean; detail?: string }[];
   };
@@ -41,15 +43,12 @@ export type ConnectOption = {
  *  surface cannot show. */
 const GATE_PROVIDERS: {
   provider: "claude" | "codex";
-  /** Kind the gate drives install/login with. */
-  kind: string;
   label: string;
-  /** Every kind that shares this provider's credentials — a login through
-   *  either CLI configures its ai-sdk sibling too. */
+  /** Actual roster keys that can drive this provider's install/login flow. */
   kinds: string[];
 }[] = [
-  { provider: "claude", kind: "claude", label: "Claude Code", kinds: ["claude", "aisdk"] },
-  { provider: "codex", kind: "codex", label: "Codex", kinds: ["codex", "codex-aisdk"] },
+  { provider: "claude", label: "Claude Code", kinds: ["claude", "aisdk"] },
+  { provider: "codex", label: "Codex", kinds: ["codex", "codex-aisdk"] },
 ];
 
 const GATE_PROVIDER_KINDS = new Set(GATE_PROVIDERS.flatMap((entry) => entry.kinds));
@@ -73,7 +72,9 @@ function binaryInstalled(agent: ConnectAgentInfo): boolean {
  * providers takes the gate's skip link instead.
  */
 export function hasConnectedGateProvider(agents: ConnectAgentInfo[]): boolean {
-  return agents.some((agent) => GATE_PROVIDER_KINDS.has(agent.key) && agent.status.configured);
+  return agents.some(
+    (agent) => GATE_PROVIDER_KINDS.has(agent.key) && agent.status.accountConnected === true,
+  );
 }
 
 /**
@@ -97,17 +98,19 @@ export function shouldShowEmbeddedConnectGate(input: {
 export function embeddedConnectOptions(agents: ConnectAgentInfo[]): ConnectOption[] {
   const options: ConnectOption[] = [];
   for (const entry of GATE_PROVIDERS) {
-    const agent = agents.find((item) => item.key === entry.kind);
+    const agent = entry.kinds
+      .map((kind) => agents.find((item) => item.key === kind))
+      .find((item) => item !== undefined);
     if (!agent) continue;
     options.push({
       provider: entry.provider,
-      kind: entry.kind,
+      kind: agent.key,
       label: entry.label,
       installed: binaryInstalled(agent),
-      // Credentials are per provider: the ai-sdk sibling reports the same
-      // login, so either kind being configured means this row is connected.
+      // Runtime API keys make the agent usable, but only a user-owned account
+      // login completes this first-run connection step.
       configured: agents.some(
-        (item) => entry.kinds.includes(item.key) && item.status.configured,
+        (item) => entry.kinds.includes(item.key) && item.status.accountConnected === true,
       ),
       canAutoSetup: agent.status.canAutoSetup,
     });


### PR DESCRIPTION
## What changed

- Added an explicit `accountConnected` status for Claude and Codex that excludes inherited platform API keys.
- Updated the embedded first-run gate to use that user-owned connection status and the actual agent roster keys (`aisdk` / `codex-aisdk`).
- Made newly written Claude credentials visible on the next poll instead of after the Keychain cache window.
- Added regressions for platform-key-only Computers and immediate post-login credential detection.

## Why

Fresh omg Computers inherit platform API keys so agents can run, but those keys were incorrectly treated as the user connecting Claude Code or Codex. The embedded connection card therefore disappeared even though the user had never signed in.

## Impact

A new embedded Computer now prompts the user to connect Claude Code or Codex, uses the existing browser login flow, and closes immediately after a real account login completes.

## Verification

- `bun test` — 291 passed, 0 failed
- `bun run typecheck` — clean
- `bun run build` in `web/` — clean