### PR TITLE
feat(mobile): dismiss and start-session on auto findings

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -39,7 +39,7 @@ import {
   type SessionNode,
 } from "../src/omg/session-tree";
 import { AutoFindingCard } from "../src/omg/auto-agent-card";
-import { selectHomeAutoFindings, useAutoAgents } from "../src/omg/auto-agents";
+import { selectHomeAutoFindings, useAutoAgents, type AutoFindingRow } from "../src/omg/auto-agents";
 import { useComputerPicker } from "../src/omg/computer-picker";
 import { useDictation } from "../src/omg/dictation";
 import { PressableScale } from "../src/omg/motion";
@@ -333,7 +333,12 @@ export default function SessionsScreen() {
   // to a box too old to have that endpoint.
   const { providers: usage, loading: usageLoading } = useUsage();
   const { sessions: resumable, refresh: refreshResumable } = useResumable();
-  const { agents: autoAgents, findings: autoFindings, refresh: refreshAuto } = useAutoAgents();
+  const {
+    agents: autoAgents,
+    findings: autoFindings,
+    refresh: refreshAuto,
+    setFindingStatus: setAutoFindingStatus,
+  } = useAutoAgents();
   const agentPicker = useAgentPicker();
   const projectPicker = useProjectPicker();
 
@@ -692,6 +697,83 @@ export default function SessionsScreen() {
     [client, load],
   );
 
+  /**
+   * DISMISS. The finding said its piece; the user doesn't want to act on it.
+   *
+   * Delegates to `setFindingStatus`, which owns the optimistic removal and
+   * the real request (POST /api/auto/findings/{id} {status:"dismissed"}) —
+   * the same status change the web's Dismiss button sends. There is
+   * deliberately no local-only hide: a dismiss that reappears on next launch
+   * because it never reached the server is worse than no dismiss at all.
+   */
+  const dismissFinding = useCallback(
+    (findingId: string) => {
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      void setAutoFindingStatus(findingId, "dismissed");
+    },
+    [setAutoFindingStatus],
+  );
+
+  /**
+   * Which finding is graduating into a session right now. ONE at a time — a
+   * finding launches into the composer's own /api/sessions/new call, and the
+   * button that fired it is the only one that should show a spinner.
+   */
+  const [startingFindingId, setStartingFindingId] = useState<string | null>(null);
+
+  /**
+   * START SESSION. The one-tap path web calls "Make the change": no typed
+   * instruction, just "go implement the suggested fix" — a phone has no room
+   * for the web sheet's launch-settings picker, so this launches on the
+   * finding's OWN agent's backend/model/cwd, the same defaults the web falls
+   * back to when nothing is overridden.
+   *
+   * Composes the same reference text `replyToFinding` sends in
+   * web/src/App.tsx (agent name, title, reasoning, suggestion, then the
+   * instruction) so a session graduated from mobile reads identically to one
+   * graduated from the web. Marks the finding `session` — not `dismissed` —
+   * so its lifecycle in src/auto/store.ts correctly says WHY it left the open
+   * list, and navigates to the new session the same way the composer's own
+   * Start button does.
+   */
+  const startSessionFromFinding = useCallback(
+    async (row: AutoFindingRow) => {
+      if (!client || startingFindingId) return;
+      const { finding, agent } = row;
+      setStartingFindingId(finding.id);
+      const prompt = [
+        `An automated watch agent ("${agent?.name ?? "Auto agent"}") flagged this:`,
+        "",
+        finding.title,
+        ...(finding.reasoning?.length ? ["", "Reasoning:", ...finding.reasoning.map((r) => `- ${r}`)] : []),
+        ...(finding.suggest ? ["", `Suggested fix: ${finding.suggest}`] : []),
+        "",
+        "Now do this: Go ahead and implement this fix now.",
+      ].join("\n");
+      try {
+        const res = await client.transport.request<{ sessionId?: string }>("/api/sessions/new", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt,
+            title: finding.title.trim().slice(0, 200),
+            agent: agent?.agent ?? undefined,
+            model: agent?.model ?? undefined,
+            cwd: agent?.cwd ?? undefined,
+          }),
+        });
+        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        await setAutoFindingStatus(finding.id, "session");
+        await load();
+        if (res?.sessionId) router.push(`/session/${res.sessionId}`);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setStartingFindingId(null);
+      }
+    },
+    [client, startingFindingId, setAutoFindingStatus, load, router],
+  );
 
   /**
    * The bar is the system's, not ours.
@@ -1030,9 +1112,12 @@ export default function SessionsScreen() {
              *
              * Auto agents run on a timer and report findings; a finding is
              * not a session, so it does not belong in Working or Idle, where
-             * a tap opens a transcript and a swipe archives — see
-             * auto-agents.ts. Its own section, ADDED rather than
-             * substituted: the three above are untouched.
+             * a tap opens a transcript. A swipe here still dismisses, same
+             * gesture as archive, different target — see the long note atop
+             * auto-agent-card.tsx for why dismiss gets both that swipe and a
+             * visible button, and why "start session" only gets the button.
+             * Its own section, ADDED rather than substituted: the three above
+             * are untouched.
              *
              * ONE ROW PER OPEN FINDING, matching the web's own live view
              * (the "Auto" section in web/src/App.tsx) rather than a roster of
@@ -1066,6 +1151,9 @@ export default function SessionsScreen() {
                           current === row.finding.id ? null : row.finding.id,
                         )
                       }
+                      onDismiss={() => dismissFinding(row.finding.id)}
+                      onStartSession={() => void startSessionFromFinding(row)}
+                      busy={startingFindingId === row.finding.id}
                     />
                   ))}
                 </View>

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -1,12 +1,12 @@
 /**
- * One open finding, as a home-screen row.
+ * One open finding, as a home-screen row — and, expanded, the two things you
+ * can actually do about it.
  *
  * WHY THIS IS NOT A SessionCard. The two look alike on purpose — same card
  * shape, same density — because they sit in the same list and a person
  * should not have to learn a second visual language halfway down the screen.
- * But the affordances differ: there is no transcript to push to, and nothing
- * to swipe away (yet — see the follow-up PR that adds dismiss and "start a
- * session from this").
+ * But the affordances are different: there is no transcript to push to, and
+ * a swipe here dismisses the FINDING, not a session (there isn't one yet).
  *
  * WHAT A ROW SAYS, AND WHY IT SAYS THAT.
  *
@@ -17,29 +17,53 @@
  * running indicator: those described the AGENT, and this row is about the
  * FINDING. One finding, one row, so there is nothing left to count.
  *
- * TAPPING OPENS IT IN PLACE. Nothing else on the phone lists findings, so a
- * row that shows a title and cannot show the reasoning behind it is a tease.
- * Expanding is all a read-only surface can honestly offer for now — acting on
- * a finding (dismiss, start a session) is a real mutation with a lifecycle
- * behind it (see FindingStatus in src/auto/store.ts) and lands separately.
+ * TWO WAYS TO DISMISS, ON PURPOSE. The web's FindingSheet has a single
+ * visible "Dismiss" button in its action row. A phone could offer that same
+ * button AND nothing else, but this app already taught a swipe-to-archive
+ * gesture for exactly this shape of action (SessionCard, components.tsx),
+ * and a finding row sitting right below those session rows that suddenly
+ * doesn't respond to the same swipe would be the inconsistency. So this row
+ * does both: swipe to dismiss immediately (the fast, native path), or expand
+ * and tap "Dismiss" (the discoverable, visible path — same label web uses).
+ * Neither is hidden in favor of the other.
+ *
+ * TAPPING EXPANDS IT IN PLACE, exactly like the web sheet minus the launch
+ * settings a phone row has no room for: full reasoning, the suggested fix,
+ * and one button — Start session — which sends the same request the web's
+ * one-tap "Make the change" does (see startSessionFromFinding in
+ * app/index.tsx). Copy and Feedback stay web-only: Benny asked for two
+ * interactions, not five.
  *
  * MOTION: `useListItemMotion()` and nothing else — no `exiting`, ever. See
- * the long note in motion.tsx. The expansion below is exactly the "a
- * re-render lands mid-animation" case that stranded views: it changes this
- * row's height while a 30s poll may be resizing its siblings, and it is safe
- * only because `entering` and `layout` both END with the view in its correct
- * flow position.
+ * the long note in motion.tsx. The expansion below changes this row's height
+ * while a 30s poll may be resizing its siblings, and it is safe only because
+ * `entering` and `layout` both END with the view in its correct flow
+ * position. The dismiss swipe drives its own exit (translateX off-screen)
+ * rather than asking Reanimated for one, the same reasoning SessionCard
+ * documents for archive.
  */
 
-import { View } from "react-native";
-import Reanimated from "react-native-reanimated";
+import { useMemo, useRef } from "react";
+import Reanimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import * as Haptics from "expo-haptics";
+import { type AndroidSymbol, type SFSymbol } from "expo-symbols";
+import { Dimensions, PanResponder, View } from "react-native";
 
-import { AgentAvatar } from "../components";
+import { AgentAvatar, Icon } from "../components";
 import { Text } from "./text";
 import { useListItemMotion, PressableScale } from "./motion";
 import { useTheme } from "./theme";
 import { relativeTime } from "./format";
 import type { AutoFindingRow, AutoFindingSeverity } from "./auto-agents";
+
+const SWIPE_DISMISS_PX = 96;
+const SWIPE_DISMISS_VELOCITY = 0.5;
+const REVEAL_WIDTH = 96;
+const SCREEN_WIDTH = Dimensions.get("window").width;
 
 function severityColor(
   severity: AutoFindingSeverity | undefined,
@@ -70,89 +94,240 @@ function SeverityDot({ severity }: { severity?: AutoFindingSeverity }) {
   );
 }
 
+/** A quiet expanded-state action: an icon, a label, nothing louder than text. */
+function RowAction({
+  icon,
+  androidIcon,
+  label,
+  onPress,
+  disabled,
+  tone = "default",
+}: {
+  icon: SFSymbol;
+  androidIcon: AndroidSymbol;
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  tone?: "default" | "primary";
+}) {
+  const { colors, radius, type, space } = useTheme();
+  const isPrimary = tone === "primary";
+  return (
+    <PressableScale
+      onPress={onPress}
+      disabled={disabled}
+      scale={0.97}
+      dim={0.85}
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: space.xs,
+        paddingHorizontal: space.md,
+        paddingVertical: space.sm,
+        borderRadius: radius.pill,
+        backgroundColor: isPrimary ? colors.primary : colors.secondary,
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      <Icon
+        ios={icon}
+        android={androidIcon}
+        size={14}
+        color={isPrimary ? colors.primaryForeground : colors.text}
+      />
+      <Text
+        style={{
+          ...type.footnote,
+          fontWeight: "600",
+          color: isPrimary ? colors.primaryForeground : colors.text,
+        }}
+      >
+        {label}
+      </Text>
+    </PressableScale>
+  );
+}
+
 export function AutoFindingCard({
   row,
   expanded,
   onToggle,
+  onDismiss,
+  onStartSession,
+  busy,
 }: {
   row: AutoFindingRow;
   expanded: boolean;
   onToggle: () => void;
+  /** Fire-and-forget from here — see setFindingStatus in auto-agents.ts. */
+  onDismiss: () => void;
+  /** Async so the button can show its own spinner while the session starts. */
+  onStartSession: () => void;
+  /** True while a session is being started FROM THIS finding. */
+  busy?: boolean;
 }) {
-  const { colors, radius, type, space } = useTheme();
+  const { colors, radius, type, space, motion } = useTheme();
   const listMotion = useListItemMotion();
   const { finding, agent } = row;
   const seen = finding.occurrences ?? 1;
 
+  const corners = { borderRadius: radius.xl };
+
+  /**
+   * Swipe-to-dismiss, on PanResponder rather than react-native-gesture-handler
+   * — Swipeable's native module is not in this app's binary; see the identical
+   * note on SessionCard's swipe-to-archive in components.tsx. Same constants,
+   * same feel, on purpose: this is the second place in the app a horizontal
+   * swipe means "make this row go away."
+   */
+  const translateX = useSharedValue(0);
+  const dismissRef = useRef(onDismiss);
+  dismissRef.current = onDismiss;
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponderCapture: (_evt, gesture) =>
+          gesture.dx < -8 && Math.abs(gesture.dx) > Math.abs(gesture.dy) * 1.5,
+        onPanResponderMove: (_evt, gesture) => {
+          if (gesture.dx < 0) translateX.value = Math.max(gesture.dx, -REVEAL_WIDTH * 1.4);
+        },
+        onPanResponderRelease: (_evt, gesture) => {
+          const committed =
+            gesture.dx < -SWIPE_DISMISS_PX || gesture.vx < -SWIPE_DISMISS_VELOCITY;
+          if (committed) {
+            void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            translateX.value = withTiming(-SCREEN_WIDTH, { duration: motion.fast });
+            dismissRef.current();
+          } else {
+            translateX.value = withTiming(0, { duration: motion.quick });
+          }
+        },
+        onPanResponderTerminate: () => {
+          translateX.value = withTiming(0, { duration: motion.quick });
+        },
+      }),
+    [translateX, motion.fast, motion.quick],
+  );
+
+  const cardStyle = useAnimatedStyle(() => ({ transform: [{ translateX: translateX.value }] }));
+  const revealStyle = useAnimatedStyle(() => ({
+    opacity: Math.min(1, Math.abs(translateX.value) / REVEAL_WIDTH),
+  }));
+
   return (
     <Reanimated.View entering={listMotion.entering} layout={listMotion.layout}>
-      <PressableScale
-        onPress={onToggle}
-        scale={0.98}
-        accessibilityRole="button"
-        accessibilityLabel={`${agent?.name ?? "Auto agent"} finding: ${finding.title}`}
-        accessibilityState={{ expanded }}
-        style={({ pressed }) => ({
-          flexDirection: "row",
-          gap: space.md,
-          marginHorizontal: space.lg,
-          padding: space.md,
-          borderRadius: radius.xl,
-          borderWidth: 1,
-          borderColor: colors.borderStrong,
-          backgroundColor: pressed ? colors.cardPressed : colors.card,
-        })}
+      <Reanimated.View
+        pointerEvents="none"
+        style={[
+          revealStyle,
+          {
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            backgroundColor: colors.danger,
+            ...corners,
+            marginHorizontal: space.lg,
+            alignItems: "flex-end",
+            justifyContent: "center",
+            paddingRight: space.xl,
+          },
+        ]}
       >
-        <AgentAvatar agent={agent?.agent} size={26} plain busy={!!agent?.running} />
-        <View style={{ flex: 1, gap: 3 }}>
-          <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
-            <Text numberOfLines={1} style={{ ...type.headline, color: colors.text, flexShrink: 1 }}>
-              {agent?.name ?? "Auto agent"}
-            </Text>
-            <Text style={{ ...type.caption, color: colors.textMuted, marginLeft: "auto" }}>
-              {relativeTime(finding.lastSeenAt ?? finding.createdAt)}
-            </Text>
-          </View>
-
-          <View style={{ flexDirection: "row", gap: space.sm }}>
-            <View style={{ marginTop: 5 }}>
-              <SeverityDot severity={finding.severity} />
+        <Icon ios="xmark" android="close" size={20} color="#ffffff" />
+      </Reanimated.View>
+      <Reanimated.View style={cardStyle} {...panResponder.panHandlers}>
+        <PressableScale
+          onPress={onToggle}
+          scale={0.98}
+          accessibilityRole="button"
+          accessibilityLabel={`${agent?.name ?? "Auto agent"} finding: ${finding.title}`}
+          accessibilityState={{ expanded }}
+          style={({ pressed }) => ({
+            flexDirection: "row",
+            gap: space.md,
+            marginHorizontal: space.lg,
+            padding: space.md,
+            borderRadius: radius.xl,
+            borderWidth: 1,
+            borderColor: colors.borderStrong,
+            backgroundColor: pressed ? colors.cardPressed : colors.card,
+          })}
+        >
+          <AgentAvatar agent={agent?.agent} size={26} plain busy={!!agent?.running} />
+          <View style={{ flex: 1, gap: 3 }}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
+              <Text
+                numberOfLines={1}
+                style={{ ...type.headline, color: colors.text, flexShrink: 1 }}
+              >
+                {agent?.name ?? "Auto agent"}
+              </Text>
+              <Text style={{ ...type.caption, color: colors.textMuted, marginLeft: "auto" }}>
+                {relativeTime(finding.lastSeenAt ?? finding.createdAt)}
+              </Text>
             </View>
-            <Text
-              numberOfLines={expanded ? undefined : 2}
-              style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
-            >
-              {finding.title}
-            </Text>
-          </View>
 
-          {expanded ? (
-            <View style={{ gap: space.sm, paddingTop: space.xs }}>
-              {seen > 1 ? (
-                <Text style={{ ...type.caption, color: colors.warning }}>seen {seen}×</Text>
-              ) : null}
-              {finding.reasoning?.length ? (
-                <View style={{ gap: 2 }}>
-                  {finding.reasoning.map((line, i) => (
-                    <Text
-                      key={i}
-                      style={{ ...type.caption, color: colors.textMuted, lineHeight: 17 }}
-                    >
-                      {`· ${line}`}
-                    </Text>
-                  ))}
+            <View style={{ flexDirection: "row", gap: space.sm }}>
+              <View style={{ marginTop: 5 }}>
+                <SeverityDot severity={finding.severity} />
+              </View>
+              <Text
+                numberOfLines={expanded ? undefined : 2}
+                style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
+              >
+                {finding.title}
+              </Text>
+            </View>
+
+            {expanded ? (
+              <View style={{ gap: space.sm, paddingTop: space.xs }}>
+                {seen > 1 ? (
+                  <Text style={{ ...type.caption, color: colors.warning }}>seen {seen}×</Text>
+                ) : null}
+                {finding.reasoning?.length ? (
+                  <View style={{ gap: 2 }}>
+                    {finding.reasoning.map((line, i) => (
+                      <Text
+                        key={i}
+                        style={{ ...type.caption, color: colors.textMuted, lineHeight: 17 }}
+                      >
+                        {`· ${line}`}
+                      </Text>
+                    ))}
+                  </View>
+                ) : null}
+                {finding.suggest ? (
+                  <Text style={{ ...type.caption, color: colors.textSecondary, lineHeight: 17 }}>
+                    <Text style={{ ...type.caption, color: colors.primary }}>Suggests </Text>
+                    {finding.suggest}
+                  </Text>
+                ) : null}
+
+                <View style={{ flexDirection: "row", gap: space.sm, paddingTop: space.xs }}>
+                  <RowAction
+                    icon="checkmark"
+                    androidIcon="check"
+                    label={busy ? "Starting…" : "Start session"}
+                    onPress={onStartSession}
+                    disabled={busy}
+                    tone="primary"
+                  />
+                  <RowAction
+                    icon="xmark"
+                    androidIcon="close"
+                    label="Dismiss"
+                    onPress={onDismiss}
+                    disabled={busy}
+                  />
                 </View>
-              ) : null}
-              {finding.suggest ? (
-                <Text style={{ ...type.caption, color: colors.textSecondary, lineHeight: 17 }}>
-                  <Text style={{ ...type.caption, color: colors.primary }}>Suggests </Text>
-                  {finding.suggest}
-                </Text>
-              ) : null}
-            </View>
-          ) : null}
-        </View>
-      </PressableScale>
+              </View>
+            ) : null}
+          </View>
+        </PressableScale>
+      </Reanimated.View>
     </Reanimated.View>
   );
 }

--- a/mobile/src/omg/auto-agents.ts
+++ b/mobile/src/omg/auto-agents.ts
@@ -5,12 +5,13 @@
  * It is NOT a session on its own: it has no transcript, nothing to resume.
  * What it produces is a FINDING — one notification, at most, per run,
  * carrying its reasoning and a lifecycle (open, dismissed, or graduated into
- * a real session — acting on that lifecycle from the phone is a follow-up;
- * this file only reads and shapes the open list for now). That distinction is
- * the whole reason these get their own section on the home screen rather than
- * being folded into Working/Idle, where tapping a row opens a transcript and
- * swiping one archives a session — both would be lies here. See
- * selectHomeAutoFindings below.
+ * a real session). That distinction is the whole reason these get their own
+ * section on the home screen rather than being folded into Working/Idle,
+ * where tapping a row opens a transcript and swiping one archives a session —
+ * here tapping (then "Start session") launches a NEW session seeded from the
+ * finding, and swiping dismisses the finding, not a session that never
+ * existed. See selectHomeAutoFindings and setFindingStatus below, and
+ * startSessionFromFinding in app/index.tsx.
  *
  * WHAT THE HOME SCREEN IS FOR, AND WHY THIS LIST IS A FINDINGS LIST.
  *
@@ -83,6 +84,16 @@ export type AutoAgentsState = {
   tz: string;
   loading: boolean;
   refresh: () => void;
+  /**
+   * Move a finding off the open list — dismissed (the user doesn't want to
+   * act on it) or session (they graduated it into a real agent session; see
+   * `startSessionFromFinding` in index.tsx). Optimistic: the row leaves the
+   * screen immediately, matching `archiveSession`'s swipe. On failure the
+   * optimistic removal is undone by a real refetch rather than by re-inserting
+   * the stale object, so the phone never shows a finding the server has
+   * already resolved a different way (from another device, or the web).
+   */
+  setFindingStatus: (id: string, status: "dismissed" | "session") => Promise<void>;
 };
 
 /**
@@ -164,7 +175,29 @@ export function useAutoAgents(): AutoAgentsState {
     }, []),
   );
 
-  return { agents, findings, tz, loading, refresh };
+  // Optimistic: the row leaves `findings` the instant the user acts, the same
+  // beat archiveSession drops a session out of its list. If the request
+  // fails, don't splice the stale object back in — bump `tick` and let a real
+  // refetch decide, which is also correct if the finding was independently
+  // resolved elsewhere (another device, the web) in the meantime.
+  const setFindingStatus = useCallback(
+    async (id: string, status: "dismissed" | "session") => {
+      if (!client) return;
+      setFindings((prev) => prev.filter((f) => f.id !== id));
+      try {
+        await client.transport.request(`/api/auto/findings/${id}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        });
+      } catch {
+        setTick((n) => n + 1);
+      }
+    },
+    [client],
+  );
+
+  return { agents, findings, tz, loading, refresh, setFindingStatus };
 }
 
 const SEVERITY_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };


### PR DESCRIPTION
## Stacked on #126

This PR's diff is against `feat/mobile-auto-agents-ux-rework` (#126), not `feat/mobile-omg-foundation` directly, because it needs the flat-findings restructure #126 does first. Once #126 merges, GitHub will retarget this automatically to `feat/mobile-omg-foundation` and the diff will shrink to just this PR's changes.

## Why

The other two pieces of Benny's #117 feedback: he can't dismiss a finding from the phone, and tapping into one doesn't let him start a session on it.

## What changed

Both are real mutations against the same endpoints the web uses — not a local-only hide that would reappear on next launch:

- **Dismiss**: `POST /api/auto/findings/{id} {status:"dismissed"}` — the same request web's Dismiss button sends. Two ways to trigger it, both visible, neither hidden in favor of the other:
  - Swipe the row (matches the app's existing swipe-to-archive gesture on `SessionCard`)
  - Expand and tap the visible **Dismiss** button (matches web's own labeled affordance)

  Worth flagging explicitly: web's *only* path is the button. Mobile adds swipe as a native-idiom bonus on top of it, it doesn't replace it — happy to drop the swipe if it reads as redundant once you've used it.

- **Start session**: `POST /api/sessions/new` with the finding's context composed into the prompt (same shape as web's `replyToFinding`: agent name, title, reasoning, suggested fix), launched on the finding's own agent backend/model/cwd, then `POST /api/auto/findings/{id} {status:"session"}` and navigate to the new session. This is the one-tap path web calls "Make the change" — no typed-instruction composer, since a phone row has no room for the web sheet's launch-settings picker.

## Verified for real, not just optimistically

Against Benny's own live account/data:
- Dismissed a finding via the button, and a different one via swipe. Both confirmed **gone from `GET /api/auto/findings?status=open`** and present under `status=dismissed` — checked directly against the findings API, not just watching the row disappear on screen.
- Started a session from a finding. Confirmed via the findings API that it flipped to **`status:"session"`** (not just a 200 on the POST), confirmed a **real session exists** in the sessions list on the finding's own backend (`codex-aisdk`, the model-watch agent's configured model), and confirmed the app **navigated to its live transcript** with the agent actively working the fix.

Screenshots of both flows (expanded card with buttons, and the live session after Start session) are attached in the session that produced this PR.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)