### PR TITLE
fix(audit): mobile moved to bun.lock, so the audit root has to move too

### DIFF
--- a/scripts/audit.test.ts
+++ b/scripts/audit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -183,8 +183,21 @@ describe("audit gate", () => {
   test("each audit root maps to the lockfile its tool actually reads", () => {
     expect(rootLockfile({ dir: ".", tool: "bun" })).toBe("bun.lock");
     expect(rootLockfile({ dir: "mobile", tool: "npm" })).toBe("mobile/package-lock.json");
-    // The gate would silently cover nothing if a root named the wrong lockfile.
-    expect(AUDIT_ROOTS.map(rootLockfile)).toContain("mobile/package-lock.json");
+    expect(rootLockfile({ dir: "mobile", tool: "bun" })).toBe("mobile/bun.lock");
+  });
+
+  // The previous version of this test asserted the literal string
+  // "mobile/package-lock.json", which restated the config instead of checking
+  // it. When mobile moved to bun.lock the config became wrong and this test
+  // stayed green, because both sides said the same untrue thing. Assert against
+  // the filesystem instead: a root whose lockfile does not exist audits nothing,
+  // and `npm audit` fails outright ("This command requires an existing
+  // lockfile") before any of these tests get to run.
+  test("every configured root names a lockfile that is actually there", () => {
+    const missing = AUDIT_ROOTS.map(rootLockfile).filter(
+      (file) => !existsSync(new URL(`../${file}`, import.meta.url)),
+    );
+    expect(missing).toEqual([]);
   });
 
   test("ghsa ids come from the advisory url and a malformed url is loud", () => {

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -69,17 +69,28 @@ export const LOCKFILE_BY_TOOL: Record<AuditTool, string> = {
  * new, it audits the root a second time under a different label. assertRootsAreDistinct()
  * below refuses to run in that state rather than reporting inflated coverage.
  *
- * A root also names the tool that can read it. `mobile` is an Expo app on an npm
- * lockfile and is not a member of the root `workspaces` list, so nothing bun runs
- * will ever see its graph; it needs `npm audit`. It spent its whole life recorded
- * as a known exclusion whose stated escape route ("convert it to bun.lock") was
- * never going to happen, and two high-severity advisories were living in it. An
- * exclusion with no exit condition is the same shape of mistake as the `--ignore`
- * flag this file replaced, so the tool moved instead of the lockfile.
+ * A root also names the tool that can read it. `mobile` is not a member of the
+ * root `workspaces` list, so nothing the root audit runs will ever see its
+ * graph; it is audited as its own root.
+ *
+ * It used to be an npm root, and this comment used to say so — including that
+ * the escape route once recorded against it, "convert it to bun.lock", "was
+ * never going to happen". It happened: this branch converted the Expo app to
+ * bun and deleted `mobile/package-lock.json`. Nobody moved the tool with it, so
+ * `npm audit` was pointed at a lockfile that no longer existed and the gate died
+ * with "This command requires an existing lockfile" on every PR in the mobile
+ * stack. The coverage test had been saying exactly this the whole time —
+ * `mobile/bun.lock` neither audited nor excluded — but a hard failure in the
+ * audit step exits before the tests run, so the accurate message was never the
+ * one anybody read.
+ *
+ * Two things worth keeping from that: a root's tool has to move when its
+ * lockfile does, and a gate that dies before its own diagnostics run will
+ * misreport why it is red.
  */
 export const AUDIT_ROOTS: { dir: string; why: string; tool: AuditTool }[] = [
   { dir: ".", why: "the workspace graph — the CLI, agent backends, packages/* and web/", tool: "bun" },
-  { dir: "mobile", why: "the Expo mobile app — its own npm graph, outside the root workspaces list", tool: "npm" },
+  { dir: "mobile", why: "the Expo mobile app — its own graph, outside the root workspaces list", tool: "bun" },
 ];
 
 /** The lockfile a configured root audits, relative to the repo root. */


### PR DESCRIPTION
The audit gate has been red on **every PR in the mobile stack** (#115, #116, #117,
#118) since the Expo app moved to bun, and the error told you almost nothing:

```
Error: npm audit failed in mobile:
This command requires an existing lockfile.
```

`AUDIT_ROOTS` declares `mobile` with `tool: "npm"`, which resolves
`mobile/package-lock.json`. This branch converted the app to bun and deleted that
file. `npm audit` cannot read `mobile/bun.lock`. **`main` is unaffected** — it
still has the npm lockfile, which is why this only appears on the mobile line.

## It hid in plain sight, and it is worth knowing why

The coverage test had been failing this whole time with exactly the right message
— `mobile/bun.lock` is neither audited nor excluded. But a hard failure in the
audit **step** exits before the test **step** runs, so the only message anyone
ever saw was the confusing one.

`scripts/audit.ts`'s own header had also predicted the opposite outcome. It
recorded that the escape route for that old exclusion, *"convert it to
bun.lock"*, **"was never going to happen."** It happened. The comment now records
what actually did, and the lesson: a root's tool has to move when its lockfile
does.

## The test that let it through

```ts
expect(AUDIT_ROOTS.map(rootLockfile)).toContain("mobile/package-lock.json")
```

That restates the config instead of checking it, so when the config became wrong
the test stayed green — both sides said the same untrue thing. It now asserts
that every configured root names a lockfile **that exists on disk**.

Perturbation-checked: flipping the tool back to `"npm"` fails that test *and* the
coverage test; restoring passes both.

## ⚠️ This does not turn the check green, and it should not

With the gate able to read mobile's graph for the first time since the conversion,
it reports **3 unaccepted high-severity advisories** that were always there and
simply unaudited:

| package | advisory | reached via |
|---|---|---|
| `brace-expansion` | GHSA-rgw5-rvv9-x895 | `minimatch` |
| `js-yaml` | GHSA-5p4m-2wfm-xmqj | `@expo/xcpretty` |
| `nanoid` | GHSA-2v37-7h3g-55p8 | `expo-router`, `postcss` |

All three are transitive through Expo tooling. Upgrading them, or accepting them
with a reason and a `reviewBy` date via `bun run audit:exceptions`, is a
deliberate call — that is the entire point of this ratchet — so I have **not**
silently exception-ed them. **Benny's call.**

Before this PR the check was red for a meaningless reason. After it, it is red for
a true one.

## Verification

- 21 audit tests pass, 2 of them new
- perturbation checked in both directions
- `bun run audit` now runs to completion over **2 lockfiles** instead of aborting
  on the first
