### PR TITLE
fix(settings): make idle archiving save, and stop More reloading the app

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -117,7 +117,12 @@ import {
   noteListSessionsClientActivity,
 } from "../session-cache.ts";
 import { buildSessionUsageReport } from "../session-usage.ts";
-import { idleArchiveCandidates, idleMsFor } from "../idle-archive.ts";
+import {
+  idleArchiveCandidates,
+  idleMsFor,
+  MAX_IDLE_ARCHIVE_MINUTES,
+  MIN_IDLE_ARCHIVE_MINUTES,
+} from "../idle-archive.ts";
 import { isCommandFileAgent } from "../coding-agent-adapters.ts";
 import {
   enqueueTranscriptIndex,
@@ -2691,6 +2696,24 @@ a{color:#60a5fa}
             if (!validTranscriptView(b.transcriptView))
               return err(400, "transcriptView must be full or user-lfg-output");
             patch.transcriptView = b.transcriptView;
+          }
+          if (b?.idleAgentArchiveMinutes !== undefined) {
+            // Reject rather than lean on sanitizeIdleArchiveMinutes' clamp. The
+            // clamp is right for reading back whatever is already on disk, but
+            // as request validation it would answer 200 with a number the user
+            // did not ask for — which is how this setting silently did nothing
+            // for so long. An out-of-range value is a bug in the caller, so say
+            // so instead of quietly picking a different window.
+            const minutes = Number(b.idleAgentArchiveMinutes);
+            const inRange =
+              minutes === 0 ||
+              (minutes >= MIN_IDLE_ARCHIVE_MINUTES && minutes <= MAX_IDLE_ARCHIVE_MINUTES);
+            if (!Number.isInteger(minutes) || !inRange)
+              return err(
+                400,
+                `idleAgentArchiveMinutes must be 0 (off) or an integer from ${MIN_IDLE_ARCHIVE_MINUTES} to ${MAX_IDLE_ARCHIVE_MINUTES}`,
+              );
+            patch.idleAgentArchiveMinutes = minutes;
           }
           const settings = await setGlobalSettings(patch);
           return json({ settings });

--- a/src/settings-validation.test.ts
+++ b/src/settings-validation.test.ts
@@ -34,4 +34,43 @@ describe("persistence", () => {
       expect(writer, `${field} is never written by setGlobalSettings`).toContain(`write.run("${field}"`);
     }
   });
+
+  // The sibling hole, one layer up, and the one that actually shipped:
+  // POST /api/settings builds its patch from an explicit per-field whitelist,
+  // so a setting with no branch is dropped from the request body before
+  // setGlobalSettings ever sees it. The failure is completely silent — the
+  // handler answers 200 with the UNCHANGED settings, the client writes those
+  // back into state so the control snaps back to its old value, and the success
+  // toast still fires because nothing threw.
+  //
+  // That is exactly how idleAgentArchiveMinutes ("Archive idle agents after")
+  // spent its whole life doing nothing: the UI saved, cheerfully confirmed, and
+  // reverted, and the sweep read 0 forever. The test above could not catch it,
+  // because the value was already correct by the time it reached the writer.
+  test("every setting key is accepted by POST /api/settings", async () => {
+    const settingsSource = await Bun.file(new URL("./settings.ts", import.meta.url)).text();
+    const typeBlock = settingsSource.slice(
+      settingsSource.indexOf("export type GlobalSettings = {"),
+      settingsSource.indexOf("};", settingsSource.indexOf("export type GlobalSettings = {")),
+    );
+    const fields = [...typeBlock.matchAll(/^\s{2}(\w+):/gm)].map((m) => m[1]);
+    expect(fields.length).toBeGreaterThan(0);
+
+    const serveSource = await Bun.file(
+      new URL("./commands/serve.ts", import.meta.url),
+    ).text();
+    const routeStart = serveSource.indexOf('if (path === "/api/settings") {');
+    expect(routeStart).toBeGreaterThan(-1);
+    const handler = serveSource.slice(
+      routeStart,
+      serveSource.indexOf("const settings = await setGlobalSettings(patch);", routeStart),
+    );
+
+    for (const field of fields) {
+      expect(
+        handler,
+        `${field} has no branch in POST /api/settings, so saving it is a silent no-op`,
+      ).toContain(`patch.${field} =`);
+    }
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -324,8 +324,8 @@ import { deepActiveElement, isTypingTarget } from "@/lib/active-element";
 import { useExtensionNavTabs } from "./lib/extensions";
 import type { ExtensionNavTab } from "./lib/extensions";
 import {
-  pushSupported,
   pushPermission,
+  pushUnavailableReason,
   isSubscribed,
   enablePush,
   disablePush,
@@ -4921,14 +4921,30 @@ function useLiveSessionStream(sessions: Session[], streamIds: string[]) {
 function PushBell({ user }: { user?: string | null }) {
   const [on, setOn] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [supported] = useState(() => pushSupported());
+  // Read once: this cannot change without a remount, and re-reading it per
+  // render would make the row flicker between states.
+  const [unavailable] = useState(() => pushUnavailableReason());
 
   useEffect(() => {
-    if (!supported) return;
+    if (unavailable) return;
     void isSubscribed().then(setOn);
-  }, [supported]);
+  }, [unavailable]);
 
-  if (!supported) return null;
+  // Deliberately NOT `return null`. Rendering nothing left the "Push
+  // notifications" row with an empty right edge — the label promised a control
+  // that was not there, which is indistinguishable from a broken layout and is
+  // exactly why this looked impossible to turn on. Show the switch, disabled,
+  // next to the reason.
+  if (unavailable) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="max-w-[10rem] text-right text-xs leading-tight text-muted-foreground">
+          {unavailable}
+        </span>
+        <Switch checked={false} disabled aria-label={`Notifications unavailable: ${unavailable}`} />
+      </div>
+    );
+  }
 
   const toggle = async () => {
     if (busy) return;

--- a/web/src/embedded.d.ts
+++ b/web/src/embedded.d.ts
@@ -190,6 +190,15 @@ export interface OmgSettingsSurfaceProps {
   onNavigate?: (page: OmgSettingsPage) => void;
   className?: string;
   errorSink?: OmgErrorSink;
+  /**
+   * A service-worker scope the host dedicates to OMG push.
+   *
+   * The push toggle lives on this surface's "more" page, so a host that mounts
+   * settings without a full app surface has to grant the scope here or the
+   * toggle has nothing to subscribe against. Omitting it is safe — the toggle
+   * explains it is unavailable instead of enrolling into the host's own worker.
+   */
+  hostedPush?: HostPushConfig;
 }
 
 export declare function OmgSettingsSurface(

--- a/web/src/embedded.tsx
+++ b/web/src/embedded.tsx
@@ -10,7 +10,11 @@ import "./index.css";
 import { RootErrorBoundary } from "./App";
 import { AppDialogProvider } from "./components/ui/app-dialog";
 import { configureOmgTransport, type OmgErrorSink } from "./lib/omg-client";
-import { configureHostPush, type HostPushConfig } from "./lib/push";
+import {
+  configureHostPush,
+  configureHostedSurface,
+  type HostPushConfig,
+} from "./lib/push";
 import { BareSurfaceProvider } from "./lib/bare-surface";
 import {
   EmbeddedHostOptionsProvider,
@@ -168,6 +172,15 @@ export interface OmgSettingsSurfaceProps {
   onNavigate?: (page: OmgSettingsPage) => void;
   className?: string;
   errorSink?: OmgErrorSink;
+  /**
+   * A service-worker scope the host dedicates to OMG push.
+   *
+   * The push toggle lives on this surface's "more" page, so a host that mounts
+   * settings without a full app surface has to grant the scope here or the
+   * toggle has nothing to subscribe against. Omitting it is safe — the toggle
+   * explains it is unavailable instead of enrolling into the host's own worker.
+   */
+  hostedPush?: HostPushConfig;
 }
 
 const SETTINGS_PAGES: readonly OmgSettingsPage[] = [
@@ -198,11 +211,17 @@ export function OmgSettingsSurface({
   onNavigate,
   className,
   errorSink,
+  hostedPush,
 }: OmgSettingsSurfaceProps) {
   // The host owns the header, the back affordance and the account, so this
   // surface renders sections only — declared to the tree below, not to a
   // module global that a coexisting full-app surface would also read.
   configureOmgTransport(transport, { assetBaseUrl, errorSink });
+  // The More page owns the push toggle, so this surface — not just the full app
+  // surface — has to declare the host boundary. Without it push falls back to
+  // registering the host's own root worker; see configureHostedSurface.
+  configureHostedSurface(true);
+  configureHostPush(hostedPush ?? null);
   const [router] = useState<AnyRouter>(() =>
     createOmgRouter(
       createMemoryHistory({ initialEntries: [`/${page}?embed=true`] }),
@@ -281,6 +300,7 @@ export function OmgAppSurface({
   // cleanup that can revert another Strict Mode mount back to same-origin.
   configureOmgTransport(transport, { assetBaseUrl, errorSink });
   // Same reasoning as the transport: declare it before any child can read it.
+  configureHostedSurface(true);
   configureHostPush(hostedPush ?? null);
   const [router] = useState<AnyRouter>(() =>
     createOmgRouter(

--- a/web/src/lib/push-registration.test.ts
+++ b/web/src/lib/push-registration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   configureHostPush,
+  configureHostedSurface,
   ensurePushSubscription,
   resolvePushRegistration,
   subscriptionMatchesKey,
@@ -93,6 +94,9 @@ beforeEach(() => {
 
 afterEach(() => {
   configureHostPush(null);
+  // Module-global, so a hosted test would otherwise leak into every test that
+  // runs after it and silently turn the standalone cases into no-ops.
+  configureHostedSurface(false);
 });
 
 describe("choosing the registration to subscribe on", () => {
@@ -130,6 +134,39 @@ describe("choosing the registration to subscribe on", () => {
     expect(
       await resolvePushRegistration({ container: fakeContainer(), embedded: true }),
     ).toBeNull();
+  });
+
+  test("a hosted surface refuses even when nobody passes `embedded`", async () => {
+    // The regression this locks down. Every other test in this block states
+    // `embedded` explicitly, so they all passed while the real caller —
+    // isSubscribed(), which passes no deps at all — fell through to the
+    // standalone branch and registered the HOST's /sw.js at scope "/".
+    //
+    // On app.omg.dev that script is the cache-drain worker: activating it
+    // navigates every open client to bust caches, so opening the More page
+    // reloaded the whole dashboard, and it then unregisters itself so the next
+    // visit did it again. isEmbedded() cannot catch this — the host mounts us
+    // as plain React components, so the document is its own top-level page.
+    configureHostedSurface(true);
+    registrations.set("/", fakeRegistration("/"));
+
+    expect(await resolvePushRegistration({ container: fakeContainer() })).toBeNull();
+    expect(registerCalls).toEqual([]);
+  });
+
+  test("a hosted surface still uses a scope the host dedicates", async () => {
+    configureHostedSurface(true);
+    configureHostPush({ scope: "/__omg_push/", workerUrl: "/__omg_push/sw.js" });
+
+    const reg = await resolvePushRegistration({ container: fakeContainer() });
+    expect(reg?.scope).toBe("/__omg_push/");
+  });
+
+  test("standalone is unaffected when no host has claimed the surface", async () => {
+    registrations.set("/", fakeRegistration("/"));
+
+    const reg = await resolvePushRegistration({ container: fakeContainer(), embedded: false });
+    expect(reg?.scope).toBe("/");
   });
 
   test("embedded uses the scope the host dedicates, not the page's own worker", async () => {

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -65,6 +65,56 @@ export function configureHostPush(config: HostPushConfig | null): void {
 }
 
 /**
+ * Whether this bundle is running inside somebody else's page.
+ *
+ * `isEmbedded()` cannot answer that on its own. It reads the DOCUMENT's URL and
+ * whether we are framed, which is right for an iframe surface and wrong for a
+ * host that mounts us as plain React components: there the document is the
+ * host's own top-level page, so it reports "standalone" and we take the branch
+ * that registers `/sw.js` at scope `/` — on the HOST's origin. That is not our
+ * worker. On app.omg.dev it is the cache-drain worker, whose activate handler
+ * navigates every open client to bust its caches, so merely opening the More
+ * page reloads the whole app; it then unregisters itself, so the next visit
+ * does it again. Hence an explicit flag the surface sets, rather than a guess
+ * re-derived from `window`.
+ */
+let hostedSurface = false;
+
+/** Declared by the embedded surfaces alongside `configureHostPush`. */
+export function configureHostedSurface(hosted: boolean): void {
+  hostedSurface = hosted;
+}
+
+/** True when we must not touch a registration the host did not give us. */
+export function isHostedSurface(): boolean {
+  return hostedSurface;
+}
+
+/** Whether a host has actually dedicated a scope to us. */
+export function hasHostPushScope(): boolean {
+  return hostPush != null;
+}
+
+/**
+ * Why push cannot be turned on here, or null when it can.
+ *
+ * Returned as a sentence for the UI to show. The toggle used to render nothing
+ * at all in the unsupported case and an enabled-looking switch in the hosted
+ * case, so both failure modes read to the user as "the feature is missing"
+ * rather than "the feature is unavailable, for this reason".
+ */
+export function pushUnavailableReason(): string | null {
+  if (!pushSupported()) {
+    // The usual cause by far: iOS only exposes PushManager to an installed PWA.
+    return "Add omg to your Home Screen to turn on notifications";
+  }
+  if (hostedSurface && !hostPush) {
+    return "Not available here yet — open your Computer's own address to turn on notifications";
+  }
+  return null;
+}
+
+/**
  * The standalone app's own worker, as index.html and main.tsx already register
  * it. Registering the same script on the same scope is idempotent — it resolves
  * to the registration those two produce rather than making a second one — which
@@ -155,7 +205,12 @@ export async function resolvePushRegistration(
   // Embedded with nothing declared: the registration serving this page belongs
   // to the host and there is no way to know whether its worker handles push.
   // Refuse rather than enrol into silence.
-  if (deps.embedded ?? isEmbedded()) return null;
+  //
+  // `hostedSurface` is checked first and separately because `isEmbedded()` is
+  // only reliable for the iframe topology — see configureHostedSurface. A host
+  // that mounts us directly looks standalone to it, and falling through to the
+  // branch below would register the HOST's `/sw.js` on the HOST's origin.
+  if (deps.embedded ?? (hostedSurface || isEmbedded())) return null;
 
   // Standalone. index.html registers /sw.js on every load, so there is normally
   // one here already — but "normally" is not "always": that registration can
@@ -256,7 +311,7 @@ export async function enablePush(user?: string | null): Promise<boolean> {
   const reg = await registration;
   if (!reg) {
     throw new Error(
-      isEmbedded()
+      hostedSurface || isEmbedded()
         ? "This host hasn't given OMG a service-worker scope for notifications yet"
         : "Couldn't start the notification service worker — reload the app and try again",
     );


### PR DESCRIPTION
Three settings bugs Benny hit in the hosted UI. Two root causes.

## 1. "Archive idle agents after" never saved

`POST /api/settings` builds its patch from a per-field whitelist and
`idleAgentArchiveMinutes` had no branch, so it was dropped before
`setGlobalSettings` ever saw it.

The failure was completely silent:

- handler answers **200** with the *unchanged* settings
- client does `setSettings(payload.settings)`, so the dropdown **snaps back to "Off"**
- `toast.success("Idle agents archived after 1h")` fires anyway, because nothing threw
- the sweep reads `0` forever

The sweep itself was never broken — it reads the setting per tick and needs no
restart. It was just never given a value.

Out-of-range values are now **rejected** rather than run through
`sanitizeIdleArchiveMinutes`' clamp. That clamp is right for reading back
whatever is already on disk, but as request validation it would answer 200 with
a number the caller did not ask for, which is the same class of lie.

## 2. Settings → More reloaded the whole dashboard

The More page renders the push toggle, whose mount effect resolves a
service-worker registration. `resolvePushRegistration` fell back to
`isEmbedded()`, which reads the **document's** URL and whether we are framed.
That is correct for the iframe topology and wrong for a host that mounts us as
plain React components — there the document is the host's own top-level page, so
it reports "standalone".

So it took the standalone branch and registered **`/sw.js` at scope `/` on the
host's origin**. On app.omg.dev that script is the cache-drain worker, whose
`activate` handler calls `client.navigate(...)` on every open window to bust
caches. That navigation *is* the reload. It then unregisters itself, so the next
visit to More does the whole thing again — matching "whenever I click more
settings, it just reloads the whole thing" exactly.

Replaced the guess with an explicit flag both embedded surfaces set.
`OmgSettingsSurface` never declared the host boundary at all — it does not even
accept `hostedPush` — which is why the one surface that owns the toggle was the
one that could not be told about it.

## 3. Push notifications could not be activated

Same root cause: the only toggle lives on that More page.

It also rendered **nothing at all** when unsupported (iOS only exposes
`PushManager` to an installed PWA), leaving a "Push notifications" row with an
empty right edge. A label promising a control that is not there reads as a
broken layout, not as an unavailable feature. It now renders disabled with the
reason.

## Deliberately not fixed here

Enabling push **from the hosted dashboard** still needs two more things, and
both are host-side product calls rather than bugs:

1. the host must serve a push worker on a dedicated scope and pass `hostedPush`
   (the prop is added here so it can)
2. `PushBell`'s `user` gate keys on the local profile filter, which hosted mode
   removes — and the server matches subscriptions on that exact key
   (`row.user === opts.user`), so mapping it to an omg account id would
   **silently misroute** every notification rather than fail loudly

Until then the hosted toggle is honestly disabled instead of quietly enrolling
into a worker that discards its notifications.

## Verification

- `bun test` — 1302 pass, 1 skip, 0 fail
- `bun run typecheck` — clean
- `bun run build:packages` — builds
- Both regressions verified to **fail without the fix**:
  - reverting the push guard fails `a hosted surface refuses even when nobody passes 'embedded'`
  - removing the settings branch fails `every setting key is accepted by POST /api/settings`

The new settings guard is source-level and covers **every** `GlobalSettings`
field, so the next setting added cannot repeat this silently. It is the sibling
of the existing "every setting key is persisted" guard, one layer up.

Reproduced live on app.omg.dev beforehand: the idle dropdown reverting to Off,
and `/settings/computer/more` wedging the renderer while `storage`,
`coding-agents` and `auto` all stayed responsive.
