### PR TITLE
feat(opencode): connect the Go plan with a pasted API key, in the UI

### DIFF
--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -387,6 +387,23 @@ describe("coding agent auth detection", () => {
     expect((await opencodeStatus(home)).accountConnected).toBe(true);
   });
 
+  test("OpenCode offers Go and Zen as connectable rows before any sign-in", async () => {
+    const home = useTmpHome();
+    // The settings page renders `status.providers`, so a box with no auth.json
+    // has to carry the rows or "connect Go" has nowhere to live.
+    const providers = (await opencodeStatus(home)).providers ?? [];
+    expect(providers.map((p) => p.id)).toEqual(["opencode-go", "opencode"]);
+    expect(providers.every((p) => p.method === "api-key" && !p.connected)).toBe(true);
+  });
+
+  test("a stored Go key shows as a connected, disconnectable row", async () => {
+    const home = useTmpHome();
+    writeOpencodeAuth(home, { "opencode-go": { type: "api", key: "sk-test" } });
+    const go = ((await opencodeStatus(home)).providers ?? []).find((p) => p.id === "opencode-go");
+    expect(go?.connected).toBe(true);
+    expect(go?.fromEnv).toBeUndefined();
+  });
+
   test("Jcode reports a configured provider without claiming a connected account", async () => {
     const home = useTmpHome();
     setEnv("PATH", home);

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -21,8 +21,8 @@ import {
   piProviderMethod,
   startPiOAuthLogin,
   type PiAuthProviderId,
-  type PiProviderInfo,
 } from "./pi-auth.ts";
+import { hasOpenCodeAccountAuth, opencodeAuthProviders } from "./opencode-auth.ts";
 
 export type CodingAgentKind =
   | "claude"
@@ -70,8 +70,30 @@ export type CodingAgentStatus = {
   loginCommand?: string;
   /** Claude-only: isolated subscription accounts available to session launchers. */
   accounts?: ClaudeAccount[];
-  /** pi-only: model providers it can sign into, and whether each is connected. */
-  providers?: PiProviderInfo[];
+  /** pi and opencode: model providers signed into per provider, not per agent. */
+  providers?: AgentProviderInfo[];
+};
+
+/**
+ * One model provider an agent signs into on its own, rather than the agent
+ * holding a single account for the whole kind. pi and OpenCode both work this
+ * way, and both render through the same row in the settings UI, so the row
+ * shape lives here rather than in either credential module.
+ */
+export type AgentProviderInfo = {
+  id: string;
+  label: string;
+  method: "oauth" | "api-key";
+  connected: boolean;
+  /** Credential is real but not ours to delete (env var, or a vendor CLI's). */
+  fromEnv?: boolean;
+  /**
+   * Where the credential came from, when "From the environment" would be a lie.
+   * `fromEnv` carries two meanings the UI needs to keep apart — "cannot be
+   * deleted here" and "was set as an env var" — and only the first is always
+   * true of it.
+   */
+  detail?: string;
 };
 
 export type CodingAgentInfo = {
@@ -327,47 +349,6 @@ async function jcodeAuthStatus(): Promise<{ available: boolean; accountConnected
   } catch {
     return { available: false, accountConnected: false };
   }
-}
-
-/** OpenCode's credential store, honouring the XDG override it reads itself. */
-function opencodeAuthPath(): string {
-  const xdg = process.env.XDG_DATA_HOME?.trim();
-  return join(xdg ? xdg : join(userHome(), ".local", "share"), "opencode", "auth.json");
-}
-
-/**
- * Provider ids OpenCode holds a usable credential for.
- *
- * OpenCode keys a flat map by provider id (`opencode`, `opencode-go`, `openai`,
- * `fugu`, …) whose entries are either `{type:"api", key}` or an OAuth record
- * with `access`/`refresh`. An empty or missing file means the only models this
- * box can reach are OpenCode Zen's credential-free tier — `opencode models`
- * lists exactly those and nothing else, which is what makes this the right
- * signal for gating the picker.
- */
-function opencodeAuthProviderIds(): string[] {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(opencodeAuthPath(), "utf8"));
-  } catch {
-    return [];
-  }
-  if (!parsed || typeof parsed !== "object") return [];
-  const ids: string[] = [];
-  for (const [id, entry] of Object.entries(parsed as Record<string, unknown>)) {
-    if (!entry || typeof entry !== "object") continue;
-    const record = entry as { key?: unknown; access?: unknown; refresh?: unknown };
-    const secret = [record.key, record.access, record.refresh].some(
-      (value) => typeof value === "string" && value.trim().length > 0,
-    );
-    if (secret) ids.push(id);
-  }
-  return ids;
-}
-
-function hasOpenCodeAccountAuth(): boolean {
-  if (process.env.OPENCODE_API_KEY?.trim()) return true;
-  return opencodeAuthProviderIds().length > 0;
 }
 
 function grokPath(): string | null {
@@ -1134,10 +1115,11 @@ async function statusFor(kind: CodingAgentKind): Promise<CodingAgentStatus> {
     // It does decide which models the picker may honestly offer, though.
     accountConnected = hasOpenCodeAccountAuth();
     addBinary("OpenCode CLI", opencodePath());
+    // Go and Zen both authenticate with a pasted key, so they connect from the
+    // provider rows above. `opencode auth login` is still the way in for the
+    // OAuth providers (ChatGPT), which is why the command is still mentioned.
     instructions.push(
-      accountConnected
-        ? "OpenCode is signed in; run `opencode auth login` again to add another provider."
-        : "Run `opencode auth login` to reach paid providers — the free Zen models work without it.",
+      "Connect OpenCode Go or Zen with an API key above. The free Zen models work with no key at all, and `opencode auth login` adds OAuth providers such as ChatGPT.",
     );
   } else if (kind === "jcode") {
     const auth = await jcodeAuthStatus();
@@ -1192,6 +1174,7 @@ async function statusFor(kind: CodingAgentKind): Promise<CodingAgentStatus> {
       ? { accounts: listClaudeAccounts() }
       : {}),
     ...(kind === "pi" ? { providers: piAuthProviders() } : {}),
+    ...(kind === "opencode" ? { providers: opencodeAuthProviders() } : {}),
   };
 }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -269,6 +269,11 @@ import {
   isPiAuthProviderId,
   setPiProviderApiKey,
 } from "../pi-auth.ts";
+import {
+  deleteOpencodeCredential,
+  isOpencodeAuthProviderId,
+  setOpencodeProviderApiKey,
+} from "../opencode-auth.ts";
 import { listToolConnections } from "../tool-connections.ts";
 import {
   bindClaudeSessionAccount,
@@ -3076,30 +3081,50 @@ a{color:#60a5fa}
           }
         }
       }
-      // pi's key-based providers (OpenCode Zen) have no browser flow to run —
-      // the user pastes a key and we hand it to pi's credential store.
-      if (path === "/api/coding-agents/pi/api-key" && req.method === "POST") {
-        const body = (await req.json().catch(() => null)) as {
-          provider?: unknown;
-          key?: unknown;
-        } | null;
-        if (typeof body?.provider !== "string" || !isPiAuthProviderId(body.provider)) {
-          return err(400, "unknown pi provider");
-        }
-        if (typeof body.key !== "string") return err(400, "expected { key: string }");
-        try {
-          await setPiProviderApiKey(body.provider, body.key);
-          return json({ ok: true, agents: await listCodingAgents() });
-        } catch (e) {
-          return err(400, e instanceof Error ? e.message : "could not save API key");
+      // Key-based providers (pi's OpenCode Zen; OpenCode's own Go and Zen) have
+      // no browser flow to run — the user pastes a key and we hand it to that
+      // agent's credential store. Both agents sign in per provider rather than
+      // once per kind, so the agent owns the route and the body names which.
+      //
+      // The two id namespaces overlap — `opencode` is a provider of pi's AND of
+      // OpenCode's, pointing at different credential files — so the agent in the
+      // path, never the provider id, decides which store is written.
+      {
+        const m = path.match(/^\/api\/coding-agents\/(pi|opencode)\/api-key$/);
+        if (m && req.method === "POST") {
+          const agent = m[1];
+          const body = (await req.json().catch(() => null)) as {
+            provider?: unknown;
+            key?: unknown;
+          } | null;
+          const provider = typeof body?.provider === "string" ? body.provider : "";
+          if (typeof body?.key !== "string") return err(400, "expected { key: string }");
+          try {
+            if (agent === "pi") {
+              if (!isPiAuthProviderId(provider)) return err(400, "unknown pi provider");
+              await setPiProviderApiKey(provider, body.key);
+            } else {
+              if (!isOpencodeAuthProviderId(provider)) return err(400, "unknown opencode provider");
+              setOpencodeProviderApiKey(provider, body.key);
+            }
+            return json({ ok: true, agents: await listCodingAgents() });
+          } catch (e) {
+            return err(400, e instanceof Error ? e.message : "could not save API key");
+          }
         }
       }
       {
-        const m = path.match(/^\/api\/coding-agents\/pi\/providers\/([a-z0-9-]+)$/);
+        const m = path.match(/^\/api\/coding-agents\/(pi|opencode)\/providers\/([a-z0-9-]+)$/);
         if (m && req.method === "DELETE") {
-          if (!isPiAuthProviderId(m[1])) return err(404, "unknown pi provider");
+          const [, agent, provider] = m;
           try {
-            await deletePiCredential(m[1]);
+            if (agent === "pi") {
+              if (!isPiAuthProviderId(provider)) return err(404, "unknown pi provider");
+              await deletePiCredential(provider);
+            } else {
+              if (!isOpencodeAuthProviderId(provider)) return err(404, "unknown opencode provider");
+              deleteOpencodeCredential(provider);
+            }
             return json({ ok: true, agents: await listCodingAgents() });
           } catch (e) {
             return err(500, e instanceof Error ? e.message : "could not disconnect provider");

--- a/src/opencode-auth.test.ts
+++ b/src/opencode-auth.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// OpenCode resolves its credential file through XDG_DATA_HOME, so each test
+// gets its own store by pointing that at a fresh directory.
+let dir: string;
+let prevXdg: string | undefined;
+let prevKey: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "opencode-auth-"));
+  prevXdg = process.env.XDG_DATA_HOME;
+  prevKey = process.env.OPENCODE_API_KEY;
+  process.env.XDG_DATA_HOME = dir;
+  delete process.env.OPENCODE_API_KEY;
+});
+
+afterEach(() => {
+  if (prevXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = prevXdg;
+  if (prevKey === undefined) delete process.env.OPENCODE_API_KEY;
+  else process.env.OPENCODE_API_KEY = prevKey;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function opencodeAuth() {
+  return await import("./opencode-auth.ts");
+}
+
+function writeAuth(auth: unknown) {
+  mkdirSync(join(dir, "opencode"), { recursive: true });
+  writeFileSync(join(dir, "opencode", "auth.json"), JSON.stringify(auth));
+}
+
+function readAuth(): Record<string, { type?: string; key?: string }> {
+  return JSON.parse(readFileSync(join(dir, "opencode", "auth.json"), "utf8"));
+}
+
+test("Go and Zen are offered on a box with no auth.json at all", async () => {
+  const { opencodeAuthProviders, hasOpenCodeAccountAuth } = await opencodeAuth();
+  // The whole point of the feature: connecting Go must be reachable before
+  // anyone has run `opencode auth login`, because that is the box that needs it.
+  const providers = opencodeAuthProviders();
+  expect(providers.map((p) => p.id)).toEqual(["opencode-go", "opencode"]);
+  expect(providers.every((p) => p.method === "api-key")).toBe(true);
+  expect(providers.every((p) => !p.connected)).toBe(true);
+  expect(hasOpenCodeAccountAuth()).toBe(false);
+});
+
+test("a pasted Go key connects the provider and is written in OpenCode's own shape", async () => {
+  const { setOpencodeProviderApiKey, opencodeAuthProviders, hasOpenCodeAccountAuth } =
+    await opencodeAuth();
+  setOpencodeProviderApiKey("opencode-go", "sk-go-test");
+  // `{type:"api", key}` is what the CLI writes and what our usage reader looks
+  // for; any other shape would store a key the rest of the system cannot see.
+  expect(readAuth()["opencode-go"]).toEqual({ type: "api", key: "sk-go-test" });
+  expect(opencodeAuthProviders().find((p) => p.id === "opencode-go")?.connected).toBe(true);
+  expect(hasOpenCodeAccountAuth()).toBe(true);
+});
+
+test("a key is stored 0600 — it is a bearer credential", async () => {
+  const { setOpencodeProviderApiKey, opencodeAuthPath } = await opencodeAuth();
+  setOpencodeProviderApiKey("opencode-go", "sk-go-test");
+  expect(statSync(opencodeAuthPath()).mode & 0o777).toBe(0o600);
+});
+
+test("connecting one provider preserves credentials the CLI wrote", async () => {
+  const { setOpencodeProviderApiKey } = await opencodeAuth();
+  writeAuth({ openai: { type: "oauth", access: "at", refresh: "rt" } });
+  setOpencodeProviderApiKey("opencode-go", "sk-go-test");
+  // A read-modify-write that dropped the OAuth entry would silently sign the
+  // user out of ChatGPT as a side effect of connecting Go.
+  expect(readAuth().openai).toEqual({ type: "oauth", access: "at", refresh: "rt" } as never);
+  expect(readAuth()["opencode-go"]).toEqual({ type: "api", key: "sk-go-test" });
+});
+
+test("a surrounding key is trimmed, and an empty one is refused", async () => {
+  const { setOpencodeProviderApiKey } = await opencodeAuth();
+  setOpencodeProviderApiKey("opencode-go", "  sk-go-test\n");
+  expect(readAuth()["opencode-go"]?.key).toBe("sk-go-test");
+  expect(() => setOpencodeProviderApiKey("opencode-go", "   ")).toThrow(/Enter your OpenCode Go/);
+});
+
+test("a provider we do not own is refused rather than written", async () => {
+  const { setOpencodeProviderApiKey, opencodeAuthPath } = await opencodeAuth();
+  // `openai` is a real OpenCode provider, but its credential is an OAuth record
+  // the CLI owns. Writing an api entry there would produce a broken login.
+  expect(() => setOpencodeProviderApiKey("openai", "sk-test")).toThrow(/not an OpenCode provider/);
+  expect(existsSync(opencodeAuthPath())).toBe(false);
+});
+
+test("disconnecting removes only that provider", async () => {
+  const { setOpencodeProviderApiKey, deleteOpencodeCredential, opencodeAuthProviders } =
+    await opencodeAuth();
+  setOpencodeProviderApiKey("opencode-go", "sk-go-test");
+  setOpencodeProviderApiKey("opencode", "sk-zen-test");
+  deleteOpencodeCredential("opencode-go");
+  expect(readAuth()["opencode-go"]).toBeUndefined();
+  expect(readAuth().opencode).toEqual({ type: "api", key: "sk-zen-test" });
+  const providers = opencodeAuthProviders();
+  expect(providers.find((p) => p.id === "opencode-go")?.connected).toBe(false);
+  expect(providers.find((p) => p.id === "opencode")?.connected).toBe(true);
+});
+
+test("disconnecting with no auth.json is a no-op, not a crash", async () => {
+  const { deleteOpencodeCredential, opencodeAuthPath } = await opencodeAuth();
+  deleteOpencodeCredential("opencode-go");
+  expect(existsSync(opencodeAuthPath())).toBe(false);
+});
+
+test("a credential with no secret is not a connection", async () => {
+  const { opencodeAuthProviders, hasOpenCodeAccountAuth } = await opencodeAuth();
+  writeAuth({ "opencode-go": { type: "api" }, openai: { type: "oauth", access: "" } });
+  expect(opencodeAuthProviders().every((p) => !p.connected)).toBe(true);
+  expect(hasOpenCodeAccountAuth()).toBe(false);
+});
+
+test("OPENCODE_API_KEY connects Zen but is not ours to disconnect", async () => {
+  const { opencodeAuthProviders } = await opencodeAuth();
+  process.env.OPENCODE_API_KEY = "sk-env-test";
+  const zen = opencodeAuthProviders().find((p) => p.id === "opencode");
+  expect(zen?.connected).toBe(true);
+  // `fromEnv` is what hides the delete button; we cannot unset another
+  // process's environment, so offering to would be a lie.
+  expect(zen?.fromEnv).toBe(true);
+});
+
+test("a stored key wins over the environment, so it stays disconnectable", async () => {
+  const { setOpencodeProviderApiKey, opencodeAuthProviders } = await opencodeAuth();
+  process.env.OPENCODE_API_KEY = "sk-env-test";
+  setOpencodeProviderApiKey("opencode", "sk-stored-test");
+  expect(opencodeAuthProviders().find((p) => p.id === "opencode")?.fromEnv).toBeUndefined();
+});
+
+test("providers the CLI signed into are listed, but not offered for deletion", async () => {
+  const { opencodeAuthProviders } = await opencodeAuth();
+  writeAuth({ openai: { type: "oauth", access: "at", refresh: "rt" } });
+  // "OpenCode is signed in" never said *what to*. An OAuth row we did not
+  // create is reported so the page can answer that, and marked as not ours.
+  const extra = opencodeAuthProviders().find((p) => p.id === "openai");
+  expect(extra?.connected).toBe(true);
+  expect(extra?.method).toBe("oauth");
+  expect(extra?.fromEnv).toBe(true);
+  // `fromEnv` only means "not ours to delete" here. Letting the UI's default
+  // caption stand would tell the user this key came from an env var, which is
+  // the one thing we know it did not.
+  expect(extra?.detail).toBe("Signed in with `opencode auth login`");
+});
+
+test("the env-provided Zen key keeps the plain environment caption", async () => {
+  const { opencodeAuthProviders } = await opencodeAuth();
+  process.env.OPENCODE_API_KEY = "sk-env-test";
+  expect(opencodeAuthProviders().find((p) => p.id === "opencode")?.detail).toBeUndefined();
+});
+
+test("a corrupt auth.json reads as empty rather than throwing", async () => {
+  const { opencodeAuthProviders, hasOpenCodeAccountAuth, setOpencodeProviderApiKey } =
+    await opencodeAuth();
+  mkdirSync(join(dir, "opencode"), { recursive: true });
+  writeFileSync(join(dir, "opencode", "auth.json"), "{not json");
+  expect(hasOpenCodeAccountAuth()).toBe(false);
+  expect(opencodeAuthProviders().every((p) => !p.connected)).toBe(true);
+  // And a connect still succeeds, replacing the unreadable file.
+  setOpencodeProviderApiKey("opencode-go", "sk-go-test");
+  expect(readAuth()["opencode-go"]?.key).toBe("sk-go-test");
+});

--- a/src/opencode-auth.ts
+++ b/src/opencode-auth.ts
@@ -1,0 +1,211 @@
+// Provider credentials for the "opencode" agent kind.
+//
+// OpenCode's paid providers — the Go plan above all — were reachable only by
+// running `opencode auth login` in a terminal. That is a real gap in a UI whose
+// whole job is to get an agent runnable: the settings page could tell you the
+// command but not run it for you, and on a hosted box the person reading that
+// sentence often has no terminal to run it in. It also left the page unable to
+// answer the more basic question of *which* provider this box is signed into.
+//
+// The credential store is a documented flat map at
+// ~/.local/share/opencode/auth.json (XDG_DATA_HOME moves the parent), keyed by
+// provider id — `opencode-go`, `opencode`, `openai`, `fugu`, … — whose entries
+// are either `{type:"api", key}` or an OAuth record with `access`/`refresh`.
+// The Go plan authenticates with a pasted key, so for that provider the whole
+// login is a write to this file, which is what this module does.
+//
+// We deliberately do NOT own the OAuth-shaped entries: `opencode auth login`
+// still writes those, and we only read them (to report what is connected) or
+// delete them wholesale. Anything we do not recognise is preserved untouched on
+// every write.
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Providers we can connect from the UI, in the order the UI lists them. */
+export const OPENCODE_AUTH_PROVIDER_IDS = ["opencode-go", "opencode"] as const;
+export type OpencodeAuthProviderId = (typeof OPENCODE_AUTH_PROVIDER_IDS)[number];
+
+export type OpencodeProviderInfo = {
+  id: string;
+  label: string;
+  /** Every provider we can connect here authenticates with a pasted key. */
+  method: "oauth" | "api-key";
+  connected: boolean;
+  /** Set when the credential is not ours to delete (env var, or CLI OAuth). */
+  fromEnv?: boolean;
+  /** Overrides the UI's "From the environment" caption when that is not true. */
+  detail?: string;
+};
+
+type OpencodeProviderSpec = {
+  id: OpencodeAuthProviderId;
+  label: string;
+  /** Env vars OpenCode itself resolves, so a key set there already counts. */
+  envKeys: string[];
+  /** Where the user gets the key, shown in the connect dialog. */
+  keyUrl: string;
+};
+
+const OPENCODE_PROVIDER_SPECS: Record<OpencodeAuthProviderId, OpencodeProviderSpec> = {
+  // The subscription plan. Listed first because it is the one people are
+  // actually paying for, and the reason this module exists.
+  "opencode-go": {
+    id: "opencode-go",
+    label: "OpenCode Go",
+    envKeys: [],
+    keyUrl: "https://opencode.ai/auth",
+  },
+  // Zen's free tier needs no credential at all; a key here buys its paid
+  // models. OPENCODE_API_KEY is the env var OpenCode reads for it.
+  opencode: {
+    id: "opencode",
+    label: "OpenCode Zen",
+    envKeys: ["OPENCODE_API_KEY"],
+    keyUrl: "https://opencode.ai/zen",
+  },
+};
+
+export function isOpencodeAuthProviderId(value: string): value is OpencodeAuthProviderId {
+  return (OPENCODE_AUTH_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+export function opencodeProviderLabel(id: string): string {
+  return isOpencodeAuthProviderId(id) ? OPENCODE_PROVIDER_SPECS[id].label : id;
+}
+
+export function opencodeProviderKeyUrl(id: string): string | null {
+  return isOpencodeAuthProviderId(id) ? OPENCODE_PROVIDER_SPECS[id].keyUrl : null;
+}
+
+function userHome(): string {
+  return process.env.HOME ?? homedir();
+}
+
+/** OpenCode's credential store, honouring the XDG override it reads itself. */
+export function opencodeAuthPath(): string {
+  const xdg = process.env.XDG_DATA_HOME?.trim();
+  return join(xdg ? xdg : join(userHome(), ".local", "share"), "opencode", "auth.json");
+}
+
+// biome-ignore lint: the entry union is OpenCode's, not ours; we read two
+// discriminant fields and hand every other key back untouched.
+type OpencodeCredential = any;
+
+/** The whole credential map, or `{}` when it is missing or unreadable. */
+export function readOpencodeCredentials(): Record<string, OpencodeCredential> {
+  try {
+    const parsed = JSON.parse(readFileSync(opencodeAuthPath(), "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** A credential counts only when it carries a secret we could actually send. */
+function credentialIsUsable(entry: OpencodeCredential): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  return [entry.key, entry.access, entry.refresh].some(
+    (value) => typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+/**
+ * Provider ids OpenCode holds a usable credential for.
+ *
+ * An empty or missing file means the only models this box can reach are
+ * OpenCode Zen's credential-free tier — `opencode models` lists exactly those
+ * and nothing else, which is what makes this the right signal for gating the
+ * picker.
+ */
+export function opencodeAuthProviderIds(): string[] {
+  return Object.entries(readOpencodeCredentials())
+    .filter(([, entry]) => credentialIsUsable(entry))
+    .map(([id]) => id);
+}
+
+export function hasOpenCodeAccountAuth(): boolean {
+  if (process.env.OPENCODE_API_KEY?.trim()) return true;
+  return opencodeAuthProviderIds().length > 0;
+}
+
+/**
+ * Provider rows for the settings UI.
+ *
+ * The two connectable specs come first and always render, so "connect Go" is
+ * reachable on a box with no auth.json at all. Anything else already in the
+ * file — a ChatGPT OAuth written by `opencode auth login`, say — follows as a
+ * connected row, because "OpenCode is signed in" was never a useful answer to
+ * *which account is this*. Those rows carry `fromEnv` so the UI does not offer
+ * to delete a credential whose login flow lives in the CLI and not here.
+ */
+export function opencodeAuthProviders(): OpencodeProviderInfo[] {
+  const credentials = readOpencodeCredentials();
+  const rows: OpencodeProviderInfo[] = OPENCODE_AUTH_PROVIDER_IDS.map((id) => {
+    const spec = OPENCODE_PROVIDER_SPECS[id];
+    const stored = credentialIsUsable(credentials[id]);
+    const fromEnv = !stored && spec.envKeys.some((name) => !!process.env[name]?.trim());
+    return {
+      id,
+      label: spec.label,
+      method: "api-key" as const,
+      connected: stored || fromEnv,
+      ...(fromEnv ? { fromEnv: true } : {}),
+    };
+  });
+  for (const [id, entry] of Object.entries(credentials)) {
+    if (isOpencodeAuthProviderId(id) || !credentialIsUsable(entry)) continue;
+    rows.push({
+      id,
+      label: id,
+      method: entry?.type === "api" ? "api-key" : "oauth",
+      connected: true,
+      fromEnv: true,
+      detail: "Signed in with `opencode auth login`",
+    });
+  }
+  return rows;
+}
+
+/**
+ * Merge one entry into auth.json without disturbing the others.
+ *
+ * OpenCode takes no lock on this file, so there is none to interoperate with;
+ * the write still goes through a temp file and a rename so a concurrent reader
+ * (the CLI, mid-session) sees the old map or the new one and never a truncated
+ * one. Mode 0600 matches what OpenCode itself creates — this file holds bearer
+ * keys, and a rename would otherwise carry the default umask onto it.
+ */
+function writeOpencodeCredential(id: string, credential: OpencodeCredential | null): void {
+  const file = opencodeAuthPath();
+  const dir = join(file, "..");
+  mkdirSync(dir, { recursive: true });
+  const data = readOpencodeCredentials();
+  if (credential === null) delete data[id];
+  else data[id] = credential;
+  const tmp = join(dir, `.auth.json.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    renameSync(tmp, file);
+  } catch (e) {
+    try {
+      rmSync(tmp, { force: true });
+    } catch {}
+    throw e;
+  }
+}
+
+/** Store an API key for an OpenCode provider. */
+export function setOpencodeProviderApiKey(id: string, key: string): void {
+  const value = key.trim();
+  if (!isOpencodeAuthProviderId(id)) throw new Error(`${id} is not an OpenCode provider we can connect`);
+  if (!value) throw new Error(`Enter your ${opencodeProviderLabel(id)} API key`);
+  writeOpencodeCredential(id, { type: "api", key: value });
+}
+
+/** Forget a stored credential. Absent entries are already in the target state. */
+export function deleteOpencodeCredential(id: string): void {
+  if (!existsSync(opencodeAuthPath())) return;
+  writeOpencodeCredential(id, null);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -434,8 +434,10 @@ export type PiProviderInfo = {
   label: string;
   method: "oauth" | "api-key";
   connected: boolean;
-  /** Key came from the environment, so we must not offer to disconnect it. */
+  /** Key is not ours to delete, so we must not offer to disconnect it. */
   fromEnv?: boolean;
+  /** Where it came from, when "From the environment" would not be true. */
+  detail?: string;
 };
 
 export type ClaudeAccountInfo = {
@@ -7206,26 +7208,36 @@ export function App() {
     return startBrowserAuth(key, `/api/connections/${key}/auth`);
   }
 
-  // pi signs in per model provider, so the request carries which one. The
-  // browser flow past this point is identical to every other provider's.
-  async function loginPiProvider(provider: PiProviderInfo) {
-    if (provider.method === "api-key") return connectPiApiKeyProvider(provider);
+  // pi and OpenCode both sign in per model provider, so the request carries
+  // which one — and which agent, since the two id namespaces overlap and write
+  // to different credential stores. The browser flow past this point is
+  // identical to every other provider's.
+  async function loginAgentProvider(kind: AgentKind, provider: PiProviderInfo) {
+    if (provider.method === "api-key") return connectApiKeyProvider(kind, provider);
+    // Only pi has browser-flow providers today. Naming it rather than passing
+    // `kind` through keeps a future OAuth provider on another agent from
+    // silently running pi's flow against the wrong credential store.
+    if (kind !== "pi") {
+      toast.error(`Connect ${provider.label} with \`opencode auth login\` in a terminal`);
+      return;
+    }
     return startBrowserAuth("pi", "/api/coding-agents/pi/auth", undefined, {
       provider: provider.id,
     });
   }
 
-  async function connectPiApiKeyProvider(provider: PiProviderInfo) {
+  async function connectApiKeyProvider(kind: AgentKind, provider: PiProviderInfo) {
+    const store = kind === "opencode" ? "OpenCode's" : "pi's";
     const key = await appDialog.prompt({
       title: `Connect ${provider.label}`,
-      description: `Paste your ${provider.label} API key. It is stored with pi's other credentials and never leaves this machine.`,
+      description: `Paste your ${provider.label} API key. It is stored with ${store} other credentials and never leaves this machine.`,
       placeholder: "API key",
       confirmLabel: "Connect",
       password: true,
     });
     if (!key) return;
     try {
-      await api("/api/coding-agents/pi/api-key", {
+      await api(`/api/coding-agents/${kind}/api-key`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ provider: provider.id, key }),
@@ -7237,16 +7249,17 @@ export function App() {
     }
   }
 
-  async function disconnectPiProvider(provider: PiProviderInfo) {
+  async function disconnectAgentProvider(kind: AgentKind, provider: PiProviderInfo) {
+    const agentLabel = kind === "opencode" ? "OpenCode" : "pi";
     const confirmed = await appDialog.confirm({
       title: `Disconnect ${provider.label}?`,
-      description: "pi will stop offering this provider's models until you connect it again.",
+      description: `${agentLabel} will stop offering this provider's models until you connect it again.`,
       confirmLabel: "Disconnect",
       destructive: true,
     });
     if (!confirmed) return;
     try {
-      await api(`/api/coding-agents/pi/providers/${provider.id}`, { method: "DELETE" });
+      await api(`/api/coding-agents/${kind}/providers/${provider.id}`, { method: "DELETE" });
       await refreshCodingAgents({ refreshModels: true });
       toast.success(`${provider.label} disconnected`);
     } catch (e) {
@@ -7844,8 +7857,8 @@ export function App() {
             onLogin={(kind, accountId) => loginCodingAgent(kind, undefined, accountId)}
             onAddClaudeAccount={addClaudeAccount}
             onRemoveClaudeAccount={removeClaudeAccountFromSettings}
-            onConnectPiProvider={(provider) => void loginPiProvider(provider)}
-            onDisconnectPiProvider={(provider) => void disconnectPiProvider(provider)}
+            onConnectProvider={(kind, provider) => void loginAgentProvider(kind, provider)}
+            onDisconnectProvider={(kind, provider) => void disconnectAgentProvider(kind, provider)}
             onSetupCheck={runSetupCheck}
             onRefresh={() => void refreshCodingAgents({ refreshModels: true })}
           />

--- a/web/src/views/coding-agents-page.tsx
+++ b/web/src/views/coding-agents-page.tsx
@@ -123,8 +123,12 @@ function ExpandableRow({
   );
 }
 
-/** One model provider pi can sign into, with its connect/disconnect control. */
-function PiProviderRow({
+/**
+ * One model provider an agent can sign into, with its connect/disconnect
+ * control. pi and OpenCode both authenticate per provider rather than once per
+ * agent, so both render through this row.
+ */
+function AgentProviderRow({
   provider,
   onConnect,
   onDisconnect,
@@ -137,9 +141,9 @@ function PiProviderRow({
     <div className="flex items-center gap-2 rounded-xl border border-border/70 bg-background/55 px-2.5 py-2">
       <span className="min-w-0 flex-1">
         <span className="block truncate text-xs font-medium">{provider.label}</span>
-        {provider.fromEnv ? (
+        {provider.detail || provider.fromEnv ? (
           <span className="block truncate text-[11px] text-muted-foreground">
-            From the environment
+            {provider.detail ?? "From the environment"}
           </span>
         ) : null}
       </span>
@@ -181,8 +185,8 @@ export default function CodingAgentsPage({
   onLogin,
   onAddClaudeAccount,
   onRemoveClaudeAccount,
-  onConnectPiProvider,
-  onDisconnectPiProvider,
+  onConnectProvider,
+  onDisconnectProvider,
   onSetupCheck,
   onRefresh,
 }: {
@@ -193,8 +197,8 @@ export default function CodingAgentsPage({
   onLogin: (kind: AgentKind, claudeAccountId?: string) => void;
   onAddClaudeAccount: () => void;
   onRemoveClaudeAccount: (account: ClaudeAccountInfo) => void;
-  onConnectPiProvider: (provider: PiProviderInfo) => void;
-  onDisconnectPiProvider: (provider: PiProviderInfo) => void;
+  onConnectProvider: (kind: AgentKind, provider: PiProviderInfo) => void;
+  onDisconnectProvider: (kind: AgentKind, provider: PiProviderInfo) => void;
   onSetupCheck: (key: string) => void;
   onRefresh: () => void | Promise<void>;
 }) {
@@ -345,11 +349,11 @@ export default function CodingAgentsPage({
               {providers.length ? (
                 <div className="space-y-1.5">
                   {providers.map((provider) => (
-                    <PiProviderRow
+                    <AgentProviderRow
                       key={provider.id}
                       provider={provider}
-                      onConnect={onConnectPiProvider}
-                      onDisconnect={onDisconnectPiProvider}
+                      onConnect={(p) => onConnectProvider(agent.key, p)}
+                      onDisconnect={(p) => onDisconnectProvider(agent.key, p)}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
Connecting OpenCode's Go plan required running `opencode auth login` in a terminal. The settings page could print the command but not run it, and on a hosted Computer the person reading that sentence often has no terminal at all.

Go authenticates with a pasted key, so its whole login is a write to `~/.local/share/opencode/auth.json`. New `src/opencode-auth.ts` owns that store the way `pi-auth.ts` owns pi's, and the OpenCode agent now renders provider rows through the same settings component pi already used.

**Settings → Coding agents → opencode → Connect**, paste, done. The page also finally reports *which* provider the box is signed into, instead of only "OpenCode is signed in".

### The trap
`opencode` is a provider id of **both** pi and OpenCode, pointing at different credential files. The agent in the route path, never the provider id, decides which store is written. Posting pi's `opencode` key leaves OpenCode's `auth.json` byte-identical.

### Verified
Against a live server on an isolated `HOME`:

- connect trims the key and stores it `0600` in OpenCode's own `{type:"api", key}` shape — the shape `usage.ts` already reads for the Go plan caps
- a pre-existing ChatGPT OAuth entry survives the write
- disconnect removes only its own entry
- the row flips in place in ~5s, no reload
- rejected with 400: unknown provider, blank key, missing key field
- the real browser flow: masked input, key on disk afterwards

1557 tests pass, typecheck clean, web builds.

### Also
Fixes a caption this change would otherwise have made false: rows we cannot delete said "From the environment", untrue of a CLI-written OAuth. They now say how they were actually signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
