### PR TITLE
fix(mobile): auto agents section shows findings, not a roster

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -14,7 +14,7 @@
 import { useFocusEffect, useNavigation, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { Linking, Pressable, RefreshControl, ScrollView, View } from "react-native";
+import { Pressable, RefreshControl, ScrollView, View } from "react-native";
 import Reanimated, { useAnimatedKeyboard, useAnimatedStyle } from "react-native-reanimated";
 import { Text } from "../src/omg/text";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -38,8 +38,8 @@ import {
   sessionStableId,
   type SessionNode,
 } from "../src/omg/session-tree";
-import { AutoAgentCard } from "../src/omg/auto-agent-card";
-import { selectHomeAutoAgents, useAutoAgents } from "../src/omg/auto-agents";
+import { AutoFindingCard } from "../src/omg/auto-agent-card";
+import { selectHomeAutoFindings, useAutoAgents } from "../src/omg/auto-agents";
 import { useComputerPicker } from "../src/omg/computer-picker";
 import { useDictation } from "../src/omg/dictation";
 import { PressableScale } from "../src/omg/motion";
@@ -333,12 +333,7 @@ export default function SessionsScreen() {
   // to a box too old to have that endpoint.
   const { providers: usage, loading: usageLoading } = useUsage();
   const { sessions: resumable, refresh: refreshResumable } = useResumable();
-  const {
-    agents: autoAgents,
-    findings: autoFindings,
-    tz: autoTz,
-    refresh: refreshAuto,
-  } = useAutoAgents();
+  const { agents: autoAgents, findings: autoFindings, refresh: refreshAuto } = useAutoAgents();
   const agentPicker = useAgentPicker();
   const projectPicker = useProjectPicker();
 
@@ -354,9 +349,9 @@ export default function SessionsScreen() {
    */
   const [pulling, setPulling] = useState(false);
   /**
-   * Which auto agent is opened out to show its findings. ONE at a time: a
-   * finding carries four reasoning bullets and a suggestion, so two open at
-   * once push the Recent section off the bottom of a phone.
+   * Which open finding is expanded to show its full reasoning. ONE at a
+   * time: a finding carries several reasoning bullets and a suggestion, so
+   * two open at once push the Recent section off the bottom of a phone.
    */
   const [expandedAuto, setExpandedAuto] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -567,31 +562,26 @@ export default function SessionsScreen() {
   }, [resumable, sessions, projectPicker]);
 
   /**
-   * THE SCHEDULED FLEET, FILTERED DOWN TO THE PART THAT IS NEWS.
+   * OPEN FINDINGS, FILTERED DOWN TO THIS PROJECT.
    *
-   * Auto agents obey the project filter like everything else on this screen —
-   * the machine already resolves each one's owning repo (worktree cwds
-   * collapse; see withAutoAgentMeta), so the chip that hides another repo's
-   * sessions has to hide its schedules too, or the filter half-works.
-   *
-   * `selectHomeAutoAgents` then keeps only the ones with an open finding or a
-   * run in flight; `autoQuiet` is how many were left out. That number is
-   * printed rather than swallowed: this box has 34 auto agents and shows a
-   * handful, and a section that silently drops 26 rows teaches you not to
-   * trust the ones it kept.
+   * Findings obey the project filter like everything else on this screen —
+   * scoped through the OWNING AGENT's repo (the machine already resolves
+   * worktree cwds to it; see withAutoAgentMeta), because a finding carries no
+   * project of its own. `selectHomeAutoFindings` then lays the scoped
+   * findings out one row each, worst severity first — see auto-agents.ts for
+   * why there is no roster here to filter down from.
    */
-  const autoScoped = useMemo(
-    () =>
-      autoAgents.filter((agent) =>
-        projectPicker.matches({ project: agent.project ?? undefined, cwd: agent.cwd ?? undefined }),
-      ),
-    [autoAgents, projectPicker],
-  );
-  const autoRows = useMemo(
-    () => selectHomeAutoAgents(autoScoped, autoFindings),
-    [autoScoped, autoFindings],
-  );
-  const autoQuiet = autoScoped.length - autoRows.length;
+  const autoRows = useMemo(() => {
+    const byAgentId = new Map(autoAgents.map((agent) => [agent.id, agent]));
+    const scoped = autoFindings.filter((finding) => {
+      const agent = byAgentId.get(finding.agentId);
+      return projectPicker.matches({
+        project: agent?.project ?? undefined,
+        cwd: agent?.cwd ?? undefined,
+      });
+    });
+    return selectHomeAutoFindings(autoAgents, scoped);
+  }, [autoAgents, autoFindings, projectPicker]);
 
   const openSession = (id: string | null) => {
     if (!id) return;
@@ -1036,13 +1026,20 @@ export default function SessionsScreen() {
             ) : null}
 
             {/**
-             * THE WORK NOBODY ASKED FOR TODAY.
+             * WHAT NEEDS A DECISION TODAY.
              *
-             * Auto agents run on a timer and report findings; they are not
-             * sessions, so they do not belong in Working or Idle, where a tap
-             * opens a transcript and a swipe archives — see auto-agents.ts.
-             * Their own section, ADDED rather than substituted: the three
-             * above are untouched.
+             * Auto agents run on a timer and report findings; a finding is
+             * not a session, so it does not belong in Working or Idle, where
+             * a tap opens a transcript and a swipe archives — see
+             * auto-agents.ts. Its own section, ADDED rather than
+             * substituted: the three above are untouched.
+             *
+             * ONE ROW PER OPEN FINDING, matching the web's own live view
+             * (the "Auto" section in web/src/App.tsx) rather than a roster of
+             * every scheduled agent — most of which have nothing to say right
+             * now, which is exactly why the web doesn't list them here either
+             * (see selectHomeAutoFindings). Nothing hands off to a "manage
+             * schedules" page: there is nothing left unsaid to hand off.
              *
              * BETWEEN Idle AND Recent, and that position is the argument.
              * Working and Idle are happening now. Recent is finished and
@@ -1057,52 +1054,20 @@ export default function SessionsScreen() {
              */}
             {autoRows.length ? (
               <>
-                <SectionHeader
-                  label="Auto agents"
-                  count={autoRows.length}
-                  dotColor={colors.primary}
-                />
+                <SectionHeader label="Auto" count={autoRows.length} dotColor={colors.primary} />
                 <View style={{ gap: space.sm }}>
                   {autoRows.map((row) => (
-                    <AutoAgentCard
-                      key={row.agent.id}
+                    <AutoFindingCard
+                      key={row.finding.id}
                       row={row}
-                      tz={autoTz}
-                      expanded={expandedAuto === row.agent.id}
+                      expanded={expandedAuto === row.finding.id}
                       onToggle={() =>
                         setExpandedAuto((current) =>
-                          current === row.agent.id ? null : row.agent.id,
+                          current === row.finding.id ? null : row.finding.id,
                         )
                       }
                     />
                   ))}
-                  {/* SAY WHAT IS NOT HERE, AND OPEN IT.
-                      The count is the difference between "these are your auto
-                      agents" (a lie) and "these are the ones with something to
-                      say". As dead text it would still be a cul-de-sac — 26
-                      agents named and no way to reach them — so it hands off
-                      to the web the way the rest of the app does when it runs
-                      out of road (settings.tsx, computers.tsx). The phone has
-                      no editor for a prompt-and-cron; the web page it opens is
-                      the same one this section mirrors. */}
-                  {autoQuiet > 0 ? (
-                    <PressableScale
-                      onPress={() =>
-                        void Linking.openURL("https://app.omg.dev/settings/computer/auto")
-                      }
-                      scale={0.98}
-                      accessibilityRole="link"
-                      style={{ paddingHorizontal: space.lg, paddingTop: space.xs }}
-                    >
-                      <Text style={{ ...type.caption, color: colors.textMuted }}>
-                        {autoQuiet} more {autoQuiet === 1 ? "agent is" : "agents are"} on a
-                        schedule with nothing open ·{" "}
-                        <Text style={{ ...type.caption, color: colors.primary }}>
-                          Manage schedules
-                        </Text>
-                      </Text>
-                    </PressableScale>
-                  ) : null}
                 </View>
               </>
             ) : null}

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -1,132 +1,45 @@
 /**
- * One auto agent as a home-screen row, and its findings underneath when you
- * open it.
+ * One open finding, as a home-screen row.
  *
  * WHY THIS IS NOT A SessionCard. The two look alike on purpose — same card
- * shape, same agent mark, same density — because they sit in the same list and
- * a person should not have to learn a second visual language halfway down the
- * screen. But the affordances are different and must not be borrowed: there is
- * no transcript to push to, and nothing to swipe away. A SessionCard whose tap
- * did something else would be the worse kind of consistency.
+ * shape, same density — because they sit in the same list and a person
+ * should not have to learn a second visual language halfway down the screen.
+ * But the affordances differ: there is no transcript to push to, and nothing
+ * to swipe away (yet — see the follow-up PR that adds dismiss and "start a
+ * session from this").
  *
  * WHAT A ROW SAYS, AND WHY IT SAYS THAT.
  *
- * Matching the web's row (AutoManageView in web/src/App.tsx) is the bar, so
- * the vocabulary is lifted from it: the agent's NAME, an "N open" chip in the
- * primary tint, the running state, and the schedule rendered by the same
- * describeCron + "next …" pair its ScheduleSummary uses. Two deliberate
- * differences, both because a phone row is one line wide and the home screen
- * is a reading surface rather than an editing one:
- *
- * - The web's subtitle is the agent's PROMPT. Here it is the newest open
- *   FINDING's title. The prompt is what you need when you are editing the
- *   agent; the finding is what you need when you are deciding whether to care,
- *   and it is also the reason the row is on this screen at all. (The prompt
- *   arrives truncated from the server anyway — `promptTruncated` — so the row
- *   would have shown half a sentence.)
- * - Severity has no chip. It colours the dot in front of the finding title,
- *   which adds a fact the web's own list omits without spending a second
- *   badge on it.
+ * Matching the web's row (the "Auto" section's AutoFindingCard in
+ * web/src/App.tsx) is the bar, so the vocabulary is lifted straight from it:
+ * a severity dot, the agent's NAME, a relative time, and the finding's own
+ * title underneath — nothing else. No schedule line, no "N open" chip, no
+ * running indicator: those described the AGENT, and this row is about the
+ * FINDING. One finding, one row, so there is nothing left to count.
  *
  * TAPPING OPENS IT IN PLACE. Nothing else on the phone lists findings, so a
- * row that advertises "2 open" and cannot show them is a tease. Expanding is
- * also all a read-only surface can honestly offer: dismiss/resolve/launch are
- * real mutations with a lifecycle behind them (see FindingStatus in
- * src/auto/store.ts) and belong to a screen that can do the whole loop.
+ * row that shows a title and cannot show the reasoning behind it is a tease.
+ * Expanding is all a read-only surface can honestly offer for now — acting on
+ * a finding (dismiss, start a session) is a real mutation with a lifecycle
+ * behind it (see FindingStatus in src/auto/store.ts) and lands separately.
  *
- * MOTION: `useListItemMotion()` and nothing else — no `exiting`, ever. See the
- * long note in motion.tsx. The expansion below is exactly the "a re-render
- * lands mid-animation" case that stranded views: it changes this row's height
- * while a 10s poll may be resizing its siblings, and it is safe only because
- * `entering` and `layout` both END with the view in its correct flow position.
+ * MOTION: `useListItemMotion()` and nothing else — no `exiting`, ever. See
+ * the long note in motion.tsx. The expansion below is exactly the "a
+ * re-render lands mid-animation" case that stranded views: it changes this
+ * row's height while a 30s poll may be resizing its siblings, and it is safe
+ * only because `entering` and `layout` both END with the view in its correct
+ * flow position.
  */
 
-import { useRef } from "react";
-import Reanimated from "react-native-reanimated";
 import { View } from "react-native";
+import Reanimated from "react-native-reanimated";
 
 import { AgentAvatar } from "../components";
 import { Text } from "./text";
 import { useListItemMotion, PressableScale } from "./motion";
 import { useTheme } from "./theme";
-import { describeCron, nextRunAt } from "./cron";
-import type { AutoAgentRow, AutoFinding, AutoFindingSeverity } from "./auto-agents";
-
-/**
- * "in 3h", "in 2d" — the future half of format.ts's relativeTime, in the same
- * compact register.
- *
- * Deliberately NOT web/src/cron.ts's formatRelative, which is built on
- * `Intl.RelativeTimeFormat`. The web can assume a full-ICU browser; Hermes'
- * Intl coverage is thinner and varies by platform, and the failure mode is a
- * throw on a row that is otherwise fine. The phone already spells relative
- * time itself for the Recent section, so this matches that instead of adding
- * a second, wordier style ("in 3 hours") three lines below it.
- */
-function nextRunLabel(at: number, now: number = Date.now()): string {
-  const seconds = Math.round((at - now) / 1000);
-  if (seconds <= 60) return "in <1m";
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `in ${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `in ${hours}h`;
-  const days = Math.round(hours / 24);
-  return `in ${days}d`;
-}
-
-/**
- * The schedule, the way the web's ScheduleSummary says it.
- *
- * A DISABLED agent never gets a "next" — it appears on this screen only
- * because it left an open finding behind, and telling someone it runs again in
- * three hours when it will never run again is the kind of small lie that makes
- * a whole screen untrustworthy. It says "Paused" and keeps the cadence for
- * context.
- *
- * Both calls are wrapped: they go through `Intl.DateTimeFormat` with a
- * timezone and `formatToParts`, and a device whose ICU cannot do that should
- * lose the "next in 3h" clause, not the row.
- *
- * NEXT-RUN IS CACHED, AND CACHED CORRECTLY. nextRunAt scans forward a minute
- * at a time for up to 400 days, so a daily agent costs ~1440 formatToParts
- * calls; the list polls every 30s, and recomputing every row on every poll is
- * the exact lag the web's own ScheduleSummary comment warns about.
- *
- * The cache is TAGGED with the schedule+timezone it was computed for and
- * checked during render, rather than cached in state and invalidated from an
- * effect. An effect runs after commit, so the frame where an agent's schedule
- * changes would render the OLD agent's next-run — a stale value that is merely
- * scheduled for deletion is still a stale value that reached the screen. A tag
- * that does not match is unusable rather than pending. (Same failure the
- * composer's pill-width cache had.)
- *
- * The second condition is what the web gets from its 30s tick: once the cached
- * instant is in the past, it is recomputed. Everything else reuses it.
- */
-function useScheduleLine(schedule: string, enabled: boolean, tz: string): string {
-  const cache = useRef<{ key: string; at: number | null } | null>(null);
-  const now = Date.now();
-  const key = `${schedule}|${tz}`;
-  if (!cache.current || cache.current.key !== key || (cache.current.at ?? Infinity) <= now) {
-    let at: number | null = null;
-    try {
-      at = nextRunAt(schedule, tz, now);
-    } catch {
-      at = null;
-    }
-    cache.current = { key, at };
-  }
-
-  let described: string;
-  try {
-    described = describeCron(schedule);
-  } catch {
-    described = schedule.trim();
-  }
-  if (!enabled) return `Paused · ${described}`;
-  const at = cache.current.at;
-  return at ? `${described} · next ${nextRunLabel(at, now)}` : described;
-}
+import { relativeTime } from "./format";
+import type { AutoFindingRow, AutoFindingSeverity } from "./auto-agents";
 
 function severityColor(
   severity: AutoFindingSeverity | undefined,
@@ -151,75 +64,25 @@ function SeverityDot({ severity }: { severity?: AutoFindingSeverity }) {
         width: 7,
         height: 7,
         borderRadius: 3.5,
-        marginTop: 5,
         backgroundColor: severityColor(severity, colors),
       }}
     />
   );
 }
 
-/** One open finding, expanded: what it found, why, and what it suggests. */
-function FindingDetail({ finding }: { finding: AutoFinding }) {
-  const { colors, type, space } = useTheme();
-  const seen = finding.occurrences ?? 1;
-  return (
-    <View style={{ flexDirection: "row", gap: space.sm }}>
-      <SeverityDot severity={finding.severity} />
-      <View style={{ flex: 1, gap: space.xs }}>
-        <Text style={{ ...type.footnote, fontWeight: "600", color: colors.text, lineHeight: 18 }}>
-          {finding.title}
-        </Text>
-        {/* A repeat is the strongest signal a finding carries — the same
-            problem reported N times is not N times as noisy, it is N times as
-            real. src/auto/store.ts tracks it precisely because a recurrence
-            that reads as brand new gets triaged as brand new. */}
-        {seen > 1 ? (
-          <Text style={{ ...type.caption, color: colors.warning }}>seen {seen}×</Text>
-        ) : null}
-        {finding.reasoning?.length ? (
-          <View style={{ gap: 2 }}>
-            {finding.reasoning.map((line, i) => (
-              <Text
-                key={i}
-                style={{ ...type.caption, color: colors.textMuted, lineHeight: 17 }}
-              >
-                {`· ${line}`}
-              </Text>
-            ))}
-          </View>
-        ) : null}
-        {finding.suggest ? (
-          <Text style={{ ...type.caption, color: colors.textSecondary, lineHeight: 17 }}>
-            <Text style={{ ...type.caption, color: colors.primary }}>Suggests </Text>
-            {finding.suggest}
-          </Text>
-        ) : null}
-      </View>
-    </View>
-  );
-}
-
-export function AutoAgentCard({
+export function AutoFindingCard({
   row,
-  tz,
   expanded,
   onToggle,
 }: {
-  row: AutoAgentRow;
-  /** The MACHINE's schedule timezone. See cron.ts. */
-  tz: string;
+  row: AutoFindingRow;
   expanded: boolean;
   onToggle: () => void;
 }) {
   const { colors, radius, type, space } = useTheme();
-  // Outer, style-less view owns list membership, exactly as SessionCard does —
-  // press feedback and list motion are different concerns with different
-  // lifetimes.
   const listMotion = useListItemMotion();
-  const { agent, findings } = row;
-  const headline = findings[0];
-  const open = findings.length;
-  const schedule = useScheduleLine(agent.schedule, agent.enabled, tz);
+  const { finding, agent } = row;
+  const seen = finding.occurrences ?? 1;
 
   return (
     <Reanimated.View entering={listMotion.entering} layout={listMotion.layout}>
@@ -227,7 +90,7 @@ export function AutoAgentCard({
         onPress={onToggle}
         scale={0.98}
         accessibilityRole="button"
-        accessibilityLabel={`${agent.name}, ${open} open finding${open === 1 ? "" : "s"}`}
+        accessibilityLabel={`${agent?.name ?? "Auto agent"} finding: ${finding.title}`}
         accessibilityState={{ expanded }}
         style={({ pressed }) => ({
           flexDirection: "row",
@@ -240,69 +103,54 @@ export function AutoAgentCard({
           backgroundColor: pressed ? colors.cardPressed : colors.card,
         })}
       >
-        {/* The ring around the mark is how "working" reads everywhere else in
-            this app, and a scheduled run in flight is the same fact. */}
-        <AgentAvatar agent={agent.agent} size={26} plain busy={!!agent.running} />
+        <AgentAvatar agent={agent?.agent} size={26} plain busy={!!agent?.running} />
         <View style={{ flex: 1, gap: 3 }}>
           <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
             <Text numberOfLines={1} style={{ ...type.headline, color: colors.text, flexShrink: 1 }}>
-              {agent.name}
+              {agent?.name ?? "Auto agent"}
             </Text>
-            {/* "N open" — the web's words, in the web's tint. */}
-            {open ? (
-              <View
-                style={{
-                  paddingHorizontal: 6,
-                  paddingVertical: 1,
-                  borderRadius: radius.pill,
-                  backgroundColor: colors.accentSoft,
-                }}
-              >
-                <Text
-                  style={{
-                    ...type.caption,
-                    fontSize: 10,
-                    fontWeight: "600",
-                    color: colors.primary,
-                  }}
-                >
-                  {open} open
-                </Text>
-              </View>
-            ) : null}
-            {/* An agent with no findings is here only because it is running,
-                and the ring alone does not say so in words. */}
-            {!open && agent.running ? (
-              <Text style={{ ...type.caption, color: colors.warning }}>running</Text>
-            ) : null}
+            <Text style={{ ...type.caption, color: colors.textMuted, marginLeft: "auto" }}>
+              {relativeTime(finding.lastSeenAt ?? finding.createdAt)}
+            </Text>
           </View>
 
-          {headline && !expanded ? (
-            <View style={{ flexDirection: "row", gap: space.sm }}>
-              <SeverityDot severity={headline.severity} />
-              <Text
-                numberOfLines={2}
-                style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
-              >
-                {headline.title}
-              </Text>
+          <View style={{ flexDirection: "row", gap: space.sm }}>
+            <View style={{ marginTop: 5 }}>
+              <SeverityDot severity={finding.severity} />
+            </View>
+            <Text
+              numberOfLines={expanded ? undefined : 2}
+              style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
+            >
+              {finding.title}
+            </Text>
+          </View>
+
+          {expanded ? (
+            <View style={{ gap: space.sm, paddingTop: space.xs }}>
+              {seen > 1 ? (
+                <Text style={{ ...type.caption, color: colors.warning }}>seen {seen}×</Text>
+              ) : null}
+              {finding.reasoning?.length ? (
+                <View style={{ gap: 2 }}>
+                  {finding.reasoning.map((line, i) => (
+                    <Text
+                      key={i}
+                      style={{ ...type.caption, color: colors.textMuted, lineHeight: 17 }}
+                    >
+                      {`· ${line}`}
+                    </Text>
+                  ))}
+                </View>
+              ) : null}
+              {finding.suggest ? (
+                <Text style={{ ...type.caption, color: colors.textSecondary, lineHeight: 17 }}>
+                  <Text style={{ ...type.caption, color: colors.primary }}>Suggests </Text>
+                  {finding.suggest}
+                </Text>
+              ) : null}
             </View>
           ) : null}
-
-          {expanded && findings.length ? (
-            <View style={{ gap: space.md, paddingTop: space.xs }}>
-              {findings.map((finding) => (
-                <FindingDetail key={finding.id} finding={finding} />
-              ))}
-            </View>
-          ) : null}
-
-          {/* The schedule stays on every row, expanded or not: it is the one
-              fact that makes this an AUTO agent rather than a session, and it
-              answers "when do I get a better answer than this one". */}
-          <Text numberOfLines={1} style={{ ...type.caption, color: colors.textMuted }}>
-            {schedule}
-          </Text>
         </View>
       </PressableScale>
     </Reanimated.View>

--- a/mobile/src/omg/auto-agents.ts
+++ b/mobile/src/omg/auto-agents.ts
@@ -2,29 +2,35 @@
  * Auto agents — the ones that run on a timer instead of because you asked.
  *
  * An auto agent is JUST a prompt plus a cron schedule (see src/auto/store.ts).
- * It is NOT a session: it has no transcript, nothing to resume, and nothing to
- * archive. What it produces is a FINDING — one notification, at most, per run,
- * carrying its reasoning and a lifecycle. That distinction is the whole reason
- * these get their own section on the home screen rather than being folded into
- * Working/Idle, where tapping a row opens a transcript and swiping one
- * archives a session; both of those would be lies here.
+ * It is NOT a session on its own: it has no transcript, nothing to resume.
+ * What it produces is a FINDING — one notification, at most, per run,
+ * carrying its reasoning and a lifecycle (open, dismissed, or graduated into
+ * a real session — acting on that lifecycle from the phone is a follow-up;
+ * this file only reads and shapes the open list for now). That distinction is
+ * the whole reason these get their own section on the home screen rather than
+ * being folded into Working/Idle, where tapping a row opens a transcript and
+ * swiping one archives a session — both would be lies here. See
+ * selectHomeAutoFindings below.
  *
- * WHAT THE HOME SCREEN IS FOR, AND WHY THIS LIST IS FILTERED.
+ * WHAT THE HOME SCREEN IS FOR, AND WHY THIS LIST IS A FINDINGS LIST.
  *
- * This box has 34 auto agents. Rendering all of them would put ~2000pt of
- * configuration under the three sections that show live work, which is the
- * opposite of what the screen is for — and it is not what the web does either:
- * the web keeps the full roster on a MANAGEMENT page (/settings/computer/auto,
- * titled "Schedules") and surfaces findings on the live view. The phone has no
- * management page, so the home section shows the agents that have something to
- * say right now — an open finding, or a run in progress — and index.tsx says
- * out loud how many quiet ones were left out. See selectHomeAutoAgents.
+ * This box can have dozens of auto agents. Rendering that roster would put
+ * a wall of configuration under the three sections that show live work,
+ * which is the opposite of what the screen is for — and it is not what the
+ * web does either: the web keeps the full roster on a MANAGEMENT page
+ * (/settings/computer/auto, titled "Schedules") and its live view shows only
+ * open findings, one row each, agent-grouping and all (see the "Auto"
+ * section in web/src/App.tsx). The phone has no management page, so this
+ * mirrors the live view exactly rather than inventing a phone-only shape: the
+ * home section shows one row per open finding, nothing about the quiet
+ * agents that produced none. See selectHomeAutoFindings.
  *
  * Both reads degrade to nothing rather than to an error, the same way
  * resumable.ts does: an older machine has no /api/auto/* at all, and someone
- * who opened this screen to see what is running should not be told about it.
- * They degrade INDEPENDENTLY, too — a machine that can list agents but not
- * findings still owes you the running ones.
+ * who opened this screen to see what needs attention should not be told
+ * about it. They degrade INDEPENDENTLY, too — a machine that can list
+ * findings but not agents still owes you the findings, with a generic mark
+ * where the agent's name and avatar would be (see AutoFindingRow).
  */
 
 import { useFocusEffect } from "expo-router";
@@ -80,15 +86,15 @@ export type AutoAgentsState = {
 };
 
 /**
- * 30s. The rows make LIVE claims — "running", "next in 56m" — so this cannot
- * be resumable.ts's fetch-once, which would leave an agent advertising a run
- * that finished ten minutes ago and a countdown that never counts. It is
- * slower than the session list's 10s on purpose: cron granularity is a whole
- * minute, so nothing here can change faster than that, and this pulls the
+ * 30s. A finding is a live fact — dismissed on another device, or graduated
+ * into a session from the web — so this cannot be resumable.ts's fetch-once,
+ * which would leave a row on screen the server has already closed out. It is
+ * slower than the session list's 10s on purpose: these are cron-scheduled
+ * writes, nothing here changes faster than a minute, and this pulls the
  * entire roster plus every open finding rather than a delta.
  *
- * Re-fetching is also what keeps the relative labels honest — the card derives
- * "next in …" at render time, so a poll that re-renders is the clock. See
+ * Re-fetching is also what keeps each row's relative time honest — the card
+ * derives it at render time, so a poll that re-renders is the clock. See
  * auto-agent-card.tsx.
  */
 const AUTO_POLL_MS = 30_000;
@@ -163,58 +169,44 @@ export function useAutoAgents(): AutoAgentsState {
 
 const SEVERITY_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };
 
-export type AutoAgentRow = {
-  agent: AutoAgent;
-  /** This agent's open findings, newest first. */
-  findings: AutoFinding[];
+export type AutoFindingRow = {
+  finding: AutoFinding;
+  /**
+   * Undefined only in the gap between a finding arriving and its agent
+   * roster catching up (they are two independent fetches; see
+   * `useAutoAgents`). The row still renders — see auto-agent-card.tsx — with
+   * a generic mark rather than being dropped, because an open finding is
+   * never the thing to hide.
+   */
+  agent: AutoAgent | undefined;
 };
 
 /**
- * The agents worth a row on the home screen, in the order they deserve one.
+ * The open findings worth a row on the home screen, in the order they most
+ * want a decision.
  *
- * An agent qualifies by having an open finding or by running right now.
- * Everything else is a schedule that is behaving — real, but not news, and the
- * home screen is a news surface. A disabled agent with a stale finding still
- * qualifies: the finding is open regardless of whether the agent will ever run
- * again, and hiding it would strand it where nothing else on the phone lists
- * findings at all.
+ * ONE ROW PER FINDING, not per agent. This box can have dozens of auto
+ * agents; almost none of that is news. What is news is a finding, and the
+ * web's own live view (the "Auto" section in web/src/App.tsx) already proved
+ * the right grain: a flat, chronological-by-severity list of findings, not a
+ * roster of the agents that produced them. An agent with nothing open —
+ * including one running right now — earns no row here; "running" is a
+ * schedule-management fact (web's AutoManageView), not news.
  *
- * Order: running first (it is about to change), then by worst severity, then
- * by most findings, then by most recent — so the row at the top is the one
- * that most wants a decision.
+ * Order: worst severity first, then most recently seen — so the row at the
+ * top is the one that most wants a decision, matching selectHomeAutoAgents's
+ * old ordering minus the "running" tiebreaker that no longer applies.
  */
-export function selectHomeAutoAgents(
+export function selectHomeAutoFindings(
   agents: AutoAgent[],
   findings: AutoFinding[],
-): AutoAgentRow[] {
-  const byAgent = new Map<string, AutoFinding[]>();
-  for (const finding of findings) {
-    const list = byAgent.get(finding.agentId);
-    if (list) list.push(finding);
-    else byAgent.set(finding.agentId, [finding]);
-  }
-  for (const list of byAgent.values()) {
-    list.sort((a, b) => (b.lastSeenAt ?? b.createdAt ?? 0) - (a.lastSeenAt ?? a.createdAt ?? 0));
-  }
+): AutoFindingRow[] {
+  const byId = new Map(agents.map((agent) => [agent.id, agent]));
+  const rows = findings.map((finding) => ({ finding, agent: byId.get(finding.agentId) }));
 
-  const rows: AutoAgentRow[] = [];
-  for (const agent of agents) {
-    const own = byAgent.get(agent.id) ?? [];
-    if (!own.length && !agent.running) continue;
-    rows.push({ agent, findings: own });
-  }
+  const sev = (row: AutoFindingRow) => SEVERITY_RANK[row.finding.severity ?? "low"] ?? 2;
+  const seen = (row: AutoFindingRow) => row.finding.lastSeenAt ?? row.finding.createdAt ?? 0;
 
-  const worst = (row: AutoAgentRow) =>
-    row.findings.reduce((acc, f) => Math.min(acc, SEVERITY_RANK[f.severity ?? "low"] ?? 2), 3);
-  const newest = (row: AutoAgentRow) =>
-    row.findings.reduce((acc, f) => Math.max(acc, f.lastSeenAt ?? f.createdAt ?? 0), 0);
-
-  rows.sort(
-    (a, b) =>
-      Number(!!b.agent.running) - Number(!!a.agent.running) ||
-      worst(a) - worst(b) ||
-      b.findings.length - a.findings.length ||
-      newest(b) - newest(a),
-  );
+  rows.sort((a, b) => sev(a) - sev(b) || seen(b) - seen(a));
   return rows;
 }


### PR DESCRIPTION
## Why

Direct feedback from Benny on #117: the home-screen auto agents section shows all the agents, and has too many labels — specifically a "27 more"-style count row.

Cross-checked the live dashboard (app.omg.dev, signed in) and its source (`web/src/App.tsx`) before touching anything: the web's own "Auto" section is a **flat list of open findings**, one row each — never a roster of agents, and no overflow/"N more" label anywhere. `AutoManageView` (the roster) lives on a separate management page (`/settings/computer/auto`, "Schedules"), and the live view never shows it.

Mobile's `#117` code instead grouped by agent (one card per agent, nested findings inside) and added a `"28 more agents are on a schedule with nothing open · Manage schedules"` row — chrome the web doesn't have.

## What changed

- `selectHomeAutoFindings` replaces `selectHomeAutoAgents`: one row per open finding, not per agent.
- `AutoFindingCard` replaces `AutoAgentCard`: severity dot + agent name + relative time + finding title. No schedule line, no "N open" chip, no running indicator — those described the *agent*, and the row is about the *finding* now.
- The "N more agents..." overflow row is gone. There's nothing left unsaid to hand off to a management page the phone doesn't have anyway.
- Net diff is a subtraction: -368/+173 lines across `app/index.tsx`, `auto-agent-card.tsx`, `auto-agents.ts`.

## Verified

In the iPhone 17 Pro simulator, against Benny's own live account (real findings, real data):
- Before/after screenshots (attached in the session) show the old grouped-roster-plus-overflow-row UI vs. the new flat findings list.
- Tapping a finding row expands it in place and shows the full reasoning bullets + suggested fix — confirmed working live.
- `tsc --noEmit` clean.

## Not in this PR

Dismiss and "start a session from a finding" are real mutations with a server-side lifecycle — deliberately a separate PR (interactions, not display), stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)