### PR TITLE
fix(mobile): no calls to action pointing at an external purchase

### DIFF
--- a/mobile/app/computers.tsx
+++ b/mobile/app/computers.tsx
@@ -6,8 +6,9 @@
  * status:"upgrade_required" / blockedReason:"plan_downgraded" — observed live —
  * and the session proxy then answers every request with a permanent 425. If
  * that row looks selectable, the app sends you to a spinner that never ends.
- * So a blocked machine is rendered as blocked, with the reason and a way out to
- * the web where billing actually lives.
+ * So a blocked machine is rendered as blocked, with the reason stated plainly.
+ * A way out to the web is offered only for blocks that are not about money —
+ * see WEB_FIXABLE_CLOUD_STATUSES below.
  */
 
 import { useRouter } from "expo-router";
@@ -25,6 +26,27 @@ import { bindingLabel, cloudStatusLabel, machineSpec, relativeTime } from "../sr
 import { CLOUD_BINDING_ID } from "../src/omg/config";
 
 const BLOCKED_CLOUD_STATUSES = new Set(["upgrade_required", "recycled"]);
+
+/**
+ * Blocked, but NOT for a reason you would fix by paying.
+ *
+ * "Fix this on omg.dev" is only offered for these. `upgrade_required` is
+ * deliberately absent: that state means "Included computer time is used up" or
+ * "Your plan no longer covers this computer", so a button next to it saying
+ * fix this on the web is, in substance, a call to action pointing at a
+ * purchasing mechanism that is not in-app purchase — which App Review
+ * Guideline 3.1.1(a) prohibits everywhere except the United States storefront.
+ * It reads more like a paywall exit than the settings row did, because it
+ * appears at exactly the moment someone is being asked for money.
+ *
+ * `recycled` stays: a removed machine is not a billing state, and getting it
+ * back is account management.
+ *
+ * The status text still tells the truth about why the machine will not serve.
+ * Stating a fact is not a call to action. See app/settings.tsx for the whole
+ * reasoning and for where the upgrade nudge went instead.
+ */
+const WEB_FIXABLE_CLOUD_STATUSES = new Set(["recycled"]);
 
 export default function ComputersScreen() {
   const router = useRouter();
@@ -51,6 +73,9 @@ export default function ComputersScreen() {
   };
 
   const cloudBlocked = BLOCKED_CLOUD_STATUSES.has(cloud?.status ?? "");
+  // See WEB_FIXABLE_CLOUD_STATUSES: blocked is not the same question as
+  // "should we offer a way out to the web".
+  const cloudFixableOnWeb = WEB_FIXABLE_CLOUD_STATUSES.has(cloud?.status ?? "");
   const cloudSpec = machineSpec(cloud?.machine);
 
   return (
@@ -138,7 +163,7 @@ export default function ComputersScreen() {
           ) : null}
         </Row>
 
-        {cloudBlocked ? (
+        {cloudFixableOnWeb ? (
           <>
             <Separator inset="text" />
             <Row onPress={() => void Linking.openURL("https://app.omg.dev/")}>
@@ -166,8 +191,7 @@ export default function ComputersScreen() {
         }}
       >
         Pair a new machine by running{" "}
-        <Text style={{ color: colors.text }}>omg connect</Text> on it. Billing and plans live on
-        the web.
+        <Text style={{ color: colors.text }}>omg connect</Text> on it.
       </Text>
     </ScrollView>
   );

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -36,11 +36,38 @@ import {
   type PushPermissionStatus,
 } from "../src/omg/push";
 
+/**
+ * Account management that lives on the web. NOT billing — see below.
+ *
+ * NO PURCHASE LINKS IN THIS APP. There used to be a "Plan & billing" row here
+ * opening `app.omg.dev/settings/billing`, and it has to stay gone until omg
+ * sells through StoreKit.
+ *
+ * App Review Guideline 3.1.1(a): "In all other storefronts, except for the
+ * United States storefront, where this prohibition does not apply, apps and
+ * their metadata may not include buttons, external links, or other calls to
+ * action that direct customers to purchasing mechanisms other than in-app
+ * purchase." omg ships outside the US, so the exception does not cover us and
+ * this row was the clearest possible example of the thing it prohibits.
+ *
+ * The rows that remain are account MANAGEMENT — which agents are connected,
+ * what is scheduled, how much disk is used. None of them is a way to pay, and
+ * 3.1.1 is aimed at purchasing, not at a companion app linking to its own
+ * dashboard.
+ *
+ * The upgrade nudge is not lost, it MOVED. 3.1.3: "Developers can send
+ * communications outside of the app to their user base about purchasing
+ * methods other than in-app purchase." So running out of included time is
+ * stated as a fact in the app and followed up by email, which is allowed in
+ * every storefront.
+ *
+ * When StoreKit lands, the honest fix is an in-app purchase here, not this
+ * link coming back.
+ */
 const WEB_PAGES: { label: string; path: string }[] = [
   { label: "Coding agents", path: "/settings/computer/coding-agents" },
   { label: "Schedules", path: "/settings/computer/auto" },
   { label: "Storage", path: "/settings/computer/storage" },
-  { label: "Plan & billing", path: "/settings/billing" },
 ];
 
 export default function SettingsScreen() {

--- a/mobile/src/omg/computer-picker.ts
+++ b/mobile/src/omg/computer-picker.ts
@@ -14,7 +14,7 @@
  * and the session proxy then answers every request with a permanent 425. If
  * that row looks pickable, the app sends you to a spinner that never ends. So
  * a blocked machine is listed disabled, with its reason folded into the label
- * and a way out to the web where billing actually lives.
+ * and, for blocks that are not about money, a way out to the web.
  */
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo } from "react";
@@ -27,6 +27,15 @@ import { useOmg } from "./provider";
 import { useToast } from "./toast";
 
 const BLOCKED_CLOUD_STATUSES = new Set(["upgrade_required", "recycled"]);
+
+/**
+ * Blocked, but NOT for a reason you would fix by paying. Mirrors the set in
+ * app/computers.tsx — see that file for why `upgrade_required` is excluded
+ * (App Review 3.1.1(a): no calls to action pointing at a purchasing mechanism
+ * other than in-app purchase, outside the US storefront) and app/settings.tsx
+ * for where the upgrade nudge went instead.
+ */
+const WEB_FIXABLE_CLOUD_STATUSES = new Set(["recycled"]);
 
 export function useComputerPicker() {
   const router = useRouter();
@@ -76,7 +85,7 @@ export function useComputerPicker() {
       onPress: () => void selectBinding(CLOUD_BINDING_ID),
     });
 
-    if (cloudBlocked) {
+    if (WEB_FIXABLE_CLOUD_STATUSES.has(cloud?.status ?? "")) {
       rows.push({
         label: "Fix this on omg.dev",
         onPress: () => void Linking.openURL("https://app.omg.dev/"),


### PR DESCRIPTION
## Why

omg ships **outside the US storefront**, so App Review Guideline 3.1.1(a) applies:

> In all other storefronts, except for the United States storefront, where this
> prohibition does not apply, apps **and their metadata** may not include buttons,
> external links, or other calls to action that direct customers to purchasing
> mechanisms other than in-app purchase.

Until omg sells through StoreKit, the app cannot point anyone at web checkout.

## What was carrying a CTA

| surface | verdict |
|---|---|
| `settings.tsx` "Plan & billing" → `/settings/billing` | **removed** — the plainest example of the prohibited thing |
| `"Fix this on omg.dev"` (computers.tsx + computer-picker) | **gated to `recycled`** — see below |
| `"Billing and plans live on the web."` | **removed** |
| Coding agents / Schedules / Storage links | kept — account management, not purchasing |
| `"Included computer time is used up"` | kept — states a fact, is not a call to action |

**`"Fix this on omg.dev"` was the worst of the three**, worse than the settings row.
It renders whenever the cloud Computer is blocked, and the blocked state that
actually occurs in practice is `upgrade_required` — i.e. it appears directly
beneath "Included computer time is used up", at exactly the moment someone is
being told they need to pay. A reviewer reads that as a paywall exit regardless
of the fact that the link only opens the dashboard root. Now gated to
`recycled`, which is a removed machine, not a billing state.

## Where the upgrade nudge went

Guideline 3.1.3: *"Developers can send communications outside of the app to
their user base about purchasing methods other than in-app purchase."* So the
app states the fact and the follow-up happens by email — allowed in every
storefront, and it converts better than a settings row.

Each site carries the reasoning inline so it doesn't get helpfully re-added.
When StoreKit lands the answer is an in-app purchase, not these links returning.

## Verification

`tsc --noEmit` clean. Not device-verified — these are deletions and one
predicate narrowing, and the remaining `recycled` path is unchanged.

**Still outstanding, not in this PR:** 3.1.1(a) says "apps *and their metadata*."
The TestFlight Test Information and App Store description need the same review —
if either mentions signing up or paying on omg.dev, that counts too.
