### PR TITLE
Keep scheduled runs out of the interactive session cap

### DIFF
--- a/src/agent-admission.test.ts
+++ b/src/agent-admission.test.ts
@@ -8,6 +8,9 @@ import {
   NO_AGENT_LIMIT,
   agentLaunchMemoryBudget,
   computerAgentAdmissionContext,
+  interactiveResidentCount,
+  isScheduleSpawned,
+  scheduleResidentCount,
 } from "./agent-admission.ts";
 
 describe("Computer agent admission", () => {
@@ -18,6 +21,18 @@ describe("Computer agent admission", () => {
     expect(
       residentAgentCount([{ busy: true }, { launching: true }, { busy: false }]),
     ).toBe(3);
+  });
+
+  test("scheduled runs sit in their own resident pool", () => {
+    const sessions = [
+      { busy: false, spawnedBy: "schedule" },
+      { busy: false },
+      { launching: true, spawnedBy: "schedule" },
+    ];
+    expect(interactiveResidentCount(sessions)).toBe(1);
+    expect(scheduleResidentCount(sessions)).toBe(2);
+    expect(isScheduleSpawned("schedule")).toBe(true);
+    expect(isScheduleSpawned("subagent")).toBe(false);
   });
 
   test("an idle-only fleet can still fill the cap", () => {
@@ -32,26 +47,32 @@ describe("Computer agent admission", () => {
     expect(computerAgentAdmissionContext("free")).toEqual({
       plan: "free",
       limit: 1,
+      scheduleLimit: 1,
     });
     expect(computerAgentAdmissionContext("computer_5")).toEqual({
       plan: "computer_5",
       limit: 5,
+      scheduleLimit: 2,
     });
     expect(computerAgentAdmissionContext("computer_10")).toEqual({
       plan: "computer_10",
       limit: 16,
+      scheduleLimit: 3,
     });
     expect(computerAgentAdmissionContext("computer_20")).toEqual({
       plan: "computer_20",
       limit: 24,
+      scheduleLimit: 4,
     });
     expect(computerAgentAdmissionContext("computer_early")).toEqual({
       plan: "computer_early",
       limit: 24,
+      scheduleLimit: 4,
     });
     expect(computerAgentAdmissionContext("computer_trial")).toEqual({
       plan: "computer_trial",
       limit: 1,
+      scheduleLimit: 1,
     });
     const admission = new AgentAdmissionController();
     expect(admission.tryAcquire(1, [{ busy: true }])).toMatchObject({
@@ -177,6 +198,7 @@ describe("Computer agent admission", () => {
     expect(computerAgentAdmissionContext("retired-plan")).toEqual({
       plan: "free",
       limit: 1,
+      scheduleLimit: 1,
     });
     expect(computerAgentAdmissionContext("")).toBeNull();
   });
@@ -222,11 +244,13 @@ describe("Computer agent admission", () => {
       expect(computerAgentAdmissionContext(undefined, path)).toEqual({
         plan: "computer_5",
         limit: 5,
+        scheduleLimit: 2,
       });
       writeFileSync(path, "free\n");
       expect(computerAgentAdmissionContext(undefined, path)).toEqual({
         plan: "free",
         limit: 1,
+        scheduleLimit: 1,
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/src/agent-admission.ts
+++ b/src/agent-admission.ts
@@ -71,6 +71,8 @@ const LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
 
 // Scheduled fires are not interactive sessions. They get a smaller, separate
 // pool so a leftover cron cannot fill the Computer and block "New session".
+// These numbers exist only when computerAgentAdmissionContext() is non-null
+// (a managed Computer). Self-hosted lfg serve never reads this table.
 const SCHEDULE_LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
   free: 1,
   computer_trial: 1,

--- a/src/agent-admission.ts
+++ b/src/agent-admission.ts
@@ -18,11 +18,14 @@ export type AgentAdmissionPlan =
 export type AgentAdmissionContext = {
   plan: AgentAdmissionPlan;
   limit: number;
+  /** Concurrent scheduled runs. Separate from `limit` — a cron must not fill the interactive cap. */
+  scheduleLimit: number;
 };
 
 export type AgentActivity = {
   busy?: boolean;
   launching?: boolean;
+  spawnedBy?: string | null;
 };
 
 export type AgentMemoryBudget = {
@@ -66,6 +69,21 @@ const LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
   computer_early: 24,
 };
 
+// Scheduled fires are not interactive sessions. They get a smaller, separate
+// pool so a leftover cron cannot fill the Computer and block "New session".
+const SCHEDULE_LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
+  free: 1,
+  computer_trial: 1,
+  computer_5: 2,
+  computer_10: 3,
+  computer_20: 4,
+  computer_early: 4,
+};
+
+export function isScheduleSpawned(spawnedBy: string | null | undefined): boolean {
+  return spawnedBy === "schedule";
+}
+
 const COMPUTER_PLAN_FILE = "/etc/omg/computer-plan";
 
 function currentComputerPlan(planFile: string): string | undefined {
@@ -100,11 +118,11 @@ export function computerAgentAdmissionContext(
     plan === "computer_20" ||
     plan === "computer_early"
   ) {
-    return { plan, limit: LIMITS[plan] };
+    return { plan, limit: LIMITS[plan], scheduleLimit: SCHEDULE_LIMITS[plan] };
   }
   // A stale or malformed cloud-plan value must fail safe for the Computer,
   // while ordinary non-Computer LFG installs keep their local setting policy.
-  return { plan: "free", limit: LIMITS.free };
+  return { plan: "free", limit: LIMITS.free, scheduleLimit: SCHEDULE_LIMITS.free };
 }
 
 /**
@@ -123,6 +141,15 @@ export function computerAgentAdmissionContext(
  */
 export function residentAgentCount(sessions: readonly AgentActivity[]): number {
   return sessions.length;
+}
+
+/** Interactive New-session / resume / fork work. Scheduled runs are a different pool. */
+export function interactiveResidentCount(sessions: readonly AgentActivity[]): number {
+  return residentAgentCount(sessions.filter((session) => !isScheduleSpawned(session.spawnedBy)));
+}
+
+export function scheduleResidentCount(sessions: readonly AgentActivity[]): number {
+  return residentAgentCount(sessions.filter((session) => isScheduleSpawned(session.spawnedBy)));
 }
 
 /**

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -564,22 +564,31 @@ function formatMemory(bytes: number): string {
 // when granted, the memory budget below still has to clear, so an override
 // can oversubscribe the setting but never the machine.
 async function activationGate(
-  options?: { overLimit?: boolean },
+  options?: { overLimit?: boolean; kind?: "interactive" | "schedule" },
 ): Promise<Response | { release: () => void; reclaimed?: number }> {
   const settings = getGlobalSettingsSync();
   if (settings.agentsPaused) {
     return err(503, "agent activation is paused");
   }
   const computer = computerAgentAdmissionContext();
-  const limit = computer?.limit ?? settings.maxLiveAgents;
+  const kind = options?.kind ?? "interactive";
+  const limit =
+    kind === "schedule"
+      ? (computer?.scheduleLimit ?? 1)
+      : (computer?.limit ?? settings.maxLiveAgents);
   if (limit === 0) return { release: () => {} };
   const overLimit = !computer && options?.overLimit === true;
   const reservation = await agentAdmission.acquire(
     overLimit ? NO_AGENT_LIMIT : limit,
     async () => {
       const available = hostAvailableMemory();
+      const sessions = await listSessions().catch(() => []);
+      const pool =
+        kind === "schedule"
+          ? sessions.filter((session) => session.spawnedBy === "schedule")
+          : sessions.filter((session) => session.spawnedBy !== "schedule");
       return {
-        sessions: await listSessions().catch(() => []),
+        sessions: pool,
         // Always measured, so every launch books its share of memory even on
         // the count-capped path. Only whether a shortfall REFUSES is
         // conditional.
@@ -626,6 +635,13 @@ async function activationGate(
       429,
       `${reservation.resident} of ${limit} agents live — close an agent, or raise the limit in Settings`,
       "agent_limit",
+    );
+  }
+  if (kind === "schedule") {
+    return err(
+      429,
+      `your ${computer.plan} Computer plan allows ${computer.scheduleLimit} concurrent scheduled runs; ${reservation.resident} live — wait for one to finish`,
+      "plan_limit",
     );
   }
   return err(
@@ -4799,7 +4815,10 @@ a{color:#60a5fa}
         // Global pause / live-agent cap. Applies to every activation — main and
         // subagent alike. Fork reaches here via its internal POST to
         // /api/sessions/new, so it inherits this gate for free.
-        const gate = await activationGate({ overLimit: body?.overLimit === true });
+        const gate = await activationGate({
+          overLimit: body?.overLimit === true,
+          kind: spawnedBy === "schedule" ? "schedule" : "interactive",
+        });
         if (gate instanceof Response) return gate;
         try {
         const tmuxName = `lfg-${randomBytes(3).toString("hex")}`;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -571,10 +571,12 @@ async function activationGate(
     return err(503, "agent activation is paused");
   }
   const computer = computerAgentAdmissionContext();
-  const kind = options?.kind ?? "interactive";
+  // Schedule admission is a Computer-plan rule. A self-hosted box has no plan
+  // file, so spawnedBy=schedule is just another session under maxLiveAgents.
+  const kind = computer && options?.kind === "schedule" ? "schedule" : "interactive";
   const limit =
     kind === "schedule"
-      ? (computer?.scheduleLimit ?? 1)
+      ? computer.scheduleLimit
       : (computer?.limit ?? settings.maxLiveAgents);
   if (limit === 0) return { release: () => {} };
   const overLimit = !computer && options?.overLimit === true;
@@ -583,8 +585,9 @@ async function activationGate(
     async () => {
       const available = hostAvailableMemory();
       const sessions = await listSessions().catch(() => []);
-      const pool =
-        kind === "schedule"
+      const pool = !computer
+        ? sessions
+        : kind === "schedule"
           ? sessions.filter((session) => session.spawnedBy === "schedule")
           : sessions.filter((session) => session.spawnedBy !== "schedule");
       return {
@@ -2908,6 +2911,9 @@ a{color:#60a5fa}
             },
             onboarding: boot.onboarding ?? null,
             version: appVersion(),
+            // Null on self-hosted. The live rail and admission use this to
+            // keep Computer schedule rules off a normal lfg serve.
+            computer: computerAgentAdmissionContext(),
           },
           { headers: { "Content-Type": "application/json", "Cache-Control": "no-cache" } },
         );

--- a/src/session-recovery.test.ts
+++ b/src/session-recovery.test.ts
@@ -23,6 +23,7 @@ describe("command-file session boot recovery", () => {
 
   afterEach(() => {
     delete process.env.LFG_TEST_HARNESS_CAPTURE;
+    delete process.env.LFG_COMPUTER_PLAN;
     resetManagedRegistryForTests();
     PATHS.data = originalData;
     rmSync(root, { recursive: true, force: true });
@@ -173,7 +174,8 @@ describe("command-file session boot recovery", () => {
     expect(managedLaunchRow(managed, {}, {})).toBeNull();
   });
 
-  test("does not relaunch a scheduled run after boot", async () => {
+  test("does not relaunch a scheduled run after boot on a Computer", async () => {
+    process.env.LFG_COMPUTER_PLAN = "computer_5";
     const key = "88888888-8888-4888-8888-888888888888";
     addManaged({
       tmuxName: "lfg-schedule-fire",
@@ -199,11 +201,48 @@ describe("command-file session boot recovery", () => {
       createdAt: 1,
     });
 
+    try {
+      const result = await reconcileCommandFileSessions(() => {});
+      expect(result.skippedSchedule).toBe(1);
+      expect(result.recovered).toBe(0);
+      expect(listManaged()).toEqual([]);
+      expect(readEntry(key)?.recoveryClaimBootId).toBe(currentBootId());
+      expect(() => readFileSync(capture, "utf8")).toThrow();
+    } finally {
+      delete process.env.LFG_COMPUTER_PLAN;
+    }
+  });
+
+  test("self-hosted LFG still recovers a spawnedBy=schedule session", async () => {
+    delete process.env.LFG_COMPUTER_PLAN;
+    const key = "99999999-9999-4999-8999-999999999999";
+    addManaged({
+      tmuxName: "lfg-self-hosted-schedule",
+      cwd: root,
+      createdAt: 1,
+      agent: "aisdk",
+      sessionId: key,
+      nativeSessionId: key,
+      model: "opus",
+      launchState: "running",
+      spawnedBy: "schedule",
+    });
+    writeEntry({
+      sessionId: key,
+      agent: "claude",
+      harnessPid: 2147483647,
+      tmuxName: "lfg-self-hosted-schedule",
+      supervisor: "process",
+      bootId: "prior-boot",
+      cwd: root,
+      model: "opus",
+      busy: false,
+      createdAt: 1,
+    });
+
     const result = await reconcileCommandFileSessions(() => {});
-    expect(result.skippedSchedule).toBe(1);
-    expect(result.recovered).toBe(0);
-    expect(listManaged()).toEqual([]);
-    expect(readEntry(key)?.recoveryClaimBootId).toBe(currentBootId());
-    expect(() => readFileSync(capture, "utf8")).toThrow();
+    expect(result.skippedSchedule).toBe(0);
+    expect(result.recovered).toBe(1);
+    expect(listManaged()[0]?.tmuxName).toBe("lfg-self-hosted-schedule");
   });
 });

--- a/src/session-recovery.test.ts
+++ b/src/session-recovery.test.ts
@@ -172,4 +172,38 @@ describe("command-file session boot recovery", () => {
 
     expect(managedLaunchRow(managed, {}, {})).toBeNull();
   });
+
+  test("does not relaunch a scheduled run after boot", async () => {
+    const key = "88888888-8888-4888-8888-888888888888";
+    addManaged({
+      tmuxName: "lfg-schedule-fire",
+      cwd: root,
+      createdAt: 1,
+      agent: "aisdk",
+      sessionId: key,
+      nativeSessionId: key,
+      model: "opus",
+      launchState: "running",
+      spawnedBy: "schedule",
+    });
+    writeEntry({
+      sessionId: key,
+      agent: "claude",
+      harnessPid: 2147483647,
+      tmuxName: "lfg-schedule-fire",
+      supervisor: "process",
+      bootId: "prior-boot",
+      cwd: root,
+      model: "opus",
+      busy: false,
+      createdAt: 1,
+    });
+
+    const result = await reconcileCommandFileSessions(() => {});
+    expect(result.skippedSchedule).toBe(1);
+    expect(result.recovered).toBe(0);
+    expect(listManaged()).toEqual([]);
+    expect(readEntry(key)?.recoveryClaimBootId).toBe(currentBootId());
+    expect(() => readFileSync(capture, "utf8")).toThrow();
+  });
 });

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -6,7 +6,7 @@ import {
   type AisdkEntry,
 } from "./aisdk-registry.ts";
 import { addManaged, listManaged, patchManaged, removeManaged, type ManagedSession } from "./managed.ts";
-import { isScheduleSpawned } from "./agent-admission.ts";
+import { computerAgentAdmissionContext, isScheduleSpawned } from "./agent-admission.ts";
 import {
   spawnManagedAisdkSession,
   spawnManagedCodexAisdkSession,
@@ -107,7 +107,8 @@ export async function reconcileCommandFileSessions(
     if (!owner) continue;
     // A scheduled run already did its job. Relaunching it on every wake is
     // how five leftover crons filled a computer_5 box and blocked New session.
-    if (isScheduleSpawned(owner.spawnedBy)) {
+    // Self-hosted LFG has no Computer plan — leave those rows alone.
+    if (computerAgentAdmissionContext() && isScheduleSpawned(owner.spawnedBy)) {
       patchEntry(entry.sessionId, { recoveryClaimBootId: bootId });
       removeManaged(owner.tmuxName);
       result.skippedSchedule++;

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -5,7 +5,8 @@ import {
   patchEntry,
   type AisdkEntry,
 } from "./aisdk-registry.ts";
-import { addManaged, listManaged, patchManaged, type ManagedSession } from "./managed.ts";
+import { addManaged, listManaged, patchManaged, removeManaged, type ManagedSession } from "./managed.ts";
+import { isScheduleSpawned } from "./agent-admission.ts";
 import {
   spawnManagedAisdkSession,
   spawnManagedCodexAisdkSession,
@@ -22,6 +23,7 @@ export type RecoveryResult = {
   recovered: number;
   failed: number;
   skippedLegacy: number;
+  skippedSchedule: number;
 };
 
 function matchingManaged(entry: AisdkEntry, managed: ManagedSession[]): ManagedSession | null {
@@ -88,7 +90,14 @@ export async function reconcileCommandFileSessions(
   log: (line: string) => void = console.log,
 ): Promise<RecoveryResult> {
   const bootId = currentBootId();
-  const result: RecoveryResult = { bootId, adopted: 0, recovered: 0, failed: 0, skippedLegacy: 0 };
+  const result: RecoveryResult = {
+    bootId,
+    adopted: 0,
+    recovered: 0,
+    failed: 0,
+    skippedLegacy: 0,
+    skippedSchedule: 0,
+  };
   if (!bootId) return result;
   const managed = listManaged();
   const assignments = userAssignments();
@@ -96,6 +105,14 @@ export async function reconcileCommandFileSessions(
   for (const entry of listEntries()) {
     const owner = matchingManaged(entry, managed);
     if (!owner) continue;
+    // A scheduled run already did its job. Relaunching it on every wake is
+    // how five leftover crons filled a computer_5 box and blocked New session.
+    if (isScheduleSpawned(owner.spawnedBy)) {
+      patchEntry(entry.sessionId, { recoveryClaimBootId: bootId });
+      removeManaged(owner.tmuxName);
+      result.skippedSchedule++;
+      continue;
+    }
     const legacyTmuxAlive = !entry.bootId && tmuxHasSession(entry.tmuxName);
     // PIDs are only meaningful within the boot that recorded them. After a
     // reboot Linux may reuse the number for an unrelated process, so a stale

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6087,6 +6087,7 @@ export function App() {
         .filter(
           (session) =>
             session.sessionId &&
+            session.spawnedBy !== "schedule" &&
             // A pane target means a driveable TUI session. Harness-backed
             // sessions have no pane, so admit those explicitly; otherwise Codex
             // AI-SDK sessions are fetched from /api/sessions and then hidden here.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -842,6 +842,8 @@ type BootstrapPayload = {
   repos?: Repo[] | null;
   auto?: { agents?: AutoAgent[] | null; tz?: string; findings?: AutoFinding[] | null };
   onboarding?: OnboardingState | null;
+  /** Set only on a managed Computer. Self-hosted lfg serve leaves this null. */
+  computer?: { plan: string; limit: number; scheduleLimit: number } | null;
 };
 
 type SlashSkillState = {
@@ -5431,6 +5433,7 @@ export function App() {
     return () => window.clearTimeout(t);
   }, [loading]);
   const [autoAgents, setAutoAgents] = useState<AutoAgent[]>([]);
+  const [managedComputer, setManagedComputer] = useState(false);
   const [settings, setSettings] = useState<GlobalSettings>({
     timeZone: DEFAULT_SCHED_TZ,
     maxLiveAgents: 16,
@@ -5694,6 +5697,7 @@ export function App() {
     ) {
       setShowOnboarding(true);
     }
+    setManagedComputer(!!payload.computer);
     setCodingAgents(payload.codingAgents ?? []);
     setModelCatalog(buildAgentModelCatalog(payload.models));
     setSettings(payload.settings ?? {
@@ -6087,7 +6091,7 @@ export function App() {
         .filter(
           (session) =>
             session.sessionId &&
-            session.spawnedBy !== "schedule" &&
+            !(managedComputer && session.spawnedBy === "schedule") &&
             // A pane target means a driveable TUI session. Harness-backed
             // sessions have no pane, so admit those explicitly; otherwise Codex
             // AI-SDK sessions are fetched from /api/sessions and then hidden here.
@@ -6102,7 +6106,7 @@ export function App() {
             (a.startedAt ?? 0) - (b.startedAt ?? 0) ||
             (a.sessionId ?? "").localeCompare(b.sessionId ?? ""),
         ),
-    [sessions, removedSids],
+    [sessions, removedSids, managedComputer],
   );
 
   // Unique projects present across the (user-filtered) live sessions plus every


### PR DESCRIPTION
Scheduled Computer fires were recovered as live sessions on every wake. On a computer_5 box that filled the 5-agent cap and blocked New session.

This change:

- Gives scheduled runs (`spawnedBy: schedule`) their own admission pool
- Does not relaunch those runs after boot on a managed Computer
- Hides them from the live rail only when a Computer plan is present
- Leaves self-hosted `lfg serve` unchanged — no plan file means no schedule rules

Pairs with BennyKok/vibes `session_lfg-8bc16c` (create cap + `spawnedBy` tag). Existing Computers need a package publish and template bake before the guest enforces this.
