### PR TITLE
feat: sign in to Grok with a device code

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -76,6 +76,7 @@ function codingAgent(
       instructions: [],
       canAutoSetup: false,
       canLoginInTerminal: false,
+      canLoginInBrowser: false,
       setupRunning: false,
     },
   };

--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -62,6 +62,50 @@ describe("coding agent browser auth output", () => {
     });
   });
 
+  test("extracts the Grok device URL and code", () => {
+    // Verbatim `grok login --device-auth` output (grok 0.2.114). The code shows
+    // up twice — inside the URL and again on its own line.
+    const output = [
+      "To sign in, open this URL in your browser:",
+      "",
+      "  https://accounts.x.ai/oauth2/device?user_code=M4EY-Q586",
+      "",
+      "  (Could not open browser automatically — open the URL above manually.)",
+      "",
+      "Confirm this code in your browser:",
+      "",
+      "  M4EY-Q586",
+      "",
+      "\x1b[90mOnly continue with a code you requested. Don't share it with anyone.\x1b[0m",
+      "",
+      "Waiting for authorization...",
+    ].join("\r\n");
+
+    expect(parseAuthOutput("grok", output)).toEqual({
+      authorizationUrl: "https://accounts.x.ai/oauth2/device?user_code=M4EY-Q586",
+      userCode: "M4EY-Q586",
+      needsCode: false,
+    });
+  });
+
+  test("reads the Grok code from the prose when the URL carries no query", () => {
+    // Guards the fallback branch: if xAI ever drops user_code from the URL, the
+    // "Confirm this code" line still has to yield the code, otherwise the login
+    // dialog would render a URL with nothing to type.
+    const output = [
+      "To sign in, open this URL in your browser:",
+      "  https://accounts.x.ai/oauth2/device",
+      "Confirm this code in your browser:",
+      "  ABCD-1234",
+    ].join("\n");
+
+    expect(parseAuthOutput("grok", output)).toEqual({
+      authorizationUrl: "https://accounts.x.ai/oauth2/device",
+      userCode: "ABCD-1234",
+      needsCode: false,
+    });
+  });
+
   test("extracts Claude's OSC hyperlink and detects its code prompt", () => {
     const url = "https://claude.com/cai/oauth/authorize?code=true&state=abc";
     const output = `Opening browser…\r\nIf it didn't open: \x1b]8;;${url}\x07${url}\x1b]8;;\x07\r\nPaste code here if prompted > `;

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -43,6 +43,13 @@ export type CodingAgentStatus = {
   instructions: string[];
   canAutoSetup: boolean;
   canLoginInTerminal: boolean;
+  /**
+   * Whether this agent can sign in through the in-app URL + code dialog rather
+   * than a terminal. Reported by the server so the client doesn't keep its own
+   * copy of the list — it used to, and adding grok to the server alone left the
+   * button silently opening a terminal instead.
+   */
+  canLoginInBrowser: boolean;
   setupRunning: boolean;
   setupProgress?: {
     percent: number;
@@ -59,10 +66,12 @@ export type CodingAgentInfo = {
   status: CodingAgentStatus;
 };
 
+export type AuthProvider = "claude" | "codex" | "grok";
+
 export type CodingAgentAuthSession = {
   id: string;
   kind: CodingAgentKind;
-  provider: "claude" | "codex";
+  provider: AuthProvider;
   status: "starting" | "waiting" | "complete" | "error";
   authorizationUrl?: string;
   userCode?: string;
@@ -383,7 +392,11 @@ function hasCursorLfgMcp(): boolean {
 
 function hasGrokAuth(): boolean {
   const home = userHome();
-  return !!process.env.XAI_API_KEY || existsSync(`${home}/.grok`);
+  // auth.json, not the directory: the installer creates ~/.grok (bin, downloads,
+  // completions, config.toml) before anyone has signed in, so testing the
+  // directory reported "authenticated" the moment the CLI landed. `grok login`
+  // is what writes auth.json.
+  return !!process.env.XAI_API_KEY || existsSync(`${home}/.grok/auth.json`);
 }
 
 function hasCursorAuth(): boolean {
@@ -443,7 +456,11 @@ function loginCommandPartsFor(kind: CodingAgentKind): string[] | null {
     return [codexPath() ?? "codex", "login", "--device-auth"];
   }
   if (kind === "opencode") return [opencodePath() ?? "opencode"];
-  if (kind === "grok") return [grokPath() ?? "grok"];
+  // Device-code, not the bare TUI: `grok` on its own drops into an interactive
+  // sign-in that needs a real terminal, while `login --device-auth` prints a URL
+  // and a short code the user can approve from any device — the only flow that
+  // works when lfg is running on a headless box.
+  if (kind === "grok") return [grokPath() ?? "grok", "login", "--device-auth"];
   if (kind === "cursor") return [cursorPath() ?? "cursor-agent", "login"];
   if (kind === "hermes") return [hermesPath() ?? "hermes"];
   if (kind === "copilot") return [copilotPath() ?? "copilot"];
@@ -453,9 +470,10 @@ function loginCommandPartsFor(kind: CodingAgentKind): string[] | null {
   return null;
 }
 
-function authProviderFor(kind: CodingAgentKind): "claude" | "codex" | null {
+function authProviderFor(kind: CodingAgentKind): AuthProvider | null {
   if (kind === "claude" || kind === "aisdk") return "claude";
   if (kind === "codex" || kind === "codex-aisdk") return "codex";
+  if (kind === "grok") return "grok";
   return null;
 }
 
@@ -468,13 +486,22 @@ export function cleanAuthOutput(value: string): string {
 }
 
 export function parseAuthOutput(
-  provider: "claude" | "codex",
+  provider: AuthProvider,
   raw: string,
 ): Pick<CodingAgentAuthSession, "authorizationUrl" | "userCode" | "needsCode"> {
   const output = cleanAuthOutput(raw);
   const authorizationUrl = output.match(/https:\/\/[^\s\x07\x1b]+/)?.[0];
   if (provider === "codex") {
     const userCode = output.match(/one-time code[\s\S]{0,160}?\b([A-Z0-9]{4,}-[A-Z0-9]{4,})\b/i)?.[1];
+    return { authorizationUrl, userCode, needsCode: false };
+  }
+  if (provider === "grok") {
+    // `grok login --device-auth` prints the code twice — once inside the URL as
+    // ?user_code=, then again on its own under "Confirm this code". Read it out
+    // of the URL first: that copy can't be confused with surrounding prose.
+    const userCode =
+      output.match(/[?&]user_code=([A-Z0-9]{3,}-[A-Z0-9]{3,})/i)?.[1] ??
+      output.match(/confirm this code[\s\S]{0,120}?\b([A-Z0-9]{3,}-[A-Z0-9]{3,})\b/i)?.[1];
     return { authorizationUrl, userCode, needsCode: false };
   }
   return {
@@ -526,8 +553,12 @@ async function collectAuthOutput(
 export async function startCodingAgentAuth(kind: CodingAgentKind): Promise<CodingAgentAuthSession> {
   const provider = authProviderFor(kind);
   if (!provider) throw new Error(`${CODING_AGENT_LABELS[kind]} does not support browser login yet`);
-  const binary = provider === "claude" ? claudePath() : codexPath();
-  if (!binary) throw new Error(`Install ${provider === "claude" ? "Claude" : "Codex"} before signing in`);
+  const binary =
+    provider === "claude" ? claudePath() : provider === "codex" ? codexPath() : grokPath();
+  if (!binary) {
+    const label = { claude: "Claude", codex: "Codex", grok: "Grok" }[provider];
+    throw new Error(`Install ${label} before signing in`);
+  }
 
   for (const existing of authSessions.values()) {
     if (existing.provider === provider && (existing.status === "starting" || existing.status === "waiting")) {
@@ -536,6 +567,7 @@ export async function startCodingAgentAuth(kind: CodingAgentKind): Promise<Codin
     }
   }
 
+  // codex and grok both spell it `login --device-auth`; only claude differs.
   const argv = provider === "claude"
     ? [binary, "auth", "login", "--claudeai"]
     : [binary, "login", "--device-auth"];
@@ -693,8 +725,8 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
     instructions.push("Install Copilot CLI (npm install -g @github/copilot; requires Node 22+), then run 'copilot' once and /login, or set COPILOT_GITHUB_TOKEN (or GH_TOKEN) with the Copilot Requests scope.");
   } else {
     addBinary("Grok CLI", grokPath());
-    addAuth("Grok auth", hasGrokAuth(), "run `grok` once or set XAI_API_KEY");
-    instructions.push("Install Grok, then run `grok` once and sign in, or set XAI_API_KEY.");
+    addAuth("Grok auth", hasGrokAuth(), "use Login to sign in with a device code, or set XAI_API_KEY");
+    instructions.push("Install Grok, then use Login to sign in with a device code, or set XAI_API_KEY.");
   }
 
   return {
@@ -705,6 +737,8 @@ function statusFor(kind: CodingAgentKind): CodingAgentStatus {
     instructions,
     canAutoSetup,
     canLoginInTerminal,
+    // Single source of truth: exactly the kinds startCodingAgentAuth accepts.
+    canLoginInBrowser: authProviderFor(kind) !== null,
     setupRunning: setupRuns.has(kind),
     setupProgress: setupProgress.get(kind),
     installCommand: installCommandFor(kind) ?? undefined,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -302,6 +302,7 @@ type CodingAgentInfo = {
     setupProgress?: { percent: number; label: string };
     canAutoSetup: boolean;
     canLoginInTerminal: boolean;
+    canLoginInBrowser: boolean;
     checks: { label: string; ok: boolean; detail?: string }[];
     instructions: string[];
     installCommand?: string;
@@ -314,7 +315,7 @@ const CodingAgentsContext = createContext<CodingAgentInfo[] | undefined>(undefin
 type CodingAgentAuthSession = {
   id: string;
   kind: AgentKind;
-  provider: "claude" | "codex";
+  provider: "claude" | "codex" | "grok";
   status: "starting" | "waiting" | "complete" | "error";
   authorizationUrl?: string;
   userCode?: string;
@@ -5529,7 +5530,11 @@ export function App() {
   }
 
   async function loginCodingAgent(kind: AgentKind, inlineSid?: string) {
-    const browserAuth = kind === "aisdk" || kind === "claude" || kind === "codex" || kind === "codex-aisdk";
+    // Ask the server which agents it can actually drive through the URL + code
+    // dialog. This was a hardcoded list here, which meant teaching the server a
+    // new agent wasn't enough — the button kept falling through to a terminal.
+    const browserAuth =
+      codingAgents.find((agent) => agent.key === kind)?.status.canLoginInBrowser ?? false;
     if (!browserAuth) {
       toast.promise(
         api<{ terminalSession: string }>(`/api/coding-agents/${kind}/login-terminal`, { method: "POST" })


### PR DESCRIPTION
## Why

Grok is the one agent with an install command but no way to sign in from the app:

- `authProviderFor` returns `null` for it, so `startCodingAgentAuth` throws *"Grok does not support browser login yet"*.
- Its login command is the bare `grok` binary — an interactive TUI that needs a real terminal.
- The setup hint says to go run `grok` by hand.

On a headless box — the common lfg deployment — that leaves `XAI_API_KEY` as the only practical route.

## What

`grok login` already offers exactly what's needed:

```
--oauth        Use Grok OAuth via auth.x.ai
--device-auth  Use device-code authentication for headless/remote environments
```

So this drives the same device flow already used for codex: widen the auth provider union, spawn `grok login --device-auth`, and parse the URL and code out of its output. The code is read from the URL's `user_code` query rather than the surrounding prose, since that copy can't be confused with neighbouring text, with the "Confirm this code" line as a fallback. Both branches are pinned against verbatim grok 0.2.114 output.

## Two fixes that fell out

**False "Grok auth ok".** `hasGrokAuth` tested for the `~/.grok` *directory* — but the installer creates that (`bin`, `downloads`, `completions`, `config.toml`) before anyone has signed in, so lfg reported Grok as authenticated the moment the CLI landed. `auth.json` is what `grok login` actually writes.

**The web client kept its own copy of the provider list**, so teaching the server a new provider wasn't enough — the Login button silently fell through to `/login-terminal`. It's now reported as `status.canLoginInBrowser`, derived from `authProviderFor`, i.e. exactly the kinds `startCodingAgentAuth` will accept. Verified per agent: grok `browser=true`, cursor/opencode/copilot still terminal, pi neither.

## Deliberately not included

Installing the CLI in the container image — the binary is ~164 MB, so that's a judgement call for the image owner. I have it working via the x.ai installer if you want it as a follow-up; the wrinkle is that `DOWNLOAD_DIR` is hardcoded to `$HOME/.grok/downloads`, so the binary and the OIDC token share a directory that wants to be volume-backed.

## Verification

- `bunx tsc --noEmit` clean; `bun run build:packages && cd web && bun run build` clean.
- 2 new parser tests (URL-embedded code, and the prose fallback).
- `bun test`: 396 pass / 2 fail — both **pre-existing on `main`**, identical with these changes stashed (`Claude account credentials > observes a browser login…`, `serialized session landing script > preserves two concurrent…`).
- Ran the real flow on a deployed container: `grok login --device-auth` output captured and confirmed against the parser, and `/api/coding-agents` confirmed reporting `canLoginInBrowser` correctly per agent.

One unrelated touch: `src/agent-catalog.test.ts` gains `canLoginInBrowser: false` in its status fixture, since the field is required.

CHANGELOG untouched — release notes look maintainer-owned.