### PR TITLE
fix(web): route embedded uploads through host transport

### DIFF
--- a/test/upload-transport.test.ts
+++ b/test/upload-transport.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test";
+import { uploadFile } from "../web/src/lib/upload";
+
+test("uploadFile sends chunks through its runtime transport", async () => {
+  const requests: Array<{ path: string; init?: RequestInit }> = [];
+  const progress: number[] = [];
+  const file = new File(["image bytes"], "image.png", { type: "image/png" });
+
+  const uploaded = await uploadFile<{ path: string; name: string }>(
+    async (path, init) => {
+      requests.push({ path, init });
+      return Response.json({
+        path: "/tmp/lfg-uploads/image.png",
+        name: "image.png",
+      });
+    },
+    "/api/uploads?filename=image.png",
+    file,
+    file.type,
+    (value) => progress.push(value),
+  );
+
+  expect(uploaded).toEqual({
+    path: "/tmp/lfg-uploads/image.png",
+    name: "image.png",
+  });
+  expect(requests).toHaveLength(1);
+  expect(requests[0]!.path).toMatch(
+    /^\/api\/uploads\?filename=image\.png&uploadId=[0-9a-f-]+&offset=0&total=11$/,
+  );
+  expect(requests[0]!.init?.method).toBe("POST");
+  expect(new Headers(requests[0]!.init?.headers).get("Content-Type")).toBe(
+    "image/png",
+  );
+  expect(requests[0]!.init?.body).toBeInstanceOf(Blob);
+  expect(progress).toEqual([100]);
+});
+
+test("uploadFile retains the runtime response error", async () => {
+  const file = new File(["x"], "x.txt", { type: "text/plain" });
+
+  await expect(
+    uploadFile(
+      async () => Response.json({ error: "disk is full" }, { status: 507 }),
+      "/api/uploads",
+      file,
+      file.type,
+      () => {},
+    ),
+  ).rejects.toThrow("disk is full");
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from "./lib/embedded-connect";
 import { emitSessionCreatedToHost } from "./lib/embed-host-signal";
 import { api, lfgAssetUrl, lfgFetch } from "./lib/lfg-client";
+import { uploadFile as uploadFileThroughTransport } from "./lib/upload";
 import { EmbeddedConnectGate } from "./components/embedded-connect-gate";
 import {
   isComputerHostResumeMessage,
@@ -984,52 +985,13 @@ function uploadFile<T>(
   contentType: string,
   onProgress: (progress: number) => void,
 ): Promise<T> {
-  const chunkSize = 8 * 1024 * 1024;
-  const uploadId = crypto.randomUUID();
-
-  const sendChunk = (chunk: Blob, offset: number): Promise<T> => new Promise((resolve, reject) => {
-    const separator = path.includes("?") ? "&" : "?";
-    const request = new XMLHttpRequest();
-    request.open(
-      "POST",
-      `${path}${separator}uploadId=${encodeURIComponent(uploadId)}&offset=${offset}&total=${file.size}`,
-    );
-    request.setRequestHeader("Content-Type", contentType || "application/octet-stream");
-    request.upload.addEventListener("progress", (event) => {
-      if (file.size > 0) {
-        onProgress(Math.min(100, Math.round(((offset + event.loaded) / file.size) * 100)));
-      }
-    });
-    request.addEventListener("load", () => {
-      let data: unknown = {};
-      try {
-        data = request.responseText ? JSON.parse(request.responseText) : {};
-      } catch {
-        // Keep the HTTP status error below useful even if a proxy returns HTML.
-      }
-      if (request.status >= 200 && request.status < 300) {
-        onProgress(Math.min(100, Math.round(((offset + chunk.size) / file.size) * 100)));
-        resolve(data as T);
-        return;
-      }
-      const message =
-        typeof data === "object" && data && "error" in data && typeof data.error === "string"
-          ? data.error
-          : `${request.status} ${request.statusText}`;
-      reject(new Error(message));
-    });
-    request.addEventListener("error", () => reject(new Error("Upload failed due to a network error")));
-    request.addEventListener("abort", () => reject(new Error("Upload cancelled")));
-    request.send(chunk);
-  });
-
-  return (async () => {
-    let response: T | undefined;
-    for (let offset = 0; offset < file.size; offset += chunkSize) {
-      response = await sendChunk(file.slice(offset, Math.min(file.size, offset + chunkSize)), offset);
-    }
-    return response as T;
-  })();
+  return uploadFileThroughTransport(
+    lfgFetch,
+    path,
+    file,
+    contentType,
+    onProgress,
+  );
 }
 
 function closeSessionRequest(sid: string, source: string) {

--- a/web/src/lib/upload.ts
+++ b/web/src/lib/upload.ts
@@ -1,0 +1,63 @@
+export type UploadFetch = (
+  path: string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Upload through LFG's configured runtime transport.
+ *
+ * Standalone LFG configures a same-origin transport; embedded hosts configure
+ * their authenticated runtime origin. Keeping uploads behind that same
+ * boundary makes it impossible for an embedded composer to accidentally POST
+ * file bytes to the host application's origin.
+ */
+export async function uploadFile<T>(
+  fetchImpl: UploadFetch,
+  path: string,
+  file: File,
+  contentType: string,
+  onProgress: (progress: number) => void,
+): Promise<T> {
+  const chunkSize = 8 * 1024 * 1024;
+  const uploadId = crypto.randomUUID();
+  let result: T | undefined;
+
+  for (let offset = 0; offset < file.size; offset += chunkSize) {
+    const chunk = file.slice(offset, Math.min(file.size, offset + chunkSize));
+    const separator = path.includes("?") ? "&" : "?";
+    const response = await fetchImpl(
+      `${path}${separator}uploadId=${encodeURIComponent(uploadId)}&offset=${offset}&total=${file.size}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": contentType || "application/octet-stream",
+        },
+        body: chunk,
+      },
+    );
+    const text = await response.text();
+    let data: unknown = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      // Preserve a useful HTTP status when a proxy returns a non-JSON body.
+    }
+    if (!response.ok) {
+      const message =
+        typeof data === "object" &&
+        data &&
+        "error" in data &&
+        typeof data.error === "string"
+          ? data.error
+          : `${response.status} ${response.statusText}`;
+      throw new Error(message);
+    }
+
+    result = data as T;
+    onProgress(
+      Math.min(100, Math.round(((offset + chunk.size) / file.size) * 100)),
+    );
+  }
+
+  return result as T;
+}


### PR DESCRIPTION
## Summary
- route composer attachment chunks through the configured LFG transport
- preserve chunking, content types, progress, and server error messages
- cover hosted transport routing and error propagation

## Verification
- `bun run build:packages`
- `bun run typecheck`
- `bun test` (309 pass)