### PR TITLE
fix: self-update on macOS, and honour the injected platform

### DIFF
--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -56,16 +56,33 @@ async function run(
   return { ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
+/**
+ * True for GNU tar, false for bsdtar (what macOS ships). The two don't share an
+ * option vocabulary, and bsdtar treats an unknown long option as a hard usage
+ * error rather than ignoring it.
+ */
+async function tarIsGnu(root: string): Promise<boolean> {
+  const probe = await run(["tar", "--version"], root);
+  return probe.ok && probe.stdout.includes("GNU tar");
+}
+
 // Sandboxes can inject TAR_OPTIONS (notably --keep-old-files), which turns a
 // normal release update into hundreds of "Cannot open: File exists" failures.
 // Release contents are application files and are meant to replace the prior
 // bundle. Avoid restoring archive metadata too: shared/sandbox filesystems may
 // allow writes while rejecting chmod/chown/utime, causing a successful content
 // update to be reported as a tar failure.
+//
+// The flags have to be chosen per tar flavour. `--overwrite` and `--touch` are
+// GNU-only, and passing them to macOS's bsdtar aborts the extraction with
+// "Option --overwrite is not supported" — which broke self-update on a Mac
+// outright. bsdtar needs neither: it overwrites by default and ignores
+// TAR_OPTIONS (a GNU env var), and it spells --touch as -m.
 export async function extractReleaseArchive(
   archive: string,
   root: string,
 ): Promise<CommandResult> {
+  const gnu = await tarIsGnu(root);
   return run(
     [
       "tar",
@@ -74,10 +91,9 @@ export async function extractReleaseArchive(
       "-C",
       root,
       "--strip-components=1",
-      "--overwrite",
+      ...(gnu ? ["--overwrite", "--touch"] : ["-m"]),
       "--no-same-owner",
       "--no-same-permissions",
-      "--touch",
     ],
     root,
     { ...process.env, TAR_OPTIONS: "" },
@@ -191,8 +207,12 @@ function omgSupervisorRestartCommand(
   home = homedir(),
   procRoot = "/proc",
   currentPid = process.pid,
+  // Injectable like restartCommand's own platform argument. Reading
+  // process.platform here instead meant the caller's injected value was ignored
+  // one level down, so this branch could only ever be exercised on Linux.
+  platform: string = process.platform,
 ): string[] | null {
-  if (process.platform !== "linux") return null;
+  if (platform !== "linux") return null;
   const script = join(home, OMG_SERVE_SCRIPT);
   const pidFile = join(home, OMG_SERVE_PID);
   if (!existsSync(script) || !existsSync(pidFile)) return null;
@@ -228,7 +248,7 @@ export function restartCommand(
         } catch {}
       }
     }
-    return omgSupervisorRestartCommand(home, procRoot);
+    return omgSupervisorRestartCommand(home, procRoot, process.pid, platform);
   }
   if (platform === "darwin") {
     const launchctl = "/bin/launchctl";


### PR DESCRIPTION
Two separate faults in `src/self-update.ts`, both surfaced by the two tests in `src/self-update.test.ts` that are currently red on `main`.

### 1. Release self-update is broken on every Mac

`extractReleaseArchive` passes `--overwrite` and `--touch`. Those are GNU tar options. macOS ships bsdtar, which treats an unknown long option as a hard usage error rather than ignoring it, so extraction aborted before unpacking a single file — every release self-update on a Mac failed.

Reproduced on bsdtar 3.5.3 / libarchive 3.7.4 (macOS 15):

```console
$ tar -xzf t.tgz --overwrite
tar: Option --overwrite is not supported
Usage:
  List:    tar -tf <archive-filename>
$ echo $?
1

$ tar -xzf t.tgz -m
$ echo $?
0
```

The fix picks flags per flavour, probing `tar --version` once. bsdtar needs neither option: it overwrites by default, it ignores `TAR_OPTIONS` (a GNU env var, and the whole reason `--overwrite` was there), and it spells `--touch` as `-m`. `--no-same-owner` and `--no-same-permissions` are supported by both and stay unconditional.

### 2. `omgSupervisorRestartCommand` ignores the platform it is given

`restartCommand` takes an injectable `platform` argument and branches on it, then calls `omgSupervisorRestartCommand`, which re-read `process.platform` instead. The injected value was silently dropped one level down, so that branch could only ever be exercised on Linux — which is why the OMG supervisor test could not pass on a Mac. The caller's platform is now threaded through.

### Verification

Run on macOS, against `main` at `fc1fa2f`:

| | `main` | with this PR |
|---|---|---|
| `src/self-update.test.ts` | 6 pass, **2 fail** | **8 pass, 0 fail** |
| full `bun test` | 309 pass, 4 fail | 311 pass, **2 fail** |

The two fixed are exactly the two this PR targets:

- `release extraction > overwrites bundle files even when the host injects keep-old-files`
- `restart command > recognizes the OMG agent-template supervisor`

No test is newly broken. The 2 that remain (`Claude account credentials > observes a browser login immediately after an initial miss`, `serialized session landing script > preserves two concurrent session commits on main`) are pre-existing on `main`, unrelated to this change, and deliberately untouched — they look like two more macOS-environment gaps if you want them chased separately.

`bun run typecheck` clean. No behavior change on Linux: `tarIsGnu` returns true there and the same `--overwrite`/`--touch` pair is passed as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
