### PR TITLE
feat(mobile): account deletion, privacy policy and terms — the three links Apple requires

### DIFF
--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -359,26 +359,41 @@ export default function PlanScreen() {
                   onPress={() => void buy(product)}
                 />
               ))}
-              {/* Said once, under the list, rather than as a "Sleeps between
-                  tasks: Yes" row repeated on four of five cards. The dashboard
-                  can afford that row because it shows one rung at a time; a
-                  list of five turns the same true sentence into noise, and
-                  noise is what made the old screen unreadable. Only the rung
-                  that BREAKS this rule states it, on its own card. */}
-              {products.some((product) => product.specs) ? (
-                <Text
-                  style={{
-                    ...type.caption,
-                    color: colors.textMuted,
-                    paddingHorizontal: space.lg,
-                    paddingTop: space.md,
-                    lineHeight: 16,
-                  }}
-                >
-                  Every plan pauses while idle, so time you are not using does not come out of
-                  your hours. A paused Computer keeps its files and picks up where it left off.
-                </Text>
-              ) : null}
+              {/* ── REMOVED: an idle-billing claim that is not currently true ──
+                  This said, directly above a Buy button:
+
+                    "Every plan pauses while idle, so time you are not using
+                     does not come out of your hours. A paused Computer keeps
+                     its files and picks up where it left off."
+
+                  Session d3f4e3e8 measured a cloud Computer with no sessions
+                  and nothing connected, twice, five minutes each:
+
+                    2083 micros / 302s -> 24,830 micros/hour
+
+                  Full running rate is 25,000 and hibernated is 0, so an idle
+                  Computer bills at 99.3% of full rate. The second measurement
+                  was taken AFTER an explicit pause through the lifecycle
+                  endpoint and was identical to the byte. Idle time comes out
+                  of your hours almost entirely.
+
+                  That makes this the most consequential sentence on the
+                  screen, because it is what tells someone how to read every
+                  "N hours" above it — 20 hours of USAGE and 20 hours of
+                  CALENDAR are different products at the same price. Stating it
+                  wrongly next to a purchase is worse than not explaining the
+                  hours at all, which is the same rule this file already
+                  follows for spec numbers: degrade to silence, never to a
+                  number we cannot stand behind.
+
+                  RESTORE THIS, unchanged, once idle Computers actually stop
+                  billing — the sentence is good and it is where it belongs.
+                  Do not reword it to describe the current behaviour instead:
+                  "your hours are consumed whether or not you are working" is
+                  accurate today, but it is a platform decision in flight
+                  (raised with Benny, outside this release), and a paywall is
+                  the wrong place to litigate it. Silence is honest in both
+                  states. */}
             </>
           ) : !loadError ? (
             <EmptyState

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -33,7 +33,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, ScrollView, View } from "react-native";
+import { ActivityIndicator, Linking, ScrollView, View } from "react-native";
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -406,10 +406,57 @@ export default function PlanScreen() {
               Payment is charged to your Apple ID. Subscriptions renew monthly until cancelled in
               the App Store.
             </Text>
+            <LegalLinks />
           </View>
         </>
       )}
     </ScrollView>
+  );
+}
+
+/**
+ * Functional Privacy Policy and Terms of Use links, on the purchase surface.
+ *
+ * Required, and worth sourcing precisely because it is easy to overstate.
+ * Guideline 3.1.2(c) does not itself list link requirements — it says "Ensure
+ * you clearly communicate the requirements described in Schedule 2 of the Apple
+ * Developer Program License Agreement." Schedule 2 is where the functional
+ * privacy policy and EULA links on a subscription surface actually come from.
+ * It is one level below the guideline text, it is real, and missing links are
+ * among the most commonly cited rejections for subscription apps.
+ *
+ * The word doing the work is FUNCTIONAL. Naming the documents is not enough;
+ * these have to be tappable and they have to load. Both targets return 200.
+ *
+ * ── Not a 3.1.1(a) violation, for the same reason as settings.tsx ──────────
+ *
+ * This is the paywall, so an outbound link here looks even more alarming than
+ * the account-deletion one. It is not a purchasing mechanism: it opens a legal
+ * document, takes no money, and cannot be transacted against. 3.1.1(a) is about
+ * calls to action directing customers to OTHER WAYS TO PAY. Schedule 2 requires
+ * these on the very screen 3.1.1(a) governs, so the rules are not merely
+ * compatible — Apple expects both at once. Do not remove them to "clean up the
+ * paywall".
+ *
+ * Deliberately omg.dev, not app.omg.dev: these are public legal documents, not
+ * dashboard surfaces, and a reviewer must be able to open them signed out.
+ */
+function LegalLinks() {
+  const { colors, type, space } = useTheme();
+  const open = (path: string) => void Linking.openURL(`https://omg.dev${path}`);
+  return (
+    <View style={{ flexDirection: "row", justifyContent: "center", gap: space.lg }}>
+      <PressableScale onPress={() => open("/privacy")} hitSlop={12}>
+        <Text style={{ ...type.caption, color: colors.textMuted, textDecorationLine: "underline" }}>
+          Privacy Policy
+        </Text>
+      </PressableScale>
+      <PressableScale onPress={() => open("/terms")} hitSlop={12}>
+        <Text style={{ ...type.caption, color: colors.textMuted, textDecorationLine: "underline" }}>
+          Terms of Use
+        </Text>
+      </PressableScale>
+    </View>
   );
 }
 

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -66,6 +66,30 @@ import {
  * link did NOT come back and must not — an in-app paywall that also offers an
  * external checkout is the same 3.1.1(a) violation with an extra step.
  */
+/**
+ * Legal documents, on omg.dev rather than app.omg.dev.
+ *
+ * Guideline 5.1.1(i): "All apps must include a link to their privacy policy in
+ * the App Store Connect metadata field AND within the app in an easily
+ * accessible manner." The metadata half was already set; the in-app half was
+ * simply absent — this app shipped with no privacy link anywhere in the binary,
+ * which applies to every app and always has, not just subscription ones.
+ *
+ * These are a separate constant from WEB_PAGES on purpose. WEB_PAGES are
+ * dashboard surfaces, sit under "These open omg.dev in your browser", and point
+ * at app.omg.dev. These point at the PUBLIC site, because a reviewer has to be
+ * able to open them while signed out — behind a dashboard login they would not
+ * be "easily accessible" and arguably not accessible at all.
+ *
+ * Not a 3.1.1(a) concern: a legal document is not a purchasing mechanism. See
+ * the account-deletion comment above for the full argument; the same reasoning
+ * covers both, and Guideline 5.1.1(i) requires this one outright.
+ */
+const LEGAL_PAGES: { label: string; path: string }[] = [
+  { label: "Privacy Policy", path: "/privacy" },
+  { label: "Terms of Use", path: "/terms" },
+];
+
 const WEB_PAGES: { label: string; path: string }[] = [
   { label: "Coding agents", path: "/settings/computer/coding-agents" },
   { label: "Schedules", path: "/settings/computer/auto" },
@@ -331,6 +355,27 @@ export default function SettingsScreen() {
           </Row>
         </Card>
       </View>
+
+      <SectionLabel>Legal</SectionLabel>
+      <Card>
+        {LEGAL_PAGES.map((page, i) => (
+          <View key={page.path}>
+            {/* inset={space.lg}, not "text" — same reason as WEB_PAGES above:
+                no leading StatusDot/icon on these rows, and "text" mode budgets
+                for one. */}
+            {i > 0 ? <Separator inset={space.lg} /> : null}
+            <Row onPress={() => void Linking.openURL(`https://omg.dev${page.path}`)}>
+              <Text style={{ ...type.callout, color: colors.text, flex: 1 }}>{page.label}</Text>
+              <Icon
+                ios="arrow.up.forward.app"
+                android="open_in_new"
+                size={15}
+                color={colors.textMuted}
+              />
+            </Row>
+          </View>
+        ))}
+      </Card>
 
       <Text
         style={{

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -151,6 +151,47 @@ export default function SettingsScreen() {
     ]);
   };
 
+  /**
+   * Account deletion. Required by App Store Guideline 5.1.1(v): "Apps that
+   * support account creation must also offer account deletion", and it must be
+   * INITIATED IN THE APP — a support address or a buried web page does not
+   * satisfy it.
+   *
+   * ── This outbound app.omg.dev link is deliberate. Do not remove it. ──
+   *
+   * The header of this file exists because a "Plan & billing" row linking to
+   * app.omg.dev was removed for Guideline 3.1.1(a), and #116 then argued at
+   * length that an in-app paywall must not also offer an external checkout. So
+   * an outbound link on this exact screen looks, at a glance, like precisely
+   * the regression we spent two PRs eliminating. It is not.
+   *
+   * 3.1.1(a) prohibits calls to action that direct customers to PURCHASING
+   * MECHANISMS other than in-app purchase. Deleting an account is not a
+   * purchase, takes no money, and is the opposite of a conversion surface.
+   * 5.1.1(v) affirmatively REQUIRES this entry point to exist. The two rules
+   * do not conflict; one is about paying, the other about leaving.
+   *
+   * It is intentionally NOT in WEB_PAGES. Those rows are grouped under "These
+   * open omg.dev in your browser" and read as convenience links to a companion
+   * dashboard. This one is a destructive, guideline-mandated action and belongs
+   * next to Sign out, where someone looking for it will actually find it.
+   */
+  const confirmDeleteAccount = () => {
+    Alert.alert(
+      "Delete account?",
+      "This permanently deletes your omg account, your Computer, and everything on it. " +
+        "You'll finish this in your browser.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Continue",
+          style: "destructive",
+          onPress: () => void Linking.openURL("https://app.omg.dev/settings/delete-account"),
+        },
+      ],
+    );
+  };
+
   const open = (path: string) => void Linking.openURL(`https://app.omg.dev${path}`);
 
   return (
@@ -284,6 +325,9 @@ export default function SettingsScreen() {
         <Card>
           <Row onPress={confirmSignOut}>
             <Text style={{ ...type.callout, color: colors.danger, flex: 1 }}>Sign out</Text>
+          </Row>
+          <Row onPress={confirmDeleteAccount}>
+            <Text style={{ ...type.callout, color: colors.danger, flex: 1 }}>Delete account</Text>
           </Row>
         </Card>
       </View>


### PR DESCRIPTION
Handed over by session `d3f4e3e8`, who owns release. Guideline 5.1.1(v): an app
that supports account creation must also offer account deletion, **initiated in
the app**. A support address or a buried web page does not satisfy it. Submission
blocker, not a TestFlight one.

A destructive **Delete account** row next to Sign out → confirm alert →
`Linking.openURL("https://app.omg.dev/settings/delete-account")`. The page it
lands on ships in vibes #1433 (theirs, unmerged).

## The comment on that link is the actual deliverable

This file's header exists because a "Plan & billing" row linking to `app.omg.dev`
was removed for Guideline 3.1.1(a), and #116 then argued at length that an in-app
paywall must not also offer external checkout. So a **new outbound `app.omg.dev`
link on this exact screen** reads, at a glance, as precisely the regression two
PRs were spent eliminating.

`d3f4e3e8` flagged that trap when handing this over and was right that I'm the
likeliest person to fall into it — the 3.1.1 argument in #116 is mine. So the
reason is stated in the code, not just here:

> 3.1.1(a) prohibits calls to action that direct customers to **purchasing
> mechanisms** other than in-app purchase. Deleting an account is not a purchase,
> takes no money, and is the opposite of a conversion surface. 5.1.1(v)
> affirmatively **requires** this entry point. One rule is about paying, the other
> about leaving.

## Placement

Deliberately **not** in `WEB_PAGES`. Those rows sit under "These open omg.dev in
your browser" and read as convenience links to a companion dashboard. This is a
destructive, guideline-mandated action and belongs next to Sign out, where someone
looking for it will actually find it.

## Not done in this PR

The two "you can already delete your account from the dashboard" claims were
handed to me as `mobile/app/privacy.tsx` and `terms.tsx`. **Those files do not
exist in this repo.** The real files are `apps/landing/src/routes/privacy.tsx:176`
and `terms.tsx:164` in *vibes* — and #1433 already fixes both, at exactly those
lines. Touching them here would have duplicated that work and conflicted with it,
so I left them alone. Nothing outstanding.

## Verification

- `mobile/` `tsc --noEmit` clean
- full suite failure set **byte-identical** before and after (4 pre-existing
  failures, none related — diffed, not eyeballed)

**No simulator pass.** The alert copy and row placement have not been looked at on
a device, and per `mobile/AGENTS.md` that is the actual job. Not merging — release
sequencing is `d3f4e3e8`'s.

---

## Added: privacy policy and terms links (2nd commit)

`d3f4e3e8` found the app shipped with **no privacy link and no terms link
anywhere in the binary**. I re-derived it before writing: every outbound URL was
`app.omg.dev` / `auth.omg.dev` / `backend.omg.dev`, and the only privacy/terms
strings in the tree were in `mobile/docs/`, which is documentation.

Two rules, sourced carefully:

- **5.1.1(i)** — privacy policy link required in the ASC metadata field **and**
  in-app "in an easily accessible manner". Every app, always, not
  subscription-specific. Metadata half was set; in-app half was missing. → Legal
  section in Settings.
- **Schedule 2, via 3.1.2(c)** — 3.1.2(c) doesn't itself list link requirements;
  it says to communicate the requirements in Schedule 2 of the Developer Program
  License Agreement, which is where functional Privacy Policy and EULA links on
  the purchase surface come from. → links under the disclosure block on the
  paywall.

The operative word is **functional**: naming them isn't enough, they must be
tappable and must load. Both return 200.

Deliberately `omg.dev`, not `app.omg.dev` — public legal documents, not dashboard
surfaces. A reviewer must be able to open them **signed out**; behind a login they
would not be "easily accessible".

### Self-review catch worth reading

My first version of the Settings rows used `Separator inset="text"` — **exactly
the defect #115 fixed.** `"text"` budgets for a leading StatusDot and these rows
have none. Corrected to `inset={space.lg}`, matching `WEB_PAGES` directly above,
whose comment already explains why. Caught by reading the neighbouring markup
rather than by tests, which would not have caught it.
