### PR TITLE
feat(voice): stream dictation through the omg relay on hosted workspaces

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -221,6 +221,7 @@ import {
   saveVoiceProviderKey,
   listProviders,
   voiceSetupInfo,
+  sttStreamingAvailable,
   openSttStream,
   type VoiceSettings,
   type SttStreamBridge,
@@ -2379,6 +2380,10 @@ a{color:#60a5fa}
         return json({
           settings: await getVoiceSettings(),
           providers: listProviders(),
+          // Whether dictation will show words as they are spoken. False means the
+          // browser will still transcribe, but only after the take ends — the UI
+          // says so rather than leaving it looking broken.
+          streaming: sttStreamingAvailable(),
           setup: voiceSetupInfo(),
         });
       }

--- a/src/voice-providers.ts
+++ b/src/voice-providers.ts
@@ -40,9 +40,12 @@ export type SttStreamBridge = {
   close: () => void; // stream end → tear down the upstream
 };
 
-const DEFAULTS: VoiceSettings = {
-  sttProvider: "elevenlabs",
-};
+// On a hosted omg workspace there is no ElevenLabs key to enter — the platform
+// relays transcription for us — so the default has to follow the environment
+// rather than being a fixed string. A local install is unchanged.
+const DEFAULTS = (): VoiceSettings => ({
+  sttProvider: sttOmg.available() && !sttElevenLabs.available() ? "omg" : "elevenlabs",
+});
 
 const TIMEOUT_MS = 30000;
 
@@ -217,6 +220,124 @@ function elevenLabsRealtimeStream(handlers: SttStreamHandlers): SttStreamBridge 
   };
 }
 
+// ---------------------------------------------------------------- omg relay
+//
+// On a hosted omg workspace the platform runs the realtime STT upstream for us:
+// the sandbox holds no provider key, and OMG_MEDIA_URL points at the per-sandbox
+// media proxy. Its /realtime/transcribe websocket speaks the SAME neutral
+// protocol this module already defines, so the bridge is a straight pipe:
+//
+//   we send  : binary PCM frames, {"type":"flush"}, {"type":"eof"}
+//   we get   : {"type":"ready"|"partial"|"final"|"error"}
+//
+// Auth is ambient — reaching the proxy at all proves which sandbox you are — so
+// there is no key to configure and nothing to put in the setup dialog.
+function omgRelayURL(): string | null {
+  const base = process.env.OMG_MEDIA_URL;
+  if (!base) return null;
+  return `${base.replace(/\/+$/, "").replace(/^http/, "ws")}/realtime/transcribe`;
+}
+
+function omgRelayStream(handlers: SttStreamHandlers): SttStreamBridge | null {
+  const url = omgRelayURL();
+  if (!url) return null;
+
+  let up: WebSocket;
+  try {
+    up = new WebSocket(url);
+  } catch (e) {
+    console.log(`[voice] omg relay could not connect: ${(e as { message?: string })?.message || e}`);
+    return null;
+  }
+  up.binaryType = "arraybuffer";
+
+  let open = false;
+  let closed = false;
+  // Frames captured before the socket opens. openStream() must construct
+  // synchronously (the ws open() handler can't await), so early audio queues
+  // here rather than being dropped.
+  const outbox: Array<string | Uint8Array> = [];
+
+  const send = (frame: string | Uint8Array) => {
+    if (closed) return;
+    if (!open) {
+      outbox.push(frame);
+      return;
+    }
+    try {
+      up.send(frame);
+    } catch {}
+  };
+
+  up.addEventListener("open", () => {
+    open = true;
+    for (const frame of outbox) {
+      try {
+        up.send(frame);
+      } catch {}
+    }
+    outbox.length = 0;
+  });
+
+  up.addEventListener("message", (ev) => {
+    let d: { type?: string; text?: string; message?: string; status?: string };
+    try {
+      d = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+    } catch {
+      return;
+    }
+    if (d.type === "partial") handlers.onPartial((d.text || "").trim());
+    else if (d.type === "final") handlers.onFinal((d.text || "").trim());
+    else if (d.type === "error") {
+      // Fail loud: an exhausted allowance or a missing Computer grant is a real
+      // condition the operator needs to see, not a silent downgrade.
+      console.log(`[voice] omg relay error (${d.status || "unknown"}): ${d.message || ""}`);
+    }
+  });
+
+  up.addEventListener("close", () => {
+    closed = true;
+    handlers.onClose?.();
+  });
+  up.addEventListener("error", (e) => {
+    console.log(`[voice] omg relay ws error: ${(e as { message?: string })?.message || e}`);
+  });
+
+  return {
+    pushPcm: (pcm) => {
+      // Bun may reuse the underlying buffer for the next frame.
+      const copy = new Uint8Array(pcm.length);
+      copy.set(pcm);
+      send(copy);
+    },
+    flush: () => send(JSON.stringify({ type: "flush" })),
+    close: () => {
+      if (closed) return;
+      send(JSON.stringify({ type: "eof" }));
+      closed = true;
+      try {
+        up.close();
+      } catch {}
+    },
+  };
+}
+
+const sttOmg: SttProvider = {
+  id: "omg",
+  label: "OMG (hosted)",
+  envVar: "OMG_MEDIA_URL",
+  accountUrl: "https://omg.dev",
+  available: () => !!process.env.OMG_MEDIA_URL,
+  openStream: (handlers) => omgRelayStream(handlers),
+  async transcribe() {
+    // The relay is realtime-only: the platform's batch job API takes a public
+    // audio URL, not bytes, so there is nothing to POST a clip to. Say so
+    // plainly instead of returning an empty transcript the caller would treat
+    // as silence.
+    return eres(503, "omg relay is realtime-only; batch transcription is unavailable");
+  },
+};
+
 const sttElevenLabs: SttProvider = {
   id: "elevenlabs",
   label: "ElevenLabs (Scribe)",
@@ -275,6 +396,7 @@ const sttOpenAI: SttProvider = {
 };
 
 const STT: Record<string, SttProvider> = {
+  [sttOmg.id]: sttOmg,
   [sttElevenLabs.id]: sttElevenLabs,
   [sttOpenAI.id]: sttOpenAI,
 };
@@ -335,16 +457,23 @@ export async function saveVoiceProviderKey(providerId: string, apiKey: string): 
 
 const filePath = () => join(PATHS.data, "voice-settings.json");
 
+// A saved choice only survives while that provider is actually usable. A stale
+// "elevenlabs" from a local install would otherwise pin a hosted workspace to a
+// keyless provider and silently downgrade every take to the batch path — the
+// exact failure this relay exists to remove.
+function resolveSttProvider(saved: string | undefined): string {
+  if (saved && STT[saved]?.available()) return saved;
+  return DEFAULTS().sttProvider;
+}
+
 export async function getVoiceSettings(): Promise<VoiceSettings> {
   const f = Bun.file(filePath());
-  if (!(await f.exists())) return { ...DEFAULTS };
+  if (!(await f.exists())) return DEFAULTS();
   try {
     const p = JSON.parse(await f.text()) as Partial<VoiceSettings>;
-    return {
-      sttProvider: p.sttProvider && STT[p.sttProvider] ? p.sttProvider : DEFAULTS.sttProvider,
-    };
+    return { sttProvider: resolveSttProvider(p.sttProvider) };
   } catch {
-    return { ...DEFAULTS };
+    return DEFAULTS();
   }
 }
 
@@ -354,11 +483,9 @@ export async function getVoiceSettings(): Promise<VoiceSettings> {
 function getVoiceSettingsSync(): VoiceSettings {
   try {
     const p = JSON.parse(readFileSync(filePath(), "utf8")) as Partial<VoiceSettings>;
-    return {
-      sttProvider: p.sttProvider && STT[p.sttProvider] ? p.sttProvider : DEFAULTS.sttProvider,
-    };
+    return { sttProvider: resolveSttProvider(p.sttProvider) };
   } catch {
-    return { ...DEFAULTS };
+    return DEFAULTS();
   }
 }
 
@@ -382,6 +509,7 @@ export function listProviders() {
       envVar: string;
       accountUrl: string;
       available: () => boolean;
+      openStream?: unknown;
     },
   ) => ({
     id: p.id,
@@ -389,6 +517,9 @@ export function listProviders() {
     envVar: p.envVar,
     accountUrl: p.accountUrl,
     available: p.available(),
+    // Whether this provider can show words as you speak, rather than only after
+    // the take ends.
+    streaming: !!p.openStream,
   });
   return {
     stt: Object.values(STT).map(map),
@@ -410,7 +541,18 @@ export function voiceSetupInfo() {
 function pickStt(id: string): SttProvider {
   const p = STT[id];
   if (p && p.available()) return p;
-  return sttElevenLabs;
+  return firstAvailable((c) => !!c.transcribe) ?? sttElevenLabs;
+}
+
+// The configured provider is not always the usable one (a hosted workspace has
+// no local key; a local install has no relay). Rather than hardcoding one
+// fallback, take the first registered provider that is actually wired up and
+// can do the job asked of it.
+function firstAvailable(supports: (p: SttProvider) => boolean): SttProvider | null {
+  for (const p of Object.values(STT)) {
+    if (p.available() && supports(p)) return p;
+  }
+  return null;
 }
 
 export async function transcribeStt(audio: ArrayBuffer): Promise<Response> {
@@ -419,15 +561,23 @@ export async function transcribeStt(audio: ArrayBuffer): Promise<Response> {
 }
 
 // Open a realtime STT bridge for the /api/voice/stt-stream websocket. Picks the
-// configured provider; if it has no realtime path, falls back to ElevenLabs when
-// available, else returns null so the proxy closes the socket (the worker then
-// has no interim transcripts and the operator should unset STT_WS_URL). Sync so
-// the websocket open() handler can build it without racing the first frame.
+// configured provider; if it has no realtime path, falls back to any other
+// provider that does (the omg relay on a hosted workspace, ElevenLabs on a local
+// install), else returns null so the proxy closes the socket and the browser
+// degrades to the batch path. Sync so the websocket open() handler can build it
+// without racing the first frame.
 export function openSttStream(handlers: SttStreamHandlers): SttStreamBridge | null {
   const s = getVoiceSettingsSync();
   const chosen = STT[s.sttProvider];
   if (chosen?.available() && chosen.openStream) return chosen.openStream(handlers);
-  if (sttElevenLabs.available() && sttElevenLabs.openStream)
-    return sttElevenLabs.openStream(handlers);
-  return null;
+  const fallback = firstAvailable((p) => !!p.openStream);
+  return fallback?.openStream?.(handlers) ?? null;
+}
+
+/** Whether a live (streaming) transcript is possible right now. Drives the UI's
+ * "live vs after-the-fact" indicator, so a silent downgrade becomes visible. */
+export function sttStreamingAvailable(): boolean {
+  const chosen = STT[getVoiceSettingsSync().sttProvider];
+  if (chosen?.available() && chosen.openStream) return true;
+  return firstAvailable((p) => !!p.openStream) !== null;
 }

--- a/test/omg-relay-stt.test.ts
+++ b/test/omg-relay-stt.test.ts
@@ -1,0 +1,130 @@
+// The omg relay provider: on a hosted workspace there is no local STT key, so
+// dictation streams through the platform's per-sandbox media proxy instead of
+// silently degrading to the after-the-fact batch path.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+type Listener = (ev: { data?: unknown; message?: string }) => void;
+
+class FakeWebSocket {
+  static last: FakeWebSocket | null = null;
+  url: string;
+  binaryType = "";
+  sent: Array<string | Uint8Array> = [];
+  closed = false;
+  private listeners: Record<string, Listener[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.last = this;
+  }
+  addEventListener(type: string, fn: Listener) {
+    (this.listeners[type] ||= []).push(fn);
+  }
+  emit(type: string, ev: { data?: unknown; message?: string } = {}) {
+    for (const fn of this.listeners[type] || []) fn(ev);
+  }
+  send(frame: string | Uint8Array) {
+    this.sent.push(frame);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+const realWebSocket = globalThis.WebSocket;
+const realMediaURL = process.env.OMG_MEDIA_URL;
+const realElevenKey = process.env.ELEVENLABS_API_KEY;
+
+beforeEach(() => {
+  (globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket;
+  FakeWebSocket.last = null;
+  process.env.OMG_MEDIA_URL = "http://172.20.3.1:9090/media";
+  delete process.env.ELEVENLABS_API_KEY;
+});
+
+afterEach(() => {
+  (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
+  if (realMediaURL === undefined) delete process.env.OMG_MEDIA_URL;
+  else process.env.OMG_MEDIA_URL = realMediaURL;
+  if (realElevenKey === undefined) delete process.env.ELEVENLABS_API_KEY;
+  else process.env.ELEVENLABS_API_KEY = realElevenKey;
+});
+
+test("a hosted workspace with no local key streams through the omg relay", async () => {
+  const { openSttStream, sttStreamingAvailable } = await import("../src/voice-providers.ts");
+
+  expect(sttStreamingAvailable()).toBe(true);
+
+  const partials: string[] = [];
+  const finals: string[] = [];
+  const bridge = openSttStream({
+    onPartial: (t) => partials.push(t),
+    onFinal: (t) => finals.push(t),
+  });
+  expect(bridge).not.toBeNull();
+
+  const ws = FakeWebSocket.last!;
+  // http:// → ws://, and the relay path is appended to OMG_MEDIA_URL.
+  expect(ws.url).toBe("ws://172.20.3.1:9090/media/realtime/transcribe");
+
+  // Audio pushed before the socket opens must be queued, not dropped.
+  bridge!.pushPcm(new Uint8Array(3200));
+  expect(ws.sent.length).toBe(0);
+  ws.emit("open");
+  expect(ws.sent.length).toBe(1);
+  expect((ws.sent[0] as Uint8Array).length).toBe(3200);
+
+  // Interim and committed transcripts reach the handlers.
+  ws.emit("message", { data: JSON.stringify({ type: "partial", text: "hello wor" }) });
+  ws.emit("message", { data: JSON.stringify({ type: "final", text: "hello world" }) });
+  expect(partials).toEqual(["hello wor"]);
+  expect(finals).toEqual(["hello world"]);
+
+  // flush marks the utterance boundary; close says goodbye before hanging up.
+  bridge!.flush();
+  expect(ws.sent.at(-1)).toBe(JSON.stringify({ type: "flush" }));
+  bridge!.close();
+  expect(ws.sent.at(-1)).toBe(JSON.stringify({ type: "eof" }));
+  expect(ws.closed).toBe(true);
+});
+
+test("the relay bridge copies each PCM frame", async () => {
+  const { openSttStream } = await import("../src/voice-providers.ts");
+  const bridge = openSttStream({ onPartial: () => {}, onFinal: () => {} })!;
+  const ws = FakeWebSocket.last!;
+  ws.emit("open");
+
+  // Bun reuses the read buffer between frames, so a retained reference would be
+  // silently rewritten with the NEXT frame's audio.
+  const frame = new Uint8Array([1, 2, 3, 4]);
+  bridge.pushPcm(frame);
+  frame.fill(9);
+  expect(Array.from(ws.sent[0] as Uint8Array)).toEqual([1, 2, 3, 4]);
+});
+
+test("a stale saved provider does not pin a hosted workspace to a keyless one", async () => {
+  const { openSttStream } = await import("../src/voice-providers.ts");
+  // data/voice-settings.json in this repo says "elevenlabs", and no key is set
+  // here — the resolver must fall through to the relay rather than returning
+  // null (which is what made every take batch-only).
+  const bridge = openSttStream({ onPartial: () => {}, onFinal: () => {} });
+  expect(bridge).not.toBeNull();
+  expect(FakeWebSocket.last!.url).toContain("/realtime/transcribe");
+});
+
+test("the relay reports batch transcription as unavailable rather than empty", async () => {
+  const { transcribeStt } = await import("../src/voice-providers.ts");
+  const res = await transcribeStt(new ArrayBuffer(8));
+  expect(res.status).toBe(503);
+  const body = (await res.json()) as { error?: string };
+  expect(body.error).toContain("realtime-only");
+});
+
+test("without OMG_MEDIA_URL the relay is not offered", async () => {
+  delete process.env.OMG_MEDIA_URL;
+  const { sttStreamingAvailable, listProviders } = await import("../src/voice-providers.ts");
+  expect(sttStreamingAvailable()).toBe(false);
+  const omg = listProviders().stt.find((p) => p.id === "omg");
+  expect(omg?.available).toBe(false);
+  expect(omg?.streaming).toBe(true);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -233,6 +233,7 @@ import {
   invalidateVoiceConfig,
   prefetchVoiceConfig,
   showVoiceSetup,
+  voiceBatchOnlyCached,
   voiceConfiguredCached,
   VoiceSetupDialog,
 } from "./voice-setup";
@@ -3477,6 +3478,7 @@ const MicButton = forwardRef<
 
   if (!supported) return null;
   const recording = state === "recording";
+  const batchOnly = voiceBatchOnlyCached();
   // While recording, the button reacts to the live mic level: it scales up and
   // throws a red glow ring that swells with your volume. Inline transitions keep
   // it snappy (the className `transition` would lag the per-frame updates by
@@ -3508,7 +3510,17 @@ const MicButton = forwardRef<
               : "Stop dictation — tap the X above, or press Esc, to cancel"
             : "Dictate"
         }
-        title={recording ? "Tap to send · X or Esc to cancel" : "Tap to dictate · hold to talk"}
+        title={
+          // A batch-only provider still transcribes, it just can't show words as
+          // you speak. Saying so beats looking frozen until the take ends.
+          batchOnly
+            ? recording
+              ? "Transcribes after you stop · X or Esc to cancel"
+              : "Tap to dictate · transcript appears after you stop"
+            : recording
+              ? "Tap to send · X or Esc to cancel"
+              : "Tap to dictate · hold to talk"
+        }
         style={reactiveStyle}
         className={cn(
           "flex shrink-0 touch-none select-none items-center justify-center rounded-full transition",

--- a/web/src/voice-setup.tsx
+++ b/web/src/voice-setup.tsx
@@ -27,8 +27,17 @@ type ProviderOption = {
 export type VoiceConfig = {
   settings: { sttProvider: string };
   providers: { stt: ProviderOption[] };
+  /** Dictation shows words as you speak. False = transcript only after the take. */
+  streaming?: boolean;
   setup: { envFile: string; restartCommand: string };
 };
+
+/** True when dictation will only produce text after the take ends. The mic still
+ * works; it just can't show a running transcript, and the UI should say so
+ * rather than looking like it hung. */
+export function voiceIsBatchOnly(cfg: VoiceConfig | null): boolean {
+  return cfg?.streaming === false;
+}
 
 const SETUP_EVENT = "lfg:voice-setup";
 
@@ -116,6 +125,17 @@ export function voiceConfiguredCached(capability: VoiceCapability): boolean | nu
     prefetchVoiceConfig(); // refresh in the background, answer from what we have
   }
   return voiceReady(cached.cfg, capability);
+}
+
+/** Synchronous, cache-only read of whether dictation is batch-only right now.
+ * Unknown (nothing cached yet) reads as false so the UI never claims a downgrade
+ * it hasn't confirmed. */
+export function voiceBatchOnlyCached(): boolean {
+  if (!cached) {
+    prefetchVoiceConfig();
+    return false;
+  }
+  return voiceIsBatchOnly(cached.cfg);
 }
 
 export async function ensureVoiceConfigured(capability: VoiceCapability): Promise<boolean> {


### PR DESCRIPTION
## Why

On a hosted workspace there is no `ELEVENLABS_API_KEY`, so `openSttStream` returned `null`, the browser's realtime socket was closed on arrival, and every dictation take degraded to the batch path: nothing on screen while you spoke, transcript only after you stopped, and no indication why.

## What

An `omg` provider that bridges to the platform's per-sandbox media proxy (`OMG_MEDIA_URL` → `/realtime/transcribe`, added in BennyKok/vibes#1224). It speaks the neutral protocol this module already defines, so it's a straight pipe — binary PCM up, `partial`/`final` down. Auth is ambient (reaching the proxy proves which sandbox you are), so there's no key to enter and nothing to add to the setup dialog.

## Three silent-fallback traps closed

The relay alone wasn't enough — each of these would have kept a hosted box on the batch path anyway:

1. `DEFAULTS.sttProvider` was the fixed string `"elevenlabs"`; it now follows the environment, so a hosted workspace defaults to the relay.
2. A saved choice was accepted as long as the provider *existed*. A stale `data/voice-settings.json` saying `elevenlabs` pinned a keyless box to a dead provider — a saved choice now only survives while it is actually `available()`.
3. Both fallbacks hardcoded ElevenLabs; they now pick the first registered provider that can do the job asked of it.

## Honest degradation

The relay is realtime-only (the platform's batch API takes a public URL, not bytes), so its `transcribe()` returns a 503 saying so rather than an empty string a caller would read as silence. `/api/voice/config` now reports whether dictation is live, and the mic button says *"transcribes after you stop"* when it isn't — the downgrade is visible instead of looking like a hang.

## Verification

New unit tests cover the URL derivation, pre-open frame queueing, PCM frame copying (Bun reuses the read buffer), the stale-provider fallthrough, and the batch 503.

Driven for real against a live relay + the live ElevenLabs API, with all local STT keys stripped so the relay was genuinely exercised:

```
partial: The quick brown
partial: The quick brown fox jumps-
...
FINAL:   The quick brown fox jumps over the lazy dog. Streaming transcription should show these words as they are spoken.
partials=7 finals=1
PASS: live transcript through the LFG omg-relay bridge
```

`bun x tsc --noEmit` clean; full suite green apart from 3 pre-existing `thinking-level-label` failures on main.

Note: reaching hosted workspaces needs a release + template bake after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)