### PR TITLE
docs(mobile): empty production privacy URL, and why OTA stalled at #114

### DIFF
--- a/mobile/docs/TESTFLIGHT-PUBLIC-LINK.md
+++ b/mobile/docs/TESTFLIGHT-PUBLIC-LINK.md
@@ -233,6 +233,29 @@ the reviewer's first open may take a few seconds. **Check `getCloudComputer`
 still reports `live` before each review round**, and re-provision if the
 instance has been recycled.
 
+## Blocker for full App Store submission: production Privacy Policy URL is empty
+
+Verified 2026-08-17 in App Store Connect, logged in as Benny. There are **two
+separate Privacy Policy URL fields** and they are in different states — do not
+assume checking one tells you about the other:
+
+| Field | Location | State |
+|---|---|---|
+| TestFlight Privacy Policy URL | TestFlight → Test Information → Beta App Information | `https://omg.dev/privacy`, set, resolves 200 |
+| App Store Privacy Policy URL | Distribution (App Store) → App Privacy | **empty** (`–`) |
+
+The TestFlight one is what governs Beta App Review — including build 24's —
+and it is correct, which is why this has not blocked anything so far. The
+second one belongs to `iOS App Version 1.0`, the app's full App Store
+listing, which has never been submitted (still "Prepare for Submission",
+no screenshots, no description — an untouched shell separate from the
+TestFlight track this app actually ships on).
+
+**It will not surface again until someone starts a real App Store
+submission**, at which point it blocks — Apple requires it in the metadata
+field, not just in-app. Fill it in (`https://omg.dev/privacy`, same as the
+TestFlight field) before that submission, not after Apple rejects for it.
+
 ## Test Information to fill in
 
 Required once for external testing, in App Store Connect → TestFlight → Test

--- a/mobile/docs/TESTFLIGHT.md
+++ b/mobile/docs/TESTFLIGHT.md
@@ -43,7 +43,22 @@ gracefully. Current native modules: `expo-updates`, `expo-clipboard`,
 `expo-symbols`, `expo-haptics`, `expo-router`, `react-native-screens`,
 `react-native-safe-area-context`, `@siteed/audio-studio` (added 2026-08-15
 for streaming dictation, replacing `expo-audio` — see
-`mobile/docs/DICTATION.md`).
+`mobile/docs/DICTATION.md`), `expo-iap` (added 2026-08-16 for StoreKit,
+`#115`).
+
+**`expo-iap` landing is why the OTA channel stalled at `#114`.** Verified
+2026-08-17: the last `eas update` ever published to `production` is group
+`7c6c1c91` (2026-08-16 09:50 UTC, `gitCommitHash 9367263` — exactly `#114`).
+Everything from `#115` onward (StoreKit, the new paywall, the auto-agents
+home section, account deletion/privacy/terms) is merged but was never
+published, and — once `#115` added `expo-iap` — **can no longer be
+OTA-published to any build-24 install at all**: every build-24 binary was
+compiled before `expo-iap` existed, so shipping that JS to it would crash on
+launch per the rule above. This is not a `runtimeVersion`/`appVersion`
+mismatch (`build 25` kept `appVersion` at `1.0.2`, matching build 24's), it's
+the native graph. `#115`+ only becomes live once a build containing
+`expo-iap` (25 or later) actually reaches a device — from then on, a fresh
+`eas update` is deliverable again under the same runtime version.
 
 `runtimeVersion` is `{"policy":"appVersion"}`, so an update only reaches builds
 sharing that app version. Bumping the version in app.json deliberately cuts old


### PR DESCRIPTION
Two findings from re-verifying the release state directly in ASC and EAS on 2026-08-17, after the ASC login blocker cleared.

## Empty production Privacy Policy URL

Two separate Privacy Policy URL fields exist in App Store Connect, in different states:

| Field | Location | State |
|---|---|---|
| TestFlight Privacy Policy URL | TestFlight → Test Information → Beta App Information | `https://omg.dev/privacy`, set, resolves 200 |
| App Store Privacy Policy URL | Distribution → App Privacy | **empty** |

The TestFlight one governs Beta App Review (including build 24's) and is correct. The App Store one belongs to the full listing (`iOS App Version 1.0`, never submitted — no screenshots, no description). Not a build 24/25 risk, but it will block a real App Store submission if left unfilled.

## OTA channel stalled at #114, and it's structural, not a version mismatch

`eas update:view` on the latest `production` group shows `gitCommitHash 9367263` — exactly `#114`. `#115` added `expo-iap` for StoreKit, a native module. So `#115` onward isn't merely unpublished — it's impossible to OTA-publish to any build-24 install, because that binary predates `expo-iap` and would crash on launch importing it. This is not a `runtimeVersion`/`appVersion` mismatch (build 25 kept `appVersion` at `1.0.2`, matching build 24). `#115`+ only reaches anyone once a build containing `expo-iap` (25+) is actually installed.

Docs only, no code changes.
