### PR TITLE
Add v0.1.367 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent product updates and deployment notes.
 
+## August 14, 2026 - Hosted Computers start with credential-free OpenCode (v0.1.367)
+
+- **A new hosted Computer now opens with OpenCode selected.** The host can set
+  the first coding agent before the composer starts, so a first prompt cannot
+  fall through to the managed Claude path.
+- **Your saved agent still wins.** The new host default applies only when this
+  browser has no valid saved selection.
+
 ## August 13, 2026 - Hosted owner filter no longer hides every session (v0.1.366)
 
 Hosted Computers create unassigned sessions with an empty roster. A leftover


### PR DESCRIPTION
## Summary
- add release notes for the hosted OpenCode default fix

## Verification
- bun run test (1419 passed, 1 skipped)