### PR TITLE
fix(live): never greet an unidentified viewer as "Unassigned"

### DIFF
--- a/test/live-header-context.test.ts
+++ b/test/live-header-context.test.ts
@@ -21,9 +21,11 @@ describe("contextual mobile Live header", () => {
       /isMobile && tab === "live"[\s\S]*?<LiveHeaderContext[\s\S]*?embedded \? null : \([\s\S]*?<UserFilterMenu[\s\S]*?<PagesMenu/,
     );
     expect(source).not.toContain('isMobile && tab === "live" && !embedded');
-    expect(source).toContain("const welcomeMessage = `Welcome, ${firstName}`");
     expect(source).toContain(
-      "viewerName?.trim() || user?.name?.trim() || shortUser(identity)",
+      'const welcomeMessage = firstName ? `Welcome, ${firstName}` : "Welcome"',
+    );
+    expect(source).toContain(
+      'viewerName?.trim() || user?.name?.trim() || (identity ? shortUser(identity) : "")',
     );
     expect(source).toContain('`${busyCount} agent${busyCount === 1 ? "" : "s"} building`');
     expect(source).toContain("const actionInMotion = busyCount > 0;");
@@ -54,6 +56,19 @@ describe("contextual mobile Live header", () => {
     expect(styleSource).toContain("--text-swap-dur: 150ms");
     expect(styleSource).toContain(".lfg-shimmer-text::before");
     expect(styleSource).toContain("animation: none !important");
+  });
+
+  test("never greets an unidentified viewer as the roster's Unassigned label", async () => {
+    const source = await app();
+    // shortUser() answers "unassigned" for a missing email — a roster filter
+    // label, not a person. The signed-out omg preview passes no viewer, no
+    // user and no identity, so it used to render "Welcome, Unassigned".
+    expect(source).not.toContain("shortUser(identity)`");
+    expect(source).toContain('(identity ? shortUser(identity) : "")');
+    expect(source).toContain('const firstNamePart = rawName.split(/\\s+/)[0] ?? "";');
+    expect(source).toContain(': "Welcome"');
+    expect(source).toContain(': "An agent needs you"');
+    expect(source).toContain(": `${questionCount} agents need you`");
   });
 
   test("keeps urgent questions accessible without restoring a badge", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7390,9 +7390,16 @@ function LiveHeaderContext({
   // roster. omg Computers have no roster by design, so deriving this welcome
   // from session ownership would either say "Unassigned" or reintroduce the
   // rejected-user bug that roster-less hosted instances were built to avoid.
-  const rawName = viewerName?.trim() || user?.name?.trim() || shortUser(identity);
-  const firstNamePart = rawName.split(/\s+/)[0] || "there";
-  const firstName = `${firstNamePart.charAt(0).toUpperCase()}${firstNamePart.slice(1)}`;
+  // When nothing identifies the viewer at all — a roster-less host that passes
+  // no viewer, or omg's signed-out preview — there is no name to greet, so the
+  // greeting drops the name entirely. It must NOT fall through to shortUser()'s
+  // "unassigned": that is a roster FILTER label ("show unowned sessions"),
+  // never a person, and it rendered as "Welcome, Unassigned" in the preview.
+  const rawName = viewerName?.trim() || user?.name?.trim() || (identity ? shortUser(identity) : "");
+  const firstNamePart = rawName.split(/\s+/)[0] ?? "";
+  const firstName = firstNamePart
+    ? `${firstNamePart.charAt(0).toUpperCase()}${firstNamePart.slice(1)}`
+    : "";
   const questionCount = questions.length;
   const showCard = intro;
   const actionInMotion = busyCount > 0;
@@ -7401,11 +7408,15 @@ function LiveHeaderContext({
   const ambientTextRef = useRef<HTMLSpanElement>(null);
   const ambientSwapTimerRef = useRef<number | null>(null);
   const ambientContext = `${busyCount} agent${busyCount === 1 ? "" : "s"} building`;
-  const welcomeMessage = `Welcome, ${firstName}`;
+  const welcomeMessage = firstName ? `Welcome, ${firstName}` : "Welcome";
   const headline = questionCount
     ? questionCount === 1
-      ? `${firstName}, an agent needs you`
-      : `${firstName}, ${questionCount} agents need you`
+      ? firstName
+        ? `${firstName}, an agent needs you`
+        : "An agent needs you"
+      : firstName
+        ? `${firstName}, ${questionCount} agents need you`
+        : `${questionCount} agents need you`
     : actionInMotion && showAmbientStatus
       ? ambientContext
       : welcomeMessage;


### PR DESCRIPTION
The signed-out omg preview (app.omg.dev) greeted every visitor with **"Welcome, Unassigned"**.

`LiveHeaderContext` derived the welcome name as `viewerName || user?.name || shortUser(identity)`. `shortUser()` answers `"unassigned"` for a missing email — that string is a roster **filter** label ("show unowned sessions"), never a person. The preview passes no viewer, no user and no identity, so it hit that fallback.

Now: no identity → no name. `"Welcome"` instead of `"Welcome, Unassigned"`, and the question headlines drop their name prefix the same way (`"An agent needs you"`, `"3 agents need you"`). Signed-in and hosted-viewer paths are unchanged.

Covered by `test/live-header-context.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)