### PR TITLE
Fix hosted default coding agent

### DIFF
--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -389,6 +389,7 @@ describe("coding agent auth detection", () => {
 
   test("Jcode reports a configured provider without claiming a connected account", async () => {
     const home = useTmpHome();
+    setEnv("PATH", home);
     const jcode = join(home, "jcode");
     writeFileSync(
       jcode,
@@ -405,6 +406,7 @@ describe("coding agent auth detection", () => {
 
   test("Jcode reports stored provider credentials as a connected account", async () => {
     const home = useTmpHome();
+    setEnv("PATH", home);
     const jcode = join(home, "jcode");
     writeFileSync(
       jcode,

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -294,8 +294,9 @@ function opencodePath(): string | null {
 
 function jcodePath(): string | null {
   const home = userHome();
+  const override = process.env.LFG_JCODE_PATH?.trim();
+  if (override) return existsSync(override) ? override : null;
   return which("jcode", [
-    process.env.LFG_JCODE_PATH ?? "",
     `${home}/.local/bin/jcode`,
     `${home}/.jcode/bin/jcode`,
     "/usr/local/bin/jcode",

--- a/src/commands/mcp.test.ts
+++ b/src/commands/mcp.test.ts
@@ -190,6 +190,6 @@ describe("sendToOrigin", () => {
     await expect(sendToOrigin({
       text: "wrong target",
       sessionId: "22222222-2222-4222-8222-222222222222",
-    })).rejects.toThrow("owning OMG session");
+    })).rejects.toThrow("owning omg.dev session");
   });
 });

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -143,6 +143,6 @@ describe("caller identity over the shared MCP endpoint", () => {
     );
 
     expect(reply.isError).toBe(true);
-    expect(reply.text).toContain("can only target their owning OMG session");
+    expect(reply.text).toContain("can only target their owning omg.dev session");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -369,6 +369,7 @@ import {
   configuredAgentOptions,
   displayedAgentOption,
   lockedAgentOptions,
+  resolveInitialAgent,
   scheduledAgentOptions,
   type AgentAccessMode,
   type AgentKind,
@@ -5133,7 +5134,7 @@ export function App() {
   // Host-mounted single page: suppress every piece of LFG shell chrome the
   // host already renders (header, brand, nav, composer).
   const bare = useBareSurface();
-  const { connectionOnboarding, viewer } = useEmbeddedHostOptions();
+  const { connectionOnboarding, defaultAgent, viewer } = useEmbeddedHostOptions();
   // Session deep-links win over filter/identity work so the target card opens
   // as soon as bootstrap returns sessions.
   const prioritizeSession = shouldPrioritizeSession(deepLinkSearch) || !!sessionDeepLinkRef.current;
@@ -6749,7 +6750,10 @@ export function App() {
       repos: repos.map((repo) => ({ cwd: repo.cwd, project: repoProject(repo) })),
       fallbackCwd: localStorage.getItem("lfg_v2_repo"),
     });
-    const launchAgent = (localStorage.getItem("lfg_v2_agent") as AgentKind | null) || "aisdk";
+    const launchAgent = resolveInitialAgent(
+      localStorage.getItem("lfg_v2_agent"),
+      defaultAgent,
+    );
     const launchModel =
       localStorage.getItem(`lfg_model_${launchAgent}`) ||
       localStorage.getItem("lfg_model") ||
@@ -6851,7 +6855,10 @@ export function App() {
       projectFilter !== "__all"
         ? repos.find((repo) => repoProject(repo) === projectFilter)
         : undefined;
-    const launchAgent = (localStorage.getItem("lfg_v2_agent") as AgentKind | null) || "aisdk";
+    const launchAgent = resolveInitialAgent(
+      localStorage.getItem("lfg_v2_agent"),
+      defaultAgent,
+    );
     const launchModel =
       localStorage.getItem(`lfg_model_${launchAgent}`) ||
       localStorage.getItem("lfg_model") ||
@@ -17272,17 +17279,18 @@ function NewSessionDialog({
 }) {
   const catalog = useAgentModelCatalog();
   const accessMode = useContext(AgentAccessModeContext);
+  const { defaultAgent } = useEmbeddedHostOptions();
   const defaultModelFor = (key: AgentKind) => catalog.defaults[key] ?? AGENT_DEFAULT_MODEL[key];
   const [agent, setAgent] = useState<AgentKind>(
-    () => (localStorage.getItem("lfg_v2_agent") as AgentKind | null) || "aisdk",
+    () => resolveInitialAgent(localStorage.getItem("lfg_v2_agent"), defaultAgent),
   );
   const [claudeAccountId, setClaudeAccountId] = useState("");
   const [repo, setRepo] = useState(() => localStorage.getItem("lfg_v2_repo") || "");
   const [model, setModel] = useState(
     () =>
-      localStorage.getItem(`lfg_model_${localStorage.getItem("lfg_v2_agent") || "aisdk"}`) ||
+      localStorage.getItem(`lfg_model_${agent}`) ||
       localStorage.getItem("lfg_model") ||
-      defaultModelFor((localStorage.getItem("lfg_v2_agent") as AgentKind | null) || "aisdk"),
+      defaultModelFor(agent),
   );
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
     () => savedThinkingLevel(),

--- a/web/src/embedded.d.ts
+++ b/web/src/embedded.d.ts
@@ -9,6 +9,18 @@ export type {
   OmgTransport,
 } from "@omg-dev/client";
 
+export type AgentKind =
+  | "claude"
+  | "aisdk"
+  | "codex"
+  | "codex-aisdk"
+  | "opencode"
+  | "jcode"
+  | "grok"
+  | "cursor"
+  | "pi"
+  | "copilot";
+
 /**
  * Central sink for client errors raised inside the surface, in addition to the
  * report that goes through the transport into the user's own lfg instance.
@@ -91,6 +103,8 @@ export interface OmgAppSurfaceProps {
   assetBaseUrl?: string;
   sessionId?: string | null;
   className?: string;
+  /** The agent used when this browser has no valid saved selection. */
+  defaultAgent?: AgentKind;
   /**
    * Show LFG's embedded first-run provider connection gate. Defaults to true.
    * Managed hosts that preselect a credential-free agent can disable this and

--- a/web/src/embedded.tsx
+++ b/web/src/embedded.tsx
@@ -25,6 +25,7 @@ import {
 } from "./lib/embedded-host-options";
 import { claimSurfaceAttribute } from "./lib/surface-attribute";
 import { createOmgRouter } from "./router";
+import type { AgentKind } from "./lib/coding-agent-options";
 
 export type {
   EmbeddedViewer,
@@ -59,6 +60,8 @@ export interface OmgAppSurfaceProps {
   assetBaseUrl?: string;
   sessionId?: string | null;
   className?: string;
+  /** The agent used when this browser has no valid saved selection. */
+  defaultAgent?: AgentKind;
   /**
    * Show LFG's embedded first-run provider connection gate. Defaults to true.
    * Managed hosts that preselect a credential-free agent can disable this and
@@ -302,6 +305,7 @@ export function OmgAppSurface({
   assetBaseUrl,
   sessionId,
   className,
+  defaultAgent = "aisdk",
   connectionOnboarding = true,
   viewer,
   hostedTranscription,
@@ -331,6 +335,7 @@ export function OmgAppSurface({
     <div className={className} data-lfg-app-surface="">
       <EmbeddedHostOptionsProvider
         value={{
+          defaultAgent,
           connectionOnboarding,
           viewer,
           hostedTranscription,

--- a/web/src/lib/coding-agent-options.test.ts
+++ b/web/src/lib/coding-agent-options.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveInitialAgent } from "./coding-agent-options";
+
+describe("resolveInitialAgent", () => {
+  test("uses the host default when no saved agent exists", () => {
+    expect(resolveInitialAgent(null, "opencode")).toBe("opencode");
+  });
+
+  test("keeps a valid saved selection", () => {
+    expect(resolveInitialAgent("codex-aisdk", "opencode")).toBe("codex-aisdk");
+  });
+
+  test("rejects an invalid saved selection", () => {
+    expect(resolveInitialAgent("managed-anthropic", "opencode")).toBe("opencode");
+  });
+});

--- a/web/src/lib/coding-agent-options.ts
+++ b/web/src/lib/coding-agent-options.ts
@@ -43,6 +43,21 @@ export const AGENT_CATALOG: readonly AgentCatalogEntry[] = [
   { key: "copilot", label: "copilot" },
 ];
 
+const AGENT_KEYS = new Set<AgentKind>(AGENT_CATALOG.map((entry) => entry.key));
+
+/**
+ * Use a saved agent when it is valid. Otherwise, use the default selected by
+ * the host. This keeps the host default in one place for every launch path.
+ */
+export function resolveInitialAgent(
+  savedAgent: string | null,
+  defaultAgent: AgentKind,
+): AgentKind {
+  return savedAgent && AGENT_KEYS.has(savedAgent as AgentKind)
+    ? (savedAgent as AgentKind)
+    : defaultAgent;
+}
+
 /** The catalog subset a scheduled auto agent can actually run. */
 export function scheduledAgentOptions(): AgentCatalogEntry[] {
   return AGENT_CATALOG.filter((option) => option.scheduled);

--- a/web/src/lib/embedded-host-options.tsx
+++ b/web/src/lib/embedded-host-options.tsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, type ReactNode } from "react";
+import type { AgentKind } from "./coding-agent-options";
 
 export interface EmbeddedHostOptions {
+  /** The agent used when this browser has no valid saved selection. */
+  defaultAgent: AgentKind;
   /**
    * Whether LFG should own the first-run provider connection gate. A managed
    * host can disable it when it has already selected a credential-free agent
@@ -95,6 +98,7 @@ export interface EmbeddedViewer {
 }
 
 const EmbeddedHostOptionsContext = createContext<EmbeddedHostOptions>({
+  defaultAgent: "aisdk",
   connectionOnboarding: true,
 });
 


### PR DESCRIPTION
## Summary
- let an embedded host select the initial coding agent
- use that host default in all new-session launch paths
- reject invalid saved agent values
- stabilize existing agent contract tests

## Verification
- bun run build:packages
- bun run test (1419 passed, 1 skipped)