### PR TITLE
feat(mobile): iOS sells Starter through Pro, not Always On

### DIFF
--- a/mobile/src/omg/billing.ts
+++ b/mobile/src/omg/billing.ts
@@ -175,12 +175,9 @@ const MOCK_CATALOG: unknown = [
     label: "Pro",
     specs: { parallelAgents: 16, vcpus: 8, memoryMb: 16384, diskGb: 128, computeHours: 300, alwaysOn: false },
   },
-  {
-    productId: "dev.omg.computer.computer_20.monthly.v1",
-    plan: "computer_20",
-    label: "Always On",
-    specs: { parallelAgents: 24, vcpus: 12, memoryMb: 36864, diskGb: 256, computeHours: 750, alwaysOn: true },
-  },
+  // Always On is not sold on iOS, so the mock does not pretend it is. A mock
+  // that shows a rung production won't is a screenshot waiting to mislead
+  // someone — including whoever reviews this screen next.
 ];
 
 /** The same list with every `specs` null — a server that can sell but cannot describe. */

--- a/mobile/src/omg/plan-specs.ts
+++ b/mobile/src/omg/plan-specs.ts
@@ -159,11 +159,15 @@ export function parseCatalogTiers(value: unknown): CatalogTier[] | null {
  *
  * `computer_20` IS mapped in `OMG_APP_STORE_CONFIG.products`, so leaving it
  * here would not have risked the money-taken-and-rejected failure above. It is
- * absent because Benny's call is that iOS sells Starter through Pro only, and
- * that decision should be true in this list rather than enforced by the
- * accident that the product does not exist in App Store Connect — StoreKit
- * silently drops ids it cannot find, so this list would have looked wrong and
- * behaved right, until the day someone created the product for a sandbox test.
+ * absent because Always On is SALES-LED: those customers come through a call
+ * and the plan is shaped around them, so what they are billed is not what a
+ * fixed App Store product id can represent. It is not a rung waiting for
+ * StoreKit to mature, and it should not be added back when it does.
+ *
+ * It is enforced here rather than left to the fact that no such product exists
+ * in App Store Connect. StoreKit silently drops ids it cannot find, so this
+ * list would have looked wrong and behaved right, until the day someone created
+ * the product for a sandbox test.
  *
  * Cost, stated rather than discovered: `labelForPlan` reads names out of this
  * same list, so an Always On subscriber on the web now reads "This account is

--- a/mobile/src/omg/plan-specs.ts
+++ b/mobile/src/omg/plan-specs.ts
@@ -154,6 +154,21 @@ export function parseCatalogTiers(value: unknown): CatalogTier[] | null {
  * "unmapped App Store productId" AFTER Apple has taken the money. When the
  * server does send a catalog its ids win, and that mismatch stops being
  * possible rather than merely being commented about.
+ *
+ * ── Always On is not here, and that is the second kind of disagreement ─────
+ *
+ * `computer_20` IS mapped in `OMG_APP_STORE_CONFIG.products`, so leaving it
+ * here would not have risked the money-taken-and-rejected failure above. It is
+ * absent because Benny's call is that iOS sells Starter through Pro only, and
+ * that decision should be true in this list rather than enforced by the
+ * accident that the product does not exist in App Store Connect — StoreKit
+ * silently drops ids it cannot find, so this list would have looked wrong and
+ * behaved right, until the day someone created the product for a sandbox test.
+ *
+ * Cost, stated rather than discovered: `labelForPlan` reads names out of this
+ * same list, so an Always On subscriber on the web now reads "This account is
+ * billed on the web" instead of "Your Always On plan is billed on the web".
+ * Every call site already treats the label as optional for exactly this reason.
  */
 export const FALLBACK_TIERS: readonly CatalogTier[] = [
   {
@@ -178,12 +193,6 @@ export const FALLBACK_TIERS: readonly CatalogTier[] = [
     productId: "dev.omg.computer.computer_10.monthly.v1",
     plan: "computer_10",
     label: "Pro",
-    specs: null,
-  },
-  {
-    productId: "dev.omg.computer.computer_20.monthly.v1",
-    plan: "computer_20",
-    label: "Always On",
     specs: null,
   },
 ] as const;

--- a/mobile/storekit/omg.storekit
+++ b/mobile/storekit/omg.storekit
@@ -168,31 +168,6 @@
           "referenceName" : "Pro",
           "subscriptionGroupID" : "21654321",
           "type" : "RecurringSubscription"
-        },
-        {
-          "adHocOffers" : [
-
-          ],
-          "codeOffers" : [
-
-          ],
-          "displayPrice" : "599.99",
-          "familyShareable" : false,
-          "groupNumber" : 1,
-          "internalID" : "31000005",
-          "introductoryOffer" : null,
-          "localizations" : [
-            {
-              "description" : "Always-on 12 vCPU, 36 GB memory, 256 GB storage, 24 agents.",
-              "displayName" : "Always On",
-              "locale" : "en_US"
-            }
-          ],
-          "productID" : "dev.omg.computer.computer_20.monthly.v1",
-          "recurringSubscriptionPeriod" : "P1M",
-          "referenceName" : "Always On",
-          "subscriptionGroupID" : "21654321",
-          "type" : "RecurringSubscription"
         }
       ]
     }

--- a/test/mobile-plan-specs.test.ts
+++ b/test/mobile-plan-specs.test.ts
@@ -148,6 +148,27 @@ describe("the bundled fallback carries ids, never facts", () => {
     }
   });
 
+  test("iOS sells Starter through Pro, and does not offer Always On", () => {
+    // Benny's call. Enforced here rather than left to the accident that the
+    // product does not exist in App Store Connect — StoreKit silently drops
+    // ids it cannot find, so without this the list would look wrong and
+    // behave right until someone created the product for a sandbox test.
+    expect(FALLBACK_TIERS.map((tier) => tier.plan)).toEqual([
+      "computer_s20",
+      "computer_s40",
+      "computer_5",
+      "computer_10",
+    ]);
+  });
+
+  test("but a server that DOES send Always On is still rendered", () => {
+    // Not offering it is a merchandising decision, not a parser limit. If the
+    // control plane ever publishes that rung again, this screen shows it
+    // without a new build.
+    const tiers = parseCatalogTiers([{ ...PERSONAL, plan: "computer_20", label: "Always On" }]);
+    expect(tiers?.map((tier) => tier.label)).toEqual(["Always On"]);
+  });
+
   test("no price string is compiled into the bundle", () => {
     // Apple's displayPrice is the only price this screen may render. Anything
     // that looks like money here is wrong in most of the world.


### PR DESCRIPTION
Benny's call: the iOS paywall offers **Starter through Pro**. Always On is
**sales-led** — those customers come through a call and the plan is shaped around
them, so what they are billed is not what a fixed App Store product id can
represent. It is not a rung waiting for StoreKit to mature, and it should not be
added back when it does.

Stacked on `feat/mobile-paywall-tiers` (#116). The server half is vibes
`246c2a90` on `agent/app-store-plan-catalog` (#1432), which drops `computer_20`
from `STOREKIT_PLAN_ORDER` so the published catalog never carries it.

## This PR is the paths that do NOT read that catalog

| file | why it mattered |
|---|---|
| `FALLBACK_TIERS` | what the phone offers when the control plane publishes nothing |
| `MOCK_CATALOG` | the dev mock store |
| `omg.storekit` | the simulator's local products |

`FALLBACK_TIERS` is the one worth reading twice. Left alone it would have **looked
wrong and behaved right** — StoreKit silently drops ids it cannot find, so the
Always On row simply would not render, *because the App Store Connect product
does not exist yet*. That is enforcement by accident, and it expires the moment
someone creates that product for a sandbox test.

## What is deliberately unchanged

**The parser.** Not offering a rung is a merchandising decision, not a parser
limit. A new test proves a server that *does* send `computer_20` still renders
it, so re-offering Always On later is one line in the vibes catalog plus the App
Store Connect product — no new build of this app.

**`OMG_APP_STORE_CONFIG.products`** still maps the Always On id, server-side.
That list is what we can *honour*; `STOREKIT_PLAN_ORDER` is what we *sell*.
Narrowing the map too would create the one failure this whole area is built to
avoid — a transaction Apple took money for that the server cannot attribute.

## The cost, stated rather than discovered

`labelForPlan` resolves plan names out of the same tier list. So an Always On
subscriber on the web who opens this screen now reads:

> This account is billed on the web, not through the App Store.

instead of "Your Always On plan is billed on the web". All three call sites
already treat the label as optional for exactly this reason (`?? "new"`,
`?? entitlement.plan`, and the `label ? … : "This account is"` ternary), and
naming a plan we don't sell would need a new field on a wire contract that is
frozen and already built against.

## Verification

- 19 plan-spec tests pass, 2 of them new
- `mobile/` `tsc --noEmit` clean
- `omg.storekit` still parses and lists exactly the four ids; the edit is a
  25-line deletion, not a reformat
- full repo suite: **11 failures before and after** — all pre-existing and
  unrelated (missing `@omg-dev/client` build, jcode auth detection, audit
  lockfile coverage)

**NOT re-verified on the simulator.** The screen loses one card and nothing else,
but nobody has looked at it.


## App Store Connect state (done)

Group `omg.dev Cloud Computer` (`22312997`) holds exactly four products, each
available in all 175 territories with English (U.S.) localization:

| product ID | ref | US price | verified US row |
|---|---|---|---|
| `…computer_10.monthly.v1` | Pro | $179.99 | `United States (USD) $179.99` |
| `…computer_5.monthly.v1` | Personal | $57.99 | `United States (USD) $57.99` |
| `…computer_s40.monthly.v1` | Starter Plus | $11.99 | `United States (USD) $11.99` |
| `…computer_s20.monthly.v1` | Starter | $5.99 | `United States (USD) $5.99` |

There is **no Always On product in App Store Connect**, so nothing can buy it
through Apple today even by accident. Server notification URLs (production and
sandbox) point at `https://backend.omg.dev/api/webhooks/app-store`.
