### PR TITLE
feat: notify when a session finishes a turn

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -438,6 +438,7 @@ const OPENCODE_DISABLED_MODELS = new Set<string>([
 ]);
 import { enqueueMessage, listQueue, retryMessage, clearResolved, reconcileQueued, getMessage } from "../sendq.ts";
 import { startFleetWatcher, subscribeFleet, type FleetEvent } from "../voice-bus.ts";
+import { startSessionPushBridge } from "../session-push.ts";
 import { handleElevenLlm, handleElevenToken } from "../voice-eleven-llm.ts";
 import { resolveVoiceIntent, type VoiceIntentRequest } from "../voice-intent.ts";
 
@@ -6387,6 +6388,9 @@ export async function cmdServe() {
   // Watch the fleet for busy -> idle transitions and fan "completed" events out
   // to voice subscribers (/api/voice/events). Idempotent + best-effort.
   startFleetWatcher();
+  // Bridge those same completions to Web Push, so an installed PWA hears
+  // about a landed turn with the app closed. Must follow startFleetWatcher().
+  startSessionPushBridge();
   // Keep SQLite as the chat read model for every active session. Transcript
   // JSONL files are treated as an import source; live draft deltas stay
   // ephemeral until the provider writes the completed turn.

--- a/src/live-ws.ts
+++ b/src/live-ws.ts
@@ -288,6 +288,23 @@ type SidTail = {
   transcriptDbPolling: boolean;
 };
 
+// Live view of the active support instance's sid tails, so out-of-band callers
+// can ask "is anyone actually looking at this session right now?". Read through
+// a pointer rather than a mirrored Set — a parallel copy would drift the moment
+// a socket closed on a path that forgot to update it.
+let activeSidTails: Map<string, SidTail> | null = null;
+
+/**
+ * True when a live WebSocket is currently subscribed to this session's
+ * transcript — i.e. the user has it open. Used to keep push notifications quiet
+ * about a session already on screen. Tails are torn down as soon as their last
+ * socket goes (see cleanupSidTail), so this can't report a stale yes.
+ */
+export function isSessionWatched(sid: string): boolean {
+  const tail = activeSidTails?.get(sid);
+  return !!tail && tail.sockets.size > 0;
+}
+
 export function createLiveWsSupport(opts: {
   evlog?: Evlog;
   getAgentRun?: (runId: string) => AgentRunSnapshot | null;
@@ -297,6 +314,7 @@ export function createLiveWsSupport(opts: {
   const evlog = opts.evlog ?? defaultEvlog;
   const sockets = new WeakMap<LiveWs, SocketState>();
   const sidTails = new Map<string, SidTail>();
+  activeSidTails = sidTails;
   const channelStates = new Map<string, ChannelState>();
   const agentRunUnsubs = new Map<string, () => void>();
   const summaryTails = new Map<string, SummaryTail>();

--- a/src/push.ts
+++ b/src/push.ts
@@ -217,7 +217,19 @@ async function sendOne(sub: PushSubscription): Promise<{ gone: boolean }> {
     },
   });
   // 404/410 = subscription expired/unsubscribed → caller prunes it.
-  return { gone: res.status === 404 || res.status === 410 };
+  const gone = res.status === 404 || res.status === 410;
+  // Anything else non-2xx is a real failure we can do nothing about here, but
+  // silence makes it undebuggable: a 403 (the VAPID key no longer matches the
+  // one the browser subscribed with, e.g. after data/push/vapid.json was
+  // regenerated) otherwise presents as "notifications just stopped" with
+  // nothing in the logs to explain it.
+  if (!res.ok && !gone) {
+    const detail = (await res.text().catch(() => "")).slice(0, 200);
+    console.warn(
+      `[push] ${aud} rejected delivery: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`,
+    );
+  }
+  return { gone };
 }
 
 /**
@@ -242,8 +254,11 @@ export async function notifyAll(
       try {
         const { gone } = await sendOne(sub);
         if (gone) dead.push(sub.endpoint);
-      } catch {
-        // transient network error to one push service — ignore, try next time
+      } catch (e) {
+        // Transient network error to one push service — don't retry here (the
+        // next notify will), but say so, otherwise a push service we can't
+        // reach at all looks identical to having nothing to send.
+        console.warn(`[push] delivery failed: ${e instanceof Error ? e.message : String(e)}`);
       }
     }),
   );

--- a/src/session-push.ts
+++ b/src/session-push.ts
@@ -1,0 +1,108 @@
+// Notify when a coding session finishes a turn.
+//
+// notifyAll() already fires for auto-agent findings, client errors, ask-user
+// questions and shipped results. The ordinary case — an agent finishing what
+// you asked it to do — had no trigger, so an installed PWA stayed silent for
+// the thing you actually wait on.
+//
+// Nothing new is needed to detect it: the fleet watcher in src/voice-bus.ts
+// already samples every session's busy state and emits a settled busy -> idle
+// edge, which is exactly "that session just landed a turn". So far only the
+// voice worker subscribed. This bridges the same bus to Web Push, using the
+// queued-notification path so the notice names the session that caused it.
+
+import { subscribeFleet } from "./voice-bus.ts";
+import { isSessionWatched } from "./live-ws.ts";
+import { notifyAll } from "./push.ts";
+import { listSessionsCached } from "./session-cache.ts";
+
+/**
+ * How long to hold a completion back when the session looks like it's on
+ * screen. Must clear live-ws's IDLE_CLOSE_MS (60s) — that is how long a
+ * suspended client's socket survives before the server reaps it.
+ */
+const WATCHED_RECHECK_MS = 75_000;
+
+/** First non-empty line, trimmed to notification length. */
+function firstLine(text: string): string {
+  const line = text
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line) return "";
+  return line.length > 140 ? `${line.slice(0, 139)}…` : line;
+}
+
+/**
+ * What the session has to say for itself: the first line of its last assistant
+ * turn, or the reason it is stuck. Read at emit time, which is safe because the
+ * watcher only emits after idle has held for SETTLE_TICKS — the turn is written
+ * by then.
+ */
+async function bodyForSession(sessionId: string): Promise<string> {
+  try {
+    const session = (await listSessionsCached()).find((s) => s.sessionId === sessionId);
+    if (session?.status === "blocked") {
+      return session.statusDetail || "Session is blocked and needs you.";
+    }
+    const last = session?.last;
+    if (last && last.role === "assistant" && last.kind === "text") {
+      const summary = firstLine(last.text);
+      if (summary) return summary;
+    }
+  } catch {
+    // Session listing is unavailable — fall through to the generic body.
+  }
+  return "Finished its turn.";
+}
+
+let started = false;
+
+/**
+ * Bridge fleet completions to Web Push. Idempotent, so it is safe to call
+ * unconditionally at boot alongside startFleetWatcher().
+ */
+export function startSessionPushBridge(): void {
+  if (started) return;
+  started = true;
+  // Unscoped subscriber: we want every session's completion and do the
+  // per-user targeting through notifyAll's own `user` filter.
+  subscribeFleet(null, (ev) => {
+    if (ev.type !== "completed") return;
+
+    const notify = () =>
+      void (async () => {
+        await notifyAll({
+          user: ev.user,
+          notification: {
+            title: ev.title,
+            body: await bodyForSession(ev.sessionId),
+            // Deep-link straight to the session that finished.
+            url: `/?session=${encodeURIComponent(ev.sessionId)}`,
+            // Per session, so a second completion replaces that session's
+            // notice rather than stacking another one behind it.
+            tag: `session-${ev.sessionId}`,
+          },
+        });
+      })().catch(() => {});
+
+    if (!isSessionWatched(ev.sessionId)) {
+      notify();
+      return;
+    }
+
+    // The user appears to have this session open, so buzzing now is noise.
+    // Defer rather than drop: a phone that suspends holds its socket open for
+    // up to IDLE_CLOSE_MS, so "actively watching" and "just locked the screen"
+    // are indistinguishable at this instant — and dropping would eat the
+    // notification in exactly the case it matters most.
+    const timer = setTimeout(() => {
+      // Still watching after the socket would have been reaped: they are really
+      // there and have already seen it.
+      if (isSessionWatched(ev.sessionId)) return;
+      notify();
+    }, WATCHED_RECHECK_MS);
+    // Never let a pending re-check hold the process open at shutdown.
+    (timer as { unref?: () => void }).unref?.();
+  });
+}


### PR DESCRIPTION
## Why

`notifyAll()` fires for auto-agent findings, client errors, ask-user questions and shipped results. The ordinary case — **an agent finishing what you asked it to do** — has no trigger, so an installed PWA stays silent for the thing you actually wait on.

## What

Nothing new is needed to detect it. The fleet watcher in `src/voice-bus.ts` already samples every session's busy state and emits a settled busy → idle edge, which is exactly *"that session just landed a turn"*. So far only the voice worker subscribed.

This bridges the same bus to Web Push through the **queued-notification path added for shipped**, so the notice names the session that caused it and deep-links to it:

```ts
notifyAll({
  user: ev.user,
  notification: {
    title: ev.title,
    body: await bodyForSession(ev.sessionId),
    url: `/?session=${encodeURIComponent(ev.sessionId)}`,
    tag: `session-${ev.sessionId}`,
  },
});
```

- **Body** is the first line of the session's last assistant turn, or its blocked reason. Read at emit time, which is safe because the watcher only emits once idle has held for `SETTLE_TICKS` — the turn is written by then.
- **Tagged per session**, so a second completion replaces that session's notice rather than stacking another behind it.
- **A completion for a session the user is watching is deferred, not dropped.** A suspended client keeps its socket open for up to `IDLE_CLOSE_MS`, so "actively watching" and "screen just locked" are indistinguishable at the instant a turn lands — dropping would eat the notification in exactly the case it matters most. `live-ws` gains `isSessionWatched()` for this, reading the live tail map rather than a mirrored copy that could drift.

Also logs non-2xx and network failures in `push.ts`. Silence there is why a dead subscription presents as *"notifications just stopped"* with nothing in the logs — a 403 from a rotated VAPID key looks identical to having nothing to send.

## Note on scope

An earlier version of this PR carried its own `/api/push/pending` events array and service-worker rendering. All of that is dropped in favour of `queuePushNotification`, which does the job better — the queue is per-subscription and persisted, consumed exactly once, and the badge count is derived from visible notifications rather than a counter that can drift. This PR is now four files.

I also tried replacing `client.navigate(target)` in `notificationclick` with a `postMessage`, so a click on an already-open PWA routes in place instead of reloading and discarding the live session. That broke `shipped notifications > renders the exact queued notice and navigates an open PWA window`, i.e. it argues against behaviour you've deliberately encoded in a test — so it's out of this PR. Happy to raise it separately if the reload is unintended; happy to drop it if it isn't.

## Verification

- `bunx tsc --noEmit` clean; `bun run build:packages && cd web && bun run build` clean.
- `bun test`: **447 pass / 3 fail — identical to `main` with these changes stashed.** The two named failures are `Claude account credentials > observes a browser login immediately after an initial miss` and `serialized session landing script > preserves two concurrent session commits on main`, both addressed in #74.
- Ran end to end on a real deployment before the rework: launched a session, confirmed the fleet event produced a notification carrying the agent's actual reply, and confirmed it arrived on an iOS PWA.

CHANGELOG untouched — release notes look maintainer-owned.
