### PR TITLE
feat: list plugin commands in the skills catalog

### DIFF
--- a/src/skills-catalog.ts
+++ b/src/skills-catalog.ts
@@ -61,7 +61,8 @@ function validSkillItem(item: SkillCatalogItem): boolean {
     !!item.name.trim() &&
     !!item.trigger.trim() &&
     !/\s/.test(item.trigger) &&
-    item.path.endsWith("SKILL.md")
+    // SKILL.md for skills, <command>.md for plugin commands.
+    item.path.endsWith(".md")
   );
 }
 
@@ -89,6 +90,60 @@ async function findSkillFiles(root: string, maxDepth = 6): Promise<string[]> {
   return out;
 }
 
+/**
+ * Plugin *commands* — `<plugin>/<version>/commands/**\/*.md`. The agent offers
+ * these exactly like skills (`/ralph-loop:help`), so omitting them left the
+ * app's list disagreeing with what could actually be run. Note some plugins
+ * ship commands and no skills at all.
+ */
+async function findPluginCommandFiles(root: string, maxDepth = 8): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string, depth: number, inCommands: boolean) {
+    if (depth > maxDepth) return;
+    let entries: Dirent[];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    await Promise.all(
+      entries.map(async (e) => {
+        // AppleDouble sidecars (`._foo.md`) sit next to the real file on
+        // anything that has touched a Mac volume; they are not commands.
+        if (e.name.startsWith("._")) return;
+        const full = join(dir, e.name);
+        if (e.isDirectory()) {
+          if (e.name.startsWith(".git")) return;
+          await walk(full, depth + 1, inCommands || e.name === "commands");
+          return;
+        }
+        if (inCommands && e.isFile() && e.name.toLowerCase().endsWith(".md")) out.push(full);
+      }),
+    );
+  }
+  await walk(root, 0, false);
+  return out;
+}
+
+/**
+ * "<plugin>:<command>" for a plugin command path, mirroring how the agent
+ * addresses it. Nested command dirs namespace with ":" the same way the agent
+ * does (commands/tasks/build.md -> notion:tasks:build).
+ */
+function pluginCommandTrigger(commandPath: string): string | null {
+  const parts = commandPath.split(/[\\/]+/);
+  const cacheIdx = parts.lastIndexOf("cache");
+  const cmdIdx = parts.indexOf("commands", cacheIdx >= 0 ? cacheIdx : 0);
+  if (cacheIdx < 0 || cmdIdx < 0 || cacheIdx + 3 > cmdIdx) return null;
+  const plugin = parts[cacheIdx + 2];
+  const name = parts
+    .slice(cmdIdx + 1)
+    .join(":")
+    .replace(/\.md$/i, "");
+  if (!plugin || !name) return null;
+  return name.startsWith(`${plugin}:`) ? name : `${plugin}:${name}`;
+}
+
 function pluginSkillTrigger(skillPath: string, name: string): string {
   const parts = skillPath.split(/[\\/]+/);
   const skillsIdx = parts.lastIndexOf("skills");
@@ -106,10 +161,12 @@ async function buildSkillCatalog(repoRoots: string[] = []): Promise<SkillCatalog
   const selfRepo = PATHS.root;
   // Installed-plugin caches. Skills found under these get a "plugin:name"
   // trigger (see pluginSkillTrigger); everything else is addressed by bare name.
-  const pluginCacheRoots = [
-    join(codexHome, "plugins", "cache"),
-    join(claudeHome, "plugins", "cache"),
+  // These are also the only roots scanned for plugin commands.
+  const pluginRoots: { root: string; source: SkillCatalogItem["source"] }[] = [
+    { root: join(codexHome, "plugins", "cache"), source: "codex" },
+    { root: join(claudeHome, "plugins", "cache"), source: "claude" },
   ];
+  const pluginCacheRoots = pluginRoots.map((r) => r.root);
   const roots: { root: string; source: SkillCatalogItem["source"] }[] = [
     { root: join(codexHome, "skills"), source: "codex" },
     { root: join(codexHome, "plugins", "cache"), source: "codex" },
@@ -136,13 +193,23 @@ async function buildSkillCatalog(repoRoots: string[] = []): Promise<SkillCatalog
     roots.push({ root: join(cwd, "skills"), source: "agent" });
     roots.push({ root: join(cwd, "packages", "skills", "skills"), source: "agent" });
   }
-  const files = (
+  const skillFiles = (
     await Promise.all(
       [...new Map(roots.map((r) => [`${r.source}:${r.root}`, r])).values()].map(async (r) =>
-        (await findSkillFiles(r.root)).map((path) => ({ ...r, path })),
+        (await findSkillFiles(r.root)).map((path) => ({ ...r, path, command: false })),
       ),
     )
   ).flat();
+  // Commands come second so a plugin that ships both a skill and a command of
+  // the same name keeps the skill — it carries the richer frontmatter.
+  const commandFiles = (
+    await Promise.all(
+      pluginRoots.map(async (r) =>
+        (await findPluginCommandFiles(r.root)).map((path) => ({ ...r, path, command: true })),
+      ),
+    )
+  ).flat();
+  const files = [...skillFiles, ...commandFiles];
   const seen = new Set<string>();
   const items: SkillCatalogItem[] = [];
   for (const file of files) {
@@ -153,14 +220,27 @@ async function buildSkillCatalog(repoRoots: string[] = []): Promise<SkillCatalog
       continue;
     }
     const fm = parseSkillFrontmatter(raw);
-    const name = fm.name || file.path.split(/[\\/]+/).at(-2) || "skill";
-    // Namespace every plugin-provided skill as "plugin:name", whichever agent's
-    // cache it came from. Beyond matching how the agent addresses them, this is
-    // what keeps two plugins that ship the same skill name from colliding on
-    // `key` below and having one silently dropped.
-    const trigger = pluginCacheRoots.some((root) => file.path.startsWith(root))
-      ? pluginSkillTrigger(file.path, name)
-      : name;
+    let name: string;
+    let trigger: string;
+    if (file.command) {
+      // A command's identity is its path — the frontmatter carries only a
+      // description, never a name.
+      const commandTrigger = pluginCommandTrigger(file.path);
+      if (!commandTrigger) continue;
+      trigger = commandTrigger;
+      name = commandTrigger.slice(commandTrigger.indexOf(":") + 1);
+    } else {
+      name = fm.name || file.path.split(/[\\/]+/).at(-2) || "skill";
+      // Namespace every plugin-provided skill as "plugin:name", whichever
+      // agent's cache it came from. Beyond matching how the agent addresses
+      // them, this is what keeps two plugins that ship the same skill name from
+      // colliding on `key` below and having one silently dropped.
+      trigger = pluginCacheRoots.some((root) => file.path.startsWith(root))
+        ? pluginSkillTrigger(file.path, name)
+        : name;
+    }
+    // Dedup also collapses a plugin installed at two versions (the cache keeps
+    // the old directory around), which would otherwise list the same command twice.
     const key = `${file.source}:${trigger}`;
     if (seen.has(key)) continue;
     seen.add(key);


### PR DESCRIPTION
Follow-on to #68 (which added the `~/.claude/plugins/cache` root).

## Why

The catalog only looks for `SKILL.md`, but the agent offers a plugin's *commands* exactly the way it offers its skills — `/ralph-loop:help`, `/notion:create-page`. Some plugins ship commands and **no skills at all** (`agent-sdk-dev`, `ralph-loop`), so they show nothing in the app despite being fully usable. On my box that's 22 invocable entries the skills list simply didn't know about.

## What

Index `<plugin>/<version>/commands/**/*.md` from the plugin caches. Nested command directories namespace with `:` the way the agent addresses them, so `commands/tasks/build.md` lists as `notion:tasks:build`.

Two wrinkles worth naming:

- **AppleDouble sidecars** (`._foo.md`) sit next to the real file on anything that has touched a Mac volume, and are skipped — otherwise every command appears twice.
- **The cache keeps older version directories around** (e.g. both `agent-sdk-dev/unknown/` and `agent-sdk-dev/<sha>/`), so the existing per-source dedup is what stops one command being listed twice.

A plugin installed under *both* the codex and claude caches still yields two entries. That's deliberate and pre-existing — the UI badges each with its source, so the pair reads as "available to both agents".

## Verification

- `bunx tsc --noEmit` clean; `bun run build:packages && cd web && bun run build` clean.
- Ran the catalog: 133 entries, 22 of them commands, with correct `plugin:name` and nested `plugin:dir:name` triggers.
- `bun test`: 394 pass / 2 fail — both **pre-existing on `main`**, unchanged by this PR (`Claude account credentials > observes a browser login…`, `serialized session landing script > preserves two concurrent…`).

CHANGELOG untouched — release notes look maintainer-owned.