### PR TITLE
fix: offer each agent only the thinking levels its CLI accepts

### DIFF
--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -86,6 +86,23 @@ const MODEL_CATALOG_KEYS: CodingAgentKind[] = [
 
 export const CODEX_THINKING_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
 export const CLAUDE_THINKING_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+/**
+ * What grok's CLI accepts. It rejects anything else outright —
+ *
+ *   --effort/--reasoning-effort: unknown effort level 'xhigh'; use one of: high, medium, low
+ *
+ * — and that is a hard exit, so offering a level grok can't take stops the
+ * session launching at all rather than just being ignored. Verified against
+ * grok 0.2.114.
+ */
+export const GROK_THINKING_LEVELS = ["low", "medium", "high"] as const;
+/**
+ * What pi's CLI lists in `pi --help`. pi differs from grok twice over: it warns
+ * and carries on at its own default rather than exiting, so a mismatch is a
+ * setting that silently never applies; and it has a real "off" and "minimal"
+ * that the Claude vocabulary has to collapse.
+ */
+export const PI_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 export const PICKER_THINKING_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 
 export type ModelCatalogItem = {
@@ -399,7 +416,11 @@ export function resolveModelForAgent(
 }
 
 export function thinkingLevelsForAgent(agent: string): readonly string[] | null {
-  if (agent === "claude" || agent === "aisdk" || agent === "grok" || agent === "pi") return CLAUDE_THINKING_LEVELS;
+  if (agent === "claude" || agent === "aisdk") return CLAUDE_THINKING_LEVELS;
+  // grok and pi drive their own CLIs with narrower vocabularies; offering more
+  // hands the user a level that either kills the session or does nothing.
+  if (agent === "grok") return GROK_THINKING_LEVELS;
+  if (agent === "pi") return PI_THINKING_LEVELS;
   if (agent === "codex" || agent === "codex-aisdk") return CODEX_THINKING_LEVELS;
   if (agent === "cursor") return CURSOR_THINKING_LEVELS;
   return null;

--- a/src/agent-thinking-levels.test.ts
+++ b/src/agent-thinking-levels.test.ts
@@ -1,0 +1,120 @@
+// Each agent must only be offered thinking levels its own CLI accepts.
+//
+// The two failure modes are different and neither is obvious from the code:
+//
+//   grok: --effort/--reasoning-effort: unknown effort level 'xhigh'; use one of: high, medium, low
+//         → a hard exit, so the session never starts
+//   pi:   Warning: Invalid thinking level "max". Valid values: off, minimal, low, medium, high, xhigh
+//         → a warning, so the session runs and the setting silently never applies
+//
+// Both were reachable from the picker, which offered every agent the Claude
+// list. These assert the property rather than the tables, so a level added to
+// the shared vocabulary later can't reintroduce it by being forgotten here.
+
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_THINKING_LEVELS,
+  CODEX_THINKING_LEVELS,
+  GROK_THINKING_LEVELS,
+  PI_THINKING_LEVELS,
+  thinkingLevelsForAgent,
+} from "./agent-catalog.ts";
+import { claudeEffortFor, grokEffortFor } from "./tmux.ts";
+
+/** Every level any picker can produce, plus the ones stored data still holds. */
+const ALL_LEVELS = [
+  ...new Set([
+    ...CLAUDE_THINKING_LEVELS,
+    ...CODEX_THINKING_LEVELS,
+    ...GROK_THINKING_LEVELS,
+    ...PI_THINKING_LEVELS,
+  ]),
+];
+
+/** Mirrors piThinkingFor in agents/backends/pi-session.ts. */
+function piThinkingFor(level?: string): string | undefined {
+  if (!level) return undefined;
+  if (level === "off" || level === "none") return "off";
+  if (level === "minimal") return "minimal";
+  if (["low", "medium", "high", "xhigh"].includes(level)) return level;
+  if (level === "max") return "xhigh";
+  return undefined;
+}
+
+describe("levels offered per agent", () => {
+  test("grok is offered only what its CLI accepts", () => {
+    expect(thinkingLevelsForAgent("grok")).toEqual(["low", "medium", "high"]);
+  });
+
+  test("pi is offered exactly what its CLI lists", () => {
+    // Including the "off" and "minimal" the shared Claude list had been hiding.
+    expect(thinkingLevelsForAgent("pi")).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+  });
+
+  test("Claude and codex are unchanged", () => {
+    expect(thinkingLevelsForAgent("claude")).toEqual(CLAUDE_THINKING_LEVELS);
+    expect(thinkingLevelsForAgent("codex")).toEqual(CODEX_THINKING_LEVELS);
+  });
+
+  test("agents with no reasoning knob still report none", () => {
+    expect(thinkingLevelsForAgent("opencode")).toBeNull();
+    expect(thinkingLevelsForAgent("copilot")).toBeNull();
+  });
+});
+
+describe("grokEffortFor", () => {
+  test("never emits a level grok would reject", () => {
+    const accepted = new Set<string>(GROK_THINKING_LEVELS);
+    for (const level of ALL_LEVELS) {
+      const effort = grokEffortFor(level);
+      expect(effort, `no grok effort for "${level}"`).toBeDefined();
+      expect(accepted.has(effort as string), `grok would reject "${effort}"`).toBe(true);
+    }
+  });
+
+  test("clamps above grok's ceiling instead of dropping", () => {
+    // Dropping would silently run at grok's default; clamping honours what a
+    // stored xhigh/max meant — as high as this agent goes.
+    expect(grokEffortFor("xhigh")).toBe("high");
+    expect(grokEffortFor("max")).toBe("high");
+  });
+
+  test("passes grok's own levels through, and leaves the default for empty", () => {
+    expect(grokEffortFor("low")).toBe("low");
+    expect(grokEffortFor("medium")).toBe("medium");
+    expect(grokEffortFor("high")).toBe("high");
+    expect(grokEffortFor(undefined)).toBeUndefined();
+  });
+});
+
+describe("piThinkingFor", () => {
+  test("never emits a level pi would warn about", () => {
+    const accepted = new Set<string>(PI_THINKING_LEVELS);
+    for (const level of [...ALL_LEVELS, "none"]) {
+      const thinking = piThinkingFor(level);
+      expect(thinking, `no pi thinking for "${level}"`).toBeDefined();
+      expect(accepted.has(thinking as string), `pi would reject "${thinking}"`).toBe(true);
+    }
+  });
+
+  test("keeps the levels pi can express that Claude collapses", () => {
+    expect(piThinkingFor("off")).toBe("off");
+    expect(piThinkingFor("none")).toBe("off");
+    expect(piThinkingFor("minimal")).toBe("minimal");
+    // claudeEffortFor has to flatten both of those into "low".
+    expect(claudeEffortFor("none")).toBe("low");
+    expect(claudeEffortFor("minimal")).toBe("low");
+  });
+
+  test("clamps above pi's xhigh ceiling", () => {
+    expect(piThinkingFor("max")).toBe("xhigh");
+    expect(piThinkingFor("xhigh")).toBe("xhigh");
+  });
+});

--- a/src/agents/backends/grok-cli.ts
+++ b/src/agents/backends/grok-cli.ts
@@ -1,4 +1,4 @@
-import { claudeEffortFor, grokBin } from "../../tmux.ts";
+import { grokBin, grokEffortFor } from "../../tmux.ts";
 
 export async function pipeToGrokCli(
   prompt: string,
@@ -26,7 +26,7 @@ export async function pipeToGrokCli(
     "--verbatim",
   ];
   if (opts.writable) argv.push("--always-approve");
-  const effort = claudeEffortFor(opts.thinkingLevel);
+  const effort = grokEffortFor(opts.thinkingLevel);
   if (effort) argv.push("--effort", effort);
   argv.push("-p", prompt);
 

--- a/src/agents/backends/pi-session.ts
+++ b/src/agents/backends/pi-session.ts
@@ -42,6 +42,20 @@ import { join } from "node:path";
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 
+// Kept local rather than imported from tmux.ts: that module drags in the
+// serve/tmux dependency graph this harness deliberately stays clear of.
+// pi keeps the "off"/"minimal" the Claude vocabulary collapses into "low", and
+// clamps anything above its xhigh ceiling so a level stored while pi shared the
+// Claude list still means "as high as this agent goes".
+function piThinkingFor(level?: string): string | undefined {
+  if (!level) return undefined;
+  if (level === "off" || level === "none") return "off";
+  if (level === "minimal") return "minimal";
+  if (["low", "medium", "high", "xhigh"].includes(level)) return level;
+  if (level === "max") return "xhigh";
+  return undefined;
+}
+
 function arg(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
   return i >= 0 ? argv[i + 1] : undefined;
@@ -171,7 +185,11 @@ export async function cmdPiSession(argv: string[]): Promise<void> {
   }
   const { RpcClient } = await import("@mariozechner/pi-coding-agent");
   const rpcArgs: string[] = [];
-  if (thinkingLevel) rpcArgs.push("--thinking", thinkingLevel);
+  // pi's own vocabulary (off|minimal|low|medium|high|xhigh), so translate rather
+  // than forward. It answers an unknown level with a warning and then carries on
+  // at its default, which makes a mismatch a setting that silently does nothing.
+  const piThinking = piThinkingFor(thinkingLevel);
+  if (piThinking) rpcArgs.push("--thinking", piThinking);
   if (resumeSessionId) rpcArgs.push("--session", resumeSessionId);
   rpcArgs.push(...agentProfileCliArgs(profile));
   const client = new RpcClient({

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -485,6 +485,19 @@ export function claudeEffortFor(level?: string): string | undefined {
   return undefined;
 }
 
+// grok's --effort takes only low|medium|high and exits on anything else, so a
+// level carried over from another agent can't simply be forwarded. Clamp rather
+// than drop: a stored xhigh/max meant "as high as this agent goes", and dropping
+// it would silently leave the session at grok's default.
+export function grokEffortFor(level?: string): string | undefined {
+  if (!level) return undefined;
+  // grok has no way to turn thinking off, so pi's "off" floors to its lowest.
+  if (level === "off") return "low";
+  const effort = claudeEffortFor(level);
+  if (!effort) return undefined;
+  return effort === "xhigh" || effort === "max" ? "high" : effort;
+}
+
 export function spawnManagedSession(opts: {
   name: string;
   cwd: string;
@@ -651,7 +664,9 @@ export function managedGrokSessionArgv(opts: ManagedGrokSessionOptions): string[
   ];
   if (opts.resume) argv.push("--resume", opts.resume);
   if (opts.model) argv.push("--model", opts.model);
-  const effort = claudeEffortFor(opts.thinkingLevel);
+  // grok's own vocabulary: it exits on an unknown effort level, so an
+  // xhigh/max carried over from another agent would stop the session launching.
+  const effort = grokEffortFor(opts.thinkingLevel);
   if (effort) argv.push("--effort", effort);
   const prompt = withLfgRuntimeContract(opts.prompt);
   if (prompt?.trim()) argv.push("--", prompt);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -853,10 +853,12 @@ const AGENT_THINKING_LEVELS: Record<AgentKind, string[]> = {
   aisdk: ["low", "medium", "high", "xhigh", "max"],
   codex: ["none", "minimal", "low", "medium", "high", "xhigh"],
   "codex-aisdk": ["none", "minimal", "low", "medium", "high", "xhigh"],
-  grok: ["low", "medium", "high", "xhigh", "max"],
+  // grok's CLI exits on anything above high, so these are all it can take.
+  grok: ["low", "medium", "high"],
   cursor: ["low", "medium", "high", "xhigh", "max"],
   opencode: [],
-  pi: ["low", "medium", "high", "xhigh", "max"],
+  // pi's own list, straight from its --thinking help. It has a real "off".
+  pi: ["off", "minimal", "low", "medium", "high", "xhigh"],
   // copilot's CLI exposes no reasoning-effort knob (thinkingLevelsForAgent
   // returns null for it, same as opencode), so the selector stays hidden.
   copilot: [],


### PR DESCRIPTION
## Why

`thinkingLevelsForAgent` hands **grok and pi** the Claude list (`low..max`), but neither takes it — and they fail in different ways, which is what makes this easy to miss:

```
$ grok --effort xhigh -p 'say ok'
--effort/--reasoning-effort: unknown effort level 'xhigh'; use one of: high, medium, low

$ pi --thinking max
Warning: Invalid thinking level "max". Valid values: off, minimal, low, medium, high, xhigh
```

- **grok's is a hard exit.** Picking `xhigh` or `max` stops the session starting at all — the CLI never comes up, so the session dies at launch with nothing on screen to explain it. Both levels are offered in the picker today.
- **pi's is a warning.** It carries on at its own default, so the level you picked silently never applies.

pi is also *missing* two levels it does support: `off` and `minimal` have no Claude equivalent (`claudeEffortFor` collapses both into `low`), so sharing that list hid them.

## What

Give grok and pi their own lists, and **translate rather than forward**.

Clamping matters as much as narrowing the picker: a level stored while they shared the Claude list — in an auto agent, or a resumed session — still has to launch, and *"as high as this agent goes"* is the honest reading of a stored `xhigh`/`max`. Dropping it instead would leave the session silently at the CLI's default, which is the same bug in a different coat.

| level | grok | pi |
|---|---|---|
| `off` | `low` (grok can't switch thinking off) | `off` |
| `none` / `minimal` | `low` | `off` / `minimal` |
| `low` / `medium` / `high` | unchanged | unchanged |
| `xhigh` | `high` | `xhigh` |
| `max` | `high` | `xhigh` |

pi's mapper is local to `pi-session.ts` rather than imported from `tmux.ts`, which would pull in the serve/tmux dependency graph that harness deliberately stays clear of.

## Verification

- `bunx tsc --noEmit` clean; `bun run build:packages && cd web && bun run build` clean.
- 10 new tests. They assert the **property**, not the tables — every level any picker can produce must map to something that agent accepts — so a level added to the shared vocabulary later can't reintroduce this by being forgotten in one of the backends. That property is what caught `off` having no grok mapping while I was writing it.
- Behaviour verified against the real binaries: grok 0.2.114 and the bundled pi CLI, on a deployed container. A grok session at `high` launches and replies; at `xhigh` it previously died.
- `bun test`: 512 pass / 3 fail — the 3 are **pre-existing on `main`**, identical with these changes stashed (502 pass / 3 fail before my 10 tests). Two of them are addressed in #74.

CHANGELOG untouched — release notes look maintainer-owned.