### PR TITLE
Make shipped sessions terminal and resumable

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1065,8 +1065,8 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
     const timer = setInterval(() => void pollSessionEvents(seen, () => currentWs), EVENTS_POLL_MS);
     timer.unref?.();
     // Shipped-post watcher — same opt-in, same cadence, same best-effort
-    // posture. A ship (lfg_ship / POST /api/shipped) is an explicit showcase,
-    // so it's forwarded as its own `ship.posted` frame with the summary.
+    // posture. A ship (lfg_ship / POST /api/shipped) is an explicit terminal
+    // result, so it's forwarded as its own `ship.posted` frame with the summary.
     const shipState = { seenShips: new Map<string, number>(), seeded: false };
     const shipTimer = setInterval(() => void pollShipEvents(shipState, () => currentWs), EVENTS_POLL_MS);
     shipTimer.unref?.();

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -931,7 +931,7 @@ export async function cmdMcp() {
     {
       title: "Post To The LFG Shipped Channel",
       description:
-        "Showcase finished work in the LFG Shipped channel — a feed of what agents completed, with visuals. Call this when you finish something worth showing. Write it like a launch tweet: a punchy headline + at most 1-2 short sentences on WHAT shipped and why it matters. NOT a changelog — no bullet lists, no headings, no implementation detail, no file names; the session transcript already holds all of that. Attach the screenshots/recordings you captured while verifying (mediaPaths), or embed an existing artifact like a live dashboard (artifactIds). Images are optimized automatically before storage. To UPDATE an earlier post (e.g. after follow-up feedback), pass its id — the post revises in place and the feed shows the new version.",
+        "TERMINAL ACTION: post the assigned task's successful final result in the LFG Shipped/Finished channel, then automatically close this source session into the resumable finished-session roster. This includes completed changes, docs/analysis, verified no-ops, and work found already complete; never use it for planning, partial, blocked, or still-unverified work. Call it only after all work is complete, and do not continue after it succeeds. Write it like a launch tweet: a punchy headline + at most 1-2 short sentences on the outcome and why it matters. NOT a changelog — no bullet lists, no headings, no implementation detail, no file names; the session transcript already holds all of that. Attach the strongest evidence when available. To UPDATE an earlier post after a resumed follow-up, pass its id — the post revises in place and the session closes again.",
       inputSchema: {
         title: z.string().min(1).describe("Short headline for what shipped (e.g. 'WhatsApp reconnect loop fixed')."),
         id: z.string().optional().describe("Existing ship post id to update in place (returned when the post was created)."),
@@ -952,12 +952,16 @@ export async function cmdMcp() {
     },
     async ({ title, id, summary, mediaPaths, artifactIds, project, sessionId }) => {
       const sid = await activeSessionId(sessionId);
-      const data = await api<{ ok: boolean; post: unknown }>("/api/shipped", {
+      const data = await api<{
+        ok: boolean;
+        post: unknown;
+        session?: { status: "closing"; resumable: boolean };
+      }>("/api/shipped", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title, id, summary, mediaPaths, artifactIds, project, sessionId: sid }),
       });
-      return result({ shipped: true, post: data.post });
+      return result({ shipped: true, post: data.post, session: data.session });
     },
   );
 
@@ -1116,12 +1120,12 @@ export async function cmdMcp() {
         "The single verb for everything you send to the human. NARRATE your decisions and progress here as you work — do not go dark. `to` picks the destination: " +
         "'thread' delivers text and/or media back to the channel that launched this session (e.g. iMessage) — this is your default running narration; " +
         "'session' shows evidence inline in the LFG transcript (a screenshot/recording via `media`, or a self-contained HTML report/dashboard via `html`); " +
-        "'shipped' posts a finished, verified result to the Shipped feed (`title` + tweet-length `text`, plus the strongest `media`). " +
+        "'shipped' is terminal: it posts a finished, verified result to the Shipped feed (`title` + tweet-length `text`, plus the strongest `media`), then automatically closes the source session so it can be resumed later. Use it only as your final action and do not continue after success. " +
         "Attach local files with `media` (images/videos by absolute path) and/or existing artifacts with `artifactIds`. Re-use `id` to update an artifact or ship post in place. This is non-blocking — never wait after calling it.",
       inputSchema: {
         to: z
           .enum(["thread", "session", "shipped"])
-          .describe("Destination: 'thread' (originating channel / iMessage — your running narration), 'session' (inline transcript evidence), 'shipped' (verified completion feed)."),
+          .describe("Destination: 'thread' (originating channel / iMessage — your running narration), 'session' (inline transcript evidence), 'shipped' (terminal verified completion: post result, close source session, remain resumable)."),
         text: z
           .string()
           .max(4_000)
@@ -1148,12 +1152,16 @@ export async function cmdMcp() {
       }
       if (to === "shipped") {
         const sid = await activeSessionId(sessionId);
-        const data = await api<{ ok: boolean; post: unknown }>("/api/shipped", {
+        const data = await api<{
+          ok: boolean;
+          post: unknown;
+          session?: { status: "closing"; resumable: boolean };
+        }>("/api/shipped", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ title, id, summary: text, mediaPaths: media, artifactIds, project, sessionId: sid }),
         });
-        return result({ shipped: true, post: data.post });
+        return result({ shipped: true, post: data.post, session: data.session });
       }
       // to === "session"
       if (html !== undefined) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1181,6 +1181,50 @@ async function closeLiveSession(
   return { ok: true, mode };
 }
 
+// Shipping is a terminal lifecycle transition, but the POST response has to
+// reach the calling agent before its tmux session disappears. Persist the
+// resumable record synchronously at the call site, then close from a short
+// deferred task. This is the same response-flush grace period used for terminal
+// subagent reports below.
+const SHIPPED_CLOSE_DELAY_MS = 1_500;
+
+function scheduleShippedSessionClose(sessionId: string): void {
+  setTimeout(() => {
+    void (async () => {
+      const sess = (await listSessions()).find(
+        (session) =>
+          session.sessionId === sessionId || session.nativeSessionId === sessionId,
+      );
+      if (!sess) {
+        evlog("shipped_session_close_skipped", {
+          sessionId,
+          source: "shipped_terminal_state",
+          reason: "not_live",
+        });
+        return;
+      }
+      const outcome = await closeLiveSession(sess, sess.sessionId ?? sessionId, {
+        sessionId: sess.sessionId ?? sessionId,
+        source: "shipped_terminal_state",
+      });
+      if (!outcome.ok) {
+        evlog("shipped_session_close_failed", {
+          sessionId: sess.sessionId ?? sessionId,
+          source: "shipped_terminal_state",
+          reason: outcome.reason,
+          status: outcome.status,
+        });
+      }
+    })().catch((error) => {
+      evlog("shipped_session_close_failed", {
+        sessionId,
+        source: "shipped_terminal_state",
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, SHIPPED_CLOSE_DELAY_MS);
+}
+
 type ParentableSession = {
   sessionId?: string | null;
   nativeSessionId?: string | null;
@@ -5094,7 +5138,33 @@ export async function cmdServe() {
                 )?.agent
               : undefined;
             const post = await addShipPost({ ...body, agent: body.agent ?? sourceAgent, title: shipTitle });
-            return json({ ok: true, post });
+            const sourceSession = body.sessionId
+              ? (await listSessions()).find(
+                  (session) =>
+                    session.sessionId === body.sessionId ||
+                    session.nativeSessionId === body.sessionId,
+                )
+              : undefined;
+            if (sourceSession && body.sessionId) {
+              // Make the resumable row durable before acknowledging the ship.
+              // The deferred close repeats this defensively, but doing it now
+              // guarantees the finished session is recoverable even if serve
+              // restarts during the response-flush grace period.
+              persistManagedResume(sourceSession);
+              scheduleShippedSessionClose(body.sessionId);
+              evlog("shipped_session_close_scheduled", {
+                sessionId: sourceSession.sessionId ?? body.sessionId,
+                source: "shipped_terminal_state",
+                delayMs: SHIPPED_CLOSE_DELAY_MS,
+              });
+            }
+            return json({
+              ok: true,
+              post,
+              session: sourceSession
+                ? { status: "closing", resumable: true }
+                : undefined,
+            });
           } catch (e) {
             return err(400, e instanceof Error ? e.message : "could not add shipped post");
           }

--- a/src/lfg-capabilities.test.ts
+++ b/src/lfg-capabilities.test.ts
@@ -14,6 +14,8 @@ describe("LFG runtime capabilities", () => {
     expect(prompt).toContain("lfg_input");
     expect(prompt).toContain("to:'thread'");
     expect(prompt).toContain("to:'shipped'");
+    expect(prompt).toContain("SHIP IS TERMINAL");
+    expect(prompt).toContain("automatically closes this session");
     expect(prompt).toContain("lfg_find_sessions");
     expect(prompt).toContain("lfg_close_session");
     expect(prompt).toEndWith("=== USER TASK ===\nFix the mobile navigation");

--- a/src/lfg-capabilities.ts
+++ b/src/lfg-capabilities.ts
@@ -3,14 +3,14 @@ import type { CodingAgentKind } from "./coding-agents.ts";
 // Bump whenever an agent-facing LFG capability or its operating guidance
 // changes. Managed sessions persist the value they launched with, which lets
 // the UI identify long-lived sessions whose MCP/tool catalog predates a ship.
-export const LFG_CAPABILITY_VERSION = "2026-07-24.1";
+export const LFG_CAPABILITY_VERSION = "2026-07-29.1";
 
 export const LFG_CAPABILITIES = [
   {
     tool: "lfg_output",
     useWhen: "Anything you send to the human — running narration, inline evidence, or a verified completion. This is the tell verb; use it continuously so a session never goes dark.",
     guidance:
-      "Narrate decisions/progress with to:'thread' (the originating channel, e.g. iMessage). Show evidence inline with to:'session' (media or self-contained html). Post a verified completion with to:'shipped' (headline + tweet-length blurb + strongest media). Non-blocking; the adapter owns transport/identity — never request phone numbers or credentials.",
+      "Narrate decisions/progress with to:'thread' (the originating channel, e.g. iMessage). Show evidence inline with to:'session' (media or self-contained html). When the assigned task reaches a successful terminal outcome, post its result with to:'shipped' only as the final action; this closes the session and leaves it resumable. The adapter owns transport/identity — never request phone numbers or credentials.",
   },
   {
     tool: "lfg_input",
@@ -61,7 +61,7 @@ export function lfgRuntimeContract(): string {
     "- The whole agent<->human channel is TWO verbs: `lfg_output` (tell the human) and `lfg_input` (ask the human). Reach for these first.",
     "- NARRATE as you work: keep the human posted through `lfg_output` with `to:'thread'` at each meaningful decision or step. Do not go dark — a silent session is a failed session. This is a duty, not an option.",
     "- Show evidence with `lfg_output` `to:'session'` — attach screenshots/recordings as `media`, or publish a self-contained report/dashboard as `html` (re-use `id` to update in place).",
-    "- When material user-visible work is complete and verified, use `lfg_output` `to:'shipped'` with a concise headline + tweet-length blurb and the strongest media. Do not ship diagnosis, planning, partial, invisible, or trivial work.",
+    "- SHIP IS TERMINAL: when the assigned task reaches a successful terminal outcome (including a completed fix/feature, docs or analysis, a verified no-op, or work already completed elsewhere), make `lfg_output` `to:'shipped'` your final action with a concise headline + tweet-length result and the strongest evidence. A successful ship automatically closes this session into the resumable finished-session roster. Put the result in that ship post; do not continue working or send another message afterward. Do not ship planning, diagnosis-in-progress, partial work, or blocked work.",
     "- DECIDE, don't park: make the reasonable call yourself and narrate it. Use `lfg_input` (`from:'user'`) ONLY for a genuinely irreversible, risky, or ambiguous decision — never to check in or report progress. It is fire-and-forget: do not poll or block; the answer arrives later. Use `from:'advisor'` to consult LFG's advisor.",
     "- The channel adapter owns transport identity and credentials; never request phone numbers or channel credentials.",
     "- Use `lfg_find_sessions` to locate ended or historical sessions by id, owner, project, text, or last-activity range; use `lfg_list_sessions` for the live fleet.",

--- a/src/shipped.ts
+++ b/src/shipped.ts
@@ -1,5 +1,6 @@
-// The "Shipped" channel: a curated feed agents post to when they finish
-// something worth showing — title, a short summary, and rich media. Media
+// The "Shipped" channel: the finished-session feed agents post to when an
+// assigned task reaches a successful terminal outcome — title, a short result,
+// and optional rich media. Media
 // entries are ordinary artifacts (image / video / html), so the feed reuses
 // the artifact store, serving, and sandboxing wholesale.
 //

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5646,6 +5646,15 @@ export function App() {
                 setTab("live");
                 setLiveFocus({ sid, n: Date.now() });
               }}
+              onResumeSession={async (sid) => {
+                const resumed = await api<{ sessionId?: string }>("/api/sessions/resume", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ sessionId: sid, user: identity || undefined }),
+                });
+                await refreshSessions();
+                return resumed.sessionId || sid;
+              }}
             />
           </div>
         ) : null}
@@ -17809,24 +17818,43 @@ function ShipMedia({
   );
 }
 
-// Read-only transcript view for a ship post whose session is no longer live:
-// clicking the post can't drop you into a running chat, so show what the agent
-// did instead. Live sessions skip this entirely and jump into the session.
-function ShipTranscriptSheet({ post, onClose }: { post: ShipPost; onClose: () => void }) {
-  const [messages, setMessages] = useState<Message[] | null>(null);
+// A shipped session uses the exact same transcript renderer as a live session.
+// The only different chrome is lifecycle-aware: it is read-only while closed
+// and offers a single Resume action that returns it to the live fleet.
+function ShipTranscriptSheet({
+  post,
+  onClose,
+  onResume,
+}: {
+  post: ShipPost;
+  onClose: () => void;
+  onResume: (sessionId: string) => Promise<void>;
+}) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [nextBefore, setNextBefore] = useState<number | null>(null);
+  const [resuming, setResuming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let alive = true;
+    setMessages([]);
+    setNextBefore(null);
+    setLoading(true);
+    setError(null);
     (async () => {
       try {
-        const data = await api<{ messages: Message[] }>(
-          `/api/sessions/${post.sessionId}/messages?limit=60`,
+        const data = await api<{ messages: Message[]; nextBefore?: number | null }>(
+          `/api/sessions/${encodeURIComponent(post.sessionId ?? "")}/messages?limit=80`,
           { cache: "no-store" },
         );
-        if (alive) setMessages(data.messages);
+        if (!alive) return;
+        setMessages(Array.isArray(data.messages) ? data.messages : []);
+        setNextBefore(data.nextBefore ?? null);
       } catch (e) {
         if (alive) setError(e instanceof Error ? e.message : "Couldn't load the transcript");
+      } finally {
+        if (alive) setLoading(false);
       }
     })();
     return () => {
@@ -17834,13 +17862,42 @@ function ShipTranscriptSheet({ post, onClose }: { post: ShipPost; onClose: () =>
     };
   }, [post.sessionId]);
 
-  const visible = (messages ?? []).filter(
-    (m) => m.kind === "text" || m.kind === "image" || m.kind === "video" || m.kind === "html",
+  const loadOlderMessages = useCallback<LoadOlderMessages>(
+    async (sid) => {
+      const before = nextBefore;
+      if (before == null) return false;
+      const page = await api<{ messages: Message[]; nextBefore?: number | null }>(
+        `/api/sessions/${encodeURIComponent(sid)}/messages?page=backward&before=${before}&limit=80`,
+        { cache: "no-store" },
+      );
+      const older = Array.isArray(page.messages) ? page.messages : [];
+      setMessages((current) => {
+        const seen = new Set(current.map((message) => message.id).filter(Boolean));
+        const prepend = older.filter((message) => !message.id || !seen.has(message.id));
+        return prepend.length ? [...prepend, ...current] : current;
+      });
+      const next = page.nextBefore ?? null;
+      setNextBefore(next);
+      return next !== null;
+    },
+    [nextBefore],
   );
+
+  const resume = async () => {
+    if (!post.sessionId || resuming) return;
+    setResuming(true);
+    setError(null);
+    try {
+      await onResume(post.sessionId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't resume the session");
+      setResuming(false);
+    }
+  };
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center"
+      className="fixed inset-0 z-[140] flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center"
       onClick={onClose}
     >
       <div
@@ -17853,9 +17910,20 @@ function ShipTranscriptSheet({ post, onClose }: { post: ShipPost; onClose: () =>
               {post.sessionTitle ?? post.title}
             </div>
             <div className="text-[11px] text-muted-foreground">
-              Session ended · read-only transcript
+              Shipped · ready to resume
             </div>
           </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={!post.sessionId || resuming}
+            onClick={() => void resume()}
+            className="h-8 rounded-full"
+          >
+            {resuming ? <Loader2 className="size-3.5 animate-spin" /> : <RotateCcw className="size-3.5" />}
+            {resuming ? "Resuming…" : "Resume"}
+          </Button>
           <button
             type="button"
             onClick={onClose}
@@ -17865,53 +17933,14 @@ function ShipTranscriptSheet({ post, onClose }: { post: ShipPost; onClose: () =>
             <X className="size-4" />
           </button>
         </div>
-        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4">
-          {error ? <div className="text-sm text-destructive">{error}</div> : null}
-          {messages === null && !error ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
-          ) : null}
-          {messages !== null && visible.length === 0 ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              No transcript available for this session.
-            </div>
-          ) : null}
-          {visible.map((m, i) => {
-            if ((m.kind === "image" || m.kind === "video") && m.url) {
-              return m.kind === "video" ? (
-                <video key={m.id ?? i} src={m.url} controls playsInline preload="metadata" className="max-h-60 rounded-lg" />
-              ) : (
-                <ZoomableImage key={m.id ?? i} src={m.url} alt={m.alt || m.name || "media"} className="max-h-60 rounded-lg border border-border/60" />
-              );
-            }
-            if (m.kind === "html" && m.url) {
-              return (
-                <a
-                  key={m.id ?? i}
-                  href={m.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-primary hover:bg-foreground/[0.03]"
-                >
-                  <LayoutDashboard className="size-3.5" />
-                  {m.title || m.caption || m.name || "Artifact"}
-                </a>
-              );
-            }
-            const isUser = m.role === "user";
-            return (
-              <div key={m.id ?? i} className={cn("flex", isUser && "justify-end")}>
-                <div
-                  className={cn(
-                    "max-w-[85%] rounded-2xl px-3 py-2 text-[13px] leading-relaxed",
-                    isUser ? "bg-primary/10" : "bg-card/60 border border-border/60",
-                  )}
-                >
-                  <MessageResponse>{m.text ?? ""}</MessageResponse>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        {error ? <div className="border-b border-border/70 px-3 py-1.5 text-xs text-destructive">{error}</div> : null}
+        <ChatStream
+          sid={post.sessionId ?? null}
+          messages={messages}
+          busy={false}
+          loading={loading}
+          onLoadOlderMessages={loadOlderMessages}
+        />
       </div>
     </div>
   );
@@ -17932,11 +17961,13 @@ const GALLERY_PAGE = 24;
 // free, and revalidate once when it becomes active again.
 function ShippedPage({
   onOpenSession,
+  onResumeSession,
   liveSessionIds,
   artifactsOnly = false,
   active = true,
 }: {
   onOpenSession: (sessionId: string) => void;
+  onResumeSession?: (sessionId: string) => Promise<string>;
   liveSessionIds: Set<string>;
   artifactsOnly?: boolean;
   active?: boolean;
@@ -17967,6 +17998,13 @@ function ShippedPage({
   const postsLen = useRef(Math.max(FEED_PAGE, cachedPosts?.items.length ?? 0));
   const openArtifact = useContext(ArtifactViewerContext);
   const appDialog = useAppDialog();
+
+  const resumeShippedSession = async (sessionId: string) => {
+    if (!onResumeSession) throw new Error("Session resume is unavailable");
+    const liveSessionId = await onResumeSession(sessionId);
+    setViewing(null);
+    onOpenSession(liveSessionId);
+  };
 
   useEffect(() => {
     if (view !== "artifacts") return;
@@ -18173,7 +18211,9 @@ function ShippedPage({
           </h1>
           {artifactsOnly ? (
             <p className="mt-0.5 text-xs text-muted-foreground">Interactive reports and live dashboards</p>
-          ) : null}
+          ) : (
+            <p className="mt-0.5 text-xs text-muted-foreground">Finished sessions · review or resume anytime</p>
+          )}
         </div>
       </div>
 
@@ -18279,8 +18319,7 @@ function ShippedPage({
 
       {posts !== null && posts.length === 0 ? (
         <div className="rounded-2xl border border-border bg-card/40 px-4 py-10 text-center text-sm text-muted-foreground">
-          Nothing shipped yet — agents post here (via <code>lfg_ship</code>) when they finish
-          something worth showing.
+          Nothing finished yet — agents post their final result here before the session closes.
         </div>
       ) : null}
 
@@ -18294,8 +18333,8 @@ function ShippedPage({
             return (
               <article key={post.id} className="border-b border-border/50 pb-3 last:border-b-0">
                 {/* Tapping the post opens the conversation: straight into the
-                    live session when it's still running, read-only transcript
-                    when not. */}
+                    live session when it's still running, the same shared chat
+                    renderer plus Resume when it has shipped and closed. */}
                 <button
                   type="button"
                   onClick={() => {
@@ -18375,7 +18414,13 @@ function ShippedPage({
       ) : null}
         </>
       )}
-      {viewing ? <ShipTranscriptSheet post={viewing} onClose={() => setViewing(null)} /> : null}
+      {viewing ? (
+        <ShipTranscriptSheet
+          post={viewing}
+          onClose={() => setViewing(null)}
+          onResume={resumeShippedSession}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- Treat a successful Shipped result as an explicit terminal session transition.
- Persist resumable metadata before closing the source session after a response-flush grace period.
- Strengthen the runtime contract so successful outcomes finish through `lfg_output(to: 'shipped')`, while partial and blocked work remain live.
- Reuse the normal chat transcript renderer for finished sessions and add one-tap Resume.
- Fix the finished-session sheet stacking above the mobile composer.

## Why

Shipped posts previously updated only the showcase feed. The source agent stayed in the live fleet, and ended shipped sessions opened a separate transcript renderer. That made completed work hard to distinguish from ongoing work and created UI drift.

## Impact

Finished work now leaves Live automatically but remains recoverable. Users can review it in Shipped/Finished with the same conversation rendering as Live and resume it when follow-up work is needed.

## Validation

- `bun run build:packages`
- `bun test` — 301 passing
- `bun run typecheck`
- `bun run build` in `web/`
- Desktop and mobile browser verification of the finished-session transcript and Resume UI