### PR TITLE
fix(embedded): the More page is not the host's to mount

### DIFF
--- a/test/embedded-connect-gate.test.ts
+++ b/test/embedded-connect-gate.test.ts
@@ -442,9 +442,11 @@ describe("host-mounted settings navigation", () => {
     expect(embedded).toContain("onNavigate?: (page: OmgSettingsPage) => void");
     expect(embedded).toContain('router.subscribe("onResolved"');
     // Controlled: the host echoing back the page we just reported must not
-    // navigate a second time.
+    // navigate a second time. Compared against the MOUNTED page, not the raw
+    // prop — a host still asking for a page we no longer mount would otherwise
+    // never match, and this effect would navigate on every render.
     expect(embedded).toContain(
-      "if (pathToSettingsPage(router.state.location.pathname) === page) return;",
+      "if (pathToSettingsPage(router.state.location.pathname) === mounted) return;",
     );
     // The published types are hand-written, so they drift silently unless
     // pinned alongside the implementation.
@@ -456,6 +458,26 @@ describe("host-mounted settings navigation", () => {
     // an unfiltered pathname→page cast would hand the host a page id it has no
     // route for.
     expect(embedded).toContain("SETTINGS_PAGES.includes(page) ? page : null");
+  });
+
+  test("the More page is not host-mountable", () => {
+    // "more" is device-level — push, appearance, sound, haptics, install — and
+    // a host already owns every one of those for its own app. Mounting ours put
+    // a second set of switches beside the host's, and ours were the ones that
+    // could not work: the push toggle would have had to borrow a service worker
+    // from an origin we do not own, and the only one going spare on app.omg.dev
+    // is a cache-drain worker that reloads every open tab when it activates.
+    // That is what made opening More reload the whole dashboard.
+    const pages = embedded.slice(
+      embedded.indexOf("const SETTINGS_PAGES"),
+      embedded.indexOf("]", embedded.indexOf("const SETTINGS_PAGES")),
+    );
+    expect(pages).not.toContain('"more"');
+    expect(dts).not.toContain('| "more"');
+    // A host pinned to an older build still passes it, and the internal route
+    // still exists, so the type change alone does not stop it rendering.
+    expect(embedded).toContain("function mountablePage(");
+    expect(embedded).toContain('SETTINGS_PAGES.includes(page) ? page : "settings"');
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22528,7 +22528,15 @@ function SettingsView({
 
       <OmgUpdateSection />
 
-      {/* More — the long tail lives on its own page so this one stays scannable. */}
+      {/* More — the long tail lives on its own page so this one stays scannable.
+          Hidden on a host-mounted surface: everything behind it (push,
+          appearance, sound, haptics, install) describes the DEVICE, and the
+          host already owns those for its own app. Showing ours put a second
+          set of switches next to the host's, and ours were the ones that could
+          not work — the push toggle would have had to borrow a service worker
+          from an origin we do not own. `bare` is true only for
+          OmgSettingsSurface, which is exactly the host-mounted case. */}
+      {bare ? null : (
       <section className="space-y-2">
         <div className="overflow-hidden rounded-2xl border border-border bg-card/40">
           <button
@@ -22551,6 +22559,7 @@ function SettingsView({
           </button>
         </div>
       </section>
+      )}
     </div>
   );
 }

--- a/web/src/embedded.d.ts
+++ b/web/src/embedded.d.ts
@@ -161,12 +161,20 @@ export declare function OmgAppSurface(
  * Machine-owned settings pages a host can mount on their own, underneath its
  * own account and plan UI, instead of reimplementing them.
  */
+/**
+ * The machine's settings pages a host can mount.
+ *
+ * "more" is not one of them. That page is device-level (push, appearance,
+ * sound, haptics, install) rather than machine-level, so the host owns it —
+ * mounting the machine's copy would show a second, non-working switch beside
+ * the host's own. A host that still passes `page: "more"` gets the settings
+ * root instead of an error.
+ */
 export type OmgSettingsPage =
   | "settings"
   | "coding-agents"
   | "auto"
-  | "storage"
-  | "more";
+  | "storage";
 
 export interface OmgSettingsSurfaceProps {
   transport: OmgTransport;

--- a/web/src/embedded.tsx
+++ b/web/src/embedded.tsx
@@ -188,13 +188,25 @@ const SETTINGS_PAGES: readonly OmgSettingsPage[] = [
   "coding-agents",
   "auto",
   "storage",
-  "more",
 ];
 
 function pathToSettingsPage(pathname: string): OmgSettingsPage | null {
   const seg = pathname.split("/").filter(Boolean)[0];
   const page = (seg ? decodeURIComponent(seg) : "settings") as OmgSettingsPage;
   return SETTINGS_PAGES.includes(page) ? page : null;
+}
+
+/**
+ * The page to actually mount.
+ *
+ * Hosts pinned to an older build still pass `page: "more"`, and the internal
+ * route for it has not gone anywhere — so without this the type change alone
+ * would not stop it rendering. Fall back to the settings root: the host's own
+ * device settings are what that person should be looking at, and a page that
+ * silently shows the root beats one that shows two competing push toggles.
+ */
+function mountablePage(page: OmgSettingsPage): OmgSettingsPage {
+  return SETTINGS_PAGES.includes(page) ? page : "settings";
 }
 
 /**
@@ -213,18 +225,21 @@ export function OmgSettingsSurface({
   errorSink,
   hostedPush,
 }: OmgSettingsSurfaceProps) {
+  const mounted = mountablePage(page);
   // The host owns the header, the back affordance and the account, so this
   // surface renders sections only — declared to the tree below, not to a
   // module global that a coexisting full-app surface would also read.
   configureOmgTransport(transport, { assetBaseUrl, errorSink });
-  // The More page owns the push toggle, so this surface — not just the full app
-  // surface — has to declare the host boundary. Without it push falls back to
-  // registering the host's own root worker; see configureHostedSurface.
+  // Declare the host boundary before any child can read it. Push must never
+  // fall back to registering the host's own root worker; see
+  // configureHostedSurface. This stays even though the page that owned the
+  // toggle is no longer mountable — the guard is about what this bundle is
+  // allowed to touch, not about which screen happens to be on.
   configureHostedSurface(true);
   configureHostPush(hostedPush ?? null);
   const [router] = useState<AnyRouter>(() =>
     createOmgRouter(
-      createMemoryHistory({ initialEntries: [`/${page}?embed=true`] }),
+      createMemoryHistory({ initialEntries: [`/${mounted}?embed=true`] }),
     ),
   );
 
@@ -248,9 +263,9 @@ export function OmgSettingsSurface({
   // surface. Guarded on the current location because the common case is the
   // host echoing back the page we just reported.
   useEffect(() => {
-    if (pathToSettingsPage(router.state.location.pathname) === page) return;
-    void router.navigate({ to: `/${page}`, search: { embed: true }, replace: true });
-  }, [router, page]);
+    if (pathToSettingsPage(router.state.location.pathname) === mounted) return;
+    void router.navigate({ to: `/${mounted}`, search: { embed: true }, replace: true });
+  }, [router, mounted]);
 
   // Ref-counted: a host can have two surfaces alive at once, and the first one
   // to unmount must not strip the stylesheet's anchor off the other.

--- a/web/src/lib/embedded-host-options.tsx
+++ b/web/src/lib/embedded-host-options.tsx
@@ -59,13 +59,20 @@ export interface EmbeddedHostOptions {
  * The machine-owned settings pages a host can mount on its own. Mirrors
  * OmgSettingsSurface's `page` prop — declared here rather than in embedded.tsx
  * so app code can reference it without importing the package entrypoint.
+ *
+ * "more" is deliberately NOT here. Everything on that page — push
+ * notifications, appearance, sound, haptics, install — is a property of the
+ * DEVICE you are holding, not of the machine you are talking to. A host
+ * already owns all of those for its own app, so mounting the machine's copy
+ * gives the person two switches for one thing, and the machine's copy is the
+ * one that cannot work: its push toggle would have to borrow a service worker
+ * from an origin it does not own. The host owns this page.
  */
 export type HostSettingsPage =
   | "settings"
   | "coding-agents"
   | "auto"
-  | "storage"
-  | "more";
+  | "storage";
 
 export interface PlanLimitDetail {
   /** The server's own sentence, already written for a human to read. */


### PR DESCRIPTION
Follow-up to #90, taking the structural fix rather than the defensive one.

Everything on **More** describes the **device** — push notifications, appearance, sound, haptics, install. A host embedding this UI already owns all of those for its own app, so mounting our copy showed a second set of switches beside the host's, and ours were the ones that could not work.

The push toggle is the clearest case. A subscription belongs to a service-worker registration, and we do not own an origin on the host's page, so ours had to borrow one. The only registration going spare on app.omg.dev is the **cache-drain worker**, whose activate handler navigates every open client to bust caches and then unregisters itself — which is exactly why opening More reloaded the whole dashboard, and why it did it again on the next visit.

v0.1.349 stopped us reaching for that worker. This removes the reason we were reaching at all.

## Changes

- `"more"` dropped from `HostSettingsPage` / `OmgSettingsPage` and `SETTINGS_PAGES`.
- The More row is hidden when `bare` — true only for `OmgSettingsSurface`, i.e. precisely the host-mounted case. **The standalone app is untouched** and keeps the page.
- `mountablePage()` falls a stale `page: \"more\"` back to the settings root. Hosts pinned to an older build still pass it and the internal route still exists, so the type change alone would not stop it rendering.

Kept from v0.1.349: the `configureHostedSurface` guard in `push.ts`. That is about what this bundle may touch, not about which screen happens to be on.

## Verification

- `bun run typecheck` clean, `bun run build:packages` builds
- `bun test`: 1301 pass, 1 skip, 2 fail — both failures are `coding agent auth detection > Jcode …`, **verified pre-existing on clean main**
- Source-pinned navigation test updated to compare against `mounted`; new test asserts `\"more\"` cannot quietly become host-mountable again

The hosted push toggle belongs to the host, against the host's own worker and its own event router — see BennyKok/vibes#1308.