### PR TITLE
setup: honour OMG_* env vars in the curl|bash install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then open **http://127.0.0.1:8766**.
 That's the whole install. The script provisions Bun, `tmux`, and `git`,
 downloads the latest release, writes `.env`, and starts `omg` as a user service
 bound to loopback. On a fresh Ubuntu/Debian box, add
-`LFG_INSTALL_SYSTEM_DEPS=1` so it may `apt-get` the base packages.
+`OMG_INSTALL_SYSTEM_DEPS=1` so it may `apt-get` the base packages.
 
 Next: [connect a coding agent](#connect-a-coding-agent) so you have something to
 run, then [reach it from your phone](#reach-it-from-your-phone).

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,20 @@
 
 set -euo pipefail
 
+# ---- prefix compatibility ----
+# Shell twin of src/env-compat.ts. Every knob below is read as LFG_*, but the
+# project's prefix is now OMG_* and this script already writes OMG_* into .env
+# and the service units. The TS CLI aliases the two before spawning this script,
+# so `omg setup` already honours OMG_*; the `curl | bash` entry point does not,
+# which makes OMG_INSTALL_SYSTEM_DEPS=1 the one documented knob that silently
+# does nothing. Mirror OMG_* onto LFG_*; OMG_* wins when both are set.
+for _omg_var in "${!OMG_@}"; do
+  _omg_suffix="${_omg_var#OMG_}"
+  [ -n "$_omg_suffix" ] || continue
+  printf -v "LFG_${_omg_suffix}" '%s' "${!_omg_var}"
+done
+unset _omg_var _omg_suffix
+
 # ---- config (override via env) ----
 LFG_REPO_URL="${LFG_REPO_URL:-https://github.com/BennyKok/omg.dev.git}"
 # Where prebuilt release tarballs live (GitHub "owner/repo"). Defaults align


### PR DESCRIPTION
Follow-up to #86, reduced to only what's still additive after your edits landed.

### The gap

The README documents the `OMG_` prefix, and `scripts/setup.sh` already *writes* `OMG_` into `.env` and the service units — but it *reads* all 22 of its own knobs as `LFG_*` only.

`src/cli.ts` calls `applyEnvAliases()` at startup, so `omg setup` and `omg connect` already honour `OMG_*`. The gap is the `curl | bash` entry point, which never runs any TypeScript.

That leaves `OMG_INSTALL_SYSTEM_DEPS=1` as the one documented knob that silently does nothing — and it's referenced by the first command in the README. On a fresh Ubuntu box:

```
[x] Missing or unchecked system deps. Re-run with LFG_INSTALL_SYSTEM_DEPS=1, ...
```

### The fix

The shell twin of `src/env-compat.ts`, ahead of the config block: mirror `OMG_*` onto `LFG_*`, `OMG_` winning when both are set. Same precedence as the TS side. README line switched to `OMG_`.

### Verification

Sourced the real config block (lines 19–84) under `set -u`:

| Env | `INSTALL_SYSTEM_DEPS` | `PORT` | `TAILSCALE_SERVE` |
|---|---|---|---|
| none | 1 (Linux default) | 8766 | 0 |
| `OMG_PORT=9999 OMG_TAILSCALE_SERVE=1` | 1 | **9999** | **1** |
| `LFG_PORT=1111 LFG_TAILSCALE_SERVE=1` | 1 | **1111** | **1** |
| `OMG_PORT=9999 LFG_PORT=1111` | 1 | **9999** (OMG_ wins) | 0 |

Back-compat intact; no error when no `OMG_*` vars are set. `bash -n` clean.