### PR TITLE
fix(sessions): stop listing a codex-aisdk harness child as its own session

### DIFF
--- a/src/omg-capabilities.ts
+++ b/src/omg-capabilities.ts
@@ -99,6 +99,17 @@ const CONTRACT_ENDS = [
   "=== END LFG RUNTIME CONTRACT ===",
 ] as const;
 const USER_TASK = "=== USER TASK ===";
+// The subagent envelope is a second, independent wrapper: serve.ts wraps a
+// delegated prompt in this before the harness wraps the result in the runtime
+// contract, so a subagent's prompt carries BOTH and stripping one still leaves
+// the other as the visible title. Unlike the runtime contract it has no
+// "=== END … ===" line — it is terminated by USER_TASK. Same branding history
+// applies; only the first entry is ever written.
+const SUBAGENT_HEADERS = [
+  "=== LFG SUBAGENT OPERATING CONTRACT ===",
+  "=== OMG SUBAGENT OPERATING CONTRACT ===",
+  "=== omg.dev SUBAGENT OPERATING CONTRACT ===",
+] as const;
 
 /** Earliest occurrence of any known contract marker, or -1. */
 function firstIndexOf(text: string, needles: readonly string[], from = 0): { at: number; needle: string } {
@@ -136,14 +147,34 @@ export function withOmgRuntimeContract(prompt: string | undefined): string | und
  * original text rather than blanking the card.
  */
 export function stripOmgRuntimeContract(text: string): string {
-  const header = firstIndexOf(text, CONTRACT_HEADERS);
-  if (header.at < 0) return text;
-  const end = firstIndexOf(text, CONTRACT_ENDS, header.at + header.needle.length);
-  if (end.at < 0) return text;
+  let out = text;
+  // Bounded: a prompt carries at most a runtime + a subagent envelope today,
+  // and a loop that can't make progress exits on the identity check anyway.
+  for (let i = 0; i < 4; i++) {
+    const next = stripOneContract(out);
+    if (next === null || next === out) break;
+    out = next;
+  }
+  return out;
+}
+
+/** One envelope peeled off the front, or null when there is nothing to strip. */
+function stripOneContract(text: string): string | null {
+  const header = firstIndexOf(text, [...CONTRACT_HEADERS, ...SUBAGENT_HEADERS]);
+  if (header.at < 0) return null;
+  const isSubagent = (SUBAGENT_HEADERS as readonly string[]).includes(header.needle);
+  const afterHeader = header.at + header.needle.length;
+  // The subagent envelope has no end marker; USER_TASK is its only terminator,
+  // so a missing one means we can't tell contract from task and must not guess.
+  const end = isSubagent
+    ? { at: afterHeader, needle: "" }
+    : firstIndexOf(text, CONTRACT_ENDS, afterHeader);
+  if (end.at < 0) return null;
   const after = text.slice(end.at + end.needle.length);
   const taskAt = after.indexOf(USER_TASK);
+  if (isSubagent && taskAt < 0) return null;
   const body = taskAt < 0 ? after : after.slice(taskAt + USER_TASK.length);
-  return `${text.slice(0, header.at)}${body}`.trim() || text;
+  return `${text.slice(0, header.at)}${body}`.trim() || null;
 }
 
 /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -2416,6 +2416,13 @@ export async function listSessions(): Promise<Session[]> {
     // would emit a SECOND row with the SAME visible sessionId (via
     // managedVisibleId) whose busy flag comes from the log pane (always idle),
     // clobbering the registry row's live busy state in the client.
+    //
+    // Ancestry is the primary test, mirroring the claude scan above. The tmux
+    // lookup that follows cannot see a codex-aisdk harness at all: it runs
+    // headless under `systemd-run` with no tmux session, so targetForPid()
+    // returns null and the guard silently never fires. That is how the `codex
+    // exec` child surfaced as its own root-level row.
+    if (hasAncestorPid(p.pid, harnessPids)) continue;
     {
       const t = tmux.targetForPid(p.pid);
       const rec = t ? managedByName.get(t.split(":")[0]) : undefined;
@@ -2433,6 +2440,12 @@ export async function listSessions(): Promise<Session[]> {
     } catch {}
     profile?.add("codex_proc_reads_sum_ms", performance.now() - procT0);
     let sessionId = p.cmd.match(new RegExp(`(?:resume|fork)\\s+(${UUID.source})`))?.[1] ?? null;
+    // Id backstop, for when the ancestry walk misses (harness restarted, or the
+    // engine reparented away from it). A `resume <uuid>` that names a live
+    // codex-aisdk thread or harness key IS that session, not a second one —
+    // both ids resolve to the same transcript downstream, so emitting a row
+    // here can only ever produce a duplicate.
+    if (sessionId && (claimedCodex.has(sessionId) || aisdkSessionIds.has(sessionId))) continue;
     let thread = sessionId ? codex.find((t) => t.id === sessionId) : null;
     const prompt = codexPromptFromCmd(p.cmd);
     if (!thread && cwd && prompt) {
@@ -3028,6 +3041,35 @@ function ppidOf(pid: number): number | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * True when any ancestor of `pid` (up to `maxDepth` hops) is in `pids`.
+ *
+ * A direct-ppid check covers a child the harness spawns itself, but engine
+ * processes are not always one hop away — an SDK may put a wrapper in between,
+ * and that distance is a vendored dependency's implementation detail we
+ * shouldn't encode. Walking a few levels keeps the filter correct when it
+ * changes. Bounded so a cycle or a bad /proc read can't spin.
+ *
+ * `parentOf` is injectable for tests; production always reads /proc.
+ */
+export function hasAncestorPid(
+  pid: number,
+  pids: ReadonlySet<number>,
+  maxDepth = 4,
+  parentOf: (pid: number) => number | null = ppidOf,
+): boolean {
+  let cur = pid;
+  for (let i = 0; i < maxDepth; i++) {
+    const parent = parentOf(cur);
+    // pid 1 and below is init/kernel — no harness lives there, and continuing
+    // past it would walk every session into the same shared ancestry.
+    if (parent === null || !Number.isFinite(parent) || parent <= 1) return false;
+    if (pids.has(parent)) return true;
+    cur = parent;
+  }
+  return false;
 }
 
 // A subagent launched via containedAgentCommand runs as a systemd transient

--- a/test/codex-harness-child-filter.test.ts
+++ b/test/codex-harness-child-filter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { hasAncestorPid } from "../src/sessions.ts";
+
+// A codex-aisdk harness runs headless under systemd-run with no tmux session,
+// so the pane-based guard in listSessions() can never resolve it — it returned
+// null and silently passed the harness's own `codex exec` child through as a
+// standalone `agent: codex` row. One conversation, two rows in the session list,
+// both opening the same transcript. Ancestry is the guard that actually holds.
+describe("hasAncestorPid", () => {
+  // 4200 -> 4100 (sdk wrapper) -> 4000 (harness) -> 1 (systemd)
+  const tree = new Map([
+    [4200, 4100],
+    [4100, 4000],
+    [4000, 1],
+    [7000, 1],
+  ]);
+  const parentOf = (pid: number) => tree.get(pid) ?? null;
+  const harnessPids = new Set([4000]);
+
+  test("catches the engine child spawned directly by the harness", () => {
+    expect(hasAncestorPid(4100, harnessPids, 4, parentOf)).toBe(true);
+  });
+
+  test("catches it through an SDK wrapper process", () => {
+    expect(hasAncestorPid(4200, harnessPids, 4, parentOf)).toBe(true);
+  });
+
+  test("leaves a standalone session alone", () => {
+    expect(hasAncestorPid(7000, harnessPids, 4, parentOf)).toBe(false);
+  });
+
+  test("does not walk past init into shared ancestry", () => {
+    // Every managed process descends from pid 1; treating that as a match would
+    // hide every codex session instead of just the harness's own child.
+    expect(hasAncestorPid(4200, new Set([1]), 8, parentOf)).toBe(false);
+  });
+
+  test("stops at maxDepth instead of searching forever", () => {
+    expect(hasAncestorPid(4200, harnessPids, 1, parentOf)).toBe(false);
+  });
+
+  test("terminates on an unreadable ppid and on a cycle", () => {
+    expect(hasAncestorPid(999, harnessPids, 4, () => null)).toBe(false);
+    const cycle = new Map([
+      [1, 2],
+      [2, 1],
+    ]);
+    expect(hasAncestorPid(1, harnessPids, 4, (p) => cycle.get(p) ?? null)).toBe(false);
+  });
+});

--- a/test/omg-runtime-contract-strip.test.ts
+++ b/test/omg-runtime-contract-strip.test.ts
@@ -83,6 +83,47 @@ describe("stripOmgRuntimeContract", () => {
     expect(sessionTitleFromPrompt("   ")).toBeNull();
   });
 
+  // Delegated work carries a SECOND envelope: serve.ts wraps the prompt in the
+  // subagent contract, then the harness wraps that in the runtime contract. Only
+  // stripping the outer one left every subagent card titled
+  // "=== LFG SUBAGENT OPERATING CONTRACT === - You are an LFG-managed subage…".
+  const subagentEnvelope = (task: string) =>
+    [
+      "=== LFG SUBAGENT OPERATING CONTRACT ===",
+      "- You are an LFG-managed subagent.",
+      "- Parent session id: 51e5799d. Send progress there.",
+      "=== USER TASK ===",
+      task,
+    ].join("\n");
+
+  test("strips the subagent envelope, which has no end marker", () => {
+    expect(stripOmgRuntimeContract(subagentEnvelope("Fix the redirect loop"))).toBe(
+      "Fix the redirect loop",
+    );
+  });
+
+  test("strips both envelopes when a subagent prompt is wrapped for launch", () => {
+    const wrapped = withOmgRuntimeContract(subagentEnvelope("Fix the redirect loop"))!;
+    expect(stripOmgRuntimeContract(wrapped)).toBe("Fix the redirect loop");
+    expect(sessionTitleFromPrompt(wrapped)).toBe("Fix the redirect loop");
+  });
+
+  test("strips the subagent envelope after card whitespace collapsing", () => {
+    const flattened = withOmgRuntimeContract(subagentEnvelope("Fix the redirect loop"))!.replace(
+      /\s+/g,
+      " ",
+    );
+    expect(stripOmgRuntimeContract(flattened)).toBe("Fix the redirect loop");
+  });
+
+  test("keeps an unterminated subagent envelope rather than guessing", () => {
+    // No USER_TASK marker means there is no way to tell contract from task.
+    const unterminated = "=== LFG SUBAGENT OPERATING CONTRACT ===\n- You are a subagent.";
+    expect(stripOmgRuntimeContract(unterminated)).toBe(unterminated);
+    const taskless = `${subagentEnvelope("")}`;
+    expect(stripOmgRuntimeContract(taskless)).toBe(taskless);
+  });
+
   test("survives the whitespace collapsing that card previews apply", () => {
     // Titles flatten to one line; the markers must still be findable after it.
     const flattened = withOmgRuntimeContract("Ship the fix")!.replace(/\s+/g, " ");


### PR DESCRIPTION
## What you saw

One conversation showed up as two rows in the iOS session list, and tapping either opened the same thing.

- `51e5799d` — the real `codex-aisdk` harness, titled "Fix a production redirect loop…"
- `01a005fe` — a phantom, titled `=== LFG SUBAGENT OPERATING CONTRACT === - You are an LFG-managed subage…`

## Why

`01a005fe` was never a session. It is the `codex exec` child the codex SDK forks per turn, surfaced by the `/proc` scan in `listSessions()`. Both guards meant to suppress it were dead:

1. `/\bapp-server\b/` — stale. The SDK now spawns `codex exec --experimental-json … resume <threadId>`.
2. The tmux-pane → managed-record lookup — dead **by construction** for `codex-aisdk`, which runs headless under `systemd-run` with no tmux session. `targetForPid()` returns null, so the lookup finds nothing and the guard never fires.

The claude scan has a third filter the codex scan was missing: drop any process whose parent is a known harness pid.

Downstream, the phantom had no managed record, so no lineage (root in the tree) and no title — falling back to the raw first prompt.

## Fix

- `hasAncestorPid()` filter on the codex proc scan, mirroring the claude path. Walks a few levels so an SDK wrapper process between harness and engine doesn't defeat it.
- Id backstop: skip a `resume <uuid>` that names a live aisdk threadId or harness key. Those already resolve to the same transcript, so a row here can only be a duplicate.
- `stripOmgRuntimeContract()` now strips repeatedly and knows the subagent envelope, which has no `=== END … ===` line and is terminated by `USER_TASK`. Previously a delegated prompt carried two envelopes and only the outer one came off.

## Verification

- New `test/codex-harness-child-filter.test.ts` — ancestry through a wrapper, standalone sessions untouched, no walking past init into shared ancestry, depth bound, cycle/unreadable-ppid termination.
- Extended `test/omg-runtime-contract-strip.test.ts` — single and double envelope, post-whitespace-collapse, and unterminated envelopes left alone rather than guessed at.
- Full suite: 1478 pass. The 10 failures are pre-existing in `web/` (unbuilt `@omg-dev/client` workspace package) and reproduce on a clean checkout of `main`.
- `bun run typecheck` clean apart from that same pre-existing `@omg-dev/client` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)