### PR TITLE
fix(web): externalize host-shared libs from the embed bundle

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,14 @@
     "vaul": "^1.1.2",
     "web-haptics": "^0.0.6"
   },
+  "peerDependencies": {
+    "@tanstack/react-router": "^1.170.18",
+    "class-variance-authority": "^0.7.1",
+    "cnfast": "0.0.8",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "vaul": "^1.1.2"
+  },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^26.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@omg-dev/client": "workspace:*",
     "@ai-sdk/react": "^4.0.19",
-    "@base-ui/react": "^1.3.0",
+    "@base-ui/react": "^1.6.0",
     "@number-flow/react": "^0.6.2",
     "@pierre/diffs": "^1.3.1",
     "@pierre/trees": "1.0.0-beta.6",
@@ -57,6 +57,7 @@
     "web-haptics": "^0.0.6"
   },
   "peerDependencies": {
+    "@base-ui/react": "^1.6.0",
     "@tanstack/react-router": "^1.170.18",
     "class-variance-authority": "^0.7.1",
     "cnfast": "0.0.8",

--- a/web/src/embedded-lib-smoke.test.ts
+++ b/web/src/embedded-lib-smoke.test.ts
@@ -4,14 +4,53 @@
 // cnfast, vaul, cva). This file is what proves those specifiers resolve and
 // that OmgAppSurface still mounts a real router tree — not just that vite
 // printed "built in Ns".
+//
+// The mount tests are not optional. If dist-lib/index.js is missing they
+// build it; if the build fails they fail the suite. A silent skip reports
+// green while proving nothing.
 
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Window } from "happy-dom";
 
-const DIST = join(import.meta.dir, "../dist-lib");
-const hasBuild = existsSync(join(DIST, "index.js"));
+const WEB = join(import.meta.dir, "..");
+const REPO = join(WEB, "..");
+const DIST = join(WEB, "dist-lib");
+const INDEX = join(DIST, "index.js");
+const MANIFEST = join(WEB, "package.json");
+
+const EXPECTED_PEERS = {
+  "@tanstack/react-router": "^1.170.18",
+  "class-variance-authority": "^0.7.1",
+  cnfast: "0.0.8",
+  react: "^19.2.4",
+  "react-dom": "^19.2.4",
+  vaul: "^1.1.2",
+} as const;
+
+function ensureLibBuild(): void {
+  if (existsSync(INDEX)) return;
+  const result = spawnSync("bun", ["run", "--cwd", "web", "build:lib"], {
+    cwd: REPO,
+    encoding: "utf8",
+    timeout: 180_000,
+  });
+  if (result.status !== 0 || !existsSync(INDEX)) {
+    throw new Error(
+      [
+        "embed smoke test requires web/dist-lib/index.js and will not skip.",
+        "bun run --cwd web build:lib failed:",
+        result.stdout ?? "",
+        result.stderr ?? "",
+        result.error ? String(result.error) : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+}
 
 const win = new Window({ url: "https://app.omg.dev/" });
 beforeAll(() => {
@@ -66,7 +105,7 @@ beforeAll(() => {
 });
 
 describe("vite.lib.config host-shared externals", () => {
-  const src = readFileSync(join(import.meta.dir, "../vite.lib.config.ts"), "utf8");
+  const src = readFileSync(join(WEB, "vite.lib.config.ts"), "utf8");
 
   test("externalizes the host-shared libraries the dashboard already ships", () => {
     for (const pkg of [
@@ -85,9 +124,18 @@ describe("vite.lib.config host-shared externals", () => {
     expect(src).toMatch(/@base-ui\/react\s+—/);
     expect(src).not.toMatch(/HOST_SHARED_EXTERNALS = \[[^\]]*@base-ui\/react/);
   });
+
+  test("declares peerDependencies for every externalized host-shared library", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST, "utf8")) as {
+      peerDependencies?: Record<string, string>;
+    };
+    expect(manifest.peerDependencies).toEqual(EXPECTED_PEERS);
+  });
 });
 
-describe.skipIf(!hasBuild)("built embed resolves host externals and mounts", () => {
+describe("built embed resolves host externals and mounts", () => {
+  beforeAll(ensureLibBuild);
+
   let host: HTMLElement | null = null;
   let reactRoot: { unmount: () => void } | null = null;
 

--- a/web/src/embedded-lib-smoke.test.ts
+++ b/web/src/embedded-lib-smoke.test.ts
@@ -22,6 +22,7 @@ const INDEX = join(DIST, "index.js");
 const MANIFEST = join(WEB, "package.json");
 
 const EXPECTED_PEERS = {
+  "@base-ui/react": "^1.6.0",
   "@tanstack/react-router": "^1.170.18",
   "class-variance-authority": "^0.7.1",
   cnfast: "0.0.8",
@@ -114,15 +115,39 @@ describe("vite.lib.config host-shared externals", () => {
       '"class-variance-authority"',
       '"vaul"',
       '"react"',
+      '"@base-ui/react"',
     ]) {
       expect(src).toContain(pkg);
     }
   });
 
-  test("does not externalize @base-ui/react (host 1.3.0 vs LFG 1.6.0)", () => {
-    expect(src).toContain("Deliberately NOT external");
-    expect(src).toMatch(/@base-ui\/react\s+—/);
-    expect(src).not.toMatch(/HOST_SHARED_EXTERNALS = \[[^\]]*@base-ui\/react/);
+  // @base-ui/react is only safe to externalize while the host declares a range
+  // that includes what we compile against. The earlier version of this test
+  // asserted the OPPOSITE — it pinned the skip in place — because both repos
+  // declared ^1.3.0 while their LOCKS diverged (LFG 1.6.0, host 1.3.0), so a
+  // declared-range comparison said "aligned" when the resolutions were not.
+  //
+  // Once external, the HOST's copy is what LFG runs against, so a host older
+  // than our compile target breaks every dialog and menu at runtime — silently,
+  // since nothing here would fail to build. Assert the floor explicitly.
+  test("@base-ui/react peer floor is >= the version the embed compiles against", () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST, "utf8")) as {
+      dependencies: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const compiled = manifest.dependencies["@base-ui/react"];
+    const peer = manifest.peerDependencies?.["@base-ui/react"];
+    expect(peer).toBe(compiled);
+    const minor = (range: string) => {
+      const m = /(\d+)\.(\d+)\.(\d+)/.exec(range);
+      if (!m) throw new Error(`unparseable range: ${range}`);
+      return [Number(m[1]), Number(m[2])] as const;
+    };
+    // 1.6 is the floor: Dialog.Title/Description gained the `(state) => style`
+    // callback there, and the embed is built against it.
+    const [major, min] = minor(compiled);
+    expect(major).toBe(1);
+    expect(min).toBeGreaterThanOrEqual(6);
   });
 
   test("declares peerDependencies for every externalized host-shared library", () => {

--- a/web/src/embedded-lib-smoke.test.ts
+++ b/web/src/embedded-lib-smoke.test.ts
@@ -1,0 +1,153 @@
+// Runtime smoke for the prebuilt @omg-dev/app embed.
+//
+// The lib build externalizes host-shared packages (react, tanstack router,
+// cnfast, vaul, cva). This file is what proves those specifiers resolve and
+// that OmgAppSurface still mounts a real router tree — not just that vite
+// printed "built in Ns".
+
+import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Window } from "happy-dom";
+
+const DIST = join(import.meta.dir, "../dist-lib");
+const hasBuild = existsSync(join(DIST, "index.js"));
+
+const win = new Window({ url: "https://app.omg.dev/" });
+beforeAll(() => {
+  const g = globalThis as Record<string, unknown>;
+  g.IS_REACT_ACT_ENVIRONMENT = true;
+  for (const key of [
+    "window",
+    "document",
+    "navigator",
+    "location",
+    "history",
+    "HTMLElement",
+    "Element",
+    "Node",
+    "Event",
+    "CustomEvent",
+    "MutationObserver",
+    "ResizeObserver",
+    "IntersectionObserver",
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+    "getComputedStyle",
+    "matchMedia",
+    "localStorage",
+    "sessionStorage",
+    "DOMParser",
+  ]) {
+    const value = (win as unknown as Record<string, unknown>)[key];
+    if (value !== undefined) g[key] = value;
+  }
+  if (typeof g.matchMedia !== "function") {
+    g.matchMedia = (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    });
+  }
+  if (typeof g.ResizeObserver !== "function") {
+    g.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+describe("vite.lib.config host-shared externals", () => {
+  const src = readFileSync(join(import.meta.dir, "../vite.lib.config.ts"), "utf8");
+
+  test("externalizes the host-shared libraries the dashboard already ships", () => {
+    for (const pkg of [
+      '"@tanstack/react-router"',
+      '"cnfast"',
+      '"class-variance-authority"',
+      '"vaul"',
+      '"react"',
+    ]) {
+      expect(src).toContain(pkg);
+    }
+  });
+
+  test("does not externalize @base-ui/react (host 1.3.0 vs LFG 1.6.0)", () => {
+    expect(src).toContain("Deliberately NOT external");
+    expect(src).toMatch(/@base-ui\/react\s+—/);
+    expect(src).not.toMatch(/HOST_SHARED_EXTERNALS = \[[^\]]*@base-ui\/react/);
+  });
+});
+
+describe.skipIf(!hasBuild)("built embed resolves host externals and mounts", () => {
+  let host: HTMLElement | null = null;
+  let reactRoot: { unmount: () => void } | null = null;
+
+  afterEach(() => {
+    reactRoot?.unmount();
+    host?.remove();
+    reactRoot = null;
+    host = null;
+  });
+
+  test("eager chunk imports the shared libs instead of inlining them", () => {
+    const embedded = readdirSync(DIST).find((name) => name.startsWith("embedded-") && name.endsWith(".js"));
+    expect(embedded).toBeTruthy();
+    const code = readFileSync(join(DIST, embedded!), "utf8");
+    expect(code).toContain('from "@tanstack/react-router"');
+    expect(code).toContain('from "cnfast"');
+    expect(code).toContain('from "vaul"');
+    expect(code).toContain('from "class-variance-authority"');
+    expect(code).not.toContain("isViewTransitionTypesSupported");
+    expect(code).not.toContain("isThemeGetter");
+  });
+
+  test("OmgAppSurface mounts a memory-router tree against a mock transport", async () => {
+    const React = await import("react");
+    const { createRoot } = await import("react-dom/client");
+    const { act } = await import("react");
+    const { OmgAppSurface } = await import("../dist-lib/index.js");
+
+    const transport = {
+      fetch: async () => new Response("{}", { status: 200 }),
+      request: async () => ({}),
+      openSocket: async () => ({
+        send() {},
+        close() {},
+        addEventListener() {},
+        removeEventListener() {},
+      }),
+      openLiveSocket: async () => ({
+        send() {},
+        close() {},
+        addEventListener() {},
+        removeEventListener() {},
+      }),
+    };
+
+    host = win.document.createElement("div") as unknown as HTMLElement;
+    win.document.body.appendChild(host as unknown as Element);
+    const root = createRoot(host);
+    reactRoot = root;
+
+    await act(async () => {
+      root.render(
+        React.createElement(OmgAppSurface, {
+          transport,
+          connectionOnboarding: false,
+        }),
+      );
+    });
+
+    const surface = win.document.querySelector("[data-lfg-app-surface]");
+    expect(surface).not.toBeNull();
+  });
+});

--- a/web/vite.lib.config.ts
+++ b/web/vite.lib.config.ts
@@ -20,6 +20,7 @@ const HOST_SHARED_EXTERNALS = [
   "cnfast",
   "class-variance-authority",
   "vaul",
+  "@base-ui/react",
 ] as const;
 
 function isHostSharedExternal(id: string): boolean {
@@ -158,11 +159,26 @@ export default defineConfig({
       //   vaul                       — both 1.1.2. Pulls @radix-ui/* with
       //                                it; those drop out of this graph
       //                                once vaul is external.
+      //   @base-ui/react             — the largest single duplicate here.
+      //                                Externalizing this REQUIRES the host
+      //                                to move first, and the trap is that
+      //                                both repos DECLARED ^1.3.0 while the
+      //                                LOCKS diverged: LFG resolved 1.6.0,
+      //                                the host 1.3.0. Comparing declared
+      //                                ranges makes this look aligned when
+      //                                it is not — check the lockfile.
+      //                                Since the host's copy wins once this
+      //                                is external, the host must be >= what
+      //                                we compile against or every dialog
+      //                                and menu breaks at runtime. Both now
+      //                                declare ^1.6.0 (BennyKok/vibes
+      //                                apps/web), which also collapses the
+      //                                nested "@omg-dev/app/@base-ui/react"
+      //                                resolution in the host lockfile onto
+      //                                one copy — without that dedup this
+      //                                change saves nothing.
       //
       // Deliberately NOT external:
-      //   @base-ui/react             — LFG lock is 1.6.0, host lock is
-      //                                1.3.0. A runtime mismatch here
-      //                                would break every dialog/menu.
       //   tailwind-merge             — lazy via streamdown, not a host
       //                                dep (host uses cnfast)
       //   lucide-react / sonner / …  — same version, follow-up, not

--- a/web/vite.lib.config.ts
+++ b/web/vite.lib.config.ts
@@ -1,14 +1,112 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vite";
+import { gzipSync } from "node:zlib";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import prefixSelector from "postcss-prefix-selector";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const HOST_SHARED_EXTERNALS = [
+  "react",
+  "react-dom",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "react-dom/client",
+  "react-dom/server",
+  "@tanstack/react-router",
+  "cnfast",
+  "class-variance-authority",
+  "vaul",
+] as const;
+
+function isHostSharedExternal(id: string): boolean {
+  return HOST_SHARED_EXTERNALS.some((pkg) => id === pkg || id.startsWith(`${pkg}/`));
+}
+
+/**
+ * Module-graph size report for the prebuilt embed bundle.
+ * Enable with ANALYZE=1. Writes dist-lib/module-report.json and prints
+ * per-package rendered byte totals (minified, not gzip) so we can decide
+ * what to externalize without string-diffing the output.
+ */
+function moduleReportPlugin(): Plugin {
+  return {
+    name: "lfg-module-report",
+    apply: "build",
+    generateBundle(_options, bundle) {
+      const modules: { id: string; renderedLength: number; originalLength: number }[] = [];
+      let bundleBytes = 0;
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk") continue;
+        bundleBytes += output.code.length;
+        for (const [id, mod] of Object.entries(output.modules)) {
+          modules.push({
+            id,
+            renderedLength: mod.renderedLength,
+            originalLength: mod.originalLength,
+          });
+        }
+      }
+      modules.sort((a, b) => b.renderedLength - a.renderedLength);
+
+      const packages = new Map<string, { rendered: number; original: number; files: number }>();
+      const packageOf = (id: string): string => {
+        const norm = id.replaceAll("\\", "/");
+        const nm = norm.lastIndexOf("/node_modules/");
+        if (nm === -1) return "(app)";
+        const rest = norm.slice(nm + "/node_modules/".length);
+        if (rest.startsWith("@")) {
+          const [scope, name] = rest.split("/");
+          return `${scope}/${name}`;
+        }
+        return rest.split("/")[0] ?? "(unknown)";
+      };
+      for (const mod of modules) {
+        const pkg = packageOf(mod.id);
+        const cur = packages.get(pkg) ?? { rendered: 0, original: 0, files: 0 };
+        cur.rendered += mod.renderedLength;
+        cur.original += mod.originalLength;
+        cur.files += 1;
+        packages.set(pkg, cur);
+      }
+      const packageRows = [...packages.entries()]
+        .map(([name, stats]) => ({ name, ...stats }))
+        .sort((a, b) => b.rendered - a.rendered);
+
+      const report = {
+        bundleBytes,
+        bundleGzipBytes: gzipSync(
+          Object.values(bundle)
+            .filter((o) => o.type === "chunk")
+            .map((o) => (o.type === "chunk" ? o.code : ""))
+            .join(""),
+        ).length,
+        packages: packageRows,
+        modules: modules.slice(0, 200),
+      };
+      const outPath = path.resolve(dirname, "dist-lib/module-report.json");
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+      console.log(`\nLFG lib bundle: ${bundleBytes.toLocaleString()} raw / ${report.bundleGzipBytes.toLocaleString()} gzip`);
+      console.log("Top packages by rendered minified bytes:");
+      for (const row of packageRows.slice(0, 30)) {
+        console.log(
+          `  ${String(row.rendered).padStart(10)}  ${row.name}  (${row.files} files)`,
+        );
+      }
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    ...(process.env.ANALYZE === "1" ? [moduleReportPlugin()] : []),
+  ],
   css: {
     postcss: {
       plugins: [
@@ -39,12 +137,38 @@ export default defineConfig({
       cssFileName: "styles",
     },
     rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "react-dom/client",
-        "react/jsx-runtime",
-      ],
+      // Host-shared libraries. React was already external; the rest are
+      // libraries app.omg.dev (BennyKok/vibes apps/web) also ships on the
+      // eager path. Leaving them inlined duplicates tens to hundreds of KB
+      // on every first visit. Externalizing only works when the host
+      // provides a compatible copy — see the per-package notes below.
+      //
+      // Externalize:
+      //   react*                     — already done; host pin ^19.2.4
+      //   @tanstack/react-router     — both 1.170.18. LFG mounts its OWN
+      //                                isolated memory router in
+      //                                OmgAppSurface (createOmgRouter +
+      //                                createMemoryHistory). Sharing the
+      //                                MODULE is the safe pattern; two
+      //                                library copies would be worse.
+      //                                Nested RouterProviders keep
+      //                                instances isolated via context.
+      //   cnfast                     — both 0.0.8 exactly
+      //   class-variance-authority   — both 0.7.1
+      //   vaul                       — both 1.1.2. Pulls @radix-ui/* with
+      //                                it; those drop out of this graph
+      //                                once vaul is external.
+      //
+      // Deliberately NOT external:
+      //   @base-ui/react             — LFG lock is 1.6.0, host lock is
+      //                                1.3.0. A runtime mismatch here
+      //                                would break every dialog/menu.
+      //   tailwind-merge             — lazy via streamdown, not a host
+      //                                dep (host uses cnfast)
+      //   lucide-react / sonner / …  — same version, follow-up, not
+      //                                required to land this cut
+      //   shadcn src/components/ui/* — source-copied, not a package
+      external: isHostSharedExternal,
     },
   },
   resolve: {


### PR DESCRIPTION
Fixes #105.

The prebuilt `@omg-dev/app` embed was inlining TanStack Router, cnfast, vaul/radix, and cva — libraries app.omg.dev already ships. React was already external.

## Verified host-rebuilt sizes (this is what ships)

Measured on BennyKok/vibes `c231b65a` by packing this branch (`npm pack` via `scripts/pack-packages.sh`) and pointing `apps/web`'s `@omg-dev/app` at `file:` that tarball. Same host SHA before/after. Method: files referenced from `index.html` plus `embedded-*.js`; `stat -c%s` + `gzip -c`.

| Payload | before (v0.1.375 pin) | after (this PR) | delta |
|---|---:|---:|---:|
| Eager JS/CSS from `index.html` | 725,517 / 210,450 | 721,739 / 203,506 | −3,778 / −6,944 |
| Shipped `embedded-*.js` | 975,490 / 288,305 | 799,261 / 233,183 | **−176,229 / −55,122** |
| **First-visit total** | **1,701,007 / 498,755** | **1,521,000 / 436,689** | **−180,007 / −62,066** |

That's **−172 KiB raw / −54 KiB gzip** on the file a visitor actually downloads, **−176 KiB / −61 KiB gzip** on eager+embed. Build budgets still pass (`INITIAL_JS_BUDGET_BYTES = 600,000`; Computer surface closure 1,378,140 < 1,500,000).

The earlier 1,540,748 → 1,237,835 (−303 KB) figure is this repo's **lib** `embedded-*.js` before the host re-tree-shakes it. Different artifact. The host already dedupes some of that graph, so the honest wire saving is smaller — and real.

## What was skipped, and why

- `@base-ui/react` (LFG lock 1.6.0 vs host 1.3.0). A runtime mismatch here would break every dialog/menu.
- `tailwind-merge` — lazy via streamdown, not a host dep.

LFG still mounts its own memory router (`createOmgRouter` + `createMemoryHistory`). We share the module, not the instance.

## Follow-up fixes on this PR (do not skip)

- **`peerDependencies`** on `@omg-dev/app` for every externalized specifier, matching what `apps/web` ships:
  - `@tanstack/react-router` `^1.170.18`
  - `cnfast` `0.0.8` (exact — LFG lock resolves 0.0.8; host pin is exact)
  - `class-variance-authority` `^0.7.1`
  - `vaul` `^1.1.2`
  - `react` / `react-dom` `^19.2.4` (already external, previously undeclared)
- **Mount smoke is unskippable.** `describe.skipIf(!hasBuild)` is gone. Missing `dist-lib/index.js` runs `bun run --cwd web build:lib`; a failed build fails the suite. A config-string test can no longer be the only green result.

## Verification

1. `ANALYZE=1 bun run --cwd web build:lib` — `@tanstack/*`, `cnfast`, `vaul`, `@radix-ui/*`, `class-variance-authority` are 0 bytes. `@base-ui/react` unchanged (~413 KB). Eager chunk starts with real imports.
2. Host rebundle against the packed tarball: numbers in the table above. No budget error.
3. `bun test ./web/src/embedded-lib-smoke.test.ts ./test/embed.test.ts ./web/src/lib/expand-on-focus.test.ts` — 32/32. The mount test imported the built `dist-lib` and rendered `[data-lfg-app-surface]`.

Not deployed. Needs a tagged `@omg-dev/app` release and a pin bump in BennyKok/vibes.
