### PR TITLE
Never mute a recurring high-severity finding; make 'resolved' reachable

### DIFF
--- a/src/auto/runner.ts
+++ b/src/auto/runner.ts
@@ -189,12 +189,29 @@ export async function runAutoAgent(
   }
 }
 
-async function runAutoAgentInner(
-  agent: AutoAgent,
-  onLog: (s: string) => void = () => {},
-): Promise<Finding | null> {
-  const mine = (await listFindings()).filter((f) => f.agentId === agent.id);
-  const dismissed = mine.filter((f) => f.status === "dismissed").slice(0, 20);
+/**
+ * Prior-findings context appended to an agent's prompt.
+ *
+ * Dismissal silences an OPINION, not a broken system. Feeding every dismissed
+ * title back as "do NOT resurface" also muted recurring health checks: a daily
+ * e2e went red, the finding was dismissed, and the agent then stayed silent
+ * through every later red run — the test stayed broken for a day with nothing
+ * alerting. It also contradicted store.ts, which deliberately counts
+ * `dismissed` as UNRESOLVED so repeats escalate. The two mechanisms were
+ * fighting and the prompt won.
+ *
+ * So HIGH severity is never suppressed. If one recurs the agent reports it,
+ * recordRecurrence matches the still-unresolved title, and the occurrence
+ * count escalates it back into a notification. Low/med dismissals still stick,
+ * which is where the anti-noise value actually was.
+ *
+ * Exported for test — this rule is the difference between a muted outage and
+ * an alert, so it is worth pinning directly.
+ */
+export function buildFindingFeedback(mine: Finding[]): string {
+  const dismissed = mine
+    .filter((f) => f.status === "dismissed" && f.severity !== "high")
+    .slice(0, 20);
   const open = mine.filter((f) => f.status === "open").slice(0, 20);
 
   let feedback = "";
@@ -208,6 +225,15 @@ async function runAutoAgentInner(
       "\n\n## Already open (don't repeat):\n" +
       open.map((f) => `- ${f.title}`).join("\n");
   }
+  return feedback;
+}
+
+async function runAutoAgentInner(
+  agent: AutoAgent,
+  onLog: (s: string) => void = () => {},
+): Promise<Finding | null> {
+  const mine = (await listFindings()).filter((f) => f.agentId === agent.id);
+  const feedback = buildFindingFeedback(mine);
 
   const prompt = `${SYSTEM}\n\n## Instruction\n${agent.prompt}${feedback}`;
   // The agent's base repo (chosen from the repo list in the UI) is where it runs

--- a/src/commands/agents-auto.ts
+++ b/src/commands/agents-auto.ts
@@ -54,6 +54,7 @@ Findings:
   lfg agents auto findings [--status open]  List findings (--agent, --limit, --json)
   lfg agents auto dismiss <findingId>       Dismiss (feeds back: stops resurfacing)
   lfg agents auto read <findingId>          Mark read
+  lfg agents auto resolve <findingId>       Mark the underlying problem FIXED (terminal)
 
 Common flags:
   --cwd PATH            Base repo the agent runs in (default: cwd, --no-repo to skip)
@@ -291,6 +292,8 @@ export async function cmdAutoAgents(args: string[]): Promise<void> {
       return autoSetFindingStatus(rest, "dismissed");
     case "read":
       return autoSetFindingStatus(rest, "read");
+    case "resolve":
+      return autoSetFindingStatus(rest, "resolved");
     case undefined:
     case "help":
     case "-h":
@@ -671,10 +674,24 @@ async function autoFindings(args: string[]): Promise<void> {
 
 // Dismissing is part of the anti-noise loop, not just bookkeeping: the runner
 // feeds dismissed titles back into the next prompt so the agent stops
-// resurfacing them. Same store call the UI's dismiss button makes.
+// resurfacing them (except high severity — see runner.ts). Same store call the
+// UI's dismiss button makes.
+//
+// `resolve` exists because "resolved" is documented in store.ts as the ONLY
+// status meaning the underlying problem is actually gone, and until now
+// nothing could set it: the CLI offered dismiss/read and the HTTP route's body
+// type excluded it. Everything therefore accumulated in the unresolved
+// statuses — the same reason 302 of 396 findings once sat in "session" and
+// recurrence never matched.
+const STATUS_COMMAND: Partial<Record<FindingStatus, string>> = {
+  dismissed: "dismiss",
+  read: "read",
+  resolved: "resolve",
+};
+
 async function autoSetFindingStatus(args: string[], status: FindingStatus): Promise<void> {
   const id = positional(args);
-  if (!id) fail(`Usage: lfg agents auto ${status === "dismissed" ? "dismiss" : "read"} <findingId>`);
+  if (!id) fail(`Usage: lfg agents auto ${STATUS_COMMAND[status] ?? status} <findingId>`);
   let updated = await updateFinding(id!, { status });
   if (!updated) {
     const matches = (await listFindings()).filter((f) => f.id.startsWith(id!));

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -3233,7 +3233,10 @@ a{color:#60a5fa}
         const m = path.match(/^\/api\/auto\/findings\/([0-9a-f]+)$/);
         if (m && req.method === "POST") {
           const b = (await req.json().catch(() => null)) as {
-            status?: "open" | "dismissed" | "session" | "read";
+            // "resolved" is the only status that means the problem is gone
+            // (store.ts). Omitting it here left it unreachable from the UI, so
+            // findings could only ever pile up in unresolved states.
+            status?: "open" | "dismissed" | "session" | "read" | "resolved";
             sessionId?: string;
           } | null;
           const patch: { status?: NonNullable<typeof b>["status"]; sessionId?: string } = {};

--- a/test/auto-feedback.test.ts
+++ b/test/auto-feedback.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { buildFindingFeedback } from "../src/auto/runner.ts";
+import type { Finding } from "../src/auto/store.ts";
+
+function finding(over: Partial<Finding>): Finding {
+  return {
+    id: "f1",
+    agentId: "a",
+    title: "t",
+    reasoning: [],
+    severity: "low",
+    createdAt: 0,
+    status: "open",
+    ...over,
+  };
+}
+
+describe("buildFindingFeedback", () => {
+  test("a dismissed HIGH finding is never suppressed", () => {
+    // The regression this encodes: a daily e2e went red, the finding was
+    // dismissed, and the agent was then told not to resurface it — so every
+    // subsequent red run was silent and the break went unnoticed for a day.
+    const out = buildFindingFeedback([
+      finding({ severity: "high", status: "dismissed", title: "Self-hosted Computer e2e FAILED" }),
+    ]);
+    expect(out).not.toContain("Self-hosted Computer e2e FAILED");
+    expect(out).not.toContain("do NOT resurface");
+  });
+
+  test("dismissed low/med findings still stick", () => {
+    const out = buildFindingFeedback([
+      finding({ severity: "low", status: "dismissed", title: "nit: rename a var" }),
+      finding({ severity: "med", status: "dismissed", title: "med thing", id: "f2" }),
+    ]);
+    expect(out).toContain("do NOT resurface");
+    expect(out).toContain("nit: rename a var");
+    expect(out).toContain("med thing");
+  });
+
+  test("high dismissal does not drag low dismissals out with it", () => {
+    const out = buildFindingFeedback([
+      finding({ severity: "high", status: "dismissed", title: "prod is on fire" }),
+      finding({ severity: "low", status: "dismissed", title: "cosmetic", id: "f2" }),
+    ]);
+    expect(out).toContain("cosmetic");
+    expect(out).not.toContain("prod is on fire");
+  });
+
+  test("open findings are still listed as already-open", () => {
+    const out = buildFindingFeedback([finding({ status: "open", title: "already open thing" })]);
+    expect(out).toContain("Already open");
+    expect(out).toContain("already open thing");
+  });
+
+  test("no findings means no feedback block at all", () => {
+    expect(buildFindingFeedback([])).toBe("");
+  });
+});


### PR DESCRIPTION
A daily e2e watch went red, its HIGH finding was dismissed, and the agent then stayed **silent through every later red run** — the break went unnoticed for a day. Nothing alerted, because the runner feeds every dismissed title into the next prompt as *"do NOT resurface"*.

That's right for an opinion and wrong for a health check. It also directly contradicted `store.ts`, which counts `dismissed` as UNRESOLVED **precisely so repeats escalate** — its own comment says a finding isn't done because someone looked at it. Two mechanisms disagreed and the prompt won.

**High severity is now never suppressed.** A recurrence gets reported, `recordRecurrence` matches the still-unresolved title, and the occurrence count escalates it back into a notification. Low/med dismissals still stick, which is where the anti-noise value actually was.

### Second half of the same problem

`resolved` is documented as the **only** status meaning the underlying problem is gone — and nothing could set it. The CLI offered `dismiss`/`read`; the HTTP route's body type left it out. So findings could only ever accumulate in unresolved states, which is the same shape as the 302-of-396 stuck in `session` that the store comment already calls out.

Adds `lfg agents auto resolve <id>` and accepts `resolved` over HTTP.

### Tests

Feedback selection is extracted to `buildFindingFeedback` and pinned directly — this rule is the difference between a muted outage and an alert. 13 pass, including the original regression as a named case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)