### PR TITLE
fix(mobile): resolve the 3 unaccepted Expo-tooling advisories

### DIFF
--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -45,6 +45,11 @@
       },
     },
   },
+  "overrides": {
+    "brace-expansion": "^5.0.9",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.18",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
@@ -484,7 +489,7 @@
 
     "bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -778,7 +783,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsc-safe-url": ["jsc-safe-url@0.2.4", "", {}, "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q=="],
 
@@ -900,7 +905,7 @@
 
     "multitars": ["multitars@1.0.0", "", {}, "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": "bin/nanoid.cjs" }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -2,6 +2,11 @@
   "name": "@lfg/mobile",
   "version": "1.0.0",
   "main": "expo-router/entry",
+  "overrides": {
+    "brace-expansion": "^5.0.9",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.18"
+  },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.9",
     "@expo/ui": "~57.0.10",


### PR DESCRIPTION
## What

The mobile audit gate has been red since it first gained the ability to read
`mobile/`'s graph: 3 real, unaccepted high-severity advisories, all transitive
through Expo tooling.

| package | advisory | reached via | fixed at |
|---|---|---|---|
| `brace-expansion` | GHSA-rgw5-rvv9-x895 | `minimatch` (via `@expo/fingerprint`, `glob`) | 5.0.9 |
| `js-yaml` | GHSA-5p4m-2wfm-xmqj | `@expo/xcpretty` | 4.3.1 |
| `nanoid` | GHSA-2v37-7h3g-55p8 | `expo-router`, `postcss` | 3.3.18 |

## Why this shape

Root `package.json` already carries an `overrides` block with these exact
versions (`brace-expansion ^5.0.9`, `js-yaml ^4.3.1`, `nanoid ^3.3.18`) from an
earlier root-level advisory pass. `mobile/` isn't a member of the root
`workspaces` list, so it never inherited them and kept resolving whatever
pre-patch version its transitive deps declared.

All three patched versions are within the *existing* semver ranges the
transitive deps already declare (`minimatch` wants `^5.0.5`, `@expo/xcpretty`
wants `^4.1.0`, `expo-router`/`postcss` want `^3.3.8`/`^3.3.16`) — this isn't a
downgrade or a breaking bump, just forcing resolution to the patched version
already inside each declared range.

First attempt was `bun update brace-expansion js-yaml nanoid`, which bun
resolved by adding all three as new *direct* dependencies at their latest
majors (js-yaml 5.x, nanoid 6.x) while leaving the vulnerable versions nested
under their real parents (`minimatch/brace-expansion@5.0.8` etc.) untouched —
net effect: bigger dependency surface, gate still red. Reverted that; the
`overrides` block is the correct fix and matches the pattern already
established at the root.

## Verification

- `bun run audit`: red → green after this change.
- Reverted the change and re-ran the gate to confirm it actually goes red
  again before trusting the green result.
- `npx tsc --noEmit`: clean.

No behavior change — dependency resolution only.