### PR TITLE
feat(mobile): a paywall that says what you get, from the server that knows

### DIFF
--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -38,7 +38,8 @@ import * as Haptics from "expo-haptics";
 import { useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { Card, EmptyState, Icon, PrimaryButton, Row, SectionLabel, Separator } from "../src/components";
+import { EmptyState, Icon, PrimaryButton, SectionLabel, Separator } from "../src/components";
+import { PressableScale } from "../src/omg/motion";
 import { Text } from "../src/omg/text";
 import { useTheme } from "../src/omg/theme";
 import { useToast } from "../src/omg/toast";
@@ -52,6 +53,15 @@ import {
   type PurchaseAccount,
 } from "../src/omg/billing";
 import {
+  FALLBACK_TIERS,
+  formatComputeHours,
+  formatMachine,
+  formatParallelAgents,
+  labelForPlan,
+  sleepsBetweenTasks,
+  type TierSpecs,
+} from "../src/omg/plan-specs";
+import {
   connectStore,
   fetchTiers,
   finishPurchase,
@@ -61,9 +71,9 @@ import {
   restoreTiers,
   setMockScenario,
   StoreError,
-  tierForPlan,
   type StoreProduct,
   type StorePurchase,
+  type Tier,
 } from "../src/omg/store";
 
 /**
@@ -120,9 +130,20 @@ export default function PlanScreen() {
   const scenarioKey = `${params.mock ?? ""}:${params.auto ?? ""}`;
 
   /**
-   * Both sides, in parallel, because neither is useful alone: the token without
-   * products has nothing to buy, and products without the token cannot be
-   * attributed to an account.
+   * omg first, Apple second — and that order is now forced.
+   *
+   * These two used to run in parallel, because neither is useful alone: the
+   * token without products has nothing to buy, and products without the token
+   * cannot be attributed to an account. They can no longer be parallel, because
+   * omg's answer now contains the SKU LIST, and StoreKit has to be asked for
+   * specific product ids. The server owning that list is the point (see
+   * FALLBACK_TIERS) — it makes "an id the phone knows but the server doesn't"
+   * unrepresentable rather than merely commented about.
+   *
+   * The latency that costs is bought back by starting `connectStore()`
+   * alongside the omg call instead of before it. StoreKit's connection is the
+   * slow half and it depends on nothing, so it now overlaps the round trip that
+   * used to precede it.
    */
   const load = useCallback(async () => {
     setLoadError(null);
@@ -140,10 +161,15 @@ export default function PlanScreen() {
     }
 
     try {
-      await connectStore();
-      const [purchaseAccount, tiers] = await Promise.all([fetchPurchaseAccount(), fetchTiers()]);
+      const [, purchaseAccount] = await Promise.all([connectStore(), fetchPurchaseAccount()]);
       setAccount(purchaseAccount);
-      setProducts(tiers);
+      // A control plane that published no catalog leaves `tiers` null, and the
+      // bundled ids stand in so the screen can still sell something. They carry
+      // no specs, so the cards degrade to a name and Apple's price rather than
+      // to numbers this build remembers — the whole reason the facts moved to
+      // the server. Null and [] are different answers: [] means omg genuinely
+      // sells nothing right now, and is passed through as an empty list.
+      setProducts(await fetchTiers(purchaseAccount.tiers ?? FALLBACK_TIERS));
       setPhase({ kind: "ready" });
     } catch (error) {
       setLoadError(
@@ -226,7 +252,7 @@ export default function PlanScreen() {
   const restore = useCallback(async () => {
     setPhase({ kind: "restoring" });
     try {
-      const purchases = await restoreTiers();
+      const purchases = await restoreTiers(account?.tiers ?? FALLBACK_TIERS);
       if (purchases.length === 0) {
         setPhase({ kind: "ready" });
         toast.show("No purchases to restore on this Apple ID.");
@@ -251,7 +277,7 @@ export default function PlanScreen() {
         intent: "error",
       });
     }
-  }, [record, refreshMachines, toast]);
+  }, [account, record, refreshMachines, toast]);
 
   // MOCK-ONLY. See the note on `params` above.
   useEffect(() => {
@@ -264,6 +290,13 @@ export default function PlanScreen() {
 
   const busy = phase.kind === "purchasing" || phase.kind === "restoring";
   const currentPlan = phase.kind === "done" ? phase.entitlement.plan : account?.plan ?? null;
+  /**
+   * The tier list to NAME plans from. Not the same thing as `products`, which
+   * is only what Apple will sell right now: a plan the account is already on
+   * can be absent from the store (retired, or pulled from App Store Connect)
+   * and still needs a name in "You're all set" and in the Stripe notice.
+   */
+  const catalog = account?.tiers ?? FALLBACK_TIERS;
 
   return (
     <ScrollView
@@ -281,9 +314,9 @@ export default function PlanScreen() {
       ) : phase.kind === "unavailable" ? (
         <EmptyState title="Not available on this build" detail={phase.message} />
       ) : phase.kind === "done" ? (
-        <Subscribed entitlement={phase.entitlement} />
+        <Subscribed entitlement={phase.entitlement} catalog={catalog} />
       ) : phase.kind === "activating" ? (
-        <Activating plan={phase.plan} />
+        <Activating plan={phase.plan} catalog={catalog} />
       ) : (
         <>
           <Text
@@ -310,68 +343,42 @@ export default function PlanScreen() {
               not an edge case — so it gets an explanation rather than a
               disabled button someone has to guess the meaning of. */}
           {account && !account.canPurchase ? (
-            <AlreadySubscribed plan={account.plan} reason={account.reason} />
+            <AlreadySubscribed plan={account.plan} reason={account.reason} catalog={catalog} />
           ) : null}
 
           {products.length > 0 ? (
             <>
               <SectionLabel>Computer plans</SectionLabel>
-              <Card>
-                {products.map((product, i) => {
-                  const isCurrent = currentPlan === product.plan;
-                  const purchasing =
-                    phase.kind === "purchasing" && phase.productId === product.productId;
-                  return (
-                    <View key={product.productId}>
-                      {/* Plain padding, not "text" mode: these rows have no
-                          leading dot or icon, so their text is already flush
-                          with the card's padding. See Separator's note. */}
-                      {i > 0 ? <Separator inset={space.lg} /> : null}
-                      <Row
-                        disabled={busy || !account?.canPurchase || isCurrent}
-                        onPress={() => void buy(product)}
-                      >
-                        <View style={{ flex: 1, gap: 2 }}>
-                          <Text
-                            style={{ ...type.callout, color: colors.text, fontWeight: "600" }}
-                          >
-                            {product.label}
-                          </Text>
-                          <Text style={{ ...type.footnote, color: colors.textMuted, lineHeight: 18 }}>
-                            {product.detail}
-                          </Text>
-                        </View>
-                        <View style={{ alignItems: "flex-end", gap: 2, marginLeft: space.sm }}>
-                          {purchasing ? (
-                            <ActivityIndicator color={colors.textMuted} />
-                          ) : isCurrent ? (
-                            <Icon
-                              ios="checkmark"
-                              android="check"
-                              size={16}
-                              weight="semibold"
-                              color={colors.primary}
-                            />
-                          ) : (
-                            <>
-                              {/* Apple's string, verbatim. Never composed here —
-                                  it is a different currency in every storefront. */}
-                              <Text
-                                style={{ ...type.callout, color: colors.text, fontWeight: "600" }}
-                              >
-                                {product.displayPrice}
-                              </Text>
-                              <Text style={{ ...type.caption, color: colors.textMuted }}>
-                                per month
-                              </Text>
-                            </>
-                          )}
-                        </View>
-                      </Row>
-                    </View>
-                  );
-                })}
-              </Card>
+              {products.map((product) => (
+                <TierCard
+                  key={product.productId}
+                  product={product}
+                  current={currentPlan === product.plan}
+                  purchasing={phase.kind === "purchasing" && phase.productId === product.productId}
+                  disabled={busy || !account?.canPurchase || currentPlan === product.plan}
+                  onPress={() => void buy(product)}
+                />
+              ))}
+              {/* Said once, under the list, rather than as a "Sleeps between
+                  tasks: Yes" row repeated on four of five cards. The dashboard
+                  can afford that row because it shows one rung at a time; a
+                  list of five turns the same true sentence into noise, and
+                  noise is what made the old screen unreadable. Only the rung
+                  that BREAKS this rule states it, on its own card. */}
+              {products.some((product) => product.specs) ? (
+                <Text
+                  style={{
+                    ...type.caption,
+                    color: colors.textMuted,
+                    paddingHorizontal: space.lg,
+                    paddingTop: space.md,
+                    lineHeight: 16,
+                  }}
+                >
+                  Every plan pauses while idle, so time you are not using does not come out of
+                  your hours. A paused Computer keeps its files and picks up where it left off.
+                </Text>
+              ) : null}
             </>
           ) : !loadError ? (
             <EmptyState
@@ -407,20 +414,216 @@ export default function PlanScreen() {
 }
 
 /**
+ * One fact about a tier: an icon, what it is, and the number.
+ *
+ * Every row is exactly one line by construction. The value never wraps and
+ * never shrinks; the label yields first, because a wrapped value would make one
+ * card taller than its neighbours and break the column of numbers that makes
+ * five tiers comparable at a glance.
+ */
+function SpecRow({
+  label,
+  value,
+  emphasis = false,
+  ...glyph
+}: {
+  label: string;
+  value: string;
+  /** The number this tier is really sold on. */
+  emphasis?: boolean;
+} & ({ ios: "clock"; android: "schedule" } | { ios: "cpu"; android: "memory" } | { ios: "internaldrive"; android: "storage" } | { ios: "bolt.fill"; android: "bolt" })) {
+  const { colors, type, space } = useTheme();
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center", gap: space.md, paddingVertical: 5 }}>
+      <Icon
+        {...glyph}
+        size={15}
+        weight={emphasis ? "semibold" : "regular"}
+        color={emphasis ? colors.text : colors.textMuted}
+      />
+      <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted, flexShrink: 1 }}>
+        {label}
+      </Text>
+      <Text
+        style={{
+          ...type.footnote,
+          color: colors.text,
+          fontWeight: emphasis ? "600" : "500",
+          marginLeft: "auto",
+          flexShrink: 0,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * One tier, as something you can read rather than only price-compare.
+ *
+ * ── Why a list of cards and not the dashboard's slider ──────────────────────
+ *
+ * The dashboard shows ONE rung at a time and makes moving between them the
+ * whole interaction: a slider, ticks, a spring onto each detent. That works
+ * because a mouse is bad at direct selection and good at scrubbing, and because
+ * the overlay owns the entire viewport.
+ *
+ * Neither holds here. The equivalent of "move between the rungs" that a thumb
+ * already does perfectly is SCROLL — the vertical scroll IS this screen's
+ * slider, and it costs nothing to learn. Reproducing a drag control would also
+ * have meant five tiers hidden behind a gesture nobody was told about, on the
+ * one screen where hiding what someone is buying is the actual complaint.
+ *
+ * So: same vocabulary as the web ("Compute time", "Machine", "Disk", "agents in
+ * parallel", the same formatters), same facts, different control. All five are
+ * visible and comparable without touching anything, which a slider cannot do.
+ *
+ * ── The card makes no claim it was not handed ──────────────────────────────
+ *
+ * `specs` is null whenever the server did not describe this tier, and then the
+ * card is deliberately just a name and Apple's price. That is the honest
+ * degradation and it is the reason the numbers left the bundle: a stale spec
+ * would still render beautifully.
+ */
+function TierCard({
+  product,
+  current,
+  purchasing,
+  disabled,
+  onPress,
+}: {
+  product: StoreProduct;
+  current: boolean;
+  purchasing: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  const { colors, radius, type, space } = useTheme();
+  const specs: TierSpecs | null = product.specs;
+  const sleeps = specs ? sleepsBetweenTasks(specs) : null;
+
+  return (
+    <PressableScale
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      // One label for the whole card. VoiceOver reading eight separate nodes
+      // per tier, five times over, is how a screen becomes unusable while
+      // technically being accessible.
+      accessibilityLabel={[
+        product.label,
+        current ? "current plan" : product.displayPrice + " per month",
+        specs
+          ? `${formatParallelAgents(specs.parallelAgents)}, ${formatComputeHours(specs.computeHours)} of compute time, ${formatMachine(specs)}, ${specs.diskGb} GB disk${sleeps ? ", always on, never sleeps" : ""}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(". ")}
+      scale={0.98}
+      style={({ pressed }) => ({
+        backgroundColor: pressed && !disabled ? colors.cardPressed : colors.card,
+        borderRadius: radius.lg,
+        marginHorizontal: space.lg,
+        marginBottom: space.md,
+        padding: space.lg,
+        gap: specs ? space.md : 0,
+        // The current plan is outlined rather than dimmed. Dimming it would
+        // hide the specs of the machine someone actually has, which is the one
+        // tier they have the most reason to re-read.
+        borderWidth: current ? 1.5 : 0,
+        borderColor: current ? colors.primary : "transparent",
+        // Only a card you cannot buy fades, and the current plan is not one of
+        // those — it is disabled because it is already yours.
+        opacity: disabled && !current ? 0.5 : 1,
+      })}
+    >
+      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: space.md }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text style={{ ...type.headline, color: colors.text }}>{product.label}</Text>
+          {specs ? (
+            /* The dashboard's hero number, demoted to a subtitle. It is still
+               the headline fact — the thing the ladder is really sold on — but
+               five 40pt numbers down a scroll is five heroes and therefore
+               none. */
+            <Text style={{ ...type.subhead, color: colors.textSecondary }}>
+              {formatParallelAgents(specs.parallelAgents)}
+            </Text>
+          ) : null}
+        </View>
+        <View style={{ alignItems: "flex-end", gap: 1 }}>
+          {purchasing ? (
+            <ActivityIndicator color={colors.textMuted} />
+          ) : (
+            <>
+              {/* Apple's string, verbatim. Never composed here — it is a
+                  different currency in every storefront. */}
+              <Text style={{ ...type.headline, color: colors.text }}>{product.displayPrice}</Text>
+              {current ? (
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 3 }}>
+                  <Icon ios="checkmark" android="check" size={11} weight="semibold" color={colors.primary} />
+                  <Text style={{ ...type.caption, color: colors.primary }}>Current plan</Text>
+                </View>
+              ) : (
+                <Text style={{ ...type.caption, color: colors.textMuted }}>per month</Text>
+              )}
+            </>
+          )}
+        </View>
+      </View>
+
+      {specs ? (
+        <>
+          <Separator />
+          <View>
+            {/* Compute time carries the emphasis, matching the dashboard: it is
+                the allowance that actually runs out, and the one people are
+                surprised by. */}
+            <SpecRow
+              ios="clock"
+              android="schedule"
+              label="Compute time"
+              value={formatComputeHours(specs.computeHours)}
+              emphasis
+            />
+            <SpecRow ios="cpu" android="memory" label="Machine" value={formatMachine(specs)} />
+            <SpecRow
+              ios="internaldrive"
+              android="storage"
+              label="Disk"
+              value={`${specs.diskGb} GB`}
+            />
+            {sleeps ? (
+              <SpecRow
+                ios="bolt.fill"
+                android="bolt"
+                label="Sleeps between tasks"
+                value={sleeps}
+                emphasis
+              />
+            ) : null}
+          </View>
+        </>
+      ) : null}
+    </PressableScale>
+  );
+}
+
+/**
  * Apple has the money, omg has not confirmed yet.
  *
  * Deliberately reassuring and deliberately not an error. The transaction is
  * still in StoreKit's queue, so this resolves itself on next launch even if the
  * person kills the app right now.
  */
-function Activating({ plan }: { plan: string }) {
+function Activating({ plan, catalog }: { plan: string; catalog: readonly Tier[] }) {
   const { colors, type, space } = useTheme();
-  const tier = tierForPlan(plan);
+  const label = labelForPlan(plan, catalog);
   return (
     <View style={{ paddingTop: space.xxl }}>
       <EmptyState
         title="Purchase complete"
-        detail={`Your ${tier?.label ?? "new"} plan is being activated. This usually takes a few seconds — you can close this screen, it will finish on its own.`}
+        detail={`Your ${label ?? "new"} plan is being activated. This usually takes a few seconds — you can close this screen, it will finish on its own.`}
       />
       <View style={{ alignItems: "center", gap: space.sm }}>
         <ActivityIndicator color={colors.textMuted} />
@@ -430,14 +633,24 @@ function Activating({ plan }: { plan: string }) {
   );
 }
 
-function Subscribed({ entitlement }: { entitlement: Entitlement }) {
+function Subscribed({
+  entitlement,
+  catalog,
+}: {
+  entitlement: Entitlement;
+  catalog: readonly Tier[];
+}) {
   const { space } = useTheme();
-  const tier = tierForPlan(entitlement.plan);
+  // Falls back to the raw plan key on purpose. The server can name a plan this
+  // build has never heard of — a grandfathered rung, or one added after the
+  // binary shipped — and "computer_early" is ugly but true, where a guessed
+  // label would be neither.
+  const label = labelForPlan(entitlement.plan, catalog) ?? entitlement.plan;
   return (
     <View style={{ paddingTop: space.xxl }}>
       <EmptyState
         title={entitlement.replayed ? "Purchases restored" : "You're all set"}
-        detail={`Your cloud computer is on ${tier?.label ?? entitlement.plan}. It may take a moment to come back online.`}
+        detail={`Your cloud computer is on ${label}. It may take a moment to come back online.`}
       />
     </View>
   );
@@ -447,14 +660,35 @@ function Subscribed({ entitlement }: { entitlement: Entitlement }) {
  * Already paying, through the web.
  *
  * Buying again here would double-bill: Apple would take the money and omg would
- * owe a refund. So this states the situation plainly. It deliberately does NOT
- * link anywhere to manage the Stripe subscription — that would be a call to
- * action pointing at an external purchasing mechanism, which is the exact thing
- * 3.1.1(a) prohibits and the reason this screen exists at all.
+ * owe a refund. So this states the situation plainly.
+ *
+ * ── Every word here is load-bearing ────────────────────────────────────────
+ *
+ * It states a FACT about the account and issues no instruction. There is no
+ * link, no URL, no button, and no verb aimed at the reader — not "go to", not
+ * "manage it at", not "visit". 3.1.1(a) prohibits calls to action pointing at a
+ * purchasing mechanism other than in-app purchase outside the US storefront,
+ * and #114 removed `"Fix this on omg.dev"` for exactly that reason even though
+ * it too only opened the dashboard root. Telling someone where their existing
+ * billing already lives is not a call to action; telling them to go there is.
+ * Do not add a link to this component.
+ *
+ * The second sentence stays because the first alone does not explain why the
+ * cards below cannot be tapped, and an unexplained dead control is what #115
+ * set out to avoid. It describes this screen's own behaviour, not somewhere
+ * else's.
  */
-function AlreadySubscribed({ plan, reason }: { plan?: string | null; reason?: string | null }) {
+function AlreadySubscribed({
+  plan,
+  reason,
+  catalog,
+}: {
+  plan?: string | null;
+  reason?: string | null;
+  catalog: readonly Tier[];
+}) {
   const { colors, type, space } = useTheme();
-  const tier = tierForPlan(plan);
+  const label = labelForPlan(plan, catalog);
   const stripe = reason === "stripe_subscription_active";
   return (
     <View style={{ paddingHorizontal: space.lg, paddingTop: space.lg }}>
@@ -467,11 +701,11 @@ function AlreadySubscribed({ plan, reason }: { plan?: string | null; reason?: st
         }}
       >
         <Text style={{ ...type.callout, color: colors.text, fontWeight: "600" }}>
-          {stripe ? "You already have a subscription" : "Purchases are unavailable"}
+          {stripe ? "You're subscribed through omg.dev on the web" : "Purchases are unavailable"}
         </Text>
         <Text style={{ ...type.footnote, color: colors.textSecondary, lineHeight: 18 }}>
           {stripe
-            ? `This account is already subscribed${tier ? ` on ${tier.label}` : ""} and billed outside the App Store. Buying here would charge you twice, so it's turned off.`
+            ? `${label ? `Your ${label} plan is` : "This account is"} billed on the web, not through the App Store. Buying again here would charge you twice, so it's turned off.`
             : "This account can't purchase right now. Try again in a moment."}
         </Text>
       </View>

--- a/mobile/src/omg/billing.ts
+++ b/mobile/src/omg/billing.ts
@@ -40,11 +40,26 @@
 
 import { getAuthToken } from "./auth";
 import { CONTROLPLANE_ORIGIN } from "./config";
+import { parseCatalogTiers, type CatalogTier } from "./plan-specs";
 
 /** What the server says about this account's ability to buy, before we ask Apple for anything. */
 export type PurchaseAccount = {
   /** Stable per-customer UUID. Pass to StoreKit verbatim. */
   appAccountToken: string;
+  /**
+   * What omg sells and what each tier contains — ids included, prices NOT.
+   *
+   * Null when this control plane published no catalog at all, which is an
+   * ordinary answer from a server older than the field. The caller falls back
+   * to the product ids in the bundle and renders no specs; it must never fall
+   * back to remembered numbers. An EMPTY array is a different answer — "nothing
+   * is on sale" — and is passed through as such.
+   *
+   * Prices are absent by contract. Apple's `displayPrice` is the only price
+   * string this app renders, because it is per-storefront and localised, and a
+   * second price from omg could only ever contradict it.
+   */
+  tiers: CatalogTier[] | null;
   /**
    * False when buying here would double-bill. The live case is an account
    * already subscribed through Stripe on the web: Apple would happily take a
@@ -121,6 +136,59 @@ export function setMockBillingScenario(scenario: string): void {
 /** A fixed UUID, so the mock exercises the real "pass it through" path. */
 const MOCK_ACCOUNT_TOKEN = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 
+/**
+ * A stand-in for the catalog the control plane sends.
+ *
+ * THIS IS NOT A COPY OF THE CATALOG. It is raw JSON in the shape the server
+ * promises, fed through the SAME `parseCatalogTiers` the network path uses, so
+ * that looking at the screen exercises the real parser rather than a shortcut
+ * around it. It exists because the endpoint is being built in another repo in
+ * parallel and the screen had to be seen before it deployed.
+ *
+ * The numbers match the vibes catalog as of writing and were agreed field by
+ * field with the control-plane side. They are still MOCK numbers: what they
+ * prove is that the screen renders whatever it is handed and computes nothing.
+ * The real payload is the one that ships.
+ */
+const MOCK_CATALOG: unknown = [
+  {
+    productId: "dev.omg.computer.computer_s20.monthly.v1",
+    plan: "computer_s20",
+    label: "Starter",
+    specs: { parallelAgents: 3, vcpus: 2, memoryMb: 4096, diskGb: 16, computeHours: 20, alwaysOn: false },
+  },
+  {
+    productId: "dev.omg.computer.computer_s40.monthly.v1",
+    plan: "computer_s40",
+    label: "Starter Plus",
+    specs: { parallelAgents: 3, vcpus: 2, memoryMb: 4096, diskGb: 16, computeHours: 40, alwaysOn: false },
+  },
+  {
+    productId: "dev.omg.computer.computer_5.monthly.v1",
+    plan: "computer_5",
+    label: "Personal",
+    specs: { parallelAgents: 5, vcpus: 4, memoryMb: 8192, diskGb: 64, computeHours: 150, alwaysOn: false },
+  },
+  {
+    productId: "dev.omg.computer.computer_10.monthly.v1",
+    plan: "computer_10",
+    label: "Pro",
+    specs: { parallelAgents: 16, vcpus: 8, memoryMb: 16384, diskGb: 128, computeHours: 300, alwaysOn: false },
+  },
+  {
+    productId: "dev.omg.computer.computer_20.monthly.v1",
+    plan: "computer_20",
+    label: "Always On",
+    specs: { parallelAgents: 24, vcpus: 12, memoryMb: 36864, diskGb: 256, computeHours: 750, alwaysOn: true },
+  },
+];
+
+/** The same list with every `specs` null — a server that can sell but cannot describe. */
+const MOCK_CATALOG_NO_SPECS: unknown = (MOCK_CATALOG as Record<string, unknown>[]).map((tier) => ({
+  ...tier,
+  specs: null,
+}));
+
 async function billingFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const token = await getAuthToken();
   if (!token) throw new BillingError("Please sign in again.", 401);
@@ -169,21 +237,42 @@ async function billingFetch<T>(path: string, init?: RequestInit): Promise<T> {
 export async function fetchPurchaseAccount(): Promise<PurchaseAccount> {
   if (isMock) {
     await new Promise((r) => setTimeout(r, 500));
+    // Every branch goes through parseCatalogTiers, exactly like the network
+    // path, so the mock cannot accidentally hand the screen a shape the real
+    // parser would have rejected.
+    //   nocatalog — a control plane older than the `tiers` field
+    //   nospecs   — sells the tiers but describes none of them
+    //   nothing   — a real, empty catalog: omg sells nothing right now
+    const raw =
+      MOCK === "nocatalog" ? undefined : MOCK === "nospecs" ? MOCK_CATALOG_NO_SPECS : MOCK === "nothing" ? [] : MOCK_CATALOG;
+    const tiers = parseCatalogTiers(raw);
     if (MOCK === "stripe") {
       return {
         appAccountToken: MOCK_ACCOUNT_TOKEN,
         canPurchase: false,
         reason: "stripe_subscription_active",
         plan: "computer_5",
+        tiers,
       };
     }
-    return { appAccountToken: MOCK_ACCOUNT_TOKEN, canPurchase: true, plan: null };
+    return { appAccountToken: MOCK_ACCOUNT_TOKEN, canPurchase: true, plan: null, tiers };
   }
-  const data = await billingFetch<PurchaseAccount>("/api/billing/app-store/account-token");
-  if (!data?.appAccountToken) {
+  const data = await billingFetch<Record<string, unknown>>(
+    "/api/billing/app-store/account-token",
+  );
+  if (typeof data?.appAccountToken !== "string" || !data.appAccountToken) {
     throw new BillingError("omg did not return a purchase token.", 500);
   }
-  return data;
+  return {
+    appAccountToken: data.appAccountToken,
+    canPurchase: data.canPurchase !== false,
+    reason: typeof data.reason === "string" ? data.reason : null,
+    plan: typeof data.plan === "string" ? data.plan : null,
+    // Validated rather than trusted. Everything this returns is drawn on a
+    // payment surface, so a malformed tier is dropped and an incomplete spec
+    // becomes null — never a half-filled card. See plan-specs.ts.
+    tiers: parseCatalogTiers(data.tiers),
+  };
 }
 
 /**

--- a/mobile/src/omg/plan-specs.ts
+++ b/mobile/src/omg/plan-specs.ts
@@ -1,0 +1,254 @@
+/**
+ * What a tier GIVES you — and the rule about where those facts may come from.
+ *
+ * ── The rule ────────────────────────────────────────────────────────────────
+ *
+ * THE PHONE COPIES THE WORDS. IT NEVER COPIES THE NUMBERS.
+ *
+ * "Compute time", "Machine", "Disk", "agents in parallel", "150 hours",
+ * "8 GB" — the vocabulary and the formatting are deliberately identical to the
+ * dashboard's (apps/web/src/lib/computer-plan-ladder.ts in BennyKok/vibes), and
+ * they live in this file as a copy. A stale FORMATTER is a cosmetic bug: the
+ * worst it can do is print "20 hrs" where the web prints "20 hours".
+ *
+ * The numbers are a different kind of thing. vCPU, memory, disk, parallel
+ * agents and included hours are owned by three modules in another repo —
+ * control-plane/lib/computer-policy.ts, control-plane/lib/agent-concurrency.ts
+ * and the billing catalog — and a stale copy of those on THIS screen sells
+ * someone a machine they do not get. So they are not in this bundle at all.
+ * They arrive from the server, which can import all three directly, and this
+ * module's only job is to check that what arrived is complete and then say it.
+ *
+ * ── Why not the usual drift guard ───────────────────────────────────────────
+ *
+ * This repo's normal answer to a necessary copy is a literal copy plus a
+ * checker — scripts/check-theme-drift.ts reads web/src/index.css, compares, and
+ * fails the build. Those work because both copies are in ONE repo, so CI can
+ * read both. The billing catalog is in a different repo and a different
+ * deployment, so there is no second file for a checker to open: a copy here
+ * would rot silently and nothing would ever go red. On a paywall, rotting means
+ * showing someone specs they are not buying.
+ *
+ * ── Missing is a state, not an error ────────────────────────────────────────
+ *
+ * A control plane that predates the catalog field sends no specs. That is
+ * expected, not a failure, and the answer is to say LESS: the tier still
+ * renders with its name and Apple's price, and simply makes no claims about
+ * hardware. `parseTierSpecs` is all-or-nothing per tier for the same reason —
+ * a spec card with one row quietly missing invites the reader to assume the row
+ * they cannot see, which is worse than a card that never promised.
+ */
+
+/** The hardware and allowance facts behind one tier. Server-owned, all six or none. */
+export type TierSpecs = {
+  /** Coding agents this plan runs at the same time. The headline number. */
+  parallelAgents: number;
+  vcpus: number;
+  memoryMb: number;
+  diskGb: number;
+  /**
+   * Included active hours per month.
+   *
+   * Hours, not "credits": the plan's wallet is dollars of wall-time and the
+   * rate card is dollars per hour, so the server divides one by the other and
+   * sends the product's own unit rather than a marketing approximation.
+   */
+  computeHours: number;
+  /** True when the Computer never pauses. One rung has this; it is the reason to buy that rung. */
+  alwaysOn: boolean;
+};
+
+/** One sellable tier, as the server describes it. */
+export type CatalogTier = {
+  /** App Store Connect product id. The server owns this list too — see store.ts. */
+  productId: string;
+  /** omg plan key this product maps to. */
+  plan: string;
+  label: string;
+  /** Null when the server did not describe this tier. Render nothing, never a guess. */
+  specs: TierSpecs | null;
+};
+
+function finitePositive(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+/**
+ * The six facts, or null.
+ *
+ * Every field is required. A partial payload is treated as no payload rather
+ * than as a card with gaps — see the header. `alwaysOn` is the one field
+ * allowed to be false, so it is checked for type rather than for truth.
+ */
+export function parseTierSpecs(value: unknown): TierSpecs | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+
+  const parallelAgents = finitePositive(raw.parallelAgents);
+  const vcpus = finitePositive(raw.vcpus);
+  const memoryMb = finitePositive(raw.memoryMb);
+  const diskGb = finitePositive(raw.diskGb);
+  const computeHours = finitePositive(raw.computeHours);
+  if (
+    parallelAgents == null ||
+    vcpus == null ||
+    memoryMb == null ||
+    diskGb == null ||
+    computeHours == null ||
+    typeof raw.alwaysOn !== "boolean"
+  ) {
+    return null;
+  }
+
+  return { parallelAgents, vcpus, memoryMb, diskGb, computeHours, alwaysOn: raw.alwaysOn };
+}
+
+/**
+ * The tier list the server sent, or null when it sent none.
+ *
+ * Null and empty mean different things and the caller acts on the difference:
+ * null is "this control plane does not publish a catalog", which falls back to
+ * the product ids in the bundle; empty is "the catalog says nothing is on
+ * sale", which is a real answer and must be shown as one. A tier missing an id,
+ * a plan key or a label is dropped — it cannot be bought or named.
+ */
+export function parseCatalogTiers(value: unknown): CatalogTier[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const raw = entry as Record<string, unknown>;
+    const productId = typeof raw.productId === "string" ? raw.productId : "";
+    const plan = typeof raw.plan === "string" ? raw.plan : "";
+    const label = typeof raw.label === "string" ? raw.label : "";
+    if (!productId || !plan || !label) return [];
+    return [{ productId, plan, label, specs: parseTierSpecs(raw.specs) }];
+  });
+}
+
+/**
+ * The tiers to fall back on when the server publishes no catalog — ids only.
+ *
+ * StoreKit cannot charge a variable amount, so metered overage and credit
+ * top-ups have no representation here and must not be implied by this UI. They
+ * stay web-only. Someone who needs them is not blocked; they simply are not
+ * something Apple can sell.
+ *
+ * ── This list used to carry facts, and that is what changed ────────────────
+ *
+ * Each entry had a `detail` line — "4 vCPU, 150 active hours, 64 GB storage,
+ * 5 agents at once." — mirrored by hand from the billing catalog in the vibes
+ * repo. Those numbers were correct the day they were typed and unguardable
+ * forever after: this repo's answer to a necessary copy is a checker that reads
+ * both files (scripts/check-theme-drift.ts), and that only works INSIDE one
+ * repo. Across two there is no second file for CI to open, so the copy could
+ * only rot silently — on a paywall, where rotting means selling someone a
+ * machine they do not get.
+ *
+ * `specs: null` on every entry is therefore not an oversight. It is this module
+ * declining to have an opinion about hardware, and a test pins it that way.
+ *
+ * What remains is the minimum needed to sell anything at all against a control
+ * plane that publishes no catalog. Product ids are pinned by the backend
+ * (`OMG_APP_STORE_CONFIG.products`) and the two lists have to agree exactly: an
+ * id present here but unmapped there is a purchase the server rejects with
+ * "unmapped App Store productId" AFTER Apple has taken the money. When the
+ * server does send a catalog its ids win, and that mismatch stops being
+ * possible rather than merely being commented about.
+ */
+export const FALLBACK_TIERS: readonly CatalogTier[] = [
+  {
+    productId: "dev.omg.computer.computer_s20.monthly.v1",
+    plan: "computer_s20",
+    label: "Starter",
+    specs: null,
+  },
+  {
+    productId: "dev.omg.computer.computer_s40.monthly.v1",
+    plan: "computer_s40",
+    label: "Starter Plus",
+    specs: null,
+  },
+  {
+    productId: "dev.omg.computer.computer_5.monthly.v1",
+    plan: "computer_5",
+    label: "Personal",
+    specs: null,
+  },
+  {
+    productId: "dev.omg.computer.computer_10.monthly.v1",
+    plan: "computer_10",
+    label: "Pro",
+    specs: null,
+  },
+  {
+    productId: "dev.omg.computer.computer_20.monthly.v1",
+    plan: "computer_20",
+    label: "Always On",
+    specs: null,
+  },
+] as const;
+
+/**
+ * Name a plan key.
+ *
+ * Returns undefined rather than guessing: the server can report a plan this
+ * build has never heard of — a grandfathered rung, or one added after the
+ * binary shipped — and the caller decides whether to print the raw key or say
+ * nothing. A made-up label on a billing surface is the same class of mistake as
+ * a made-up spec.
+ */
+export function labelForPlan(
+  plan: string | null | undefined,
+  tiers: readonly CatalogTier[],
+): string | undefined {
+  if (!plan) return undefined;
+  return tiers.find((tier) => tier.plan === plan)?.label;
+}
+
+export function tierForProduct(
+  productId: string,
+  tiers: readonly CatalogTier[],
+): CatalogTier | undefined {
+  return tiers.find((tier) => tier.productId === productId);
+}
+
+/* ── The words. Copied from the dashboard on purpose; see the header. ─────── */
+
+/**
+ * "150 hours" / "40 min". Hours are whole at every real rung, but a wallet that
+ * genuinely buys some time must never round down to a bare "0 hours".
+ */
+export function formatComputeHours(hours: number): string {
+  if (hours <= 0) return "None included";
+  if (hours < 1) return `${Math.round(hours * 60)} min`;
+  const rounded = hours >= 10 ? Math.round(hours) : Math.round(hours * 10) / 10;
+  return `${rounded} hours`;
+}
+
+export function formatMemory(memoryMb: number): string {
+  return memoryMb >= 1024 ? `${memoryMb / 1024} GB` : `${memoryMb} MB`;
+}
+
+/** "4 vCPU · 8 GB" — the machine, as one unwrappable value. */
+export function formatMachine(specs: TierSpecs): string {
+  return `${specs.vcpus} vCPU · ${formatMemory(specs.memoryMb)}`;
+}
+
+/** "5 agents in parallel" / "1 agent in parallel". */
+export function formatParallelAgents(count: number): string {
+  return `${count} ${count === 1 ? "agent" : "agents"} in parallel`;
+}
+
+/**
+ * The dashboard's "Sleeps between tasks" row, but only for the rung that
+ * ANSWERS it differently.
+ *
+ * The web shows a single rung at a time, so it can afford this row on every one
+ * of them ("Yes" / "Never — always on"). This screen lists all five at once,
+ * where four identical "Yes" rows are noise — the shared behaviour is stated
+ * once, under the list, and only the rung that breaks it says so on its card.
+ * Null means "same as everything else here, don't repeat it".
+ */
+export function sleepsBetweenTasks(specs: TierSpecs): string | null {
+  return specs.alwaysOn ? "Never" : null;
+}

--- a/mobile/src/omg/store.ts
+++ b/mobile/src/omg/store.ts
@@ -50,75 +50,16 @@
 
 import { Platform } from "react-native";
 
-/** Products omg sells on iOS, in the order the paywall lists them. */
-export type Tier = {
-  /** App Store Connect product id. */
-  productId: string;
-  /** omg plan key the backend maps this product to. */
-  plan: string;
-  label: string;
-  /** One line of what you get. Prices are NEVER in here — see displayPrice. */
-  detail: string;
-};
+import { tierForProduct, type CatalogTier } from "./plan-specs";
 
 /**
- * The fixed computer tiers, and only those.
- *
- * StoreKit cannot charge a variable amount, so metered overage and credit
- * top-ups have no representation here and must not be implied by this UI. They
- * stay web-only. Someone who needs them is not blocked — they simply are not
- * something Apple can sell.
- *
- * Product ids are pinned by the backend (`AppStoreConfig.products`) and the two
- * lists have to agree exactly: an id present here but unmapped there is a
- * purchase the server rejects with "unmapped App Store productId" AFTER Apple
- * has taken the money.
- *
- * Labels and details mirror apps/web/src/lib/billing.ts so the two surfaces
- * describe the same product in the same words. Prices are the one thing NOT
- * mirrored — those come from StoreKit, because iOS pricing sits ~20% above web
- * to absorb Apple's commission and is set per-storefront in App Store Connect.
+ * A tier as the catalog describes it. Defined in plan-specs.ts, which has no
+ * platform imports — this module does (`Platform`), and anything importing
+ * react-native can only run inside Metro. Keeping the catalog out of here is
+ * what lets an ordinary Bun test assert that the bundle ships no spec numbers.
  */
-export const TIERS: readonly Tier[] = [
-  {
-    productId: "dev.omg.computer.computer_s20.monthly.v1",
-    plan: "computer_s20",
-    label: "Starter",
-    detail: "2 vCPU, 4 GB memory, 20 active hours, 3 agents at once.",
-  },
-  {
-    productId: "dev.omg.computer.computer_s40.monthly.v1",
-    plan: "computer_s40",
-    label: "Starter Plus",
-    detail: "2 vCPU, 4 GB memory, 40 active hours, 3 agents at once.",
-  },
-  {
-    productId: "dev.omg.computer.computer_5.monthly.v1",
-    plan: "computer_5",
-    label: "Personal",
-    detail: "4 vCPU, 150 active hours, 64 GB storage, 5 agents at once.",
-  },
-  {
-    productId: "dev.omg.computer.computer_10.monthly.v1",
-    plan: "computer_10",
-    label: "Pro",
-    detail: "8 vCPU, 300 active hours, 128 GB storage, 16 agents at once.",
-  },
-  {
-    productId: "dev.omg.computer.computer_20.monthly.v1",
-    plan: "computer_20",
-    label: "Always On",
-    detail: "Always-on 12 vCPU, 36 GB memory, 256 GB storage, 24 agents.",
-  },
-] as const;
+export type Tier = CatalogTier;
 
-export function tierForProduct(productId: string): Tier | undefined {
-  return TIERS.find((t) => t.productId === productId);
-}
-
-export function tierForPlan(plan: string | null | undefined): Tier | undefined {
-  return plan ? TIERS.find((t) => t.plan === plan) : undefined;
-}
 
 /** A tier joined with what Apple actually charges for it in this storefront. */
 export type StoreProduct = Tier & {
@@ -263,31 +204,39 @@ export async function connectStore(): Promise<void> {
 /**
  * The tiers Apple will actually sell, with Apple's prices.
  *
+ * Takes the catalog the SERVER published rather than reading a list in this
+ * bundle, so the skus asked of StoreKit are the same ids the server will accept
+ * a transaction for. Callers pass FALLBACK_TIERS when the server published
+ * none — see the note on that constant.
+ *
  * A product missing from the response is DROPPED rather than shown at a guessed
  * price. StoreKit omits unknown SKUs silently, and the usual cause is a product
  * that is not "Ready to Submit" in App Store Connect yet — showing it anyway
- * produces a row that cannot be bought.
+ * produces a row that cannot be bought. Note this drop is per-tier and
+ * independent of `specs`: Apple decides what is SELLABLE, omg decides what it
+ * CONTAINS, and neither is allowed to answer for the other.
  */
-export async function fetchTiers(): Promise<StoreProduct[]> {
+export async function fetchTiers(catalog: readonly Tier[]): Promise<StoreProduct[]> {
   if (isMockStore) {
     await mockDelay(700);
     if (MOCK === "empty") return [];
     if (MOCK === "error") throw new StoreError("The App Store didn't respond. Try again.");
     // Deliberately not USD, to prove the UI renders whatever Apple hands back
-    // rather than a dollar sign this app composed itself.
+    // rather than a dollar sign this app composed itself. These are fake HK$
+    // strings, NOT evidence that localisation works.
     const prices = ["HK$47.00", "HK$93.00", "HK$448.00", "HK$1,388.00", "HK$4,588.00"];
-    return TIERS.map((tier, i) => ({ ...tier, displayPrice: prices[i] ?? "HK$47.00" }));
+    return catalog.map((tier, i) => ({ ...tier, displayPrice: prices[i] ?? "HK$47.00" }));
   }
 
   const iap = nativeStore();
   if (!iap) throw new StoreError("In-app purchase isn't available in this build.");
   const products = (await iap.fetchProducts({
-    skus: TIERS.map((t) => t.productId),
+    skus: catalog.map((t) => t.productId),
     type: "subs",
   })) as unknown as { id?: string; displayPrice?: string }[];
 
   const byId = new Map((products ?? []).filter(Boolean).map((p) => [p.id ?? "", p]));
-  return TIERS.flatMap((tier) => {
+  return catalog.flatMap((tier) => {
     const product = byId.get(tier.productId);
     if (!product?.displayPrice) return [];
     return [{ ...tier, displayPrice: product.displayPrice }];
@@ -403,14 +352,16 @@ export async function purchaseTier(
  * the recovery route for a purchase whose submit failed, and for someone who
  * reinstalled or switched device.
  */
-export async function restoreTiers(): Promise<StorePurchase[]> {
+export async function restoreTiers(catalog: readonly Tier[]): Promise<StorePurchase[]> {
   if (isMockStore) {
     await mockDelay(1200);
     if (MOCK !== "owned") return [];
+    const restored = catalog[2] ?? catalog[0];
+    if (!restored) return [];
     return [
       {
-        productId: TIERS[2].productId,
-        signedTransaction: `mock.restore.${TIERS[2].productId}`,
+        productId: restored.productId,
+        signedTransaction: `mock.restore.${restored.productId}`,
         raw: { mock: true },
       },
     ];
@@ -423,7 +374,9 @@ export async function restoreTiers(): Promise<StorePurchase[]> {
   return (purchases ?? []).flatMap((purchase) => {
     const productId = String(purchase.productId ?? "");
     const signedTransaction = signedTransactionOf(purchase);
-    if (!signedTransaction || !tierForProduct(productId)) return [];
+    // Checked against the SERVER's catalog when there is one: a product this
+    // build has never heard of is still restorable if omg sells it today.
+    if (!signedTransaction || !tierForProduct(productId, catalog)) return [];
     return [{ productId, signedTransaction, raw: purchase }];
   });
 }

--- a/test/mobile-plan-specs.test.ts
+++ b/test/mobile-plan-specs.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The paywall's one safety rule, as tests: THE PHONE NEVER INVENTS A SPEC.
+ *
+ * These facts (vCPU, memory, disk, parallel agents, included hours, always-on)
+ * are owned by the control plane in the vibes repo, which can import all three
+ * of their owning modules directly. This repo cannot, and cannot run a drift
+ * checker across the boundary either — so the phone's protection is not "the
+ * copy is correct", it is "there is no copy, and a malformed payload renders as
+ * silence rather than as a number".
+ *
+ * Every test below is a way the server could hand over something wrong. The
+ * required answer is always the same: null, and a card that makes no claim.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatComputeHours,
+  formatMachine,
+  formatMemory,
+  formatParallelAgents,
+  FALLBACK_TIERS,
+  parseCatalogTiers,
+  parseTierSpecs,
+  sleepsBetweenTasks,
+} from "../mobile/src/omg/plan-specs";
+
+const PERSONAL = {
+  productId: "dev.omg.computer.computer_5.monthly.v1",
+  plan: "computer_5",
+  label: "Personal",
+  specs: {
+    parallelAgents: 5,
+    vcpus: 4,
+    memoryMb: 8192,
+    diskGb: 64,
+    computeHours: 150,
+    alwaysOn: false,
+  },
+};
+
+describe("the tier facts the server sends", () => {
+  test("a complete payload comes through unchanged", () => {
+    expect(parseTierSpecs(PERSONAL.specs)).toEqual({
+      parallelAgents: 5,
+      vcpus: 4,
+      memoryMb: 8192,
+      diskGb: 64,
+      computeHours: 150,
+      alwaysOn: false,
+    });
+  });
+
+  test("alwaysOn false is a fact, not a missing field", () => {
+    // The one field allowed to be falsy. Checking it for truth rather than for
+    // type would drop the specs of four of the five tiers.
+    expect(parseTierSpecs({ ...PERSONAL.specs, alwaysOn: false })?.alwaysOn).toBe(false);
+    expect(parseTierSpecs({ ...PERSONAL.specs, alwaysOn: true })?.alwaysOn).toBe(true);
+  });
+
+  test("ONE missing field drops the whole spec block", () => {
+    // Not five-sixths of a card. A spec card with a row quietly absent invites
+    // the reader to assume the row they cannot see.
+    for (const field of ["parallelAgents", "vcpus", "memoryMb", "diskGb", "computeHours", "alwaysOn"]) {
+      const partial: Record<string, unknown> = { ...PERSONAL.specs };
+      delete partial[field];
+      expect(parseTierSpecs(partial)).toBeNull();
+    }
+  });
+
+  test("zero, negative, NaN and stringified numbers are all refused", () => {
+    // A "0 vCPU" machine and a `"4"` that renders as 4 are both worse than
+    // saying nothing: they look exactly like real specs.
+    expect(parseTierSpecs({ ...PERSONAL.specs, vcpus: 0 })).toBeNull();
+    expect(parseTierSpecs({ ...PERSONAL.specs, diskGb: -64 })).toBeNull();
+    expect(parseTierSpecs({ ...PERSONAL.specs, computeHours: Number.NaN })).toBeNull();
+    expect(parseTierSpecs({ ...PERSONAL.specs, memoryMb: "8192" })).toBeNull();
+    expect(parseTierSpecs({ ...PERSONAL.specs, alwaysOn: "true" })).toBeNull();
+  });
+
+  test("an empty object is not a spec", () => {
+    // The contract says "all six fields or null". `{}` is the shape a server
+    // reaches for when it means null, and it must not read as one.
+    expect(parseTierSpecs({})).toBeNull();
+    expect(parseTierSpecs(null)).toBeNull();
+    expect(parseTierSpecs(undefined)).toBeNull();
+  });
+});
+
+describe("the catalog the server sends", () => {
+  test("no catalog and an empty catalog are different answers", () => {
+    // null  → this control plane does not publish a catalog; fall back to the
+    //         bundled product ids and show no specs.
+    // []    → omg sells nothing right now; say so.
+    // Collapsing these would make an old server look like a sold-out one.
+    expect(parseCatalogTiers(undefined)).toBeNull();
+    expect(parseCatalogTiers(null)).toBeNull();
+    expect(parseCatalogTiers({ tiers: [] })).toBeNull();
+    expect(parseCatalogTiers([])).toEqual([]);
+  });
+
+  test("order is preserved, because it is the ladder", () => {
+    const tiers = parseCatalogTiers([
+      { ...PERSONAL, plan: "computer_s20", label: "Starter" },
+      PERSONAL,
+      { ...PERSONAL, plan: "computer_20", label: "Always On" },
+    ]);
+    expect(tiers?.map((t) => t.label)).toEqual(["Starter", "Personal", "Always On"]);
+  });
+
+  test("a tier that cannot be bought or named is dropped", () => {
+    const tiers = parseCatalogTiers([
+      { plan: "computer_5", label: "Personal", specs: null }, // no productId
+      { productId: "x", label: "Personal", specs: null }, // no plan key
+      { productId: "x", plan: "computer_5", specs: null }, // no label
+      PERSONAL,
+    ]);
+    expect(tiers).toHaveLength(1);
+    expect(tiers?.[0]?.label).toBe("Personal");
+  });
+
+  test("a sellable tier with unusable specs still sells, it just says nothing", () => {
+    // The degradation that matters: the row is still buyable at Apple's price,
+    // and simply makes no claim about hardware.
+    const tiers = parseCatalogTiers([{ ...PERSONAL, specs: { vcpus: 4 } }]);
+    expect(tiers).toHaveLength(1);
+    expect(tiers?.[0]?.specs).toBeNull();
+  });
+});
+
+describe("the bundled fallback carries ids, never facts", () => {
+  test("every fallback tier has a null spec", () => {
+    // This is the invariant the whole design rests on. If someone ever pastes
+    // the numbers back into store.ts to "make the offline case nicer", this
+    // fails — and it should, because that copy cannot be drift-checked from
+    // this repo and would eventually sell a machine nobody gets.
+    for (const tier of FALLBACK_TIERS) {
+      expect(tier.specs).toBeNull();
+    }
+  });
+
+  test("the fallback still has enough to make a purchase attributable", () => {
+    expect(FALLBACK_TIERS.length).toBeGreaterThan(0);
+    for (const tier of FALLBACK_TIERS) {
+      expect(tier.productId).toMatch(/^dev\.omg\.computer\./);
+      expect(tier.plan).toBeTruthy();
+      expect(tier.label).toBeTruthy();
+    }
+  });
+
+  test("no price string is compiled into the bundle", () => {
+    // Apple's displayPrice is the only price this screen may render. Anything
+    // that looks like money here is wrong in most of the world.
+    for (const tier of FALLBACK_TIERS) {
+      expect(JSON.stringify(tier)).not.toMatch(/[$€£¥]|\d+\s*\/\s*mo/);
+    }
+  });
+});
+
+describe("the words, which are copied from the dashboard on purpose", () => {
+  test("hours read the way the web reads them", () => {
+    expect(formatComputeHours(20)).toBe("20 hours");
+    expect(formatComputeHours(750)).toBe("750 hours");
+    expect(formatComputeHours(1.5)).toBe("1.5 hours");
+  });
+
+  test("a wallet that buys real time never rounds down to nothing", () => {
+    // "0 hours" on a plan someone is about to pay for is a lie the rounding
+    // would tell for us.
+    expect(formatComputeHours(0.5)).toBe("30 min");
+    expect(formatComputeHours(0)).toBe("None included");
+  });
+
+  test("memory and machine match the dashboard's spec card", () => {
+    expect(formatMemory(4096)).toBe("4 GB");
+    expect(formatMemory(36864)).toBe("36 GB");
+    expect(formatMemory(512)).toBe("512 MB");
+    expect(formatMachine({ ...PERSONAL.specs })).toBe("4 vCPU · 8 GB");
+  });
+
+  test("agents are pluralised", () => {
+    expect(formatParallelAgents(1)).toBe("1 agent in parallel");
+    expect(formatParallelAgents(24)).toBe("24 agents in parallel");
+  });
+
+  test("only the always-on rung mentions sleeping", () => {
+    // Four identical "Yes" rows down a list of five is noise; the shared
+    // behaviour is stated once under the list instead.
+    expect(sleepsBetweenTasks({ ...PERSONAL.specs, alwaysOn: false })).toBeNull();
+    expect(sleepsBetweenTasks({ ...PERSONAL.specs, alwaysOn: true })).toBe("Never");
+  });
+});


### PR DESCRIPTION
Stacks on #115 (`feat/mobile-storekit-iap`) — base is that branch, not `main`.

## The problem

The paywall #115 added is five rows: a tier name, Apple's price, one line of prose. Someone can see that `computer_10` costs more than `computer_5` and cannot see what the extra money buys. No vCPU, no memory, no disk, no parallel agents, no included hours. The dashboard has said all of this for months.

**Before / after** — same five tiers, same Apple prices:

| before (#115) | after |
|---|---|
| `Personal` … `HK$448.00` | `Personal` · **5 agents in parallel** · `HK$448.00` |
| `4 vCPU, 150 active hours, 64 GB storage, 5 agents at once.` | Compute time **150 hours** · Machine **4 vCPU · 8 GB** · Disk **64 GB** |

## Where the tier facts come from, and why that changed

The five `detail` strings this PR deletes were correct the day they were typed. They were also **unguardable**. This repo's answer to a necessary copy is a checker that reads both sides — `scripts/check-theme-drift.ts` opens `web/src/index.css`, compares, and fails the build — and that only works INSIDE one repo. The billing catalog lives in `BennyKok/vibes`. There is no second file for CI here to open, so a copy could only ever rot silently, and on a paywall rotting means showing someone specs they are not buying.

So the facts now come from the control plane — which does not mirror them either. It can **import all three owners directly**:

| fact | owner (vibes) | web | control plane |
|---|---|---|---|
| vCPU / memory / disk / always-on | `control-plane/lib/computer-policy.ts` | mirrored | **imported** |
| parallel agents | `control-plane/lib/agent-concurrency.ts` | mirrored | **imported** |
| included hours | generated catalog Go already embeds | derived | **imported** |

That makes this payload strictly **more authoritative than `apps/web`'s own ladder**, which mirrors two of the three only because a browser bundle cannot reach them. The single mirror left anywhere is the Go `$/hour` rate card, and it now lives in one repo where a test can pin it against `catalog.go`.

The wire contract was agreed field by field with the control-plane side **before either half was written**. Vibes **#1432** implements it.

## The phone renders what it is handed, or it says nothing

`specs` is all six fields or JSON `null`. A partial payload is rejected **to** null rather than rendered with a gap, because a spec card with one row quietly missing invites the reader to assume the row they cannot see.

Backward compatibility is the load-bearing case, since #1432 is unmerged and **production does not serve these fields yet**:

| server says | phone shows |
|---|---|
| `tiers` absent — *today's deployed control plane* | five tiers, Apple's prices, **zero spec numbers** |
| `tiers: []` | "No plans available" — a real answer, not a missing one |
| `specs: null` on one tier | that tier sells, and claims nothing |
| full payload | the spec card |

The bundle keeps the five product ids, because StoreKit needs SKUs before any network call. Those now come from the server when it publishes them, retiring the failure #115 could only comment about: *"an id here but unmapped there is a purchase the server rejects AFTER Apple has taken the money."*

A test asserts every bundled tier has `specs: null`, so pasting the numbers back to "make the offline case nicer" **fails the build**. That is the difference between a rule and a comment about a rule.

## No slider — a deliberate deviation from the brief

The ask referenced the dashboard's slider by name. I did not reproduce it, and I think the reasoning holds.

The dashboard shows **one rung at a time** and makes moving between them the whole interaction: slider, ticks, spring onto each detent. That works because a mouse is bad at direct selection and good at scrubbing, and because the overlay owns the entire viewport.

Neither holds on a phone. The equivalent of "move between the rungs" that a thumb already does perfectly is **scroll** — the vertical scroll *is* this screen's slider, and it costs nothing to learn. Reproducing a drag control would have hidden four of five tiers behind a gesture nobody was told about, **on the one screen whose entire complaint is that you cannot see what you are buying**. That is the original problem in a new costume.

Same vocabulary as the web, different control. All five tiers are visible and comparable without touching anything, which a slider cannot do.

Two list-native edits to the web's spec card:
- The hero "N agents in parallel" becomes a **subtitle**. Five 40pt numbers down a scroll is five heroes and therefore none.
- **"Sleeps between tasks" appears only on the rung that answers it differently.** The web can afford that row on every rung because it shows one at a time; four identical "Yes" rows is noise. The shared behaviour is stated once, under the list.

## Already subscribed through Stripe

> **You're subscribed through omg.dev on the web**
> Your Personal plan is billed on the web, not through the App Store. Buying again here would charge you twice, so it's turned off.

States a fact, issues no instruction: no link, no URL, no imperative verb, no destination. 3.1.1(a) prohibits calls to action pointing at an external purchasing mechanism, and #114 removed `"Fix this on omg.dev"` for exactly that even though it only opened the dashboard root. Saying where billing already lives is not a call to action; telling someone to go there is.

The second sentence stays because the first alone does not explain why the cards below cannot be tapped, and an unexplained dead control is what #115 set out to avoid. It describes *this* screen's behaviour, not somewhere else's.

## Verification — SEEN, per `mobile/AGENTS.md`

Driven on the **iPhone 17 Pro** simulator against a mock that feeds raw JSON in the agreed shape through the **same parser the network path uses**, so looking at the screen exercises the real parser rather than a shortcut around it.

| state | result |
|---|---|
| full catalog, all five tiers | ✅ specs render; 750 hours / 12 vCPU · 36 GB / always-on on the top rung |
| **`tiers` absent — today's control plane** | ✅ five sellable tiers, Apple's prices, **not one invented number** |
| already subscribed via Stripe | ✅ new wording; current plan outlined, specs still readable |
| light mode | ✅ |
| purchase complete | ✅ "You're all set" naming the plan from the server catalog |

`tsc --noEmit` clean. 17 new tests, 65 assertions.

**Not verified, and stated rather than implied:** a real purchase (needs a signed build and a StoreKit sandbox account); the live endpoint (#1432 unmerged); and the mid-purchase spinner — its logic is unchanged from #115, only its container moved, and the dev client's bundle re-download made that window unreliable to capture. I discarded those frames rather than ship a screenshot that showed a loading screen.

⚠️ The mock's `HK$` prices are **hardcoded** to prove the UI composes no currency of its own. They are not evidence that localisation works.
