### PR TITLE
fix(voice): batch STT fallback stops picking the guaranteed-broken relay

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -394,6 +394,11 @@ export default function SessionsScreen() {
       });
     },
   );
+  // A take that definitively failed (no working STT provider, not just
+  // silence) — say so instead of leaving the mic looking like it forgot.
+  useEffect(() => {
+    if (dictation.error) toast.show(dictation.error, { intent: "error" });
+  }, [dictation.error, toast]);
   /** `startSession` is declared below the hook that has to call it. */
   const startRef = useRef<((prompt: string) => void) | null>(null);
 

--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -181,6 +181,11 @@ export default function SessionScreen() {
   useEffect(() => {
     if (error) toast.show(error, { intent: "error" });
   }, [error, toast]);
+  // A take that definitively failed (no working STT provider, not just
+  // silence) — say so instead of leaving the mic looking like it forgot.
+  useEffect(() => {
+    if (dictation.error) toast.show(dictation.error, { intent: "error" });
+  }, [dictation.error, toast]);
   const [loading, setLoading] = useState(true);
   /**
    * HOW MUCH HISTORY IS ON SCREEN. The SDK's `getMessages` takes a limit and

--- a/mobile/docs/DICTATION.md
+++ b/mobile/docs/DICTATION.md
@@ -1,0 +1,82 @@
+# Mobile dictation: how it fails, and the trap already caught here
+
+Written 2026-08-17 investigating Benny's live report: *"mic buttons
+disconnected immediately."*
+
+## How it works
+
+`mobile/src/omg/dictation.ts`'s `useDictation` hook opens a websocket to
+`/api/voice/stt-stream` **on whichever Computer is currently selected** —
+this is not a fixed backend. That machine's `lfg serve` picks an STT
+provider (`src/voice-providers.ts`) and streams partial/final transcripts
+back over the socket while you talk. If the socket never opens, breaks
+mid-take, or the Computer has no STT provider at all, the hook falls back
+to recording a complete WAV file and POSTing it to `/api/voice/stt`
+(batch) once you stop.
+
+**Both legs depend on that Computer's own configuration**, not the
+phone's. A Computer with nothing configured fails both legs silently —
+until this fix (see below), with literally nothing shown to the user: no
+toast, no server log line, nothing. From the outside that reads exactly
+like "the mic button disconnected immediately," even though what
+actually happened is closer to "recorded fine, had nowhere to send it."
+
+## Two real bugs found and fixed here
+
+1. **`src/voice-providers.ts`'s batch-provider fallback picked a
+   guaranteed-broken provider.** `firstAvailable((c) => !!c.transcribe)`
+   accepted any provider with a `transcribe` method — every provider has
+   one, including the hosted `omg` relay, whose `transcribe()`
+   unconditionally returns 503 (`"realtime-only; batch transcription is
+   unavailable"`) by design. So on a workspace where `OMG_MEDIA_URL` is
+   set *and* a real batch-capable key (ElevenLabs/OpenAI) is *also*
+   configured, batch transcription still always hit the relay and 503'd —
+   the working provider was never reached. Fixed with an explicit
+   `batchCapable` flag per provider; `pickStt` now prefers a genuinely
+   capable provider when one exists, and only falls back to the relay's
+   own (accurate, specific) error when nothing else can do the job at
+   all. Covered by tests in `src/voice-providers.test.ts`.
+2. **Total silence on failure.** `mobile/src/omg/dictation.ts`'s `stop()`
+   swallowed a definitive provider failure (the batch POST returning a
+   non-2xx) with no UI signal — "silent" was a deliberate design choice
+   for the *empty-take* case (you said nothing, nothing happens, correct),
+   but it covered the *broken-provider* case too, which is a different
+   thing and deserves a word. It now surfaces
+   `useToast()`'s error banner ("Dictation isn't available on this
+   computer" for a not-configured provider) in both `app/index.tsx` and
+   `app/session/[id].tsx`. Server-side, `src/commands/serve.ts` now logs
+   once when a stt-stream socket closes for lack of any realtime
+   provider — previously that path left zero trace anywhere, which is
+   exactly the gap that made this investigation start from scratch on
+   Benny's own Mac (see below).
+
+## A live example: Benny's own Mac had zero STT provider configured
+
+Verified 2026-08-17 by reading the actual running `lfg serve` process's
+environment on `bennykok@100.66.243.26` (not just its `.env` file) and its
+logs — this machine, at the time of writing:
+
+- `ELEVENLABS_API_KEY=` — empty.
+- `OPENAI_API_KEY=` — empty.
+- `OMG_MEDIA_URL` — unset (expected; this is not a hosted workspace).
+- No `data/voice-settings.json` on disk, so it runs on hard defaults.
+
+**If this Computer is ever selected for dictation, the take will fail
+end-to-end** — no realtime provider to stream to, no batch provider to
+fall back to. Post-fix that now shows "Dictation isn't available on this
+computer" instead of nothing; pre-fix it was indistinguishable from a
+hang.
+
+To make dictation work on this machine: set `ELEVENLABS_API_KEY` in its
+`.env` (`mobile/.../voice-providers.ts`'s `sttElevenLabs.envVar`) and
+restart the service. This doc does not do that — it's Benny's own
+environment and credentials.
+
+**This was NOT where today's specific report reproduced.** The trace log
+and stdout/stderr around the exact minute of the report show no
+stt-stream connection at all reaching this Mac, so whatever Benny hit was
+either a different (likely cloud) Computer, or failed before any network
+call (e.g. a denied mic permission). Recorded here anyway because it's a
+real, silent trap independent of that — and because "no trace anywhere"
+on this exact machine is what cost the most time in this investigation,
+which is the whole reason for fix #2 above.

--- a/mobile/docs/TESTFLIGHT.md
+++ b/mobile/docs/TESTFLIGHT.md
@@ -41,7 +41,9 @@ plugins, permissions), or an Expo SDK bump:
 missing from the installed binary crashes on launch — it does not degrade
 gracefully. Current native modules: `expo-updates`, `expo-clipboard`,
 `expo-symbols`, `expo-haptics`, `expo-router`, `react-native-screens`,
-`react-native-safe-area-context`.
+`react-native-safe-area-context`, `@siteed/audio-studio` (added 2026-08-15
+for streaming dictation, replacing `expo-audio` — see
+`mobile/docs/DICTATION.md`).
 
 `runtimeVersion` is `{"policy":"appVersion"}`, so an update only reaches builds
 sharing that app version. Bumping the version in app.json deliberately cuts old

--- a/mobile/src/omg/dictation.ts
+++ b/mobile/src/omg/dictation.ts
@@ -157,6 +157,10 @@ export function useDictation(
   // caller can tell "live" from "will transcribe after you stop" without
   // guessing from `state` alone.
   const [live, setLive] = useState(false);
+  // A take that definitively failed — the provider rejected it, not "you said
+  // nothing." Distinct from silence: an empty take is normal and stays quiet,
+  // same as before. Cleared on every new take.
+  const [error, setError] = useState<string | null>(null);
 
   const socketRef = useRef<OmgSocket | null>(null);
   const socketBrokenRef = useRef(false);
@@ -199,6 +203,7 @@ export function useDictation(
     setPartial("");
     setLevel(0);
     setLive(false);
+    setError(null);
     committedRef.current = "";
     socketBrokenRef.current = false;
     pendingRef.current = [];
@@ -320,6 +325,7 @@ export function useDictation(
       }
       closeSocket();
 
+      let providerError: string | null = null;
       if (text == null) {
         // Streaming was never live, broke, or came back empty — the file
         // this same recording wrote is a complete, independent take.
@@ -331,16 +337,30 @@ export function useDictation(
             headers: { "Content-Type": "application/octet-stream" },
             body: audio,
           });
-          const body = (await response.json()) as { text?: string };
+          const body = (await response.json().catch(() => ({}))) as {
+            text?: string;
+            error?: string;
+          };
+          if (!response.ok) {
+            // A real provider failure — this machine has no working STT, not
+            // "you didn't say anything." That is worth a word; an empty take
+            // from actual silence still stays quiet below.
+            providerError = body?.error?.includes("not configured")
+              ? "Dictation isn't available on this computer"
+              : body?.error || "Dictation failed";
+          }
           text = body?.text?.trim() || null;
         }
       }
 
       if (text && !cancelledRef.current) onText(text, { final: true });
+      else if (providerError && !cancelledRef.current) setError(providerError);
     } catch {
       // Silent: a failed take leaves the draft exactly as it was, which is
-      // the state the user can retry from. The composer is not the place to
-      // explain a provider outage.
+      // the state the user can retry from. This covers the unexpected cases
+      // (network exception, a response that wasn't JSON at all) where there
+      // is no good message to show — the provider-not-configured case above
+      // has one and says so.
     } finally {
       closeSocket();
       setPartial("");
@@ -412,5 +432,5 @@ export function useDictation(
     else void start();
   }, [start, state, stop]);
 
-  return { state, level, partial, live, toggle, cancel };
+  return { state, level, partial, live, error, toggle, cancel };
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -2073,6 +2073,11 @@ export async function cmdServe() {
             },
           });
           if (!bridge) {
+            // Documented fallback (see openSttStream): no realtime-capable
+            // provider is configured on this machine. This used to close with
+            // zero trace anywhere — the exact condition a dictation bug report
+            // like "the mic just disconnects" needs a breadcrumb for.
+            console.log("[voice] stt-stream: no realtime provider configured, closing");
             try {
               ws.close();
             } catch {}

--- a/src/voice-providers.test.ts
+++ b/src/voice-providers.test.ts
@@ -2,13 +2,50 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { writeEnvValue } from "./voice-providers.ts";
+import { pickStt, writeEnvValue } from "./voice-providers.ts";
 
 let dir = "";
+
+const VOICE_ENV_VARS = ["OMG_MEDIA_URL", "ELEVENLABS_API_KEY", "OPENAI_API_KEY"] as const;
 
 afterEach(async () => {
   if (dir) await rm(dir, { recursive: true, force: true });
   dir = "";
+  for (const key of VOICE_ENV_VARS) delete process.env[key];
+});
+
+describe("pickStt (batch STT provider selection)", () => {
+  // Regression coverage for a real bug: the batch fallback used to accept any
+  // provider with a `transcribe` method, but every provider defines one —
+  // including the hosted omg relay, whose `transcribe` unconditionally 503s
+  // because the relay is realtime-only. `firstAvailable((c) => !!c.transcribe)`
+  // could therefore never see past the relay to a provider that could
+  // actually do the job.
+  test("prefers a provider that can actually transcribe over the realtime-only relay", () => {
+    process.env.OMG_MEDIA_URL = "https://relay.example/media";
+    process.env.OPENAI_API_KEY = "test-key";
+    delete process.env.ELEVENLABS_API_KEY;
+
+    // Asking for "omg" explicitly (e.g. a saved setting from before OpenAI was
+    // configured) must not shadow a provider that can genuinely do the job.
+    const picked = pickStt("omg");
+
+    expect(picked.id).toBe("openai");
+  });
+
+  // When the relay really is the only thing configured, it should still be
+  // the pick — its own `transcribe()` gives the specific "realtime-only"
+  // reason (covered in test/omg-relay-stt.test.ts), which is more useful
+  // than a generic "not configured" from a provider nobody chose.
+  test("still returns the relay when nothing else can do batch either", () => {
+    process.env.OMG_MEDIA_URL = "https://relay.example/media";
+    delete process.env.ELEVENLABS_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+
+    const picked = pickStt("omg");
+
+    expect(picked.id).toBe("omg");
+  });
 });
 
 describe("writeEnvValue", () => {

--- a/src/voice-providers.ts
+++ b/src/voice-providers.ts
@@ -64,6 +64,13 @@ type SttProvider = {
   accountUrl: string;
   available: () => boolean;
   transcribe: (audio: ArrayBuffer) => Promise<Response>;
+  // Whether `transcribe` can ever actually produce a transcript, as opposed to
+  // existing only to satisfy the interface. The omg hosted relay is
+  // realtime-only and its `transcribe` unconditionally 503s — it still has to
+  // define the method (every provider does), so a capability check that tests
+  // for the method's mere presence can't tell those two cases apart. Defaults
+  // to true; only a provider whose `transcribe` can never succeed sets this.
+  batchCapable?: boolean;
   // Optional realtime path: open a streaming bridge for /api/voice/stt-stream.
   // Providers without realtime STT omit this and the proxy closes the socket.
   openStream?: (handlers: SttStreamHandlers) => SttStreamBridge | null;
@@ -329,6 +336,11 @@ const sttOmg: SttProvider = {
   envVar: "OMG_MEDIA_URL",
   accountUrl: "https://omg.dev",
   available: () => !!process.env.OMG_MEDIA_URL,
+  // Never actually transcribes a batch clip — see `transcribe` below. Without
+  // this, `firstAvailable`'s old `!!c.transcribe` check picked this provider
+  // for the batch fallback on every hosted workspace, because the method
+  // exists; it just always fails.
+  batchCapable: false,
   openStream: (handlers) => omgRelayStream(handlers),
   async transcribe() {
     // The relay is realtime-only: the platform's batch job API takes a public
@@ -538,10 +550,29 @@ export function voiceSetupInfo() {
 
 // ------------------------------------------------------------ dispatch
 
-function pickStt(id: string): SttProvider {
+// Exported for tests: which provider `transcribeStt` actually resolves to,
+// without needing a real network call to observe the (previously wrong) pick.
+export function pickStt(id: string): SttProvider {
   const p = STT[id];
+  // The configured provider is the right answer for batch only if it can
+  // actually do batch.
+  if (p && p.available() && p.batchCapable !== false) return p;
+  // It can't (or isn't configured) — prefer any OTHER available provider that
+  // genuinely can. This is the fix: `!!c.transcribe` used to pass for every
+  // provider, including the omg relay, whose `transcribe` unconditionally
+  // 503s — so a real batch-capable provider configured alongside the relay
+  // (e.g. an ElevenLabs key on a box that also has OMG_MEDIA_URL) was never
+  // reached.
+  const capable = firstAvailable((c) => c.batchCapable !== false);
+  if (capable) return capable;
+  // Nothing can actually do batch. If the configured provider is at least
+  // available, return IT rather than an unrelated, equally-unconfigured
+  // default — its own `transcribe()` gives the specific, accurate reason
+  // (e.g. the relay's "realtime-only; batch transcription is unavailable"),
+  // which is more useful than a generic "not configured" for a provider the
+  // caller never chose.
   if (p && p.available()) return p;
-  return firstAvailable((c) => !!c.transcribe) ?? sttElevenLabs;
+  return sttElevenLabs;
 }
 
 // The configured provider is not always the usable one (a hosted workspace has


### PR DESCRIPTION
## Summary

Investigating Benny's live report — "mic buttons disconnected immediately" — turned up a real, independently-verifiable bug in the STT provider selection, plus a design gap where a definitive dictation failure was completely silent (no UI, no server log). This PR does not claim to be Benny's exact repro (see caveat below); it fixes what the investigation actually found and verified.

- **`src/voice-providers.ts`: `pickStt()`'s batch fallback matched `(c) => !!c.transcribe`.** Every provider defines `transcribe`, including the hosted `omg` relay, whose `transcribe()` unconditionally returns 503 ("realtime-only; batch transcription is unavailable"). So a workspace with `OMG_MEDIA_URL` set *and* a real batch-capable key (ElevenLabs/OpenAI) configured alongside it still always hit the relay for batch and failed — the working provider was never reached. Also affected the plain single-provider case: `pickStt`'s first branch returned the configured provider on `available()` alone, with no check that it could do batch at all.

  Fixed with an explicit `batchCapable` flag (`false` only on the relay). `pickStt` now prefers a genuinely capable provider when one exists, and falls back to the originally-configured provider's own specific error only when nothing else can do the job — so the relay-only case still gets the accurate "realtime-only" message (covered by the existing `test/omg-relay-stt.test.ts`), not a generic, misleading one.

- **Mobile dictation swallowed a definitive failure with zero signal.** `mobile/src/omg/dictation.ts`'s `stop()` silently no-op'd when the batch POST failed — indistinguishable from a hang from the user's side. That silence was the right call for "you said nothing" (an empty take); it was wrong for "you said something and the provider rejected it." Now surfaces a toast ("Dictation isn't available on this computer" for a not-configured provider) in both `app/index.tsx` and `app/session/[id].tsx`.

- **`src/commands/serve.ts` now logs once** when a `stt-stream` socket closes for lack of any realtime provider. That path previously left zero trace anywhere — server logs, client, nothing — which is exactly the gap that made this investigation start from scratch reading Benny's Mac's raw process environment over SSH instead of a log line.

- **`mobile/docs/DICTATION.md` (new)** documents how mobile dictation actually works end to end, both bugs above, and a live example found while investigating: Benny's own Mac's `lfg serve` process has `ELEVENLABS_API_KEY`/`OPENAI_API_KEY` empty and no `OMG_MEDIA_URL` — zero STT provider configured. **Important caveat, stated plainly in the doc:** this was checked against the actual running process's environment and against the trace/stdout logs around the exact minute of Benny's report, and there is no `stt-stream` connection reaching that machine in that window — so his Mac is very likely *not* where today's failure happened. Recorded anyway because it's a real, silent trap independent of that, and it's what these fixes turn into a legible error instead of nothing.

- Small factual fix in `mobile/docs/TESTFLIGHT.md`'s native-module list, which was missing `@siteed/audio-studio` (added 2026-08-15 for streaming dictation) — found while tracing which build actually has the streaming-dictation native module compiled in.

## Test plan

- [x] `bun test src/voice-providers.test.ts` — new tests added; confirmed they fail without the fix (reverted `voice-providers.ts` only, re-ran, got a real failure) and pass with it.
- [x] `bun test test/omg-relay-stt.test.ts test/dictation-finalization.test.ts test/composer-dictation-scroll.test.ts` — existing dictation/relay coverage, all still pass (the relay-only case's specific error message is preserved).
- [x] `bun test` (full suite) — 1388 pass, 4 pre-existing unrelated failures confirmed present on `origin/feat/mobile-omg-foundation` before this branch (unrelated `mcp`/`mcp-http` session-id wording assertions).
- [x] `cd mobile && npx tsc --noEmit` — clean.
- [x] `bun run typecheck` (root, after `bash scripts/pack-packages.sh --build-only`) — clean.

## Not fixed here / still open

Benny's actual live trigger is still unconfirmed — his device/build and selected Computer weren't established before this PR went up. If it turns out to be a denied mic permission or a different Computer's config, that's separate follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)