### PR TITLE
fix(web): pair artifacts under omg_* tools, and finish the UI rename

### DIFF
--- a/test/chat-render-items.test.ts
+++ b/test/chat-render-items.test.ts
@@ -41,4 +41,27 @@ describe("chat render items", () => {
     expect(paired[0]?.type).toBe("artifact_tool");
     expect(standalone.map((item) => item.type)).toEqual(["tools", "msg"]);
   });
+
+  // The tools were renamed lfg_* -> omg_*, but the matcher was not. Every new
+  // session publishes under omg_*, so the pairing silently stopped happening
+  // and artifacts rendered as a bare tool pill.
+  test("pairs artifacts under both the omg_ and the pre-rename lfg_ tool names", () => {
+    const cases = [
+      ["omg_publish_artifact", "html"],
+      ["mcp__omg__omg_publish_artifact", "html"],
+      ["mcp__lfg__lfg_publish_artifact", "html"],
+      ["omg_display_image", "image"],
+      ["mcp__omg__omg_display_image", "image"],
+      ["omg_display_video", "video"],
+      ["mcp__omg__omg_display_video", "video"],
+    ] as const;
+
+    for (const [tool, kind] of cases) {
+      const items = buildChatRenderItems([
+        { id: "tool-1", kind: "tool_use", text: `${tool}: {}`, ts: 10 },
+        { id: "artifact-1", kind, text: "Artifact", ts: 11 },
+      ]);
+      expect(items[0]?.type, tool).toBe("artifact_tool");
+    }
+  });
 });

--- a/web/index.html
+++ b/web/index.html
@@ -302,7 +302,7 @@
 
           root.innerHTML =
             '<main style="min-height:100dvh;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center;gap:0.85rem;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;background:#000;color:#f4f4f5">' +
-            "<h1 style=\"margin:0;font-size:1.15rem;font-weight:600\">lfg did not finish loading</h1>" +
+            "<h1 style=\"margin:0;font-size:1.15rem;font-weight:600\">omg did not finish loading</h1>" +
             '<p style="margin:0;max-width:22rem;line-height:1.45;color:#a1a1aa;font-size:.95rem">' +
             (reason ||
               "The app shell is up but the UI never mounted. This is usually a network path to the box (Tailscale) or a broken install.") +

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7715,7 +7715,7 @@ function ProductBrand({
     return (
       <img
         src={omgAssetUrl(LFG_SMALL_ICON_PATH)}
-        alt="lfg"
+        alt="omg"
         className="mx-1 size-6 shrink-0 rounded-md"
       />
     );
@@ -8733,7 +8733,7 @@ function OnboardingFlow({
           <div className="flex items-center gap-2">
             <img
               src={omgAssetUrl(LFG_SMALL_ICON_PATH)}
-              alt="lfg"
+              alt="omg"
               className="size-7 shrink-0"
             />
             <span className="text-xs font-medium text-muted-foreground">
@@ -9112,7 +9112,7 @@ function WhoAreYou({
         <div className="mb-4 flex items-center gap-2">
           <img
             src={omgAssetUrl(LFG_SMALL_ICON_PATH)}
-            alt="lfg"
+            alt="omg"
             className="size-7 shrink-0"
           />
         </div>
@@ -11747,7 +11747,7 @@ function StaleCapabilitiesBanner({ session }: { session: Session }) {
   if (!session.capabilitiesStale) return null;
   return (
     <div className="border-b border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-200">
-      This session started with an older LFG capability contract. Close and resume it to load the latest shipped tools and guidance.
+      This session started with an older OMG capability contract. Close and resume it to load the latest shipped tools and guidance.
     </div>
   );
 }
@@ -13120,7 +13120,7 @@ function SessionActionsMenu({
                   Full transcript
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="user-lfg-output">
-                  User + LFG output
+                  User + OMG output
                 </DropdownMenuRadioItem>
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
@@ -13350,7 +13350,7 @@ function RailSessionContextMenu({
                   Full transcript
                 </ContextMenuRadioItem>
                 <ContextMenuRadioItem value="user-lfg-output">
-                  User + LFG output
+                  User + OMG output
                 </ContextMenuRadioItem>
               </ContextMenuRadioGroup>
             </ContextMenuSubContent>
@@ -15465,7 +15465,7 @@ function OmgInstructionsBlock({
         aria-expanded={open}
       >
         <ScrollText className="size-3.5" aria-hidden="true" />
-        <span>LFG instructions</span>
+        <span>OMG instructions</span>
         {version ? <span className="font-mono opacity-60">{version}</span> : null}
         <ChevronRight
           className={cn("size-3 transition-transform", open && "rotate-90")}
@@ -20806,7 +20806,7 @@ function StoragePage() {
           </div>
         </div>
         <p className="px-4 text-xs text-muted-foreground">
-          Whole-filesystem usage for the volume holding LFG&apos;s data directory.
+          Whole-filesystem usage for the volume holding OMG&apos;s data directory.
         </p>
       </section>
 
@@ -21324,7 +21324,7 @@ function SessionUsagePanel() {
 
               <div className="border-t border-border px-4 py-2.5 text-[11px] text-muted-foreground tabular-nums">
                 {formatBytes(usage.unattributedBytes)} in processes owned by no session
-                (the LFG server, system daemons, your own shells).
+                (the OMG server, system daemons, your own shells).
               </div>
             </>
           ) : (
@@ -21516,7 +21516,7 @@ function CodingAgentAuthDialog({
         <DialogHeader>
           <DialogTitle>Connect {providerLabel}</DialogTitle>
           <DialogDescription>
-            Finish signing in in the browser. LFG will detect approval automatically.
+            Finish signing in in the browser. OMG will detect approval automatically.
           </DialogDescription>
         </DialogHeader>
         {session ? (
@@ -21827,7 +21827,7 @@ function OmgUpdateSection() {
               {busy ? <Loader2 className="size-4 animate-spin" /> : <ArrowDown className="size-4" />}
             </span>
             <div className="min-w-0">
-              <div className="text-sm font-medium">LFG updates</div>
+              <div className="text-sm font-medium">OMG updates</div>
               <div
                 className={cn(
                   "text-xs text-muted-foreground",
@@ -21929,7 +21929,7 @@ function SettingsView({
               <span className="min-w-0">
                 <span className="block text-sm font-medium">Ping</span>
                 <span className="block truncate text-xs text-muted-foreground">
-                  Browser to LFG server
+                  Browser to OMG server
                 </span>
               </span>
             </div>

--- a/web/src/components/app-crash.tsx
+++ b/web/src/components/app-crash.tsx
@@ -127,7 +127,7 @@ export function AppCrash({
           </span>
           <h1 className="mt-5 text-lg font-semibold tracking-tight">New version available</h1>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            lfg updated while this tab was open. Reload to pick up the latest build.
+            omg updated while this tab was open. Reload to pick up the latest build.
           </p>
           <Button
             size="lg"
@@ -194,7 +194,7 @@ export function AppCrash({
           {/* Claim the report only when one was actually dispatched — a
               reassuring lie here is worse than silence, because the user
               stops telling us about a bug nobody received. */}
-          {reported && <div>Reported to lfg.</div>}
+          {reported && <div>Reported to omg.</div>}
           {(stack || componentStack) && (
             <details>
               <summary className="cursor-pointer select-none hover:text-foreground">Details</summary>

--- a/web/src/components/embedded-connect-gate.tsx
+++ b/web/src/components/embedded-connect-gate.tsx
@@ -47,7 +47,7 @@ export function EmbeddedConnectGate({
         <div className="mb-4 flex items-center justify-between gap-2">
           <img
             src={omgAssetUrl(LFG_SMALL_ICON_PATH)}
-            alt="lfg"
+            alt="omg"
             className="size-7 shrink-0"
           />
           <div

--- a/web/src/components/pwa-install.tsx
+++ b/web/src/components/pwa-install.tsx
@@ -37,11 +37,11 @@ function InstallInstructions({ mode, open, onOpenChange }: {
           <div className="mb-2 flex size-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             {ios ? <Share className="size-7" /> : <Download className="size-7" />}
           </div>
-          <DialogTitle>{ios ? "Install lfg on your Home Screen" : "Install lfg on your Mac"}</DialogTitle>
+          <DialogTitle>{ios ? "Install omg on your Home Screen" : "Install omg on your Mac"}</DialogTitle>
           <DialogDescription>
             {ios
-              ? "Open lfg like an app, without browser controls."
-              : "Add lfg to your Dock and open it in its own window."}
+              ? "Open omg like an app, without browser controls."
+              : "Add omg to your Dock and open it in its own window."}
           </DialogDescription>
         </DialogHeader>
         <ol className="space-y-3">
@@ -84,7 +84,7 @@ function useInstallAction(mode: PwaInstallMode, install: () => Promise<boolean>)
     setBusy(true);
     try {
       const installed = await install();
-      if (installed) toast.success("lfg installed");
+      if (installed) toast.success("omg installed");
     } catch {
       toast.error("Could not open the install prompt");
     } finally {
@@ -120,7 +120,7 @@ export function PwaInstallCallout() {
           className="size-10 shrink-0 rounded-xl"
         />
         <div className="min-w-0 flex-1">
-          <div className="text-sm font-semibold">Install lfg</div>
+          <div className="text-sm font-semibold">Install omg</div>
           <div className="truncate text-xs text-muted-foreground">
             Faster launch, its own window, and a home-screen icon.
           </div>
@@ -165,7 +165,7 @@ export function PwaInstallSettingsSection() {
                 <Download className="size-4" />
               </span>
               <span>
-                <span className="block text-sm font-medium">Install lfg</span>
+                <span className="block text-sm font-medium">Install omg</span>
                 <span className="block text-xs text-muted-foreground">Open it from your desktop or Home Screen</span>
               </span>
             </div>

--- a/web/src/lib/chat-render-items.ts
+++ b/web/src/lib/chat-render-items.ts
@@ -34,10 +34,20 @@ export function toolGroupLabel(items: ChatRenderMessage[]): string {
 function artifactKindForTool(message: ChatRenderMessage): "image" | "video" | "html" | null {
   if (message.kind !== "tool_use") return null;
   const name = toolName(message.text);
-  if (name === "lfg_display_image" || name.endsWith("__lfg_display_image")) return "image";
-  if (name === "lfg_display_video" || name.endsWith("__lfg_display_video")) return "video";
-  if (name === "lfg_publish_artifact" || name.endsWith("__lfg_publish_artifact")) return "html";
+  // The tools are registered as omg_*; the lfg_* spellings are kept so
+  // transcripts recorded before the rename still pair with their artifact.
+  if (matchesTool(name, "display_image")) return "image";
+  if (matchesTool(name, "display_video")) return "video";
+  if (matchesTool(name, "publish_artifact")) return "html";
   return null;
+}
+
+function matchesTool(name: string, verb: string): boolean {
+  for (const prefix of ["omg_", "lfg_"]) {
+    const full = `${prefix}${verb}`;
+    if (name === full || name.endsWith(`__${full}`)) return true;
+  }
+  return false;
 }
 
 function messageKey(message: ChatRenderMessage, index: number): string {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -115,7 +115,7 @@ function activateUpdate(worker: ServiceWorker) {
 }
 
 function promptUpdate(worker: ServiceWorker) {
-  toast("A new version of lfg is available", {
+  toast("A new version of omg is available", {
     description: "Reload to get the latest.",
     duration: Infinity,
     action: {

--- a/web/src/views/shipped-page.tsx
+++ b/web/src/views/shipped-page.tsx
@@ -552,7 +552,7 @@ export default function ShippedPage({
             <div className="py-10 text-center text-sm text-muted-foreground">Loading…</div>
           ) : gallery.length === 0 ? (
             <div className="rounded-2xl border border-border bg-card/40 px-4 py-10 text-center text-sm text-muted-foreground">
-              No artifacts yet — agents create them with <code>lfg_publish_artifact</code>.
+              No artifacts yet — agents create them with <code>omg_publish_artifact</code>.
             </div>
           ) : (
             <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">


### PR DESCRIPTION
## The bug

`artifactKindForTool` only ever matched `lfg_display_image`, `lfg_display_video` and `lfg_publish_artifact`. The MCP server registers those as `omg_*` (`src/commands/mcp.ts:772/803/834`), and `tools/list` advertises only the `omg_` spelling — the `lfg_` names survive purely as an inbound wire alias for pre-rename sessions.

So for **every session recorded after the rename** the matcher returned `null`: images and published artifacts rendered as a bare tool pill instead of pairing with their artifact card.

Fixed by matching both spellings. The `lfg_` names must keep working so transcripts recorded before the rename still render.

The new test case fails against the old matcher and passes against the new one:

```
error: omg_publish_artifact
Expected: "artifact_tool"
Received: "tools"
```

## The rest

Copy the rename missed, all of it rendered:

- `web/index.html` — the boot-failure screen (`lfg did not finish loading`)
- `main.tsx` — the update toast
- `app-crash.tsx` — the reload notice and `Reported to lfg.`
- `pwa-install.tsx` — the entire install dialog, callout and menu item
- `App.tsx` / `embedded-connect-gate.tsx` — `alt="lfg"` on the brand mark (screen readers announced "lfg")
- `App.tsx` — the stale-capability banner, `LFG instructions`, `LFG updates`, `Browser to LFG server`, the disk-usage and sign-in copy
- `shipped-page.tsx` — the empty state told people to call `lfg_publish_artifact`, which is not a tool that exists

Identifiers are untouched: the `--lfg-*` / `--lfgc-*` CSS custom properties, `.lfg-*` classes, `data-lfg-*` attributes, the `lfg_*` localStorage keys, `window.lfg`, `__LFG_CONFIG__` and the `lfg:session-created` postMessage type are all cross-package or persisted contracts.

Note `web/public/icon.svg` still draws the legacy `lfg` wordmark (see the comment in `scripts/generate-icons.ts:87-88`) — artwork, out of scope here.

## Test

`bun test ./test/chat-render-items.test.ts` → 4 pass. Related suites (shipped-notification, notification-center-unified, embedded-connect-gate, artifact-session-navigation, sw-takeover, omg-prompt-envelope) → 66 pass. `icons.test.ts` errors on a missing `sharp` in a fresh worktree, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)