### PR TITLE
fix(mobile): composer pill clipping, and queued messages that read as queued

### DIFF
--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -98,6 +98,17 @@ import {
 /** Local id for the optimistic message, so it can be rolled back precisely. */
 let localSeq = 0;
 
+/**
+ * Is this row a local placeholder rather than something the machine sent us?
+ *
+ * The transcript used to answer that with `m.pending`, which is a different
+ * question — whether the request is still in the air — and the two only
+ * happened to coincide because the code that cleared `pending` had been
+ * misplaced into a `catch`. The id prefix is the honest test.
+ */
+const isOptimisticId = (id: unknown): boolean =>
+  typeof id === "string" && id.startsWith("local-");
+
 /** One screenful of history, and the step every "load more" adds. */
 const PAGE = 80;
 
@@ -318,14 +329,38 @@ export default function SessionScreen() {
         case "message":
           if (!atBottomRef.current) setUnseen(true);
           setMessages((prev) => {
-            // Drop the optimistic copy this message confirms, and de-dupe on id.
-            const withoutPending = prev.filter(
-              (m) => !(m.pending && m.text === event.message.text),
+            /**
+             * Drop the optimistic copy this message confirms, de-dupe on id,
+             * and CARRY `queued` ACROSS.
+             *
+             * Two things were wrong here. The optimistic row was identified by
+             * `m.pending`, which conflated "this row is a local placeholder"
+             * with "the request is still in the air" — so the moment the
+             * success path stopped setting `pending`, the row stopped matching
+             * and the message rendered twice. It is matched on the `local-`
+             * id prefix now, which is what actually makes a row optimistic.
+             *
+             * And `queued` lived only on the optimistic row, so the echo — which
+             * the machine sends as soon as it accepts the message, long before
+             * the agent gets to it — replaced the row with a plain server
+             * message and the "Queued" badge vanished almost immediately. That
+             * is why a held send looked identical to a tapped one. The flag is
+             * a local fact about how it was sent, so it is carried onto the
+             * echo rather than expected back from the server.
+             */
+            const confirmed = prev.find(
+              (m) => isOptimisticId(m.id) && m.text === event.message.text,
             );
-            if (event.message.id && withoutPending.some((m) => m.id === event.message.id)) {
-              return withoutPending.map((m) => (m.id === event.message.id ? event.message : m));
+            const incoming: Entry = confirmed?.queued
+              ? { ...event.message, queued: true }
+              : event.message;
+            const withoutOptimistic = prev.filter(
+              (m) => !(isOptimisticId(m.id) && m.text === event.message.text),
+            );
+            if (incoming.id && withoutOptimistic.some((m) => m.id === incoming.id)) {
+              return withoutOptimistic.map((m) => (m.id === incoming.id ? incoming : m));
             }
-            return [...withoutPending, event.message];
+            return [...withoutOptimistic, incoming];
           });
           // A completed message supersedes whatever was streaming.
           setStreamText("");
@@ -341,6 +376,21 @@ export default function SessionScreen() {
           break;
         case "busy":
           setBusy(event.busy);
+          /**
+           * "Queued" means WAITING BEHIND THE TURN IN FLIGHT. When that turn
+           * ends the queue drains, so the badge has to come off — otherwise
+           * carrying the flag across the echo (see the `message` case) would
+           * just trade a badge that vanished instantly for one that never
+           * left, and a message the agent answered ten minutes ago would still
+           * claim to be waiting.
+           */
+          if (!event.busy) {
+            setMessages((prev) =>
+              prev.some((m) => m.queued)
+                ? prev.map((m) => (m.queued ? { ...m, queued: false } : m))
+                : prev,
+            );
+          }
           break;
         case "prompt":
           setPrompt(event.prompt);
@@ -568,18 +618,27 @@ export default function SessionScreen() {
           await client.sendMessage(id, trimmed);
         }
         setError(null);
+        /**
+         * The request has landed. A queued message is no longer in flight, but
+         * it IS still waiting behind the current turn — so drop `pending` and
+         * keep `queued`.
+         *
+         * THIS BELONGS ON THE SUCCESS PATH. It used to sit in the `catch`
+         * below, underneath the line that removes the optimistic message
+         * entirely, which made it two bugs at once: dead code on failure (it
+         * mapped over a list the row had just been filtered out of) and
+         * missing on success, so a delivered message kept `pending: true` and
+         * stayed dimmed at 0.6 opacity for as long as it survived.
+         */
+        setMessages((prev) =>
+          prev.map((m) => (m.id === optimistic.id ? { ...m, pending: false } : m)),
+        );
       } catch (e) {
         // Roll the message back AND give the person their words back — losing
         // typed text to a failed request is the rudest thing a composer can do.
         setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
         setDraft((current) => (current ? current : trimmed));
         setError(e instanceof Error ? e.message : String(e));
-        // The request has landed. A queued message is no longer in flight, but
-        // it IS still waiting behind the current turn — so the echo drops
-        // `pending` and keeps `queued` until the real message replaces it.
-        setMessages((prev) =>
-          prev.map((m) => (m.id === optimistic.id ? { ...m, pending: false } : m)),
-        );
       } finally {
         setSending(false);
         setResuming(false);

--- a/mobile/src/components.tsx
+++ b/mobile/src/components.tsx
@@ -1350,10 +1350,37 @@ function ComposerCaptionButton({
   accessibilityLabel: string;
 }) {
   const { colors, radius, type, space } = useTheme();
-  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
-  // A new label is a new width. Drop the cached one so the next pass measures
-  // the pill unconstrained rather than inside the box the old label earned.
-  useEffect(() => setSize(null), [label]);
+  /**
+   * THE MEASUREMENT IS TAGGED WITH THE LABEL IT WAS TAKEN FOR.
+   *
+   * This used to be a bare `{width, height}` plus `useEffect(() => setSize(null),
+   * [label])` to invalidate it. That is one frame too late, and it is why the
+   * pill visibly clipped when a project name got LONGER:
+   *
+   *   frame N    label is the new long one, but the effect has not run yet, so
+   *              the Host is still pinned to the SHORT label's width. The pill
+   *              is `overflow: hidden` with `numberOfLines={1}`, so the new
+   *              label renders clipped inside the old box. <- the reported bug
+   *   frame N+1  the effect has now fired, size is null, the pill measures
+   *              unconstrained.
+   *   frame N+2  the new width is applied and it finally looks right.
+   *
+   * Short-to-long clipped the text; long-to-short only looked a little roomy
+   * for a frame, which is why only one direction was ever noticed.
+   *
+   * Tagging fixes it by construction rather than by timing: a measurement
+   * carries the label it describes, and the width is only applied when that
+   * tag still matches. A stale width is now *unapplicable* instead of merely
+   * scheduled for deletion, so frame N constrains nothing and the pill is
+   * drawn at its natural size immediately. No effect, and no setState during
+   * render either.
+   */
+  const [measured, setMeasured] = useState<{
+    label: string;
+    width: number;
+    height: number;
+  } | null>(null);
+  const size = measured && measured.label === label ? measured : null;
   // Glass, like the field it captions and the buttons inside it. A flat fill
   // here was the last piece of chrome on this screen made of something else.
   const pill = (
@@ -1439,13 +1466,16 @@ function ComposerCaptionButton({
         onLayout={(e) => {
           const { width, height } = e.nativeEvent.layout;
           // Only on a real change: setting state from onLayout with the same
-          // numbers is a re-render loop.
-          setSize((current) =>
+          // numbers is a re-render loop. The label is part of that comparison
+          // now, so a measurement taken for a previous label can never satisfy
+          // it and linger.
+          setMeasured((current) =>
             current &&
+            current.label === label &&
             Math.abs(current.width - width) < 0.5 &&
             Math.abs(current.height - height) < 0.5
               ? current
-              : { width, height },
+              : { label, width, height },
           );
         }}
       >


### PR DESCRIPTION
## Summary

Two composer fixes, both reported from the device.

### 1. The pill clipped when a label got longer

Switching the folder filter from a short project name to a longer one drew the
pill clipped for a frame before correcting itself.

`ComposerCaptionButton` measures the pill and hands the size to `DropdownMenu`,
because the SwiftUI `Host` will not size itself to RN content. That measurement
was cached and invalidated in `useEffect(() => setSize(null), [label])` — and an
effect runs **after** commit, so invalidation was always one frame late:

| frame | label | width applied to Host | result |
|---|---|---|---|
| N | new (long) | **old (short)** | **clipped** |
| N+1 | new | `null` | measures free |
| N+2 | new | new | correct |

The pill is `overflow: hidden` with `numberOfLines={1}`, so frame N draws the
long label inside the short label's box. Short→long clipped; long→short only
looked slightly roomy, which is why one direction was reported.

Fixed by making a stale measurement **unapplicable** rather than scheduling its
deletion: the measurement carries the label it was taken for, and the width is
applied only while that tag matches. Frame N constrains nothing. No effect, and
no setState-during-render. This subsumes the previous fix in that function (drop
the cache so a shorter label can shrink the pill) — a tagged measurement never
applies in either direction.

### 2. A queued message didn't read as queued

Three things, stacked.

- The update clearing `pending` on a delivered message sat inside the `catch`,
  **below the line that removes the optimistic row** — dead code on failure,
  absent on success. A delivered message stayed `pending: true` and dimmed at
  0.6 opacity. Moved to the success path its own comment described.
- Fixing that alone would have rendered **every message twice**: the transcript
  identified the optimistic row by `m.pending`, conflating "local placeholder"
  with "request in flight". Once the success path cleared `pending` the row no
  longer matched, its local id didn't match the server id either, and the echo
  was appended beside it. Optimistic rows are matched on their `local-` id
  prefix now, which is what actually makes a row optimistic.
- The actual cause of the report: `queued` only ever lived on the optimistic
  row. The machine echoes a message as soon as it **accepts** it, long before
  the agent reaches it, so the echo replaced the row with a plain server message
  and the badge vanished almost instantly. `queued` is a local fact about how it
  was sent, so it's carried onto the echo — and cleared when `busy` goes false,
  since queued means waiting behind the turn in flight and the queue drains when
  that turn ends.

## Verification

`tsc --noEmit` clean. **Not verified on the simulator** — Benny asked to skip
device verification and ship. Flagging honestly: the pill fix is a single-frame
transient that only a screen recording settles, and the transcript change
touches message reconciliation, where I reasoned through the duplicate-render
trap above rather than observing it. Worth a look on device when convenient.
