### PR TITLE
feat(connect): binary frames and streamed responses over the relay

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,6 +1,14 @@
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { PATHS, localServeHost } from "../config.ts";
+import {
+  BOX_CAPS,
+  CAP_BINARY,
+  CAP_HTTP_STREAM,
+  decodeBinaryFrame,
+  encodeBinaryFrame,
+  negotiateCaps,
+} from "../relay-frames.ts";
 
 // lfg connect — generic remote-access relay client.
 //
@@ -19,11 +27,31 @@ import { PATHS, localServeHost } from "../config.ts";
 // perimeter, so this client authenticates to the RELAY (pairing code once,
 // then a persisted bearer token) — it does not change `serve` itself.
 //
-// Wire protocol (JSON frames over one WebSocket to LFG_RELAY_URL):
-//   client → relay   {type:"pair", code, computerUrl?}       (first connect only)
-//   relay  → client   {type:"paired", token, boxId}           (persist token; reconnect with it instead of a code)
-//   client → relay   {type:"hello", token, computerUrl?}      (subsequent connects)
-//   relay  → client   {type:"hello-ok"}                        (optional; unknown frame types are ignored anyway)
+// Wire protocol (frames over one WebSocket to LFG_RELAY_URL):
+//   client → relay   {type:"pair", code, computerUrl?, caps}  (first connect only)
+//   relay  → client   {type:"paired", token, boxId, caps?}     (persist token; reconnect with it instead of a code)
+//   client → relay   {type:"hello", token, computerUrl?, caps} (subsequent connects)
+//   relay  → client   {type:"hello-ok", caps?}                 (optional; unknown frame types are ignored anyway)
+//
+// CAPABILITY NEGOTIATION. `caps` is this build's wire features (see
+// src/relay-frames.ts); the relay answers with the subset it also speaks, and
+// that intersection governs the connection. Both omissions are meaningful and
+// both must keep working: a relay predating negotiation answers with no `caps`
+// and gets the JSON-only protocol below, and a box predating it advertises
+// none, so a new relay serves it the same way. Never make a cap the default.
+//
+//   binary       payload frames are [4B BE header length][JSON header][bytes]
+//                instead of base64 inside the JSON. Applies to ws-msg,
+//                stream-data and http-body.
+//   http-stream  a response comes back as http-head → http-body* → http-end
+//                rather than one buffered http-response:
+//                  client → relay  {type:"http-head", id, status, headers}
+//                  client → relay  {type:"http-body", id} + raw bytes
+//                  client → relay  {type:"http-end",  id, error?}
+//                Without it, a response body has to fit in ONE frame after a
+//                4/3 base64 inflation. That is not a soft limit — the relay's
+//                WebSocket server closes the connection on an oversized frame,
+//                so a single large artifact took the whole box offline.
 //   relay  → client   {type:"error", message}                  (pairing/hello rejected — relay closes right after)
 //   relay  → client   {type:"http", id, method, path, headers, bodyB64?}
 //   client → relay   {type:"http-response", id, status, headers, bodyB64?}
@@ -307,6 +335,10 @@ export function openLocalWsTunnel(
   tunnels: WsTunnels,
   send: (payload: unknown) => void,
   connect: (url: string) => WebSocket = (url) => new WebSocket(url),
+  /** Payload-carrying send. Defaults to base64-in-JSON so a caller that hasn't
+   *  negotiated binary framing (and every existing test) keeps working. */
+  sendPayload: (header: Record<string, unknown>, payload: Uint8Array) => void = (header, payload) =>
+    send({ ...header, dataB64: Buffer.from(payload).toString("base64") }),
 ): void {
   let local: WebSocket;
   try {
@@ -322,10 +354,10 @@ export function openLocalWsTunnel(
   local.addEventListener("message", (event: MessageEvent) => {
     const data = event.data;
     const binary = typeof data !== "string";
-    const buf = binary
-      ? Buffer.from(data as ArrayBuffer)
-      : Buffer.from(String(data), "utf8");
-    send({ type: "ws-msg", id: frame.id, dataB64: buf.toString("base64"), binary });
+    const bytes = binary
+      ? new Uint8Array(data as ArrayBuffer)
+      : new TextEncoder().encode(String(data));
+    sendPayload({ type: "ws-msg", id: frame.id, binary }, bytes);
   });
   local.addEventListener("close", (event: CloseEvent) => {
     tunnels.delete(frame.id);
@@ -345,6 +377,9 @@ export function openLocalWsTunnel(
 export function applyWsTunnelFrame(
   frame: { type: string; id: string; [k: string]: unknown },
   tunnels: WsTunnels,
+  /** Present when the frame arrived as a binary frame — already bytes, so
+   *  `dataB64` is absent and must not be consulted. */
+  payload?: Uint8Array,
 ): void {
   const local = tunnels.get(frame.id);
   if (!local) return;
@@ -357,10 +392,11 @@ export function applyWsTunnelFrame(
     }
     return;
   }
-  const dataB64 = typeof frame.dataB64 === "string" ? frame.dataB64 : "";
-  const buf = Buffer.from(dataB64, "base64");
+  const bytes =
+    payload ??
+    Buffer.from(typeof frame.dataB64 === "string" ? frame.dataB64 : "", "base64");
   try {
-    local.send(frame.binary ? buf : buf.toString("utf8"));
+    local.send(frame.binary ? bytes : new TextDecoder().decode(bytes));
   } catch {
     /* socket raced closed — the close frame will clean up */
   }
@@ -413,6 +449,9 @@ export function openLocalStreamTunnel(
   tunnels: StreamTunnels,
   send: (payload: unknown) => void,
   fetchImpl: typeof fetch = fetch,
+  /** Payload-carrying send — see openLocalWsTunnel. */
+  sendPayload: (header: Record<string, unknown>, payload: Uint8Array) => void = (header, payload) =>
+    send({ ...header, dataB64: Buffer.from(payload).toString("base64") }),
 ): void {
   const controller = new AbortController();
   tunnels.set(frame.id, controller);
@@ -439,7 +478,7 @@ export function openLocalStreamTunnel(
         const { done, value } = await reader.read();
         if (done) break;
         if (value && value.length) {
-          send({ type: "stream-data", id: frame.id, dataB64: Buffer.from(value).toString("base64") });
+          sendPayload({ type: "stream-data", id: frame.id }, value);
         }
       }
       tunnels.delete(frame.id);
@@ -462,6 +501,77 @@ export function applyStreamCloseFrame(frame: { id: string }, tunnels: StreamTunn
     controller.abort();
   } catch {
     /* already aborted */
+  }
+}
+
+/**
+ * Proxies one relayed HTTP request onto local serve and STREAMS the reply back
+ * as bounded binary frames: one `http-head`, then an `http-body` per chunk as
+ * it arrives, then `http-end`.
+ *
+ * This is the same job `forwardToLocalServe` does, minus its two costs. That
+ * one reads the entire body into memory and base64's it into a single JSON
+ * frame — a 4/3 inflation on every byte, and a frame the relay may simply
+ * refuse. An oversized frame is not a failed request: the relay's WebSocket
+ * server closes the connection, which took the whole box offline whenever
+ * someone opened a large artifact. Here no chunk is bigger than what the local
+ * response hands over, so body size and frame size are unrelated.
+ *
+ * Only used when the relay advertised CAP_HTTP_STREAM; otherwise the caller
+ * falls back to the buffered pair, which every relay understands.
+ */
+export async function streamToLocalServe(
+  frame: HttpFrame,
+  sendBinary: (header: Record<string, unknown>, payload: Uint8Array) => void,
+  sendJson: (payload: unknown) => void,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetchImpl(`http://${LOCAL_HOST}:${LOCAL_PORT}${frame.path}`, {
+      method: frame.method,
+      headers: frame.headers,
+      body: frame.bodyB64 ? Buffer.from(frame.bodyB64, "base64") : undefined,
+    });
+  } catch (error) {
+    sendJson({
+      type: "http-head",
+      id: frame.id,
+      status: 502,
+      headers: { "content-type": "text/plain" },
+    });
+    sendBinary(
+      { type: "http-body", id: frame.id },
+      new TextEncoder().encode(`lfg connect: local serve unreachable — ${String(error)}`),
+    );
+    sendJson({ type: "http-end", id: frame.id });
+    return;
+  }
+
+  sendJson({
+    type: "http-head",
+    id: frame.id,
+    status: response.status,
+    headers: Object.fromEntries(response.headers.entries()),
+  });
+
+  const body = response.body;
+  if (!body) {
+    sendJson({ type: "http-end", id: frame.id });
+    return;
+  }
+  const reader = body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value && value.length) sendBinary({ type: "http-body", id: frame.id }, value);
+    }
+    sendJson({ type: "http-end", id: frame.id });
+  } catch (error) {
+    // The head is already gone, so the relay must be told this body is short
+    // rather than being left to reassemble a truncated response as a success.
+    sendJson({ type: "http-end", id: frame.id, error: String(error) });
   }
 }
 
@@ -991,8 +1101,12 @@ function connectSocket(
 ): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(relayUrl);
+    ws.binaryType = "arraybuffer";
     ws.addEventListener("open", () => {
-      ws.send(JSON.stringify(hello));
+      // Advertise what this build speaks. A relay that predates capability
+      // negotiation ignores the extra field and answers without one, which is
+      // exactly the "no caps" answer that keeps us on the JSON-only path.
+      ws.send(JSON.stringify({ ...hello, caps: BOX_CAPS }));
       resolve(ws);
     });
     ws.addEventListener("error", (event) => reject(new Error(`relay connection failed: ${String(event)}`)));
@@ -1102,9 +1216,30 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
       // relay socket closes, so a reconnect never resurrects a stale tunnel.
       const wsTunnels: WsTunnels = new Map();
       const streamTunnels: StreamTunnels = new Map();
+      // Filled in from the relay's hello-ok/paired answer. Empty until then,
+      // and empty forever against a relay that predates negotiation — so every
+      // send below has to keep working with no caps at all.
+      const caps = new Set<string>();
       const sendFrame = (payload: unknown) => {
         try {
           ws.send(JSON.stringify(payload));
+        } catch {
+          /* relay socket closing — the close handler tears the tunnels down */
+        }
+      };
+      /** Payload-carrying send: raw bytes when the relay understands them,
+       *  base64-in-JSON when it does not. */
+      const sendPayload = (
+        header: Record<string, unknown>,
+        payload: Uint8Array,
+        legacyField = "dataB64",
+      ) => {
+        try {
+          ws.send(
+            caps.has(CAP_BINARY)
+              ? encodeBinaryFrame(header, payload)
+              : JSON.stringify({ ...header, [legacyField]: Buffer.from(payload).toString("base64") }),
+          );
         } catch {
           /* relay socket closing — the close handler tears the tunnels down */
         }
@@ -1113,9 +1248,26 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
         ws.addEventListener("message", (event) => {
           void (async () => {
             let frame: unknown;
-            try {
-              frame = JSON.parse(String(event.data));
-            } catch {
+            let payload: Uint8Array | undefined;
+            const data = event.data;
+            if (typeof data !== "string") {
+              const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : new Uint8Array(data as ArrayBufferLike);
+              const decoded = decodeBinaryFrame(bytes);
+              if (!decoded) return;
+              frame = decoded.header;
+              payload = decoded.payload;
+            } else {
+              try {
+                frame = JSON.parse(data);
+              } catch {
+                return;
+              }
+            }
+            // The relay's answer to hello/pair carries the negotiated set.
+            const frameType = (frame as { type?: unknown })?.type;
+            if (frameType === "hello-ok" || frameType === "paired") {
+              for (const cap of negotiateCaps((frame as { caps?: unknown }).caps)) caps.add(cap);
+              if (caps.size) console.log(`lfg connect: negotiated ${[...caps].join(", ")}`);
               return;
             }
             if (frame && typeof frame === "object" && (frame as { type?: unknown }).type === "ping") {
@@ -1129,22 +1281,28 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
               return;
             }
             if (isWsOpenFrame(frame)) {
-              openLocalWsTunnel(frame, wsTunnels, sendFrame);
+              openLocalWsTunnel(frame, wsTunnels, sendFrame, undefined, sendPayload);
               return;
             }
             if (isWsTunnelFrame(frame)) {
-              applyWsTunnelFrame(frame, wsTunnels);
+              applyWsTunnelFrame(frame, wsTunnels, payload);
               return;
             }
             if (isStreamOpenFrame(frame)) {
-              openLocalStreamTunnel(frame, streamTunnels, sendFrame);
+              openLocalStreamTunnel(frame, streamTunnels, sendFrame, undefined, sendPayload);
               return;
             }
             if (isStreamCloseFrame(frame)) {
               applyStreamCloseFrame(frame, streamTunnels);
               return;
             }
-            if (isHttpFrame(frame)) ws.send(JSON.stringify(await forwardToLocalServe(frame)));
+            if (isHttpFrame(frame)) {
+              if (caps.has(CAP_HTTP_STREAM)) {
+                await streamToLocalServe(frame, sendPayload, sendFrame);
+              } else {
+                ws.send(JSON.stringify(await forwardToLocalServe(frame)));
+              }
+            }
           })();
         });
         ws.addEventListener("close", () => resolveClosed());

--- a/src/relay-frames.ts
+++ b/src/relay-frames.ts
@@ -1,0 +1,80 @@
+// Binary frame codec for the box ⇄ relay tunnel.
+//
+// ⚠️ MIRROR of the vibes repo's `apps/relay/src/frames.ts`. The two files
+// implement one wire format and must be changed together — a relay built
+// against a different layout does not fail loudly, it silently loses frames.
+// The format is versioned only through capability negotiation (see BOX_CAPS):
+// this client never sends a binary frame unless the relay answered `hello` /
+// `pair` advertising that it understands them, so an old relay keeps working
+// against a new box and vice versa.
+//
+// WHY IT EXISTS. The original protocol was JSON-only, which meant every byte
+// of a proxied HTTP body or live-tunnel message had to be base64'd into a JSON
+// string. That costs a 4/3 size inflation plus an encode and a decode at each
+// hop — and it is what pushed a 26 MB video artifact past the relay's
+// WebSocket frame ceiling, where an oversized frame does not fail politely: it
+// closes this box's connection. Raw bytes ride a binary frame now.
+//
+// LAYOUT
+//   [4 bytes  big-endian uint32 : header length N]
+//   [N bytes  UTF-8 JSON        : the frame header, same shape as the text
+//                                 frame it replaces, minus the base64 field]
+//   [rest     raw bytes         : the payload]
+
+/** Cap on the JSON header so a malformed length can't drive a huge allocation.
+ *  Headers are a type, an id, and a few short fields — kilobytes at most. */
+const MAX_HEADER_BYTES = 1024 * 1024;
+
+/** Raw bytes instead of base64 for payload-carrying frames. */
+export const CAP_BINARY = "binary";
+/** http-head / http-body / http-end instead of one buffered http-response. */
+export const CAP_HTTP_STREAM = "http-stream";
+
+/** Everything this box build understands. The relay answers with the subset it
+ *  also supports, and that intersection is what the connection uses. */
+export const BOX_CAPS: readonly string[] = [CAP_BINARY, CAP_HTTP_STREAM];
+
+export type BinaryFrame = { header: Record<string, unknown>; payload: Uint8Array };
+
+export function encodeBinaryFrame(
+  header: Record<string, unknown>,
+  payload: Uint8Array,
+): Uint8Array {
+  const head = new TextEncoder().encode(JSON.stringify(header));
+  const out = new Uint8Array(4 + head.length + payload.length);
+  new DataView(out.buffer).setUint32(0, head.length, false);
+  out.set(head, 4);
+  out.set(payload, 4 + head.length);
+  return out;
+}
+
+/** Decode, or null if this isn't a well-formed binary frame — callers treat
+ *  null as "not for me" and fall through to the text-JSON path rather than
+ *  dropping the connection over one bad frame. */
+export function decodeBinaryFrame(data: Uint8Array): BinaryFrame | null {
+  if (data.length < 4) return null;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const headerLength = view.getUint32(0, false);
+  if (headerLength === 0 || headerLength > MAX_HEADER_BYTES) return null;
+  if (4 + headerLength > data.length) return null;
+  try {
+    const header = JSON.parse(
+      new TextDecoder().decode(data.subarray(4, 4 + headerLength)),
+    ) as Record<string, unknown>;
+    if (!header || typeof header !== "object" || Array.isArray(header)) return null;
+    if (typeof header.type !== "string") return null;
+    return { header, payload: data.subarray(4 + headerLength) };
+  } catch {
+    return null;
+  }
+}
+
+/** The caps both ends understand, order-stable and deduped. */
+export function negotiateCaps(
+  advertised: unknown,
+  supported: readonly string[] = BOX_CAPS,
+): string[] {
+  if (!Array.isArray(advertised)) return [];
+  const offered = new Set(advertised.filter((c): c is string => typeof c === "string"));
+  return supported.filter((cap) => offered.has(cap));
+}

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -10,8 +10,11 @@ import {
   isReportableTransition,
   isTopLevelSession,
   normalizeComputerUrl,
+  streamToLocalServe,
+  applyWsTunnelFrame,
   type SessionLite,
 } from "../src/commands/connect.ts";
+import { decodeBinaryFrame, encodeBinaryFrame, negotiateCaps } from "../src/relay-frames.ts";
 
 describe("normalizeComputerUrl", () => {
   test("canonicalizes the explicit outer URL advertised during connect", () => {
@@ -501,5 +504,199 @@ describe("diffAskEvents", () => {
     expect(events[0]!.options).toEqual(["a", "b", "c", "d"]);
     expect(events[0]!.agent).toBeNull();
     expect([...seen]).toEqual(["ok"]);
+  });
+});
+
+// ---- Binary framing + streamed http responses ----
+//
+// The JSON-only protocol had to base64 every payload byte, which cost a 4/3
+// inflation and — because a response had to fit in ONE frame — let a large
+// artifact exceed the relay's frame ceiling. An oversized frame does not fail
+// the request; the relay's WebSocket server closes the box's connection. These
+// pin the wire format, the negotiation that keeps old peers working, and the
+// streaming path that makes body size independent of frame size.
+
+describe("binary frame codec", () => {
+  test("round-trips a header and raw payload", () => {
+    const payload = new Uint8Array([0, 1, 2, 253, 254, 255]);
+    const decoded = decodeBinaryFrame(encodeBinaryFrame({ type: "http-body", id: "r1" }, payload));
+    expect(decoded?.header).toEqual({ type: "http-body", id: "r1" });
+    expect(Array.from(decoded!.payload)).toEqual(Array.from(payload));
+  });
+
+  test("survives a payload that is not valid UTF-8", () => {
+    // The whole point of binary framing: these bytes cannot survive a string
+    // round trip, which is why the JSON path had to base64 them.
+    const payload = new Uint8Array([0xff, 0xfe, 0x00, 0x80]);
+    const decoded = decodeBinaryFrame(encodeBinaryFrame({ type: "ws-msg", id: "t", binary: true }, payload));
+    expect(Array.from(decoded!.payload)).toEqual([0xff, 0xfe, 0x00, 0x80]);
+  });
+
+  test("handles an empty payload and a large one", () => {
+    expect(decodeBinaryFrame(encodeBinaryFrame({ type: "x" }, new Uint8Array(0)))?.payload.length).toBe(0);
+    const big = new Uint8Array(1_000_000).fill(9);
+    const decoded = decodeBinaryFrame(encodeBinaryFrame({ type: "x" }, big));
+    expect(decoded?.payload.length).toBe(1_000_000);
+    expect(decoded?.payload[999_999]).toBe(9);
+  });
+
+  test("rejects junk rather than throwing, so a bad frame can fall through to JSON", () => {
+    expect(decodeBinaryFrame(new Uint8Array([1, 2]))).toBeNull();
+    expect(decodeBinaryFrame(new Uint8Array([0, 0, 0, 0]))).toBeNull();
+    // Header length longer than the frame.
+    const truncated = new Uint8Array(8);
+    new DataView(truncated.buffer).setUint32(0, 999, false);
+    expect(decodeBinaryFrame(truncated)).toBeNull();
+    // Well-formed length, unparseable JSON.
+    const badJson = new Uint8Array(4 + 3);
+    new DataView(badJson.buffer).setUint32(0, 3, false);
+    badJson.set(new TextEncoder().encode("{{{"), 4);
+    expect(decodeBinaryFrame(badJson)).toBeNull();
+  });
+
+  test("a text JSON frame is never mistaken for a binary one", () => {
+    const json = new TextEncoder().encode(JSON.stringify({ type: "ping" }));
+    expect(decodeBinaryFrame(json)).toBeNull();
+  });
+});
+
+describe("capability negotiation", () => {
+  test("keeps only what both ends speak", () => {
+    expect(negotiateCaps(["binary", "http-stream"])).toEqual(["binary", "http-stream"]);
+    expect(negotiateCaps(["binary"])).toEqual(["binary"]);
+    expect(negotiateCaps(["telepathy"])).toEqual([]);
+  });
+
+  test("a peer that predates negotiation yields no caps, not a crash", () => {
+    // This is the backward-compatibility contract in one line: absent `caps`
+    // must mean "legacy JSON only", never "assume the new format".
+    expect(negotiateCaps(undefined)).toEqual([]);
+    expect(negotiateCaps(null)).toEqual([]);
+    expect(negotiateCaps("binary")).toEqual([]);
+    expect(negotiateCaps([1, 2, 3])).toEqual([]);
+  });
+});
+
+describe("streamToLocalServe", () => {
+  /** Collects what the box would put on the wire. */
+  function recorder() {
+    const json: Array<Record<string, unknown>> = [];
+    const binary: Array<{ header: Record<string, unknown>; payload: Uint8Array }> = [];
+    return {
+      json,
+      binary,
+      sendJson: (p: unknown) => json.push(p as Record<string, unknown>),
+      sendBinary: (header: Record<string, unknown>, payload: Uint8Array) =>
+        binary.push({ header, payload: new Uint8Array(payload) }),
+      body: () => {
+        const total = binary.reduce((n, b) => n + b.payload.length, 0);
+        const out = new Uint8Array(total);
+        let at = 0;
+        for (const b of binary) { out.set(b.payload, at); at += b.payload.length; }
+        return out;
+      },
+    };
+  }
+
+  test("streams a body larger than any single frame, in order and intact", async () => {
+    // 26 MB is the artifact that took the box offline on the buffered path.
+    const total = 27_508_662;
+    const chunkSize = 64 * 1024;
+    let sent = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent >= total) { controller.close(); return; }
+        const size = Math.min(chunkSize, total - sent);
+        const chunk = new Uint8Array(size);
+        // A recognisable, position-dependent pattern so reordering or a
+        // dropped chunk cannot pass.
+        for (let i = 0; i < size; i++) chunk[i] = (sent + i) % 251;
+        sent += size;
+        controller.enqueue(chunk);
+      },
+    });
+    const rec = recorder();
+    await streamToLocalServe(
+      { type: "http", id: "req-big", method: "GET", path: "/api/artifacts/vid" },
+      rec.sendBinary,
+      rec.sendJson,
+      (async () => new Response(stream, { status: 200, headers: { "content-type": "video/mp4" } })) as unknown as typeof fetch,
+    );
+
+    expect(rec.json[0]).toMatchObject({ type: "http-head", id: "req-big", status: 200 });
+    expect(rec.json.at(-1)).toEqual({ type: "http-end", id: "req-big" });
+    expect(rec.binary.length).toBeGreaterThan(1);
+    // No frame carries anything close to a whole body.
+    for (const frame of rec.binary) {
+      expect(frame.header).toEqual({ type: "http-body", id: "req-big" });
+      expect(frame.payload.length).toBeLessThanOrEqual(chunkSize);
+    }
+    const body = rec.body();
+    expect(body.length).toBe(total);
+    expect(body[0]).toBe(0);
+    expect(body[total - 1]).toBe((total - 1) % 251);
+    expect(body[12_345_678]).toBe(12_345_678 % 251);
+  });
+
+  test("reports the status and headers before any body arrives", async () => {
+    const rec = recorder();
+    await streamToLocalServe(
+      { type: "http", id: "r", method: "GET", path: "/nope" },
+      rec.sendBinary,
+      rec.sendJson,
+      (async () => new Response("missing", { status: 404, headers: { "content-type": "text/plain" } })) as unknown as typeof fetch,
+    );
+    expect(rec.json[0]).toMatchObject({ type: "http-head", id: "r", status: 404 });
+    expect(new TextDecoder().decode(rec.body())).toBe("missing");
+  });
+
+  test("an unreachable local serve becomes a 502 head, not a dropped request", async () => {
+    const rec = recorder();
+    await streamToLocalServe(
+      { type: "http", id: "r", method: "GET", path: "/x" },
+      rec.sendBinary,
+      rec.sendJson,
+      (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch,
+    );
+    expect(rec.json[0]).toMatchObject({ type: "http-head", id: "r", status: 502 });
+    expect(new TextDecoder().decode(rec.body())).toContain("local serve unreachable");
+    expect(rec.json.at(-1)).toEqual({ type: "http-end", id: "r" });
+  });
+
+  test("a body that dies mid-stream ends with an error rather than looking complete", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) { controller.enqueue(new Uint8Array([1, 2, 3])); },
+      pull() { throw new Error("disk went away"); },
+    });
+    const rec = recorder();
+    await streamToLocalServe(
+      { type: "http", id: "r", method: "GET", path: "/x" },
+      rec.sendBinary,
+      rec.sendJson,
+      (async () => new Response(stream, { status: 200 })) as unknown as typeof fetch,
+    );
+    const end = rec.json.at(-1) as { type: string; error?: string };
+    expect(end.type).toBe("http-end");
+    expect(end.error).toContain("disk went away");
+  });
+});
+
+describe("tunnel payload framing", () => {
+  test("a relayed binary ws-msg reaches the local socket as raw bytes", () => {
+    const sent: unknown[] = [];
+    const tunnels = new Map([["t1", { send: (d: unknown) => sent.push(d) } as unknown as WebSocket]]);
+    const payload = new Uint8Array([0xff, 0x00, 0x80]);
+    applyWsTunnelFrame({ type: "ws-msg", id: "t1", binary: true }, tunnels, payload);
+    expect(Array.from(sent[0] as Uint8Array)).toEqual([0xff, 0x00, 0x80]);
+  });
+
+  test("a legacy base64 ws-msg still works when no payload accompanies it", () => {
+    const sent: unknown[] = [];
+    const tunnels = new Map([["t1", { send: (d: unknown) => sent.push(d) } as unknown as WebSocket]]);
+    applyWsTunnelFrame(
+      { type: "ws-msg", id: "t1", binary: false, dataB64: Buffer.from("hi").toString("base64") },
+      tunnels,
+    );
+    expect(sent[0]).toBe("hi");
   });
 });


### PR DESCRIPTION
The box half of a two-repo protocol change. Relay half: BennyKok/vibes#1251.

## Why

The relay tunnel was JSON-only, so **every proxied byte had to be base64'd into a JSON string** — a 4/3 inflation plus an encode and a decode at each hop, on HTTP bodies *and* on every live-tunnel message (`ws-msg` carried a `binary` flag and still base64'd the payload).

It also meant a whole response had to fit in **one frame**. That is not a soft limit: the relay's WebSocket server closes the connection on an oversized frame, so a 26 MB artifact took this box offline every time someone opened it — the request 502'd and the box logged `relay connection closed — reconnecting`.

## What changed

This box advertises two capabilities in `hello`/`pair` and uses each only if the relay answers that it speaks it too:

| cap | effect |
|---|---|
| `binary` | payload frames are `[4B BE header len][JSON header][raw bytes]` instead of base64-in-JSON — `ws-msg`, `stream-data`, `http-body` |
| `http-stream` | `streamToLocalServe` sends `http-head` → `http-body`\* → `http-end` straight off the local response reader, so no body is held in memory and no frame carries a whole one |

**A relay that predates negotiation answers without `caps`, which leaves this client on the JSON path it has always used.** Absent caps means legacy; the new format is never assumed. `forwardToLocalServe` is untouched and still the fallback.

`src/relay-frames.ts` mirrors `apps/relay/src/frames.ts` in vibes — one wire format, two files, must change together.

## Verified against a real relay

A real `lfg connect` paired to a relay on loopback, proxying to a real `lfg serve`:

- negotiated `binary, http-stream`
- **26 MB artifact byte-identical** (md5 `452aaefbd9fcbe9404bf4d9d90918687`) in 1.3s, **no reconnect** — the exact request that returned `503 offline` and dropped the socket before
- live WS tunnel carried real `/api/live/ws` frames; SSE tunnel carried real `/api/live/stream` chunks
- a legacy JSON-only box against the same relay still worked — the compatibility direction that matters most

12 new tests including non-UTF-8 payloads (which cannot survive the string round trip the old path forced), a 26 MB chunked stream asserted position-by-position, mid-stream failure surfacing as an error rather than a silent truncation, and the "no caps means legacy" contract. Full suite: 978 pass, with the same 6 pre-existing failures a clean tree has.

## Rollout

Relay first (it is backward compatible with every existing box), then this. Existing boxes keep working on the JSON path until they upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)