### PR TITLE
docs: put the Discord link in the public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/BennyKok/omg.dev?style=flat)](https://github.com/BennyKok/omg.dev/stargazers)
 [![npm](https://img.shields.io/npm/v/@omg-dev/cli?label=%40omg-dev%2Fcli)](https://www.npmjs.com/package/@omg-dev/cli)
+[![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://omg.dev/discord)
 
-[Quick start](#quick-start) · [Why omg.dev](#why-omgdev) · [Agents](#connect-a-coding-agent) · [Remote access](#reach-it-from-your-phone) · [Security](#security)
+[Quick start](#quick-start) · [Join the Discord](https://omg.dev/discord) · [Why omg.dev](#why-omgdev) · [Agents](#connect-a-coding-agent) · [Remote access](#reach-it-from-your-phone) · [Security](#security)
 
 <p>
   <img src="https://raw.githubusercontent.com/BennyKok/omg.dev/main/docs/images/omg-screenshot-1.jpg" alt="omg.dev web UI" width="31%" />


### PR DESCRIPTION
## Why

The Discord link from the earlier session only ever landed in **`BennyKok/vibes`** — the private internal monorepo. The public repo people actually land on had **zero** Discord mentions, so the link was effectively invisible.

Moving it "up" in vibes would not have helped: it is already at line 3 there, and that repo is private.

## What

Adds the link to the public README in the two highest-visibility spots:

- A Discord badge in the existing badge row (static shields.io badge, verified HTTP 200).
- `Join the Discord` in the top nav line, placed second right after Quick start.

Both point at `https://omg.dev/discord`, the stable redirect (verified: → `discord.gg/6chd8rZsuW` → 200), rather than a raw invite code that can expire.

Docs-only, so no release per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)