### PR TITLE
chore: release v0.1.366

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent product updates and deployment notes.
 
+## August 13, 2026 - Hosted owner filter no longer hides every session (v0.1.366)
+
+Hosted Computers create unassigned sessions with an empty roster. A leftover
+owner filter hid them all while Settings still showed live agents — and
+"All projects" could not fix it because that is a different filter. Hosted
+surfaces now open Everyone, empty rosters clear invalid owner filters, and
+an explicit Everyone selection stays sticky.
+
 ## August 13, 2026 - Scheduled runs stop filling your session slots (v0.1.365)
 
 - **A leftover scheduled run no longer takes a New session slot.** On a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lfg",
-  "version": "0.1.365",
+  "version": "0.1.366",
   "type": "module",
   "workspaces": [
     "packages/*",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omg-dev/app",
-  "version": "0.1.91",
+  "version": "0.1.366",
   "description": "The full OMG application surface for React hosts.",
   "license": "MIT",
   "homepage": "https://omg.dev",


### PR DESCRIPTION
Release notes for the hosted owner-filter fix.