### PR TITLE
fix(web): keep dialog footers reachable when content is tall

### DIFF
--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -130,7 +130,10 @@ function DrawerContent({
         // overflowing the viewport; callers already carry their own inner
         // scroll containers.
         className={cn("max-h-[85dvh] overflow-hidden", className)}
-        innerClassName="block max-h-[85dvh] overflow-y-auto p-4"
+        // h-full rather than a second max-height: the wrapper fills the popup
+        // instead of growing past it, so the caller's height class stays
+        // authoritative and footers can't be pushed out of reach.
+        innerClassName="flex h-full min-h-0 flex-col overflow-hidden p-4"
         {...(props as React.ComponentProps<typeof DialogContent>)}
       >
         {children}


### PR DESCRIPTION
## Summary

On desktop, `DrawerContent` renders through the Dialog path and wrapped children in a `block` container carrying its own `max-h-[85dvh]`. When a caller pins a shorter height, that wrapper grows past its own popup and drags the footer out of view.

`ProjectFolderBrowser` hits this: it pins `h-[min(82dvh,42rem)]`, so at most desktop window sizes the popup resolves to the `42rem` (672px) cap while the inner wrapper expands to `85dvh`. The wrapper overflows its parent, the trailing directories clip, and **New Folder** / **Use This Folder** land below the popup — unreachable, and not scrollable into view.

The fix makes the wrapper `flex h-full min-h-0 flex-col` so it fills the popup instead of imposing a competing height. The caller's height class stays authoritative, and inner `flex-1 min-h-0` scroll regions can size correctly.

## Test plan

Reproduced against a directory with 11 subfolders, driving the real app in Chromium and measuring the footer's position relative to the popup and viewport.

Before — footer renders outside the popup at every desktop width:

| Viewport | Footer bottom | Popup bottom | Inside popup |
|---|---|---|---|
| 1200×800 | 925 | 728 | no |
| 1400×1000 | 1017 | 836 | no |
| 1280×1100 | 1067 | 886 | no |
| 1500×760 | 921 | 692 | no |

After — footer inside the popup and the viewport, list scrollable in all cases:

| Viewport | Footer bottom | Popup bottom | Inside popup |
|---|---|---|---|
| 1200×800 | 672 | 728 | yes |
| 1400×1000 | 780 | 836 | yes |
| 1280×1100 | 830 | 886 | yes |
| 1500×760 | 636 | 692 | yes |

- [x] Footer buttons sit inside the popup at 4/4 desktop widths
- [x] Directory list reports `scrollHeight > clientHeight`, so every folder is reachable
- [x] Scrolled to the end of the list and confirmed the last folder plus both buttons render and are clickable
- [ ] Mobile drawer path unchanged (this branch only touches the desktop Dialog branch)