### PR TITLE
test(sessions): cover durable recovery across agents

### DIFF
--- a/src/coding-agent-adapters.ts
+++ b/src/coding-agent-adapters.ts
@@ -5,18 +5,24 @@ export type CodingAgentTransport = "tmux" | "command-file";
 export type CodingAgentAdapter = {
   transport: CodingAgentTransport;
   managedLaunch: true;
+  /**
+   * durable: a dead agent process can be relaunched from persisted history.
+   * process-bound: LFG can rediscover the live process after serve restarts,
+   * but cannot recreate the provider conversation after that process dies.
+   */
+  recovery: "durable" | "process-bound";
 };
 
 export const CODING_AGENT_ADAPTERS = {
-  claude: { transport: "tmux", managedLaunch: true },
-  codex: { transport: "tmux", managedLaunch: true },
-  grok: { transport: "tmux", managedLaunch: true },
-  cursor: { transport: "tmux", managedLaunch: true },
-  copilot: { transport: "tmux", managedLaunch: true },
-  aisdk: { transport: "command-file", managedLaunch: true },
-  "codex-aisdk": { transport: "command-file", managedLaunch: true },
-  opencode: { transport: "command-file", managedLaunch: true },
-  pi: { transport: "command-file", managedLaunch: true },
+  claude: { transport: "tmux", managedLaunch: true, recovery: "durable" },
+  codex: { transport: "tmux", managedLaunch: true, recovery: "durable" },
+  grok: { transport: "tmux", managedLaunch: true, recovery: "durable" },
+  cursor: { transport: "tmux", managedLaunch: true, recovery: "durable" },
+  copilot: { transport: "tmux", managedLaunch: true, recovery: "process-bound" },
+  aisdk: { transport: "command-file", managedLaunch: true, recovery: "durable" },
+  "codex-aisdk": { transport: "command-file", managedLaunch: true, recovery: "durable" },
+  opencode: { transport: "command-file", managedLaunch: true, recovery: "durable" },
+  pi: { transport: "command-file", managedLaunch: true, recovery: "durable" },
 } as const satisfies Record<Exclude<CodingAgentKind, "hermes">, CodingAgentAdapter>;
 
 export const SESSION_AGENT_KINDS = [
@@ -45,6 +51,10 @@ export const COMMAND_FILE_AGENT_KINDS = [
   "opencode",
   "pi",
 ] as const satisfies readonly CodingAgentKind[];
+
+export const DURABLE_RECOVERY_AGENT_KINDS = SESSION_AGENT_KINDS.filter(
+  (agent) => CODING_AGENT_ADAPTERS[agent].recovery === "durable",
+);
 
 export function isCommandFileAgent(agent: string | null | undefined): agent is (typeof COMMAND_FILE_AGENT_KINDS)[number] {
   return !!agent && COMMAND_FILE_AGENT_KINDS.includes(agent as (typeof COMMAND_FILE_AGENT_KINDS)[number]);

--- a/src/session-recovery.integration.test.ts
+++ b/src/session-recovery.integration.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CODING_AGENT_ADAPTERS,
+  DURABLE_RECOVERY_AGENT_KINDS,
+  SESSION_AGENT_KINDS,
+} from "./coding-agent-adapters.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function run(cmd: string[], env?: Record<string, string>): ReturnType<typeof Bun.spawnSync> {
+  return Bun.spawnSync({
+    cmd,
+    cwd: import.meta.dir,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function output(result: ReturnType<typeof Bun.spawnSync>, stream: "stdout" | "stderr"): string {
+  return new TextDecoder().decode(result[stream]);
+}
+
+describe("session recovery integration", () => {
+  test("every coding agent has an explicit recovery contract", () => {
+    expect(Object.keys(CODING_AGENT_ADAPTERS).sort()).toEqual([...SESSION_AGENT_KINDS].sort());
+    expect([...DURABLE_RECOVERY_AGENT_KINDS].sort()).toEqual([
+      "aisdk",
+      "claude",
+      "codex",
+      "codex-aisdk",
+      "cursor",
+      "grok",
+      "opencode",
+      "pi",
+    ]);
+    expect(CODING_AGENT_ADAPTERS.copilot.recovery).toBe("process-bound");
+  });
+
+  test("every durable backend hands its recovery id across the tmux process boundary", () => {
+    const root = tempRoot("lfg-recovery-launch-");
+    const fakeBin = join(root, "bin");
+    const capture = join(root, "tmux-argv.json");
+    const fakeTmux = join(fakeBin, "tmux");
+    const fakeHome = join(root, "home");
+    mkdirSync(fakeBin, { recursive: true });
+    mkdirSync(fakeHome, { recursive: true });
+    writeFileSync(fakeTmux, [
+      "#!/usr/bin/env bun",
+      "const capture = process.env.LFG_TEST_TMUX_CAPTURE;",
+      "if (!capture) process.exit(2);",
+      "await Bun.write(capture, JSON.stringify(process.argv.slice(2)));",
+    ].join("\n"));
+    chmodSync(fakeTmux, 0o755);
+
+    const resume = "33333333-3333-4333-8333-333333333333";
+    for (const agent of DURABLE_RECOVERY_AGENT_KINDS) {
+      rmSync(capture, { force: true });
+      const result = run([
+        process.execPath,
+        join(import.meta.dir, "test-support", "recovery-launch-process.ts"),
+        agent,
+        root,
+        resume,
+      ], {
+        HOME: fakeHome,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        LFG_TEST_TMUX_CAPTURE: capture,
+      });
+
+      expect(result.exitCode, `${agent}: ${output(result, "stderr")}`).toBe(0);
+      const argv = JSON.parse(readFileSync(capture, "utf8")) as string[];
+      expect(argv, agent).toContain("new-session");
+      if (agent === "claude" || agent === "aisdk") {
+        const at = argv.indexOf("--session");
+        expect(argv.slice(at, at + 2), agent).toEqual(["--session", resume]);
+      } else {
+        const at = argv.indexOf("--resume");
+        expect(argv.slice(at, at + 2), agent).toEqual(["--resume", resume]);
+      }
+    }
+  });
+
+  test("a fresh process rehydrates the roster written by a previous process", () => {
+    const root = tempRoot("lfg-registry-restart-");
+    const helper = join(import.meta.dir, "test-support", "managed-registry-process.ts");
+
+    const writer = run([process.execPath, helper, "write", root]);
+    expect(writer.exitCode, output(writer, "stderr")).toBe(0);
+
+    const reader = run([process.execPath, helper, "read", root]);
+    expect(reader.exitCode, output(reader, "stderr")).toBe(0);
+    expect(JSON.parse(output(reader, "stdout"))).toEqual([
+      expect.objectContaining({
+        tmuxName: "lfg-cross-process",
+        sessionId: "11111111-1111-4111-8111-111111111111",
+        nativeSessionId: "22222222-2222-4222-8222-222222222222",
+        title: "Survives a real process restart",
+        launchState: "running",
+      }),
+    ]);
+  });
+});

--- a/src/test-support/managed-registry-process.ts
+++ b/src/test-support/managed-registry-process.ts
@@ -1,0 +1,27 @@
+import { PATHS } from "../config.ts";
+import { addManaged, listManaged } from "../managed.ts";
+
+const action = process.argv[2];
+const dataDir = process.argv[3];
+
+if (!action || !dataDir) {
+  console.error("usage: managed-registry-process <write|read> <data-dir>");
+  process.exit(2);
+}
+
+PATHS.data = dataDir;
+
+if (action === "write") {
+  addManaged({
+    tmuxName: "lfg-cross-process",
+    cwd: "/tmp/recovery-project",
+    createdAt: 123,
+    agent: "codex-aisdk",
+    sessionId: "11111111-1111-4111-8111-111111111111",
+    nativeSessionId: "22222222-2222-4222-8222-222222222222",
+    launchState: "running",
+    title: "Survives a real process restart",
+  });
+}
+
+console.log(JSON.stringify(listManaged()));

--- a/src/test-support/recovery-launch-process.ts
+++ b/src/test-support/recovery-launch-process.ts
@@ -1,0 +1,68 @@
+import {
+  spawnManagedAisdkSession,
+  spawnManagedCodexAisdkSession,
+  spawnManagedCursorSession,
+  spawnManagedGrokSession,
+  spawnManagedOpencodeAisdkSession,
+  spawnManagedPiSession,
+} from "../tmux.ts";
+import type { CodingAgentKind } from "../coding-agents.ts";
+
+const agent = process.argv[2] as CodingAgentKind | undefined;
+const cwd = process.argv[3];
+const resume = process.argv[4];
+
+if (!agent || !cwd || !resume) {
+  console.error("usage: recovery-launch-process <agent> <cwd> <resume-id>");
+  process.exit(2);
+}
+
+const common = {
+  name: `recovery-${agent}`,
+  cwd,
+  prompt: "continue",
+  model: "test-model",
+  lfgSessionId: resume,
+};
+
+// These cases intentionally mirror /api/sessions/resume. Historical Claude
+// and direct Codex sessions recover through their SDK harnesses; the other
+// durable backends relaunch their own managed transport.
+const result = agent === "claude" || agent === "aisdk"
+  ? spawnManagedAisdkSession({
+      ...common,
+      model: "opus",
+      sessionId: resume,
+    })
+  : agent === "codex" || agent === "codex-aisdk"
+    ? spawnManagedCodexAisdkSession({
+        ...common,
+        key: `key-${resume}`,
+        resume,
+      })
+    : agent === "opencode"
+      ? spawnManagedOpencodeAisdkSession({
+          ...common,
+          key: `key-${resume}`,
+          resume,
+        })
+      : agent === "pi"
+        ? spawnManagedPiSession({
+            ...common,
+            key: `key-${resume}`,
+            resume,
+          })
+        : agent === "grok"
+          ? spawnManagedGrokSession({
+              ...common,
+              resume,
+            })
+          : agent === "cursor"
+            ? spawnManagedCursorSession({
+                ...common,
+                nativeSessionId: resume,
+              })
+            : { ok: false, error: `${agent} has no durable recovery launcher` };
+
+console.log(JSON.stringify(result));
+if (!result.ok) process.exit(1);


### PR DESCRIPTION
## What changed

- gives every coding-agent adapter an explicit durable or process-bound recovery contract
- adds a hermetic child-process integration test for recovery-ID handoff across every durable backend
- adds a two-process registry test proving the managed session roster rehydrates after a real process restart

## Why

The resume and crash-recovery fixes had strong unit coverage, but no exhaustive process-bound test covering every supported coding agent. This makes recovery expectations explicit and prevents newly added agents from silently skipping recovery classification.

## Scope

Copilot remains intentionally process-bound because it has no durable provider resume handle after its process dies. Claude, Codex, AI SDK, Codex AI SDK, Cursor, Grok, OpenCode, and Pi are covered as durable recovery paths.

## Verification

- `bun test src/session-recovery.integration.test.ts` — 3 passed, 30 assertions
- `bun test` — 304 passed, 830 assertions
- `bun run typecheck`
- `git diff --check`