### PR TITLE
fix(admission): take Computer limits from the control plane, not a baked table

### DIFF
--- a/src/agent-admission.test.ts
+++ b/src/agent-admission.test.ts
@@ -43,37 +43,20 @@ describe("Computer agent admission", () => {
     expect(controller.tryAcquire(3, idle).ok).toBe(true);
   });
 
-  test("denies at the plan limit and exposes plan context", () => {
-    expect(computerAgentAdmissionContext("free")).toEqual({
-      plan: "free",
-      limit: 1,
-      scheduleLimit: 1,
-    });
-    expect(computerAgentAdmissionContext("computer_5")).toEqual({
-      plan: "computer_5",
-      limit: 5,
-      scheduleLimit: 2,
-    });
-    expect(computerAgentAdmissionContext("computer_10")).toEqual({
-      plan: "computer_10",
-      limit: 16,
-      scheduleLimit: 3,
-    });
-    expect(computerAgentAdmissionContext("computer_20")).toEqual({
-      plan: "computer_20",
-      limit: 24,
-      scheduleLimit: 4,
-    });
-    expect(computerAgentAdmissionContext("computer_early")).toEqual({
-      plan: "computer_early",
-      limit: 24,
-      scheduleLimit: 4,
-    });
-    expect(computerAgentAdmissionContext("computer_trial")).toEqual({
-      plan: "computer_trial",
-      limit: 1,
-      scheduleLimit: 1,
-    });
+  test("takes the limit from the control plane, whatever the plan is called", () => {
+    expect(
+      computerAgentAdmissionContext('{"plan":"computer_10","limit":16,"scheduleLimit":3}'),
+    ).toEqual({ plan: "computer_10", limit: 16, scheduleLimit: 3 });
+    // The regression this replaced: computer_s20 shipped after the last LFG
+    // release, so the baked plan table did not know the name and demoted a
+    // paid Computer to a single agent. A name is no longer a decision.
+    expect(
+      computerAgentAdmissionContext('{"plan":"computer_s20","limit":3,"scheduleLimit":1}'),
+    ).toEqual({ plan: "computer_s20", limit: 3, scheduleLimit: 1 });
+    // A plan invented after this bundle was built needs no LFG release at all.
+    expect(
+      computerAgentAdmissionContext('{"plan":"computer_unheard_of","limit":7,"scheduleLimit":2}'),
+    ).toEqual({ plan: "computer_unheard_of", limit: 7, scheduleLimit: 2 });
     const admission = new AgentAdmissionController();
     expect(admission.tryAcquire(1, [{ busy: true }])).toMatchObject({
       ok: false,
@@ -194,13 +177,29 @@ describe("Computer agent admission", () => {
     }
   });
 
-  test("fails safe to free when a cloud plan is unknown", () => {
-    expect(computerAgentAdmissionContext("retired-plan")).toEqual({
-      plan: "free",
-      limit: 1,
-      scheduleLimit: 1,
-    });
+  test("an unreadable entitlement holds at one agent rather than guessing", () => {
+    for (const bad of [
+      "retired-plan",
+      '{"limit":0,"scheduleLimit":1}',
+      '{"limit":3}',
+      '{"limit":2.5,"scheduleLimit":1}',
+      '"computer_5"',
+    ]) {
+      expect(computerAgentAdmissionContext(bad), bad).toEqual({
+        plan: "unknown",
+        limit: 1,
+        scheduleLimit: 1,
+      });
+    }
+    // No entitlement at all is an ordinary self-hosted box, not a broken
+    // Computer, and it keeps its own local setting policy.
     expect(computerAgentAdmissionContext("")).toBeNull();
+  });
+
+  test("clamps an absurd supplied limit instead of disabling admission", () => {
+    expect(
+      computerAgentAdmissionContext('{"plan":"x","limit":99999,"scheduleLimit":99999}'),
+    ).toEqual({ plan: "x", limit: 64, scheduleLimit: 64 });
   });
 
   test("NO_AGENT_LIMIT waives the count, and ONLY the count", () => {
@@ -236,20 +235,21 @@ describe("Computer agent admission", () => {
     });
   });
 
-  test("the managed plan file can change a live process admission limit", () => {
-    const dir = mkdtempSync(join(tmpdir(), "lfg-computer-plan-"));
-    const path = join(dir, "computer-plan");
+  test("the entitlement file can change a live process admission limit", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lfg-computer-entitlement-"));
+    const path = join(dir, "computer-entitlement.json");
     try {
-      writeFileSync(path, "computer_5\n");
+      writeFileSync(path, '{"plan":"computer_5","limit":5,"scheduleLimit":2}\n');
       expect(computerAgentAdmissionContext(undefined, path)).toEqual({
         plan: "computer_5",
         limit: 5,
         scheduleLimit: 2,
       });
-      writeFileSync(path, "free\n");
+      // A downgrade lands on the next admission, with no restart.
+      writeFileSync(path, '{"plan":"free","limit":3,"scheduleLimit":1}\n');
       expect(computerAgentAdmissionContext(undefined, path)).toEqual({
         plan: "free",
-        limit: 1,
+        limit: 3,
         scheduleLimit: 1,
       });
     } finally {

--- a/src/agent-admission.ts
+++ b/src/agent-admission.ts
@@ -7,16 +7,19 @@
  * section atomically between promise continuations.
  */
 
-export type AgentAdmissionPlan =
-  | "free"
-  | "computer_trial"
-  | "computer_5"
-  | "computer_10"
-  | "computer_20"
-  | "computer_early";
-
 export type AgentAdmissionContext = {
-  plan: AgentAdmissionPlan;
+  /**
+   * Plan label, for error copy and the dashboard only.
+   *
+   * LFG never derives a number from this string. It used to: a plan name was
+   * matched against a table baked into the bundle, and any name the table did
+   * not know fell through to the free tier's limit of 1. That made every new
+   * plan silently broken on every already-shipped Computer until an LFG
+   * release, a pin bump and a template rebake caught up, which is exactly what
+   * happened to the India Starter plans and, for far longer, to free itself.
+   * The control plane owns plan policy; this process only enforces it.
+   */
+  plan: string;
   limit: number;
   /** Concurrent scheduled runs. Separate from `limit` — a cron must not fill the interactive cap. */
   scheduleLimit: number;
@@ -56,75 +59,107 @@ export function agentLaunchMemoryBudget(
   };
 }
 
-const LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
-  // Free stays single-agent; its 4 GiB machine now has enough headroom for the
-  // runtime, LFG, and the OS instead of forcing all three into 512 MiB.
-  free: 1,
-  computer_trial: 1,
-  // Paid tiers keep roughly 1.5–1.6 GiB of RAM available per admitted agent.
-  // Admission is a safety ceiling, not a promise that every agent owns a CPU.
-  computer_5: 5,
-  computer_10: 16,
-  computer_20: 24,
-  computer_early: 24,
-};
-
-// Scheduled fires are not interactive sessions. They get a smaller, separate
-// pool so a leftover cron cannot fill the Computer and block "New session".
-// These numbers exist only when computerAgentAdmissionContext() is non-null
-// (a managed Computer). Self-hosted lfg serve never reads this table.
-const SCHEDULE_LIMITS: Readonly<Record<AgentAdmissionPlan, number>> = {
-  free: 1,
-  computer_trial: 1,
-  computer_5: 2,
-  computer_10: 3,
-  computer_20: 4,
-  computer_early: 4,
-};
-
 export function isScheduleSpawned(spawnedBy: string | null | undefined): boolean {
   return spawnedBy === "schedule";
 }
 
-const COMPUTER_PLAN_FILE = "/etc/omg/computer-plan";
+/**
+ * The control plane's entitlement drop for this Computer.
+ *
+ * Deliberately NOT the older `/etc/omg/computer-plan`, which carried a bare
+ * plan name. Bundles already in the field read that path whole and compare it
+ * to a baked list of names, so writing JSON into it would make every shipped
+ * Computer — including the paid tiers that work today — fail through to a
+ * single agent for as long as the rollout took. A new filename is invisible to
+ * those bundles: they keep reading the old file and behaving exactly as they
+ * do now, while this one carries the real numbers.
+ */
+const COMPUTER_ENTITLEMENT_FILE = "/etc/omg/computer-entitlement.json";
 
-function currentComputerPlan(planFile: string): string | undefined {
+/**
+ * Sanity ceiling on a supplied limit. Not an entitlement and not a policy — it
+ * only stops a malformed or fat-fingered value from turning admission off. The
+ * memory budget is still the real gate underneath it.
+ */
+const MAX_SUPPLIED_LIMIT = 64;
+
+/**
+ * A Computer whose entitlement we cannot read admits one agent.
+ *
+ * This branch is reached only when the control plane HAS provisioned an
+ * entitlement and it arrived unreadable, so the box is definitely managed and
+ * guessing generously would hand out capacity nobody paid for. Unlike the plan
+ * table this replaces, it is loud: a demotion that logs is a demotion someone
+ * can find, and the silence of the old fall-through is the reason a broken
+ * entitlement survived two plan launches unnoticed.
+ */
+const UNREADABLE_ENTITLEMENT: AgentAdmissionContext = {
+  plan: "unknown",
+  limit: 1,
+  scheduleLimit: 1,
+};
+
+let warnedUnreadable = false;
+
+function readEntitlementSource(entitlementFile: string): string | undefined {
   try {
     // The control plane owns this root-written file and atomically replaces it
-    // while LFG is live. Reading it per admission makes downgrades immediate;
+    // while LFG is live. Reading it per admission makes plan changes immediate;
     // a process-start environment variable cannot do that.
-    return readFileSync(planFile, "utf8");
+    return readFileSync(entitlementFile, "utf8");
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    // Standalone LFG has no managed plan file, so retain the bootstrap env as
-    // its compatibility bridge. Any other file failure fails safe to Free.
-    return code === "ENOENT"
-      ? process.env.LFG_COMPUTER_PLAN
-      : "invalid-managed-plan";
+    // Standalone LFG has no entitlement file at all, and neither does a
+    // managed Computer in the window between wake and the control plane's
+    // first sync, so the bootstrap env stays the bridge for both.
+    return code === "ENOENT" ? process.env.LFG_COMPUTER_ENTITLEMENT : "";
   }
 }
 
-/** The per-Computer plan is supplied only by the trusted control plane. */
+function positiveInteger(value: unknown, ceiling: number): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return null;
+  return Math.min(value, ceiling);
+}
+
+/**
+ * The per-Computer entitlement, supplied only by the trusted control plane.
+ *
+ * Returns null for an ordinary self-hosted `lfg serve`, which has no managed
+ * entitlement and keeps its own local setting policy.
+ */
 export function computerAgentAdmissionContext(
-  rawPlan?: string,
-  planFile = COMPUTER_PLAN_FILE,
+  rawEntitlement?: string,
+  entitlementFile = COMPUTER_ENTITLEMENT_FILE,
 ): AgentAdmissionContext | null {
-  const selectedPlan =
-    rawPlan === undefined ? currentComputerPlan(planFile) : rawPlan;
-  if (!selectedPlan?.trim()) return null;
-  const plan = selectedPlan.trim().toLowerCase();
-  if (
-    plan === "computer_trial" ||
-    plan === "computer_5" ||
-    plan === "computer_10" ||
-    plan === "computer_20" ||
-    plan === "computer_early"
-  ) {
-    return { plan, limit: LIMITS[plan], scheduleLimit: SCHEDULE_LIMITS[plan] };
+  const source =
+    rawEntitlement === undefined ? readEntitlementSource(entitlementFile) : rawEntitlement;
+  if (!source?.trim()) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    parsed = null;
   }
-  // A stale or malformed cloud-plan value must fail safe for the Computer,
-  // while ordinary non-Computer LFG installs keep their local setting policy.
-  return { plan: "free", limit: LIMITS.free, scheduleLimit: SCHEDULE_LIMITS.free };
+  if (!parsed || typeof parsed !== "object") return failUnreadable(source);
+
+  const entitlement = parsed as Record<string, unknown>;
+  const limit = positiveInteger(entitlement.limit, MAX_SUPPLIED_LIMIT);
+  const scheduleLimit = positiveInteger(entitlement.scheduleLimit, MAX_SUPPLIED_LIMIT);
+  if (limit === null || scheduleLimit === null) return failUnreadable(source);
+
+  const plan = typeof entitlement.plan === "string" ? entitlement.plan.trim() : "";
+  return { plan: plan || "managed", limit, scheduleLimit };
+}
+
+function failUnreadable(source: string): AgentAdmissionContext {
+  if (!warnedUnreadable) {
+    warnedUnreadable = true;
+    console.warn(
+      `[admission] unreadable Computer entitlement, holding at ${UNREADABLE_ENTITLEMENT.limit} agent: ${source.trim().slice(0, 200)}`,
+    );
+  }
+  return UNREADABLE_ENTITLEMENT;
 }
 
 /**

--- a/src/session-recovery.test.ts
+++ b/src/session-recovery.test.ts
@@ -23,7 +23,7 @@ describe("command-file session boot recovery", () => {
 
   afterEach(() => {
     delete process.env.LFG_TEST_HARNESS_CAPTURE;
-    delete process.env.LFG_COMPUTER_PLAN;
+    delete process.env.LFG_COMPUTER_ENTITLEMENT;
     resetManagedRegistryForTests();
     PATHS.data = originalData;
     rmSync(root, { recursive: true, force: true });
@@ -211,7 +211,8 @@ describe("command-file session boot recovery", () => {
   });
 
   test("does not relaunch a scheduled run after boot on a Computer", async () => {
-    process.env.LFG_COMPUTER_PLAN = "computer_5";
+    process.env.LFG_COMPUTER_ENTITLEMENT =
+      '{"plan":"computer_5","limit":5,"scheduleLimit":2}';
     const key = "88888888-8888-4888-8888-888888888888";
     addManaged({
       tmuxName: "lfg-schedule-fire",
@@ -245,12 +246,12 @@ describe("command-file session boot recovery", () => {
       expect(readEntry(key)?.recoveryClaimBootId).toBe(currentBootId());
       expect(() => readFileSync(capture, "utf8")).toThrow();
     } finally {
-      delete process.env.LFG_COMPUTER_PLAN;
+      delete process.env.LFG_COMPUTER_ENTITLEMENT;
     }
   });
 
   test("self-hosted LFG still recovers a spawnedBy=schedule session", async () => {
-    delete process.env.LFG_COMPUTER_PLAN;
+    delete process.env.LFG_COMPUTER_ENTITLEMENT;
     const key = "99999999-9999-4999-8999-999999999999";
     addManaged({
       tmuxName: "lfg-self-hosted-schedule",


### PR DESCRIPTION
## The bug

Admission looked a plan name up in a table compiled into this bundle. Any name the table didn't know fell through to `free`'s limit of **1**, silently.

That's a correct fail-safe for a self-hosted `lfg serve`, which has no managed plan at all. On a managed Computer it means **every plan launched after the last LFG release is broken until a release, a pin bump and a template rebake catch up** — and the two cases are indistinguishable to this code.

It has cost us twice:

- `computer_s20` / `computer_s40` shipped Aug 14 and admit **1** agent against a catalog that sells **3**.
- `free` and `computer_trial` have been capped at **1** since the platform moved them to **3** — on every Computer, for far longer, with the pricing page and plan overlay both promising otherwise.

The user sees a `429` on their *second* session: `"1 of 1 agents live"`, on a plan they paid for. No error, no log, nothing to alert on.

## The fix

Stop shipping plan policy in this repo.

The control plane already owns the numbers and already writes a file that's re-read on **every** admission — so a change lands on a live Computer with no restart. It now writes the numbers themselves instead of a name to look up.

Deleted: `LIMITS`, `SCHEDULE_LIMITS`, `AgentAdmissionPlan`, and the five-name allowlist.

What's left is mechanism, which is where this module's real value was anyway: read, clamp, count residents, reserve the slot, enforce the memory budget. `plan` survives only as a label for error copy and `/api/status`; no number is ever derived from it.

A plan invented next quarter needs no LFG release at all.

## Rollout safety

The entitlement lands in a **new** file, `/etc/omg/computer-entitlement.json`.

Bundles already in the field read `/etc/omg/computer-plan` whole and compare it to their baked list, so writing JSON into *that* path would drop every shipped Computer — including the paid tiers that work today — to one agent for as long as the rollout took. They keep reading the old file, which the control plane keeps writing, and behave exactly as they do now.

## Behaviour notes

- **No entitlement at all** → `null`, i.e. an ordinary self-hosted box that keeps its own local setting policy. Unchanged.
- **An entitlement that arrives unreadable** → holds at 1, because the box is definitely managed and guessing generously hands out capacity nobody bought. Unlike the fall-through it replaces, it **logs** (once, not per admission).
- **Supplied limits are clamped** to a sane integer ceiling of 64. Not an entitlement and not policy — it only stops a malformed value from turning admission off. The memory budget is still the real gate underneath, and the guest has passwordless sudo anyway, so this was never a security boundary.

## Verification

- Full suite: **1442 pass, 0 fail** across 200 files.
- `tsc -p tsconfig.json --noEmit` clean.
- `session-recovery.test.ts` updated for the renamed env bridge.

Pairs with BennyKok/vibes#1417, which writes the file. **Merge that first** — this bundle reads a file nothing produces until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
