### PR TITLE
feat(embed): give hosts a slot in the desktop rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Recent product updates and deployment notes.
 
 ## [Unreleased]
 
+## July 30, 2026 - Hosts get a slot in the desktop rail (v0.1.137)
+
+- Adds a `rail-footer` host slot at the bottom of the hosted desktop rail. A
+  host embedding LFG as its entire desktop surface had nowhere to put its own
+  top-level navigation, because that layout suppresses the app header and the
+  rail's top row is already full.
+- The slot is a real node the host portals into, so it moves with the rail
+  instead of floating over it and having to track its width, collapse
+  animation and position. It carries the collapsed flag so the host can stack
+  vertically in the 56px rail.
+- Unfilled slots collapse to nothing, so standalone LFG and hosts that ignore
+  the slot are unaffected.
+
 ## July 30, 2026 - Hosts can reserve the top-right corner (v0.1.136)
 
 - Adds `--lfg-host-top-inset`, the top-right counterpart to the existing

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -118,6 +118,27 @@ describe("host bottom inset contract", () => {
     );
   });
 
+  test("hosted desktop rail exposes a footer slot the host can portal into", () => {
+    const app = require("node:fs").readFileSync("web/src/App.tsx", "utf8") as string;
+    const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
+    // A host that owns the whole desktop surface has nowhere for its own
+    // top-level nav: this layout suppresses the app header and the rail's top
+    // row is full. A real node inside the rail beats having it float chrome
+    // over us and track our width, collapse animation and position.
+    expect(app).toContain('data-lfg-host-slot="rail-footer"');
+    // Hosted only — standalone LFG grows no empty node.
+    expect(app).toMatch(
+      /\{hosted \? \(\s*<div\s*\n\s*data-lfg-host-slot="rail-footer"/,
+    );
+    // The host needs to know it has 56px, not 280px, to lay out in.
+    expect(app).toContain(
+      'data-lfg-rail-collapsed={railCollapsed ? "true" : undefined}',
+    );
+    // Unfilled slots must cost nothing: the host portals in AFTER we render,
+    // so :empty is the only continuous answer.
+    expect(css).toMatch(/\[data-lfg-host-slot\]:empty\s*\{\s*display:\s*none/);
+  });
+
   test("desktop embed zeroes host-bottom-inset (omg nav is top-middle)", () => {
     const css = require("node:fs").readFileSync("web/src/index.css", "utf8") as string;
     // Match omg useIsDesktop (lg = 1024). Mobile keeps the 2.75rem bottom pill.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9870,6 +9870,23 @@ function RailStage({
             </RailGroup>
           ) : null}
         </div>
+        {/* Host-owned footer. A host embedding LFG as its whole desktop surface
+            (omg) has nowhere to put its own top-level navigation: this layout
+            suppresses the app header, and the rail's top row is already full.
+            Rather than have it float chrome over us — which would mean tracking
+            the rail's width, its collapse animation and its position — we give
+            it a real node inside the rail to portal into. Collapses to nothing
+            when unused (see [data-lfg-host-slot]:empty in index.css), so a host
+            that fills it never pays for it and one that doesn't never sees it.
+            The collapsed flag rides along so the host can stack its controls
+            vertically in the 56px rail instead of overflowing it. */}
+        {hosted ? (
+          <div
+            data-lfg-host-slot="rail-footer"
+            data-lfg-rail-collapsed={railCollapsed ? "true" : undefined}
+            className="shrink-0"
+          />
+        ) : null}
       </aside>
 
       <div

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -684,6 +684,14 @@ html.lfg-keyboard-open {
     );
   }
 
+  /* Host slots are opt-in: an unfilled one must cost nothing. The host portals
+     into the node after we render it, so we cannot know at render time whether
+     it will be used — :empty answers that continuously instead, and collapses
+     the slot the moment the host unmounts its content. */
+  [data-lfg-host-slot]:empty {
+    display: none;
+  }
+
   /* On the narrow layout the page itself is the scroll surface, framed by the
      floating nav islands and persistent composer. Extend each chrome surface
      with a real background→transparent wash so rows and transcript content


### PR DESCRIPTION
Follow-up to #73, same shape of problem at the other end of the layout.

A host that embeds LFG as its entire desktop surface has nowhere to put its own top-level navigation: `liveDesktopWorkspace` suppresses the app header outright, and the rail's top row is already carrying the brand, the clipboard and the pages menu. omg's answer so far was a pill floating in a 46px band below our card — dead space that existed only because there was no seam.

This adds a `rail-footer` host slot at the bottom of the hosted rail: a real node the host portals into.

**Why a node and not an inset.** #73 used a CSS variable because the host was floating an island in a corner we control the padding of. That doesn't transfer here — a floating desktop control would have to track the rail's width (280/56), its collapse transition and its position inside `<main>`'s gutters, all of which are ours to change freely. A node inside the rail just moves with it.

- `data-lfg-rail-collapsed` rides along so the host can stack vertically in the 56px rail instead of overflowing it.
- `[data-lfg-host-slot]:empty { display: none }` — the host portals in *after* we render, so `:empty` is the only thing that can answer "is this slot used?" continuously, including when the host unmounts its content.
- `hosted`-gated, so standalone LFG never grows the node at all.

404 tests pass; 1 new test in `test/embed.test.ts` pins the slot name, the hosted gate, the collapsed flag and the `:empty` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)