### PR TITLE
feat(embed): let the host reserve the top-right corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Recent product updates and deployment notes.
 
 ## [Unreleased]
 
+## July 30, 2026 - Hosts can reserve the top-right corner (v0.1.136)
+
+- Adds `--lfg-host-top-inset`, the top-right counterpart to the existing
+  `--lfg-host-bottom-inset`. The embedded mobile header now pads its right
+  gutter by that amount, so a host floating its own nav island in that corner
+  slides our project picker out of the way instead of colliding with it.
+- Host-driven rather than hardcoded: it defaults to `0px`, so standalone LFG
+  and any host that floats nothing up there reserve nothing, and the host sets
+  the real width on its own surface wrapper.
+
 ## July 30, 2026 - Original LFG icon restored (v0.1.135)
 
 - Restores the distinctive pixel-dissolve LFG mark across the app, PWA, touch

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -102,6 +102,22 @@ describe("host bottom inset contract", () => {
     expect(app).toContain('embedded && "pb-[var(--lfg-host-bottom-inset)]"');
   });
 
+  test("host can reserve top-right space in the embedded mobile header", () => {
+    const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
+    const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
+    // Default 0 so standalone LFG — and any host that floats nothing in that
+    // corner — reserves nothing. The value is host-driven (omg sets it on its
+    // surface wrapper), unlike the hardcoded bottom inset.
+    expect(css).toMatch(/--lfg-host-top-inset:\s*0px/);
+    // The embedded mobile header's right island slides left by the inset, so a
+    // host island in that corner never lands on the project picker.
+    expect(app).toContain("pr-[calc(0.75rem+var(--lfg-host-top-inset))]");
+    // Left stays a plain gutter — px-3 would re-symmetrise and undo the above.
+    expect(app).not.toMatch(
+      /<header className="z-40 flex shrink-0 items-center justify-between gap-2 px-3/,
+    );
+  });
+
   test("desktop embed zeroes host-bottom-inset (omg nav is top-middle)", () => {
     const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
     // Match omg useIsDesktop (lg = 1024). Mobile keeps the 2.75rem bottom pill.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5771,7 +5771,7 @@ export function App() {
         )}
       >
       {embedded && isMobile ? (
-        <header className="z-40 flex shrink-0 items-center justify-between gap-2 px-3 pb-1 pt-[calc(0.5rem+env(safe-area-inset-top))]">
+        <header className="z-40 flex shrink-0 items-center justify-between gap-2 pb-1 pl-3 pr-[calc(0.75rem+var(--lfg-host-top-inset))] pt-[calc(0.5rem+env(safe-area-inset-top))]">
           <NavIsland className="shrink-0">
             <div
               className="flex size-11 items-center justify-center rounded-full bg-background/80 backdrop-blur-xl"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -53,6 +53,13 @@
   --lfg-orb-size: 4.5rem;
   /* Host-chrome inset (omg Computer compact bottom nav). 0 outside embed. */
   --lfg-host-bottom-inset: 0px;
+  /* Host-chrome inset on the TOP-RIGHT of the embedded mobile header. The host
+     floats its own nav island in that corner, so our right-hand island has to
+     slide left by the width the host claims. Unlike the bottom inset (which we
+     hardcode, because the pill's height is fixed), this one is host-driven:
+     omg sets it on its surface wrapper. 0 by default, so a host that floats
+     nothing there — or standalone LFG — reserves nothing. */
+  --lfg-host-top-inset: 0px;
   /* Device home-indicator. Standalone uses the real inset; embed cancels it
      (host already places chrome above the home indicator). */
   --lfg-device-safe-bottom: env(safe-area-inset-bottom, 0px);


### PR DESCRIPTION
omg's Computer surface is moving its Computer/Settings switcher out of the floating bottom pill and into a top-right island. On a phone LFG owns the whole viewport and already stacks two rows of its own chrome down there — the create composer and the toolbar under it — so omg's pill made a third, and the bottom third of the screen was nothing but chrome.

That corner isn't free, though: the embedded mobile header pins the project picker there, and omg's native surface shares our document, so a host island would land straight on top of the chip with no way to negotiate.

This adds `--lfg-host-top-inset` as the mirror of the existing `--lfg-host-bottom-inset` and pads the embedded mobile header's right gutter by it, sliding the picker left by exactly what the host claims.

One deliberate difference from the bottom inset: that one is hardcoded to `2.75rem` because the pill's height is fixed and we can know it. This one defaults to `0px` and is set by the host on its own surface wrapper, so standalone LFG — and any host that floats nothing up there — reserves nothing.

Verified against omg's real mobile surface with the built bundle: island 84px wide at 12px from the edge, picker pushed to 104px, 8px gap, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)