### PR TITLE
feat(mobile): auto agents get a section on the home screen

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -13,26 +13,90 @@ with no port forwarding and no VPN setup:
 ssh bennykok@bennys-macbook-pro-2 'xcrun simctl list devices booted'
 ```
 
+## `booted` IS A COIN FLIP WHEN TWO DEVICES ARE UP. PIN THE UDID.
+
+Every `simctl` example below says `booted`, and that word resolves to *a*
+booted device, not *the* one you mean. More than one simulator is routinely
+up on this Mac — agents work in parallel and each leaves its device running —
+and then `booted` silently picks one.
+
+**The failure mode is silent and it does not look like a device mix-up.** On
+2026-08-16 one agent screenshotted with bare `booted`, computed tap
+coordinates from that image, and the taps did nothing. It re-derived the
+window origin (unchanged), concluded its calibration was fine, and gave up —
+it had been reading one device and clicking the other. A second agent hit the
+same ambiguity from the other side: `get_app_container booted dev.omg.computer`
+answered for the Pro Max while it was reasoning about the Pro. Both commands
+succeed. Both return real, plausible output. They just refer to different
+screens.
+
+So resolve the UDID once and pass it explicitly to every command:
+
+```bash
+# Pick the device by NAME, then use its UDID everywhere. Never bare `booted`.
+PRO=$(ssh bennykok@bennys-macbook-pro-2 \
+  "xcrun simctl list devices booted | awk '/iPhone 17 Pro \(/{print \$NF}'" | tr -d '()')
+ssh bennykok@bennys-macbook-pro-2 "xcrun simctl io $PRO screenshot /tmp/s.png"
+```
+
+Cheap independent check: the screenshot's pixel dimensions identify the model.
+iPhone 17 Pro is **1206x2622**, 17 Pro Max is **1320x2868**. If you are unsure
+which device you just captured, measure it rather than assume.
+
+**The device is shared.** Before you point it at your tunnel, check whether
+another Metro/tunnel is live (`ss -lntp | grep 809`, and the ngrok APIs below);
+say so when you take it, and hand it back when you are done. Re-pointing a
+device someone else is mid-run on makes them screenshot *your* build.
+
 Full loop — Metro here, simulator there:
 
 ```bash
 # 1. Metro needs --tunnel: the Mac cannot reach this box's localhost.
-cd mobile && npx expo start --tunnel --port 8081 > /tmp/metro.log 2>&1 &
+#    PICK AN UNUSED PORT — 8081 is the default and is usually already taken by
+#    another agent's worktree. Check first: ss -lntp | grep 80
+cd mobile && npx expo start --tunnel --port 8095 > /tmp/metro8095.log 2>&1 &
 
 # 2. Get the tunnel URL (it is NOT printed to the log).
-curl -s localhost:4040/api/tunnels | python3 -c \
-  "import json,sys;print(json.load(sys.stdin)['tunnels'][0]['public_url'])"
+#    NOT necessarily :4040 — that is ngrok's api port for the FIRST tunnel on
+#    the box, and every later one takes 4041, 4042, ... Scan, and match on your
+#    own port number rather than taking tunnels[0] blindly.
+for p in 4040 4041 4042 4043; do
+  curl -s --max-time 3 localhost:$p/api/tunnels \
+    | python3 -c "import json,sys;[print(t['public_url']) for t in json.load(sys.stdin)['tunnels']]" 2>/dev/null
+done | grep -m1 '^https.*-8095\.'
 
 # 3. Point the dev client at it. The scheme is `omg` (app.json -> expo.scheme),
 #    NOT `omgdev` — the bundle id is dev.omg.computer and confusing the two
-#    gives a useless `OSStatus error -10814`.
-ssh bennykok@bennys-macbook-pro-2 \
-  'xcrun simctl openurl booted "omg://expo-development-client/?url=<TUNNEL_URL_ENCODED>"'
+#    gives a useless `OSStatus error -10814`. URL-ENCODE the tunnel url.
+#    Terminate the app first or the dev client refuses with "Current Endpoint".
+ssh bennykok@bennys-macbook-pro-2 "xcrun simctl terminate $PRO dev.omg.computer;
+  xcrun simctl openurl $PRO 'omg://expo-development-client/?url=<TUNNEL_URL_ENCODED>'"
 
-# 4. Wait for `iOS Bundled` in /tmp/metro.log, then LOOK.
-ssh bennykok@bennys-macbook-pro-2 'xcrun simctl io booted screenshot /tmp/s.png'
+# 4. Wait for `iOS Bundled` in the log, then LOOK.
+ssh bennykok@bennys-macbook-pro-2 "xcrun simctl io $PRO screenshot /tmp/s.png"
 scp bennykok@bennys-macbook-pro-2:/tmp/s.png /tmp/s.png
 ```
+
+## Tapping: there is no `simctl tap`. Calibrate off the accessibility tree.
+
+`simctl` cannot synthesise touches and `idb` is not installed on this Mac.
+Drive the Simulator window with CGEvent instead, and get the mapping from the
+Simulator's own accessibility tree rather than guessing the bezel inset — the
+window's `group` element is the device surface reported at **1:1 in device
+points**, so `screen = group.origin + device_point`:
+
+```bash
+# Read the group's origin/size (size should equal the device's logical points,
+# e.g. 440x956 on a 17 Pro Max — the 1320x2868 screenshot divided by scale 3).
+ssh bennykok@bennys-macbook-pro-2 'osascript -e "tell application \"System Events\"
+  to tell process \"Simulator\" to get {position, size} of (UI elements of
+  (first window whose name contains \"Pro Max\") whose role description is \"group\")"'
+```
+
+Then post `kCGEventLeftMouseDown`/`Up` at `origin + point` via Quartz. Convert
+a screenshot pixel to a device point by dividing by the scale factor (3 on
+these devices). Raise the right window first (`AXRaise`) — clicks go to
+whatever is under the coordinate, not to a device id.
 
 Fast refresh applies edits in a couple of seconds, so the probe-and-look loop
 below is cheap. Use it instead of reasoning about what UIKit "should" do.

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -14,7 +14,7 @@
 import { useFocusEffect, useNavigation, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Pressable, RefreshControl, ScrollView, View } from "react-native";
+import { Linking, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import Reanimated, { useAnimatedKeyboard, useAnimatedStyle } from "react-native-reanimated";
 import { Text } from "../src/omg/text";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -38,8 +38,11 @@ import {
   sessionStableId,
   type SessionNode,
 } from "../src/omg/session-tree";
+import { AutoAgentCard } from "../src/omg/auto-agent-card";
+import { selectHomeAutoAgents, useAutoAgents } from "../src/omg/auto-agents";
 import { useComputerPicker } from "../src/omg/computer-picker";
 import { useDictation } from "../src/omg/dictation";
+import { PressableScale } from "../src/omg/motion";
 import { useResumable } from "../src/omg/resumable";
 import { useUsage } from "../src/omg/usage";
 import { LucideIcon } from "../src/omg/lucide";
@@ -330,6 +333,12 @@ export default function SessionsScreen() {
   // to a box too old to have that endpoint.
   const { providers: usage, loading: usageLoading } = useUsage();
   const { sessions: resumable, refresh: refreshResumable } = useResumable();
+  const {
+    agents: autoAgents,
+    findings: autoFindings,
+    tz: autoTz,
+    refresh: refreshAuto,
+  } = useAutoAgents();
   const agentPicker = useAgentPicker();
   const projectPicker = useProjectPicker();
 
@@ -344,6 +353,12 @@ export default function SessionsScreen() {
    * nobody asked, the answer is silence.
    */
   const [pulling, setPulling] = useState(false);
+  /**
+   * Which auto agent is opened out to show its findings. ONE at a time: a
+   * finding carries four reasoning bullets and a suggestion, so two open at
+   * once push the Recent section off the bottom of a phone.
+   */
+  const [expandedAuto, setExpandedAuto] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const toast = useToast();
   useEffect(() => {
@@ -550,6 +565,33 @@ export default function SessionsScreen() {
         }),
     );
   }, [resumable, sessions, projectPicker]);
+
+  /**
+   * THE SCHEDULED FLEET, FILTERED DOWN TO THE PART THAT IS NEWS.
+   *
+   * Auto agents obey the project filter like everything else on this screen —
+   * the machine already resolves each one's owning repo (worktree cwds
+   * collapse; see withAutoAgentMeta), so the chip that hides another repo's
+   * sessions has to hide its schedules too, or the filter half-works.
+   *
+   * `selectHomeAutoAgents` then keeps only the ones with an open finding or a
+   * run in flight; `autoQuiet` is how many were left out. That number is
+   * printed rather than swallowed: this box has 34 auto agents and shows a
+   * handful, and a section that silently drops 26 rows teaches you not to
+   * trust the ones it kept.
+   */
+  const autoScoped = useMemo(
+    () =>
+      autoAgents.filter((agent) =>
+        projectPicker.matches({ project: agent.project ?? undefined, cwd: agent.cwd ?? undefined }),
+      ),
+    [autoAgents, projectPicker],
+  );
+  const autoRows = useMemo(
+    () => selectHomeAutoAgents(autoScoped, autoFindings),
+    [autoScoped, autoFindings],
+  );
+  const autoQuiet = autoScoped.length - autoRows.length;
 
   const openSession = (id: string | null) => {
     if (!id) return;
@@ -844,6 +886,7 @@ export default function SessionsScreen() {
             onRefresh={() => {
               setPulling(true);
               refreshResumable();
+              refreshAuto();
               void Promise.all([probe(), load(true)]).finally(() => setPulling(false));
             }}
             tintColor={colors.textMuted}
@@ -988,6 +1031,78 @@ export default function SessionsScreen() {
                       onArchive={archiveSession}
                     />
                   ))}
+                </View>
+              </>
+            ) : null}
+
+            {/**
+             * THE WORK NOBODY ASKED FOR TODAY.
+             *
+             * Auto agents run on a timer and report findings; they are not
+             * sessions, so they do not belong in Working or Idle, where a tap
+             * opens a transcript and a swipe archives — see auto-agents.ts.
+             * Their own section, ADDED rather than substituted: the three
+             * above are untouched.
+             *
+             * BETWEEN Idle AND Recent, and that position is the argument.
+             * Working and Idle are happening now. Recent is finished and
+             * read-only. An open finding is neither — it is unfinished
+             * business that nothing is currently working on, which is exactly
+             * the gap between the two, and putting it below Recent would bury
+             * the only actionable thing on the screen under a log.
+             *
+             * Blue, matching the tint the web gives findings ("N open" in
+             * `text-primary`) and staying clear of the amber/green/grey the
+             * three session sections have already claimed.
+             */}
+            {autoRows.length ? (
+              <>
+                <SectionHeader
+                  label="Auto agents"
+                  count={autoRows.length}
+                  dotColor={colors.primary}
+                />
+                <View style={{ gap: space.sm }}>
+                  {autoRows.map((row) => (
+                    <AutoAgentCard
+                      key={row.agent.id}
+                      row={row}
+                      tz={autoTz}
+                      expanded={expandedAuto === row.agent.id}
+                      onToggle={() =>
+                        setExpandedAuto((current) =>
+                          current === row.agent.id ? null : row.agent.id,
+                        )
+                      }
+                    />
+                  ))}
+                  {/* SAY WHAT IS NOT HERE, AND OPEN IT.
+                      The count is the difference between "these are your auto
+                      agents" (a lie) and "these are the ones with something to
+                      say". As dead text it would still be a cul-de-sac — 26
+                      agents named and no way to reach them — so it hands off
+                      to the web the way the rest of the app does when it runs
+                      out of road (settings.tsx, computers.tsx). The phone has
+                      no editor for a prompt-and-cron; the web page it opens is
+                      the same one this section mirrors. */}
+                  {autoQuiet > 0 ? (
+                    <PressableScale
+                      onPress={() =>
+                        void Linking.openURL("https://app.omg.dev/settings/computer/auto")
+                      }
+                      scale={0.98}
+                      accessibilityRole="link"
+                      style={{ paddingHorizontal: space.lg, paddingTop: space.xs }}
+                    >
+                      <Text style={{ ...type.caption, color: colors.textMuted }}>
+                        {autoQuiet} more {autoQuiet === 1 ? "agent is" : "agents are"} on a
+                        schedule with nothing open ·{" "}
+                        <Text style={{ ...type.caption, color: colors.primary }}>
+                          Manage schedules
+                        </Text>
+                      </Text>
+                    </PressableScale>
+                  ) : null}
                 </View>
               </>
             ) : null}

--- a/mobile/scripts/check-cron-drift.ts
+++ b/mobile/scripts/check-cron-drift.ts
@@ -1,0 +1,143 @@
+/**
+ * Fail if the native cron helpers have drifted from the web ones.
+ *
+ * src/omg/cron.ts is a hand-maintained port of web/src/cron.ts, because
+ * mobile/ is not a workspace member and cannot import from web/. Same shape,
+ * and same reasoning, as scripts/check-attachment-drift.ts: a copy with no
+ * guard is a copy that silently rots, and the failure mode here is quiet
+ * rather than loud — the phone would keep rendering a schedule label that is
+ * merely WRONG, which nobody reports as a bug because it still looks like a
+ * schedule.
+ *
+ * The comparison is BEHAVIOURAL, not textual. Comparing source would fail on a
+ * reworded comment while passing a real semantic change made in both files at
+ * once. It also has to be, because the port is a strict subset: the picker
+ * half of web/src/cron.ts (buildCron/parseToSimple) drives an editor the phone
+ * does not have, so only the exports the phone actually uses are checked.
+ *
+ * `from` is pinned rather than Date.now() so a run at 23:59 cannot fail on a
+ * date rolling over between the two calls, and so a failure reproduces.
+ *
+ * Run: bun run scripts/check-cron-drift.ts
+ */
+
+import * as native from "../src/omg/cron";
+
+const WEB_PATH = new URL("../../web/src/cron.ts", import.meta.url).pathname;
+
+if (!(await Bun.file(WEB_PATH).exists())) {
+  console.error(`Could not read ${WEB_PATH} — is the web workspace present?`);
+  process.exit(2);
+}
+
+const web = (await import(WEB_PATH)) as typeof native;
+
+/**
+ * Every expression shape the describer recognises, every one it deliberately
+ * refuses, and the real schedules currently on the box — because the shapes a
+ * human types in the picker are not the only shapes that reach this code. The
+ * half-hourly-within-a-range and multi-hour-list cases below are live agents,
+ * and both fall through to the raw-expression fallback; if a future edit
+ * "improves" one of them on only one side, that is exactly the drift this
+ * catches.
+ */
+const CASES: string[] = [
+  "",
+  "   ",
+  "not a cron",
+  "0 11 * * *",
+  "0 9 * * *",
+  "*/30 * * * *",
+  "*/1 * * * *",
+  "*/10 * * * *",
+  "*/20 * * * *",
+  "0 * * * *",
+  "25 * * * *",
+  "15 * * * *",
+  "0 */6 * * *",
+  "15 */6 * * *",
+  "15 */4 * * *",
+  "0 */1 * * *",
+  "30 9 * * 1-5",
+  "0 9 * * 0,6",
+  "0 10 * * 1",
+  "0 9 * * 1",
+  "50 8 * * 1",
+  "0 9 * * 1,3,5",
+  "10 10 1 * *",
+  "0 0 21 * *",
+  "0 0 22 * *",
+  "0 0 23 * *",
+  // Live schedules that the describer cannot express and must pass through raw.
+  "*/30 8-23 * * *",
+  "0 8,13,18 * * *",
+  "35 8 * * *",
+  "10 9 * * *",
+  "20 9 * * *",
+  "40 9 * * *",
+  "45 9 * * *",
+  "0 14 * * *",
+  "0 11 15 6 *",
+  // Field syntax that only the matcher sees.
+  "0 0 * * 7",
+  "5,35 * * * *",
+  "0 9-17 * * *",
+  "0 0 1,15 * *",
+  // Too many / too few fields.
+  "0 11 * *",
+  "0 11 * * * *",
+];
+
+const TZS = ["Asia/Hong_Kong", "UTC", "America/Los_Angeles", "Europe/London", "Pacific/Kiritimati"];
+
+// A fixed instant: 2026-08-16T04:00:00Z. Late enough in the UTC day that the
+// Hong Kong and Los Angeles calendar dates differ, which is the case a
+// timezone bug in either copy would show up on.
+const FROM = Date.UTC(2026, 7, 16, 4, 0, 0);
+
+const LOCALES = [undefined, "en-US", "de-DE"];
+
+let failures = 0;
+function check(what: string, a: unknown, b: unknown) {
+  if (Object.is(a, b)) return;
+  failures++;
+  console.error(`DRIFT ${what}\n  native: ${JSON.stringify(a)}\n  web:    ${JSON.stringify(b)}`);
+}
+
+for (const expr of CASES) {
+  check(`isValidCron(${JSON.stringify(expr)})`, native.isValidCron(expr), web.isValidCron(expr));
+
+  for (const locale of LOCALES) {
+    check(
+      `describeCron(${JSON.stringify(expr)}, ${JSON.stringify(locale)})`,
+      native.describeCron(expr, locale),
+      web.describeCron(expr, locale),
+    );
+  }
+
+  for (const tz of TZS) {
+    check(
+      `nextRunAt(${JSON.stringify(expr)}, ${tz})`,
+      native.nextRunAt(expr, tz, FROM),
+      web.nextRunAt(expr, tz, FROM),
+    );
+    // Probe the matcher directly across a day, so an off-by-one in a field
+    // that nextRunAt happens to step over still gets seen.
+    for (let h = 0; h < 24; h += 3) {
+      const d = new Date(FROM + h * 3_600_000);
+      check(
+        `cronMatches(${JSON.stringify(expr)}, +${h}h, ${tz})`,
+        native.cronMatches(expr, d, tz),
+        web.cronMatches(expr, d, tz),
+      );
+    }
+  }
+}
+
+check("DEFAULT_SCHED_TZ", native.DEFAULT_SCHED_TZ, web.DEFAULT_SCHED_TZ);
+
+if (failures) {
+  console.error(`\n${failures} difference(s) between mobile/src/omg/cron.ts and web/src/cron.ts.`);
+  process.exit(1);
+}
+console.log(`cron port matches web/src/cron.ts (${CASES.length} expressions × ${TZS.length} zones).`);

--- a/mobile/scripts/check-cron-drift.ts
+++ b/mobile/scripts/check-cron-drift.ts
@@ -18,6 +18,20 @@
  * `from` is pinned rather than Date.now() so a run at 23:59 cannot fail on a
  * date rolling over between the two calls, and so a failure reproduces.
  *
+ * WHEN IT FAILS, IT MAY FAIL SLOWLY — THAT IS NOT THE SCRIPT HANGING.
+ * A green run takes a few seconds, because every expression here matches
+ * something soon. But a break in the MATCHER (fieldMatch/cronMatches) or in
+ * isValidCron can make an expression match nothing, and nextRunAt then scans
+ * its full 400-day budget — ~576k minutes, each a formatToParts — on BOTH
+ * implementations across all five zones before it can report the difference.
+ * Measured: two such perturbations each ran past 2 minutes. So give it a
+ * generous timeout, and if you are killing it to "fix" a hang, read the
+ * partial DRIFT lines first — the answer is usually already printed.
+ * (Verified 2026-08-16 by perturbing one side four ways — an off-by-one in
+ * nextRunAt's start minute, an exclusive bound in fieldMatch's range-step, a
+ * describeCron wording change, and DEFAULT_SCHED_TZ — and confirming each was
+ * caught rather than trusting that it would be.)
+ *
  * Run: bun run scripts/check-cron-drift.ts
  */
 

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -1,0 +1,310 @@
+/**
+ * One auto agent as a home-screen row, and its findings underneath when you
+ * open it.
+ *
+ * WHY THIS IS NOT A SessionCard. The two look alike on purpose — same card
+ * shape, same agent mark, same density — because they sit in the same list and
+ * a person should not have to learn a second visual language halfway down the
+ * screen. But the affordances are different and must not be borrowed: there is
+ * no transcript to push to, and nothing to swipe away. A SessionCard whose tap
+ * did something else would be the worse kind of consistency.
+ *
+ * WHAT A ROW SAYS, AND WHY IT SAYS THAT.
+ *
+ * Matching the web's row (AutoManageView in web/src/App.tsx) is the bar, so
+ * the vocabulary is lifted from it: the agent's NAME, an "N open" chip in the
+ * primary tint, the running state, and the schedule rendered by the same
+ * describeCron + "next …" pair its ScheduleSummary uses. Two deliberate
+ * differences, both because a phone row is one line wide and the home screen
+ * is a reading surface rather than an editing one:
+ *
+ * - The web's subtitle is the agent's PROMPT. Here it is the newest open
+ *   FINDING's title. The prompt is what you need when you are editing the
+ *   agent; the finding is what you need when you are deciding whether to care,
+ *   and it is also the reason the row is on this screen at all. (The prompt
+ *   arrives truncated from the server anyway — `promptTruncated` — so the row
+ *   would have shown half a sentence.)
+ * - Severity has no chip. It colours the dot in front of the finding title,
+ *   which adds a fact the web's own list omits without spending a second
+ *   badge on it.
+ *
+ * TAPPING OPENS IT IN PLACE. Nothing else on the phone lists findings, so a
+ * row that advertises "2 open" and cannot show them is a tease. Expanding is
+ * also all a read-only surface can honestly offer: dismiss/resolve/launch are
+ * real mutations with a lifecycle behind them (see FindingStatus in
+ * src/auto/store.ts) and belong to a screen that can do the whole loop.
+ *
+ * MOTION: `useListItemMotion()` and nothing else — no `exiting`, ever. See the
+ * long note in motion.tsx. The expansion below is exactly the "a re-render
+ * lands mid-animation" case that stranded views: it changes this row's height
+ * while a 10s poll may be resizing its siblings, and it is safe only because
+ * `entering` and `layout` both END with the view in its correct flow position.
+ */
+
+import { useRef } from "react";
+import Reanimated from "react-native-reanimated";
+import { View } from "react-native";
+
+import { AgentAvatar } from "../components";
+import { Text } from "./text";
+import { useListItemMotion, PressableScale } from "./motion";
+import { useTheme } from "./theme";
+import { describeCron, nextRunAt } from "./cron";
+import type { AutoAgentRow, AutoFinding, AutoFindingSeverity } from "./auto-agents";
+
+/**
+ * "in 3h", "in 2d" — the future half of format.ts's relativeTime, in the same
+ * compact register.
+ *
+ * Deliberately NOT web/src/cron.ts's formatRelative, which is built on
+ * `Intl.RelativeTimeFormat`. The web can assume a full-ICU browser; Hermes'
+ * Intl coverage is thinner and varies by platform, and the failure mode is a
+ * throw on a row that is otherwise fine. The phone already spells relative
+ * time itself for the Recent section, so this matches that instead of adding
+ * a second, wordier style ("in 3 hours") three lines below it.
+ */
+function nextRunLabel(at: number, now: number = Date.now()): string {
+  const seconds = Math.round((at - now) / 1000);
+  if (seconds <= 60) return "in <1m";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.round(hours / 24);
+  return `in ${days}d`;
+}
+
+/**
+ * The schedule, the way the web's ScheduleSummary says it.
+ *
+ * A DISABLED agent never gets a "next" — it appears on this screen only
+ * because it left an open finding behind, and telling someone it runs again in
+ * three hours when it will never run again is the kind of small lie that makes
+ * a whole screen untrustworthy. It says "Paused" and keeps the cadence for
+ * context.
+ *
+ * Both calls are wrapped: they go through `Intl.DateTimeFormat` with a
+ * timezone and `formatToParts`, and a device whose ICU cannot do that should
+ * lose the "next in 3h" clause, not the row.
+ *
+ * NEXT-RUN IS CACHED, AND CACHED CORRECTLY. nextRunAt scans forward a minute
+ * at a time for up to 400 days, so a daily agent costs ~1440 formatToParts
+ * calls; the list polls every 30s, and recomputing every row on every poll is
+ * the exact lag the web's own ScheduleSummary comment warns about.
+ *
+ * The cache is TAGGED with the schedule+timezone it was computed for and
+ * checked during render, rather than cached in state and invalidated from an
+ * effect. An effect runs after commit, so the frame where an agent's schedule
+ * changes would render the OLD agent's next-run — a stale value that is merely
+ * scheduled for deletion is still a stale value that reached the screen. A tag
+ * that does not match is unusable rather than pending. (Same failure the
+ * composer's pill-width cache had.)
+ *
+ * The second condition is what the web gets from its 30s tick: once the cached
+ * instant is in the past, it is recomputed. Everything else reuses it.
+ */
+function useScheduleLine(schedule: string, enabled: boolean, tz: string): string {
+  const cache = useRef<{ key: string; at: number | null } | null>(null);
+  const now = Date.now();
+  const key = `${schedule}|${tz}`;
+  if (!cache.current || cache.current.key !== key || (cache.current.at ?? Infinity) <= now) {
+    let at: number | null = null;
+    try {
+      at = nextRunAt(schedule, tz, now);
+    } catch {
+      at = null;
+    }
+    cache.current = { key, at };
+  }
+
+  let described: string;
+  try {
+    described = describeCron(schedule);
+  } catch {
+    described = schedule.trim();
+  }
+  if (!enabled) return `Paused · ${described}`;
+  const at = cache.current.at;
+  return at ? `${described} · next ${nextRunLabel(at, now)}` : described;
+}
+
+function severityColor(
+  severity: AutoFindingSeverity | undefined,
+  colors: ReturnType<typeof useTheme>["colors"],
+): string {
+  switch (severity) {
+    case "high":
+      return colors.danger;
+    case "med":
+      return colors.warning;
+    default:
+      return colors.textMuted;
+  }
+}
+
+/** The severity dot. 7pt: reads next to 13pt text without becoming a bullet. */
+function SeverityDot({ severity }: { severity?: AutoFindingSeverity }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        width: 7,
+        height: 7,
+        borderRadius: 3.5,
+        marginTop: 5,
+        backgroundColor: severityColor(severity, colors),
+      }}
+    />
+  );
+}
+
+/** One open finding, expanded: what it found, why, and what it suggests. */
+function FindingDetail({ finding }: { finding: AutoFinding }) {
+  const { colors, type, space } = useTheme();
+  const seen = finding.occurrences ?? 1;
+  return (
+    <View style={{ flexDirection: "row", gap: space.sm }}>
+      <SeverityDot severity={finding.severity} />
+      <View style={{ flex: 1, gap: space.xs }}>
+        <Text style={{ ...type.footnote, fontWeight: "600", color: colors.text, lineHeight: 18 }}>
+          {finding.title}
+        </Text>
+        {/* A repeat is the strongest signal a finding carries — the same
+            problem reported N times is not N times as noisy, it is N times as
+            real. src/auto/store.ts tracks it precisely because a recurrence
+            that reads as brand new gets triaged as brand new. */}
+        {seen > 1 ? (
+          <Text style={{ ...type.caption, color: colors.warning }}>seen {seen}×</Text>
+        ) : null}
+        {finding.reasoning?.length ? (
+          <View style={{ gap: 2 }}>
+            {finding.reasoning.map((line, i) => (
+              <Text
+                key={i}
+                style={{ ...type.caption, color: colors.textMuted, lineHeight: 17 }}
+              >
+                {`· ${line}`}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+        {finding.suggest ? (
+          <Text style={{ ...type.caption, color: colors.textSecondary, lineHeight: 17 }}>
+            <Text style={{ ...type.caption, color: colors.primary }}>Suggests </Text>
+            {finding.suggest}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export function AutoAgentCard({
+  row,
+  tz,
+  expanded,
+  onToggle,
+}: {
+  row: AutoAgentRow;
+  /** The MACHINE's schedule timezone. See cron.ts. */
+  tz: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const { colors, radius, type, space } = useTheme();
+  // Outer, style-less view owns list membership, exactly as SessionCard does —
+  // press feedback and list motion are different concerns with different
+  // lifetimes.
+  const listMotion = useListItemMotion();
+  const { agent, findings } = row;
+  const headline = findings[0];
+  const open = findings.length;
+  const schedule = useScheduleLine(agent.schedule, agent.enabled, tz);
+
+  return (
+    <Reanimated.View entering={listMotion.entering} layout={listMotion.layout}>
+      <PressableScale
+        onPress={onToggle}
+        scale={0.98}
+        accessibilityRole="button"
+        accessibilityLabel={`${agent.name}, ${open} open finding${open === 1 ? "" : "s"}`}
+        accessibilityState={{ expanded }}
+        style={({ pressed }) => ({
+          flexDirection: "row",
+          gap: space.md,
+          marginHorizontal: space.lg,
+          padding: space.md,
+          borderRadius: radius.xl,
+          borderWidth: 1,
+          borderColor: colors.borderStrong,
+          backgroundColor: pressed ? colors.cardPressed : colors.card,
+        })}
+      >
+        {/* The ring around the mark is how "working" reads everywhere else in
+            this app, and a scheduled run in flight is the same fact. */}
+        <AgentAvatar agent={agent.agent} size={26} plain busy={!!agent.running} />
+        <View style={{ flex: 1, gap: 3 }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
+            <Text numberOfLines={1} style={{ ...type.headline, color: colors.text, flexShrink: 1 }}>
+              {agent.name}
+            </Text>
+            {/* "N open" — the web's words, in the web's tint. */}
+            {open ? (
+              <View
+                style={{
+                  paddingHorizontal: 6,
+                  paddingVertical: 1,
+                  borderRadius: radius.pill,
+                  backgroundColor: colors.accentSoft,
+                }}
+              >
+                <Text
+                  style={{
+                    ...type.caption,
+                    fontSize: 10,
+                    fontWeight: "600",
+                    color: colors.primary,
+                  }}
+                >
+                  {open} open
+                </Text>
+              </View>
+            ) : null}
+            {/* An agent with no findings is here only because it is running,
+                and the ring alone does not say so in words. */}
+            {!open && agent.running ? (
+              <Text style={{ ...type.caption, color: colors.warning }}>running</Text>
+            ) : null}
+          </View>
+
+          {headline && !expanded ? (
+            <View style={{ flexDirection: "row", gap: space.sm }}>
+              <SeverityDot severity={headline.severity} />
+              <Text
+                numberOfLines={2}
+                style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
+              >
+                {headline.title}
+              </Text>
+            </View>
+          ) : null}
+
+          {expanded && findings.length ? (
+            <View style={{ gap: space.md, paddingTop: space.xs }}>
+              {findings.map((finding) => (
+                <FindingDetail key={finding.id} finding={finding} />
+              ))}
+            </View>
+          ) : null}
+
+          {/* The schedule stays on every row, expanded or not: it is the one
+              fact that makes this an AUTO agent rather than a session, and it
+              answers "when do I get a better answer than this one". */}
+          <Text numberOfLines={1} style={{ ...type.caption, color: colors.textMuted }}>
+            {schedule}
+          </Text>
+        </View>
+      </PressableScale>
+    </Reanimated.View>
+  );
+}

--- a/mobile/src/omg/auto-agents.ts
+++ b/mobile/src/omg/auto-agents.ts
@@ -1,0 +1,220 @@
+/**
+ * Auto agents — the ones that run on a timer instead of because you asked.
+ *
+ * An auto agent is JUST a prompt plus a cron schedule (see src/auto/store.ts).
+ * It is NOT a session: it has no transcript, nothing to resume, and nothing to
+ * archive. What it produces is a FINDING — one notification, at most, per run,
+ * carrying its reasoning and a lifecycle. That distinction is the whole reason
+ * these get their own section on the home screen rather than being folded into
+ * Working/Idle, where tapping a row opens a transcript and swiping one
+ * archives a session; both of those would be lies here.
+ *
+ * WHAT THE HOME SCREEN IS FOR, AND WHY THIS LIST IS FILTERED.
+ *
+ * This box has 34 auto agents. Rendering all of them would put ~2000pt of
+ * configuration under the three sections that show live work, which is the
+ * opposite of what the screen is for — and it is not what the web does either:
+ * the web keeps the full roster on a MANAGEMENT page (/settings/computer/auto,
+ * titled "Schedules") and surfaces findings on the live view. The phone has no
+ * management page, so the home section shows the agents that have something to
+ * say right now — an open finding, or a run in progress — and index.tsx says
+ * out loud how many quiet ones were left out. See selectHomeAutoAgents.
+ *
+ * Both reads degrade to nothing rather than to an error, the same way
+ * resumable.ts does: an older machine has no /api/auto/* at all, and someone
+ * who opened this screen to see what is running should not be told about it.
+ * They degrade INDEPENDENTLY, too — a machine that can list agents but not
+ * findings still owes you the running ones.
+ */
+
+import { useFocusEffect } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+
+import { useOmg } from "./provider";
+import { DEFAULT_SCHED_TZ } from "./cron";
+
+/** Mirrors AutoAgent in src/auto/store.ts, plus what withAutoAgentMeta adds. */
+export type AutoAgent = {
+  id: string;
+  name: string;
+  /** Truncated server-side (`promptTruncated`). Not shown on a row; see the card. */
+  prompt?: string;
+  /** 5-field cron, evaluated by the machine in the payload's `tz`. */
+  schedule: string;
+  enabled: boolean;
+  cwd?: string;
+  /** Backend key — "grok", "codex-aisdk", …; absent on old rows means Claude. */
+  agent?: string;
+  model?: string;
+  lastRunAt?: number;
+  /** Computed server-side: worktree cwds collapse to the owning repo. */
+  project?: string;
+  /** Computed server-side: a scheduled run is in flight right now. */
+  running?: boolean;
+};
+
+export type AutoFindingSeverity = "high" | "med" | "low";
+
+/** Mirrors Finding in src/auto/store.ts. */
+export type AutoFinding = {
+  id: string;
+  agentId: string;
+  title: string;
+  reasoning?: string[];
+  suggest?: string;
+  severity?: AutoFindingSeverity;
+  createdAt?: number;
+  /** How many times this has been independently reported. 1 on first sight. */
+  occurrences?: number;
+  lastSeenAt?: number;
+};
+
+export type AutoAgentsState = {
+  agents: AutoAgent[];
+  /** Open findings only — the ones still owed an answer. */
+  findings: AutoFinding[];
+  /** The MACHINE's schedule timezone, not the phone's. See cron.ts. */
+  tz: string;
+  loading: boolean;
+  refresh: () => void;
+};
+
+/**
+ * 30s. The rows make LIVE claims — "running", "next in 56m" — so this cannot
+ * be resumable.ts's fetch-once, which would leave an agent advertising a run
+ * that finished ten minutes ago and a countdown that never counts. It is
+ * slower than the session list's 10s on purpose: cron granularity is a whole
+ * minute, so nothing here can change faster than that, and this pulls the
+ * entire roster plus every open finding rather than a delta.
+ *
+ * Re-fetching is also what keeps the relative labels honest — the card derives
+ * "next in …" at render time, so a poll that re-renders is the clock. See
+ * auto-agent-card.tsx.
+ */
+const AUTO_POLL_MS = 30_000;
+
+export function useAutoAgents(): AutoAgentsState {
+  const { client, bindingId } = useOmg();
+  const [agents, setAgents] = useState<AutoAgent[]>([]);
+  const [findings, setFindings] = useState<AutoFinding[]>([]);
+  const [tz, setTz] = useState<string>(DEFAULT_SCHED_TZ);
+  const [loading, setLoading] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => setTick((n) => n + 1), []);
+
+  // A machine switch invalidates both lists outright: auto agents belong to
+  // the box they run on, and showing the previous machine's schedules would
+  // describe a fleet this one has never heard of. Same reasoning as
+  // resumable.ts.
+  useEffect(() => {
+    setAgents([]);
+    setFindings([]);
+  }, [bindingId]);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setLoading(true);
+
+    // Two independent requests, NOT Promise.all: a rejection there would throw
+    // away a good response alongside the bad one, and the two endpoints can
+    // fail apart (findings is newer than agents).
+    const agentsRead = client.transport
+      .request<{ agents?: AutoAgent[]; tz?: string }>("/api/auto/agents")
+      .then((payload) => {
+        if (cancelled) return;
+        setAgents(payload.agents ?? []);
+        if (payload.tz) setTz(payload.tz);
+      })
+      .catch(() => {
+        if (!cancelled) setAgents([]);
+      });
+
+    const findingsRead = client.transport
+      .request<{ findings?: AutoFinding[] }>("/api/auto/findings?status=open")
+      .then((payload) => {
+        if (!cancelled) setFindings(payload.findings ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setFindings([]);
+      });
+
+    void Promise.all([agentsRead, findingsRead]).finally(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, tick]);
+
+  // Only while the screen is focused, matching the session list: a
+  // backgrounded app has no business talking to the machine.
+  useFocusEffect(
+    useCallback(() => {
+      const timer = setInterval(() => setTick((n) => n + 1), AUTO_POLL_MS);
+      return () => clearInterval(timer);
+    }, []),
+  );
+
+  return { agents, findings, tz, loading, refresh };
+}
+
+const SEVERITY_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };
+
+export type AutoAgentRow = {
+  agent: AutoAgent;
+  /** This agent's open findings, newest first. */
+  findings: AutoFinding[];
+};
+
+/**
+ * The agents worth a row on the home screen, in the order they deserve one.
+ *
+ * An agent qualifies by having an open finding or by running right now.
+ * Everything else is a schedule that is behaving — real, but not news, and the
+ * home screen is a news surface. A disabled agent with a stale finding still
+ * qualifies: the finding is open regardless of whether the agent will ever run
+ * again, and hiding it would strand it where nothing else on the phone lists
+ * findings at all.
+ *
+ * Order: running first (it is about to change), then by worst severity, then
+ * by most findings, then by most recent — so the row at the top is the one
+ * that most wants a decision.
+ */
+export function selectHomeAutoAgents(
+  agents: AutoAgent[],
+  findings: AutoFinding[],
+): AutoAgentRow[] {
+  const byAgent = new Map<string, AutoFinding[]>();
+  for (const finding of findings) {
+    const list = byAgent.get(finding.agentId);
+    if (list) list.push(finding);
+    else byAgent.set(finding.agentId, [finding]);
+  }
+  for (const list of byAgent.values()) {
+    list.sort((a, b) => (b.lastSeenAt ?? b.createdAt ?? 0) - (a.lastSeenAt ?? a.createdAt ?? 0));
+  }
+
+  const rows: AutoAgentRow[] = [];
+  for (const agent of agents) {
+    const own = byAgent.get(agent.id) ?? [];
+    if (!own.length && !agent.running) continue;
+    rows.push({ agent, findings: own });
+  }
+
+  const worst = (row: AutoAgentRow) =>
+    row.findings.reduce((acc, f) => Math.min(acc, SEVERITY_RANK[f.severity ?? "low"] ?? 2), 3);
+  const newest = (row: AutoAgentRow) =>
+    row.findings.reduce((acc, f) => Math.max(acc, f.lastSeenAt ?? f.createdAt ?? 0), 0);
+
+  rows.sort(
+    (a, b) =>
+      Number(!!b.agent.running) - Number(!!a.agent.running) ||
+      worst(a) - worst(b) ||
+      b.findings.length - a.findings.length ||
+      newest(b) - newest(a),
+  );
+  return rows;
+}

--- a/mobile/src/omg/cron.ts
+++ b/mobile/src/omg/cron.ts
@@ -1,0 +1,208 @@
+/**
+ * Cron helpers for the phone — a hand-maintained port of web/src/cron.ts.
+ *
+ * An auto agent IS a prompt plus a schedule, so a row that shows one without
+ * the other is showing half the object. The schedule on the wire is a raw
+ * 5-field cron expression (`0 11 * * *`), which is not a thing to put in front
+ * of a person; the web turns it into "Every day at 11:00 AM · next in 3h" and
+ * the phone has to say the same words, or the two surfaces describe the same
+ * agent two different ways.
+ *
+ * WHY A COPY. mobile/ is not a workspace member and cannot import from web/ —
+ * same constraint that produced src/omg/message-attachments.ts. A copy with no
+ * guard rots silently, so scripts/check-cron-drift.ts runs both
+ * implementations over the same expressions and fails when they disagree.
+ * That checker is the reason this file is a LITERAL port: the matching and
+ * describe logic below is web/src/cron.ts's, line for line, so a diff between
+ * the two is short enough to actually read.
+ *
+ * Only the read-side is ported. The picker half (buildCron/parseToSimple) is
+ * for an editor the phone does not have, and formatRelative is deliberately
+ * left behind — see nextRunLabel in auto-agent-card.tsx for why the phone
+ * spells the relative part itself.
+ *
+ * THE TIMEZONE IS THE MACHINE'S, NOT THE PHONE'S. The backend scheduler
+ * evaluates wall-clock in the global-settings timezone (`tz` comes down with
+ * GET /api/auto/agents), so nextRunAt takes it explicitly. Reading the
+ * schedule in the phone's own zone would tell someone in a different country
+ * the wrong time for every agent they own.
+ */
+
+const DOW: Record<string, number> = {
+  Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+};
+
+export const DEFAULT_SCHED_TZ = "Asia/Hong_Kong";
+
+// ---- matching (ported from the backend so the UI agrees with it) ----
+
+function fieldMatch(field: string, value: number): boolean {
+  if (field === "*") return true;
+  for (const part of field.split(",")) {
+    if (part.includes("/")) {
+      const [range, stepStr] = part.split("/");
+      const step = parseInt(stepStr, 10) || 1;
+      if (range === "*") {
+        if (value % step === 0) return true;
+        continue;
+      }
+      const [lo, hi] = range.split("-").map((n) => parseInt(n, 10));
+      if (!Number.isNaN(lo)) {
+        const top = Number.isNaN(hi) ? lo : hi;
+        for (let v = lo; v <= top; v += step) if (v === value) return true;
+      }
+      continue;
+    }
+    if (part.includes("-")) {
+      const [a, b] = part.split("-").map((n) => parseInt(n, 10));
+      if (!Number.isNaN(a) && !Number.isNaN(b) && value >= a && value <= b) return true;
+      continue;
+    }
+    if (parseInt(part, 10) === value) return true;
+  }
+  return false;
+}
+
+// Intl.DateTimeFormat construction is expensive (~tens of µs). nextRunAt scans
+// minute-by-minute, so building one per iteration dominated the cost and made
+// the list lag. Cache one formatter per timezone.
+const fmtCache = new Map<string, Intl.DateTimeFormat>();
+function zonedFormatter(tz: string): Intl.DateTimeFormat {
+  let f = fmtCache.get(tz);
+  if (!f) {
+    f = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      hourCycle: "h23",
+      minute: "2-digit",
+      hour: "2-digit",
+      day: "2-digit",
+      month: "2-digit",
+      weekday: "short",
+    });
+    fmtCache.set(tz, f);
+  }
+  return f;
+}
+
+function zonedParts(d: Date, tz: string) {
+  const parts = Object.fromEntries(
+    zonedFormatter(tz)
+      .formatToParts(d)
+      .map((p) => [p.type, p.value]),
+  );
+  return {
+    minute: parseInt(parts.minute as string, 10),
+    hour: parseInt(parts.hour as string, 10),
+    dom: parseInt(parts.day as string, 10),
+    month: parseInt(parts.month as string, 10),
+    dow: DOW[parts.weekday as string] ?? 0,
+  };
+}
+
+export function isValidCron(expr: string): boolean {
+  return expr.trim().split(/\s+/).length === 5;
+}
+
+export function cronMatches(expr: string, d: Date, tz: string): boolean {
+  const f = expr.trim().split(/\s+/);
+  if (f.length !== 5) return false;
+  const p = zonedParts(d, tz);
+  return (
+    fieldMatch(f[0], p.minute) &&
+    fieldMatch(f[1], p.hour) &&
+    fieldMatch(f[2], p.dom) &&
+    fieldMatch(f[3], p.month) &&
+    fieldMatch(f[4], p.dow)
+  );
+}
+
+// Next minute (> from) at which the cron fires, in the scheduler tz. Scans up to
+// ~400 days forward; returns null if nothing matches (or expr is invalid).
+export function nextRunAt(expr: string, tz: string, from: number = Date.now()): number | null {
+  if (!isValidCron(expr)) return null;
+  const start = Math.floor(from / 60_000) * 60_000 + 60_000; // next whole minute
+  const maxMinutes = 400 * 24 * 60;
+  for (let i = 0; i < maxMinutes; i++) {
+    const t = start + i * 60_000;
+    if (cronMatches(expr, new Date(t), tz)) return t;
+  }
+  return null;
+}
+
+// ---- describe (cron -> locale English) ----
+
+function timeLabel(h: number, m: number, locale?: string): string {
+  const d = new Date(Date.UTC(2024, 0, 1, h, m));
+  return new Intl.DateTimeFormat(locale, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  }).format(d);
+}
+
+function weekdayName(dow: number, locale?: string): string {
+  const d = new Date(Date.UTC(2024, 0, 7 + (dow % 7))); // 2024-01-07 is a Sunday
+  return new Intl.DateTimeFormat(locale, { weekday: "long", timeZone: "UTC" }).format(d);
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+const intRe = /^\d+$/;
+const listRe = /^\d+(,\d+)*$/;
+
+export function describeCron(expr: string, locale?: string): string {
+  const trimmed = expr.trim();
+  const f = trimmed.split(/\s+/);
+  if (f.length !== 5) return trimmed || "(no schedule)";
+  const [min, hr, dom, mon, dow] = f;
+  const allDate = dom === "*" && mon === "*" && dow === "*";
+
+  // Every N minutes
+  const stepMin = min.match(/^\*\/(\d+)$/);
+  if (stepMin && hr === "*" && allDate) {
+    const n = parseInt(stepMin[1], 10);
+    return n === 1 ? "Every minute" : `Every ${n} minutes`;
+  }
+  // Every N hours
+  const stepHr = hr.match(/^\*\/(\d+)$/);
+  if (intRe.test(min) && stepHr && allDate) {
+    const n = parseInt(stepHr[1], 10);
+    return n === 1 ? "Every hour" : `Every ${n} hours`;
+  }
+  // Hourly at :mm
+  if (intRe.test(min) && hr === "*" && allDate) {
+    const m = parseInt(min, 10);
+    return m === 0 ? "Every hour" : `Every hour at :${String(m).padStart(2, "0")}`;
+  }
+
+  // From here we need a concrete time of day.
+  if (!intRe.test(min) || !intRe.test(hr)) return trimmed;
+  const at = `at ${timeLabel(parseInt(hr, 10), parseInt(min, 10), locale)}`;
+
+  // Daily / weekday / weekend / specific weekday(s)
+  if (dom === "*" && mon === "*") {
+    if (dow === "*") return `Every day ${at}`;
+    if (dow === "1-5") return `Every weekday ${at}`;
+    if (dow === "0,6" || dow === "6,0" || dow === "0,6,") return `Every weekend ${at}`;
+    if (intRe.test(dow)) return `Every ${weekdayName(parseInt(dow, 10), locale)} ${at}`;
+    if (listRe.test(dow)) {
+      const days = dow
+        .split(",")
+        .map((d) => weekdayName(parseInt(d, 10), locale))
+        .join(", ");
+      return `Every ${days} ${at}`;
+    }
+    return trimmed;
+  }
+
+  // Monthly on the Nth
+  if (intRe.test(dom) && mon === "*" && dow === "*") {
+    return `Monthly on the ${ordinal(parseInt(dom, 10))} ${at}`;
+  }
+
+  return trimmed;
+}


### PR DESCRIPTION
Adds a fourth section to the native home screen for **auto agents** — the scheduled
fleet that produces work nobody asked for. Two commits are the original author's and
are unchanged; the third is mine, from reviewing them.

The author's session died before opening this PR, so nobody had reviewed this code and
the author was not around to be questioned. What follows separates what I **re-verified
on the device** from what I **took on trust**.

## Re-verified (not inherited)

**Rebase.** Was based on `719b81b`; now on `9367263` (#112 → #113 → #114). Worth
recording that there was **no conflict to resolve** in `app/index.tsx`, contrary to
expectation: #113 touched `session/[id].tsx` + `components.tsx`, #114 touched
`computers.tsx` / `settings.tsx` / `computer-picker.ts`. Neither went near `index.tsx`.

**The cron drift guard actually guards.** `bun run mobile/scripts/check-cron-drift.ts`
passes (41 expressions × 5 zones). A passing guard proves nothing on its own, so I
perturbed the native side four ways and confirmed each was caught:

| perturbation | caught |
|---|---|
| `nextRunAt` scan starts at current minute, not next | ✅ 37 drift lines |
| `fieldMatch` range-step upper bound made exclusive | ✅ |
| `describeCron` "Every minute" wording | ✅ 3 lines |
| `DEFAULT_SCHED_TZ` changed | ✅ |

Two of those take **minutes** to fail rather than seconds, because breaking the matcher
makes `nextRunAt` scan its full 400-day budget on both implementations across five
zones. That is not the script hanging, and I documented it in the script header so the
next person does not kill it and "fix" a non-problem. The tree was restored after each.

**The `motion.tsx` rule is honoured, structurally and behaviourally.**
`useListItemMotion()` returns only `{entering, layout}` — there is no `exiting` key to
pass — and the card destructures exactly those two. So the #112 ghost-row bug is
impossible here *by construction*, not by discipline.

I also caught the real case on device. While I watched, a running agent's run finished
and the 30s poll **removed its row live**: the section went 2 rows → 1 and the overflow
count went 32 → 33 (1 + 33 = 34, consistent). A row dropped by a poll is precisely the
#112 failure case, and nothing was stranded. Collapse was captured at **350ms
mid-animation** and is clean, with Recent flowing straight up behind it.

**The rows say true things.** Verified against `GET /api/auto/agents` +
`/api/auto/findings?status=open` on this box, by computing the expected rows
independently and comparing:

- Schedule labels rendered live as `Every 10 minutes · next in 8m` and
  `Every day at 9:00 AM · next in 13h`, and the countdown ticked 8m → 7m → 6m across
  polls — the relative label is genuinely kept honest by re-render.
- A running agent showed the busy ring plus the word `running`, and sorted **above** an
  agent with open findings, matching `selectHomeAutoAgents`' documented order.
- Expanding showed severity dots (red = high, amber = med), reasoning bullets and
  `Suggests`, in place.
- The overflow row opens `app.omg.dev`.

**Compliance (#114).** Clean, and precedented rather than merely defensible: the
overflow row points at `/settings/computer/auto`, which is the **same destination
`settings.tsx` already ships** in its `WEB_PAGES` allowlist as "Schedules". A grep of
every URL in `mobile/` finds no billing or checkout target anywhere:
`app.omg.dev/settings/computer/auto`, `app.omg.dev/`, `auth.omg.dev`,
`backend.omg.dev`, and the local machine ports. Nothing to fix.

`tsc --noEmit` clean. Every theme token and `AgentAvatar` prop the card uses was checked
to exist.

## Taken on trust / could not reproduce

- The author's commit says it saw `Every hour · next in 56m`. The agent on `0 * * * *`
  exists on this box but currently has no open findings and is not running, so it is not
  in the filtered set and **that exact string was not reproducible**. The label is
  nonetheless correct by the drift guard plus direct evaluation of the real schedules.
- `Paused · <schedule>` (the disabled-agent path) was likewise not observable: the one
  disabled agent has nothing open, so it never reaches the section.
- The author's row counts (8 rows / "25 more") no longer reproduce — open findings moved
  11 → 3 while I worked, as other agents resolved them. The **selection logic** matched
  my independently computed prediction at every point I checked; only the data moved.

## The filter is a judgement call — here is the one-line flip

A row appears only if the agent has an open finding or is running (8 of 34 when I
started, 1 of 34 later). If you want the **full roster** instead, it is exactly one line
— delete this from `selectHomeAutoAgents` in `mobile/src/omg/auto-agents.ts`:

```ts
if (!own.length && !agent.running) continue;
```

Sorting still works with zero findings (`worst()` → 3, `newest()` → 0), so nothing else
changes. Confirmed, not assumed.

## One property worth knowing about

The section reads `/api/auto/agents` **through the bound machine**, so on a device paired
to an account with no live machine it is empty *by construction* — and empty is
indistinguishable from "you have no auto agents". This is not hypothetical: a device I
tested on sits in exactly that state ("Your computer isn't responding / Your included
computer time is used up"), and that is reportedly reachable on a real account today. The
section degrades to nothing rather than to an error, which is deliberate and matches
`resumable.ts`, but it does mean a user in that state is told nothing at all.

## The third commit

`docs(mobile): booted is a coin flip...` — not a code change. Two traps in
`mobile/AGENTS.md`'s own instructions cost roughly an hour across two agents in one
afternoon:

- Every `simctl` example says `booted`, which resolves to *a* booted device, not *the*
  one you mean. Two simulators are routinely up. One agent screenshotted one device and
  tapped the other, concluded its coordinate calibration had drifted, re-derived it,
  found it unchanged, and gave up. Both commands succeed and return plausible output.
  Now: resolve the UDID by name, plus the device pixel dimensions (1206x2622 vs
  1320x2868) as an independent check on which device you actually captured.
- `curl localhost:4040/api/tunnels` is right only for the *first* tunnel on the box.
  With three Metros up, 4040 belonged to another agent, and `tunnels[0]` would have
  pointed the dev client at their bundle.

It also records the tap technique #112 worked out but left only in a commit message:
there is no `simctl tap` and no `idb` here, so touches come from CGEvent, and the
mapping comes from the Simulator's accessibility tree — the window's `group` element is
the device surface at 1:1 in device points.

## Not done

Not merged. Screenshots of the section, the expanded row, the mid-animation collapse and
the live re-sort are attached in the session that produced this PR.
