### PR TITLE
fix: index Claude Code plugin skills

### DIFF
--- a/src/skills-catalog.ts
+++ b/src/skills-catalog.ts
@@ -104,10 +104,25 @@ async function buildSkillCatalog(repoRoots: string[] = []): Promise<SkillCatalog
   const codexHome = process.env.CODEX_HOME || join(homedir(), ".codex");
   const claudeHome = process.env.CLAUDE_HOME || join(homedir(), ".claude");
   const selfRepo = PATHS.root;
+  // Installed-plugin caches. Skills found under these get a "plugin:name"
+  // trigger (see pluginSkillTrigger); everything else is addressed by bare name.
+  const pluginCacheRoots = [
+    join(codexHome, "plugins", "cache"),
+    join(claudeHome, "plugins", "cache"),
+  ];
   const roots: { root: string; source: SkillCatalogItem["source"] }[] = [
     { root: join(codexHome, "skills"), source: "codex" },
     { root: join(codexHome, "plugins", "cache"), source: "codex" },
     { root: join(claudeHome, "skills"), source: "claude" },
+    // Claude Code plugin skills, the mirror of the codex plugin cache above.
+    // Without this every plugin-provided skill was invisible to the catalog even
+    // though the agent could invoke it. Only `cache/` (what is actually
+    // installed) is scanned — `plugins/marketplaces/` is a marketplace checkout
+    // that also contains plugins the user never installed, so indexing it would
+    // advertise skills that aren't available. The layout matches codex's
+    // (<marketplace>/<plugin>/<version>/skills/...), so pluginSkillTrigger
+    // already resolves the "plugin:name" trigger correctly.
+    { root: join(claudeHome, "plugins", "cache"), source: "claude" },
     { root: join(selfRepo, ".claude", "skills"), source: "claude" },
     { root: join(selfRepo, ".codex", "skills"), source: "codex" },
     { root: join(selfRepo, ".agents", "skills"), source: "agent" },
@@ -139,7 +154,11 @@ async function buildSkillCatalog(repoRoots: string[] = []): Promise<SkillCatalog
     }
     const fm = parseSkillFrontmatter(raw);
     const name = fm.name || file.path.split(/[\\/]+/).at(-2) || "skill";
-    const trigger = file.path.includes(`${codexHome}/plugins/cache`)
+    // Namespace every plugin-provided skill as "plugin:name", whichever agent's
+    // cache it came from. Beyond matching how the agent addresses them, this is
+    // what keeps two plugins that ship the same skill name from colliding on
+    // `key` below and having one silently dropped.
+    const trigger = pluginCacheRoots.some((root) => file.path.startsWith(root))
       ? pluginSkillTrigger(file.path, name)
       : name;
     const key = `${file.source}:${trigger}`;


### PR DESCRIPTION
The skills catalog scans `~/.codex/plugins/cache` but never `~/.claude/plugins/cache`, so every skill shipped by an installed Claude Code plugin is missing from the app — even though the agent can invoke it in a session.

`src/skills-catalog.ts` on `main` builds its roots like this:

```ts
{ root: join(codexHome, "skills"),             source: "codex"  },
{ root: join(codexHome, "plugins", "cache"),   source: "codex"  },
{ root: join(claudeHome, "skills"),            source: "claude" },
// ← no claudeHome/plugins/cache
```

The asymmetry looks unintentional: codex gets both its loose skills and its plugin cache, claude gets only loose skills.

### Effect

On one machine with the Notion and Superwhisper plugins installed, the catalog goes from 94 to 99 entries. The 5 that were invisible:

```
claude:notion:notion-knowledge-capture
claude:notion:notion-meeting-intelligence
claude:notion:notion-research-documentation
claude:notion:notion-spec-to-implementation
claude:superwhisper:superwhisper
```

### Two details worth reviewing

**Only `cache/` is scanned, not `plugins/marketplaces/`.** This matches the existing codex treatment. `marketplaces/` is a marketplace checkout that also holds plugins the user never installed, so indexing it would advertise skills that can't actually be run — on one box that is 31 files that would have been wrongly surfaced.

**The `plugin:name` trigger was gated on the codex path specifically**, so claude plugin skills would have landed under bare names. It is now keyed off any plugin cache. Besides matching how the agent addresses them, the namespace is what stops two plugins shipping the same skill name from colliding on the `${source}:${trigger}` dedup key and having one silently dropped.

The claude cache layout is the same as codex's (`<marketplace>/<plugin>/<version>/skills/...`), so `pluginSkillTrigger` already resolves the trigger correctly with no change.

### Verification

`bun run typecheck` clean. Full `bun test` on macOS is unchanged from `main` at `fc1fa2f` (4 pre-existing failures before and after, none of them in this path) — this code has no unit coverage upstream, so the check above was done by calling `listSkillCatalog()` directly against `main` and against this branch and diffing the result.

Worth noting for expectations: this surfaces plugin skills that are **installed on disk**. Skills injected by the Claude app at runtime have no `SKILL.md` anywhere and remain out of scope for a filesystem scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
