### PR TITLE
Add session list edge fade

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9043,7 +9043,7 @@ function RailStage({
             </div>
           </div>
         )}
-        <div className="min-h-0 flex-1 overflow-y-auto px-1.5 py-2">
+        <div className="session-list-scroll min-h-0 flex-1 overflow-y-auto px-1.5 py-2">
           {topPinnedSessions.length ? (
             <RailGroup
               label="Pinned"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -651,6 +651,26 @@ html.lfg-keyboard-open {
     contain: layout paint;
   }
 
+  /* Let the fixed session-rail chrome frame the scrollable rows without a
+     hard clipping line. A mask keeps the fade purely visual, so the full
+     scroll surface remains interactive. Include the prefixed form for Safari. */
+  .session-list-scroll {
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      black 0.75rem,
+      black calc(100% - 0.75rem),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      black 0.75rem,
+      black calc(100% - 0.75rem),
+      transparent 100%
+    );
+  }
+
   .chat-stream {
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## What changed

Adds a soft top-and-bottom fade to the desktop session rail's scroll viewport. The effect uses a CSS mask, including Safari's prefixed form, so it does not add click-blocking overlay elements.

## Why

Session rows previously ended against hard viewport clipping at the fixed rail header and bottom edge. The fade makes the scroll boundary feel intentional and communicates that more sessions continue beyond the visible area.

## Validation

- `bun run build` in `web/` (TypeScript + production Vite build)
- Playwright visual check at a mid-list scroll position
- Verified computed standard and WebKit mask styles
- `git diff --check`