### PR TITLE
fix: green test suite on macOS

### DIFF
--- a/scripts/land-session.sh
+++ b/scripts/land-session.sh
@@ -89,8 +89,28 @@ MAIN_ROOT="$(
 [ -n "$MAIN_ROOT" ] || die "could not find the main worktree"
 [ "$SESSION_ROOT" != "$MAIN_ROOT" ] || die "run this from the isolated session worktree, not main"
 
-exec 9>"$COMMON_DIR/lfg-land.lock"
-flock 9
+# Serialize landings repo-wide. `flock` is util-linux and absent on macOS, where
+# the script died with "flock: command not found" before touching anything.
+#
+# macOS ships BSD `lockf` instead, but only its command-wrapping form is usable:
+# its fd form (`lockf 9`) takes a per-process lock that is dropped the moment
+# lockf exits, so the shell is left holding nothing. Linux `flock 9` works
+# because the lock lives on the open file description the shell shares with it.
+#
+# So re-exec the whole script under whichever locker exists and let it own the
+# lock for our lifetime — which also keeps flock's release-on-death behaviour on
+# both platforms. LFG_LAND_LOCK_HELD stops the re-exec recursing; everything
+# above this point is read-only git plumbing, so running it twice is harmless.
+LAND_LOCK="$COMMON_DIR/lfg-land.lock"
+if [ -z "${LFG_LAND_LOCK_HELD:-}" ]; then
+  if command -v flock >/dev/null 2>&1; then
+    exec env LFG_LAND_LOCK_HELD=1 flock "$LAND_LOCK" "$0" "$@"
+  elif command -v lockf >/dev/null 2>&1; then
+    exec env LFG_LAND_LOCK_HELD=1 lockf -k "$LAND_LOCK" "$0" "$@"
+  else
+    die "need flock (util-linux) or lockf (BSD/macOS) to serialize landing"
+  fi
+fi
 
 [ -z "$(git -C "$SESSION_ROOT" status --porcelain)" ] \
   || die "session worktree has uncommitted changes; commit them first"

--- a/src/claude-creds.test.ts
+++ b/src/claude-creds.test.ts
@@ -1,24 +1,35 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { claudeOauthToken } from "./claude-creds.ts";
+import { claudeOauthToken, resetClaudeCredsCacheForTests } from "./claude-creds.ts";
 
 describe("Claude account credentials", () => {
   const originalHome = process.env.HOME;
   let testHome = "";
+
+  // Stand in for a machine with nothing in the Keychain. The real reader is not
+  // scoped to $HOME, so on a macOS box where the maintainer is signed in to
+  // Claude Code it answers with their live token and the "initial miss" below
+  // can never hold — the suite passed only on Linux or a signed-out Mac.
+  const noKeychain = () => null;
+
+  beforeEach(() => {
+    resetClaudeCredsCacheForTests();
+  });
 
   afterEach(() => {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
     if (testHome) rmSync(testHome, { recursive: true, force: true });
     testHome = "";
+    resetClaudeCredsCacheForTests();
   });
 
   test("observes a browser login immediately after an initial miss", () => {
     testHome = mkdtempSync(join(tmpdir(), "lfg-claude-creds-"));
     process.env.HOME = testHome;
-    expect(claudeOauthToken()).toBeNull();
+    expect(claudeOauthToken(undefined, noKeychain)).toBeNull();
 
     const credentialsDir = join(testHome, ".claude");
     mkdirSync(credentialsDir, { recursive: true });
@@ -27,6 +38,23 @@ describe("Claude account credentials", () => {
       JSON.stringify({ claudeAiOauth: { accessToken: "oauth-test-token" } }),
     );
 
-    expect(claudeOauthToken()).toBe("oauth-test-token");
+    expect(claudeOauthToken(undefined, noKeychain)).toBe("oauth-test-token");
+  });
+
+  test("prefers the credentials file over the Keychain", () => {
+    testHome = mkdtempSync(join(tmpdir(), "lfg-claude-creds-"));
+    process.env.HOME = testHome;
+    mkdirSync(join(testHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(testHome, ".claude", ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "from-file" } }),
+    );
+
+    // Pins the ordering the comment in claudeOauthToken relies on: a login that
+    // just landed in the file must win over a stale Keychain entry, otherwise
+    // the 60s cache hides it until it expires.
+    expect(
+      claudeOauthToken(undefined, () => ({ claudeAiOauth: { accessToken: "from-keychain" } })),
+    ).toBe("from-file");
   });
 });

--- a/src/claude-creds.ts
+++ b/src/claude-creds.ts
@@ -50,8 +50,25 @@ function readCredsKeychain(): ClaudeCreds | null {
   }
 }
 
-/** Claude subscription OAuth access token, or null when not signed in. */
-export function claudeOauthToken(configDir?: string): string | null {
+/**
+ * Drop the Keychain cache. Test seam: the 60s TTL is process-wide, so without
+ * this a token read by one test stays visible to the next.
+ */
+export function resetClaudeCredsCacheForTests(): void {
+  cached = null;
+}
+
+/**
+ * Claude subscription OAuth access token, or null when not signed in.
+ *
+ * `readKeychain` is injectable for tests only. Unlike the credentials file, the
+ * Keychain is not scoped to $HOME, so a test that points HOME at an empty temp
+ * directory still sees the developer's real login and cannot assert a miss.
+ */
+export function claudeOauthToken(
+  configDir?: string,
+  readKeychain: () => ClaudeCreds | null = readCredsKeychain,
+): string | null {
   // The Linux credentials file is cheap to read and can appear while LFG is
   // running after a browser login. Read it before the Keychain cache so a
   // completed first-run connection is visible on the very next status poll.
@@ -64,7 +81,7 @@ export function claudeOauthToken(configDir?: string): string | null {
   if (process.platform !== "darwin") return null;
 
   if (cached && Date.now() - cached.at < TTL_MS) return cached.token;
-  const creds = readCredsKeychain();
+  const creds = readKeychain();
   const token = creds?.claudeAiOauth?.accessToken ?? null;
   cached = { token, at: Date.now() };
   return token;

--- a/src/session-land-script.test.ts
+++ b/src/session-land-script.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { deployedHeadPath } from "./session-landing.ts";
@@ -23,7 +23,10 @@ describe("serialized session landing script", () => {
   });
 
   test("preserves two concurrent session commits on main", async () => {
-    const root = mkdtempSync(join(tmpdir(), "lfg-land-race-"));
+    // realpath: on macOS tmpdir() is /var/... which is a symlink to /private/var/...,
+    // and the shell reports the resolved path in $PWD. Without this the recorded
+    // build directories never string-match the paths built from tmpdir() here.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "lfg-land-race-")));
     roots.push(root);
     const remote = join(root, "remote.git");
     const main = join(root, "main");


### PR DESCRIPTION
`bun test` on `main` fails two tests on macOS. Both are real portability problems, not flakes — and one of them is a live bug in `land-session.sh`, not just a test issue.

```
before:  394 pass,  2 fail
after :  397 pass,  0 fail,  1 skip
```

## 1. `land-session.sh` can't run on macOS at all

The script serializes landings with `flock`, which is util-linux and **absent on macOS** — it died with `flock: command not found` (exit 127) before touching a repo. So landing a session has never worked on a Mac.

macOS ships BSD `lockf` instead, but only its command-wrapping form is usable. Its fd form (`lockf 9`) takes a per-process lock that is released the moment `lockf` exits, leaving the shell holding nothing — I confirmed two concurrent runs interleaving with it. Linux `flock 9` works because the lock lives on the open *file description* the shell shares with it.

So the script now re-execs itself under whichever locker exists and lets that own the lock for its lifetime, which preserves `flock`'s release-on-death behaviour on both platforms. `LFG_LAND_LOCK_HELD` stops the re-exec recursing; everything above the lock is read-only git plumbing, so running it twice is harmless.

Verified both ways:
- the concurrency test passes on macOS via `lockf`;
- the re-exec-under-`flock` pattern serializes correctly on Linux (in a Debian container), with the lock file auto-created.

The test had a second macOS problem hiding behind the first: it compared recorded build directories against paths built from `tmpdir()`, which on macOS is `/var/…`, a symlink to `/private/var/…`. The shell reports the resolved path in `$PWD`, so the strings never matched even once the lock worked. Resolved the temp root up front.

## 2. The Claude credential test reads the maintainer's real Keychain

`claudeOauthToken()` reads `$HOME/.claude/.credentials.json` first, then falls back to the macOS Keychain — and **the Keychain is not scoped to `$HOME`**. So *"observes a browser login immediately after an initial miss"*, which points `HOME` at an empty temp dir and asserts a null token, instead saw my live login and failed. It could only pass on Linux or a signed-out Mac.

It also printed a real `sk-ant-oat01-…` token into the test output on failure, which is worth closing on its own.

Fix: make the Keychain reader injectable, defaulting to the real one so production behaviour is unchanged, and have the test pass a stub. The 60s Keychain cache is process-wide, so there's also a reset the test calls between cases — otherwise a token read by one test stays visible to the next.

Added a second case pinning the ordering the function's own comment relies on: a login that just landed in the credentials file must beat a stale Keychain entry, or the cache hides it until the TTL expires.

## Verification

- `bunx tsc --noEmit` clean; `bun run build:packages && cd web && bun run build` clean.
- `bun test`: 397 pass / 0 fail / 1 skip on macOS (was 394 / 2).
- No production behaviour change on Linux: the `flock` branch is preserved, `realpathSync` is a no-op there, and the Keychain reader defaults to the real implementation.

CHANGELOG untouched — release notes look maintainer-owned.