### PR TITLE
fix: use connected Claude account in SDK sessions

### DIFF
--- a/src/agents/backends/aisdk-session.ts
+++ b/src/agents/backends/aisdk-session.ts
@@ -38,6 +38,7 @@ import {
 } from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
 import { readFileSync, statSync } from "node:fs";
+import { claudeAccountEnv } from "../../claude-creds.ts";
 
 function arg(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
@@ -164,6 +165,7 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   } catch {}
 
   const claudePath = resolveClaudePath();
+  const accountEnv = claudeAccountEnv();
   const { query } = await import("@anthropic-ai/claude-agent-sdk");
 
   // Control-plane registry entry — the moment this exists (and our pid is alive),
@@ -234,9 +236,12 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
       includePartialMessages: true,
       ...(effort ? { effort } : {}),
       // env is a FULL replacement for the subprocess environment when set —
-      // omitting it inherits all of process.env (PATH/HOME/LFG_*/ANTHROPIC_*),
-      // which is exactly what we want. (The old Vercel provider's sanitizing
+      // without a connected account, inherit process.env so the platform proxy
+      // remains available. With a connected account, keep the full environment
+      // except the three platform Anthropic variables that override the user's
+      // ~/.claude/.credentials.json. (The old Vercel provider's sanitizing
       // allowlist dropped LFG_* and orphaned every lfg_create_subagent child.)
+      ...(accountEnv ? { env: accountEnv } : {}),
       ...(claudePath ? { pathToClaudeCodeExecutable: claudePath } : {}),
     },
   });

--- a/src/claude-creds-env.test.ts
+++ b/src/claude-creds-env.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_PLATFORM_ENV_KEYS,
+  claudeAccountEnv,
+} from "./claude-creds.ts";
+
+describe("claudeAccountEnv", () => {
+  test("keeps platform auth untouched when no Claude account is connected", () => {
+    const source = {
+      HOME: "/home/user",
+      ANTHROPIC_API_KEY: "platform",
+      ANTHROPIC_BASE_URL: "https://proxy.example",
+    };
+    expect(claudeAccountEnv(source, false)).toBeUndefined();
+    expect(source.ANTHROPIC_API_KEY).toBe("platform");
+  });
+
+  test("removes every competing Anthropic source and preserves unrelated env", () => {
+    const source = {
+      HOME: "/home/user",
+      PATH: "/usr/bin",
+      LFG_SESSION_ID: "session-1",
+      ANTHROPIC_API_KEY: "platform",
+      ANTHROPIC_AUTH_TOKEN: "platform-token",
+      ANTHROPIC_BASE_URL: "https://proxy.example",
+    };
+
+    const env = claudeAccountEnv(source, true);
+
+    expect(env).toEqual({
+      HOME: "/home/user",
+      PATH: "/usr/bin",
+      LFG_SESSION_ID: "session-1",
+    });
+    for (const key of CLAUDE_PLATFORM_ENV_KEYS) {
+      expect(env).not.toHaveProperty(key);
+    }
+    expect(source.ANTHROPIC_BASE_URL).toBe("https://proxy.example");
+  });
+});

--- a/src/claude-creds.ts
+++ b/src/claude-creds.ts
@@ -13,6 +13,12 @@ type ClaudeCreds = { claudeAiOauth?: { accessToken?: string } };
 let cached: { token: string | null; at: number } | null = null;
 const TTL_MS = 60_000;
 
+export const CLAUDE_PLATFORM_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+] as const;
+
 function readCredsFile(): ClaudeCreds | null {
   try {
     return JSON.parse(
@@ -54,4 +60,24 @@ export function claudeOauthToken(): string | null {
   const token = creds?.claudeAiOauth?.accessToken ?? null;
   cached = { token, at: Date.now() };
   return token;
+}
+
+/**
+ * Build the full environment for a Claude subprocess owned by a connected
+ * Claude account. The Agent SDK treats `env` as a complete replacement, so
+ * preserve every unrelated variable while removing the platform proxy/auth
+ * variables that otherwise override ~/.claude/.credentials.json.
+ */
+export function claudeAccountEnv(
+  source: NodeJS.ProcessEnv = process.env,
+  accountConnected = claudeOauthToken() !== null,
+): Record<string, string> | undefined {
+  if (!accountConnected) return undefined;
+  const blocked = new Set<string>(CLAUDE_PLATFORM_ENV_KEYS);
+  return Object.fromEntries(
+    Object.entries(source).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined && !blocked.has(entry[0]),
+    ),
+  );
 }

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -5,7 +5,10 @@ import { readFileSync, writeFileSync, existsSync, realpathSync, mkdirSync } from
 import { homedir } from "node:os";
 import { reposRoot } from "./projects";
 import { LFG_CAPABILITY_VERSION, withLfgRuntimeContract } from "./lfg-capabilities.ts";
-import { claudeOauthToken } from "./claude-creds.ts";
+import {
+  CLAUDE_PLATFORM_ENV_KEYS,
+  claudeOauthToken,
+} from "./claude-creds.ts";
 
 // Known-good Claude model alias to launch with when a caller doesn't specify
 // one. Never launch a managed `claude` bare — see spawnManagedSession. Opus is
@@ -148,12 +151,6 @@ export function claudeBin(): string {
   }
   return (_claudeBin = "claude"); // last resort: let the failure surface
 }
-
-const CLAUDE_PLATFORM_ENV_KEYS = [
-  "ANTHROPIC_API_KEY",
-  "ANTHROPIC_AUTH_TOKEN",
-  "ANTHROPIC_BASE_URL",
-] as const;
 
 /**
  * A connected Claude account must be the only auth source visible to Claude.


### PR DESCRIPTION
## Summary
- sanitize the Claude Agent SDK subprocess environment when a Claude subscription credential exists
- keep the platform proxy untouched when no account is connected
- share the platform-env key list with direct tmux Claude launches

## Root cause
v0.1.84 fixed direct `claude` tmux launches, but the default embedded “claude” session is the Agent SDK harness. That harness still inherited `ANTHROPIC_*`, so the platform proxy overrode the connected account and returned 402.

## Verification
- `bun test` — 300 passed / 0 failed
- `bunx tsc -p tsconfig.json --noEmit` passed