### PR TITLE
Add Apple org conversion plan for Use Effect Limited

### DIFF
--- a/mobile/docs/apple-org-conversion.md
+++ b/mobile/docs/apple-org-conversion.md
@@ -1,0 +1,131 @@
+# Converting the Apple Developer account to Use Effect Limited
+
+Status as of 2026-08-17: shipping under Benny's **personal (Individual)** Apple
+Developer account today. This doc tracks the plan to convert that account to
+**Use Effect Limited** so App Store revenue lands on the company instead of
+him personally. Update the checklist below as each step lands — this is meant
+to stay current, not be a one-time snapshot.
+
+## Company on record
+
+Read off the actual BR certificate (not a secondhand summary):
+
+```
+USE EFFECT LIMITED
+RM 29-33 5/F BEVERLEY COMM CTR
+87-105 CHATHAM RD, TSIM SHA TSUI
+HONG KONG
+
+BR Certificate No.: 80637455-000-06-26-9
+Valid: 15/06/2026 - 14/06/2027 (current)
+Nature of Business: CORP
+Status: BODY CORPORATE
+```
+
+The BR's "Date of Commencement" (15/06/2026) is that certificate's **annual
+renewal cycle**, not the company's incorporation date — do not use it as
+"year started." The real incorporation date comes from a free HK Companies
+Registry (ICRIS) name search, which also confirms the exact registered name
+and company number. Paid searches are not needed — the registered address
+above is already sourced from the original certificate.
+
+Still needed from Benny before the D-U-N-S request can be filed:
+- [ ] Number of employees at Use Effect Limited
+- [ ] His exact title there (Director, expected but unconfirmed)
+
+## D-U-N-S number
+
+Apple requires a D&B D-U-N-S number to verify the organization before it will
+convert the account. Two paths exist and they are **not equivalent in
+speed**:
+
+| Path | Turnaround | Notes |
+| --- | --- | --- |
+| Apple's own lookup/request tool (`developer.apple.com/enroll/duns-lookup/`) | ~7 business days total (D&B issues in ≤5 business days, syncs to Apple in ≤2 more) | Free. Checks for an existing number first; if none exists, submits a new request on this fast track. **Use this path.** |
+| D&B Hong Kong direct (email `enquiryhk@dnb.com`, mail back a form) | ~30 working days (~6 weeks) | Free, but far slower. Only fall back to this if the Apple-tool path stalls past 2 weeks — Apple's own guidance in that case is to escalate via `support.dnb.com/?CUST=APPLEDEV`. |
+
+**Status: TBD** — pending browser access to run the lookup. This section
+gets updated with either the existing number (if D&B already has one on file
+for Use Effect Limited) or the fast-track request details the moment that
+lookup runs. An existing number would remove the ~7-business-day wait
+entirely.
+
+## Conversion sequence (Individual → Organization)
+
+Once the D-U-N-S number is in hand:
+
+1. **Benny**, as Account Holder, signs in at `developer.apple.com/account`.
+2. Open **Membership Details** in the left sidebar.
+3. Click **"Submit a request"** next to *Convert to Organization*.
+4. The request requires the **D-U-N-S number**. The requester must be the
+   organization's **founder or co-founder** — Benny qualifies.
+5. Apple immediately sends a confirmation email with a **case number**.
+6. **Apple calls to verify the enrollment** — expect a call to
+   `+852 6776 2685`. This is a real step, not a formality; have the BR
+   certificate and D-U-N-S details on hand for that call.
+7. After verification, Apple emails instructions to complete the conversion.
+
+Apple explicitly **rejects** DBAs, fictitious businesses, trade names, and
+branches — sole proprietorships must stay Individual. Use Effect Limited is a
+Hong Kong private company limited by shares (BODY CORPORATE per the BR), so
+it qualifies as a recognized legal entity.
+
+## What has to be redone under the company, after conversion
+
+Converting the account does not carry existing paperwork over — these are
+new, separate actions once the account is an Organization:
+
+- **A new W-8BEN-E** (the entity tax form) replacing the individual W-8BEN.
+  See the note below — this is also needed to correct a separate problem.
+- **A company bank account** for Use Effect Limited, replacing Benny's
+  personal account, so App Store payouts route to the company.
+- **Re-signing the Paid Apps Agreement** as the entity (Use Effect Limited),
+  not as Chun Hung Kok individually.
+
+## Irreversible catch: `identifierForVendor` resets on org name change
+
+Converting to an Organization and setting the org's display name changes the
+value iOS computes for `identifierForVendor` for every existing install.
+Anything keyed off that identifier (analytics, entitlements, local
+de-duplication, etc.) will see existing users as brand-new installs after the
+switch. This is **not reversible** and gets worse the longer the app runs
+under the personal account first — more installs accumulate that identity
+before the reset. Worth converting sooner rather than later once the
+D-U-N-S/paperwork is ready, specifically because of this.
+
+## Timing: conversion is not retroactive
+
+Revenue earned while the account is Individual is Benny's **personal**
+income, full stop — converting the account later does not reclassify past
+revenue as company revenue. The practical implication: the sooner the
+conversion happens after today's launch, the smaller the slice of revenue
+that has to be treated as personal income before the company takes over.
+
+## Note on today's W-8BEN (personal account)
+
+The W-8BEN filed today in App Store Connect under the Individual account has
+an inaccuracy worth recording so it isn't lost: **Part II line 9 (treaty
+residency) was checked**, but Hong Kong has no US income tax treaty, so that
+claim doesn't hold. Line 10 (the specific treaty article / reduced
+withholding rate) was left blank, so no reduced withholding rate was actually
+claimed as a result — the practical tax impact is likely limited, but the
+form as filed is not accurate.
+
+This **cannot be corrected in App Store Connect** — the form locks after
+submission, and Apple's own guidance is to contact support directly rather
+than expecting a self-service fix. Leaving it as-is is a reasonable call
+short-term: the eventual **W-8BEN-E filed under Use Effect Limited** after
+conversion supersedes it, since withholding then runs against the company's
+tax status, not Benny's personal one. Flagging here so it's a known,
+deliberate deferral and not a dropped thread.
+
+## Open items
+
+- [ ] Run the Apple D-U-N-S lookup / fast-track request, record the result
+      above.
+- [ ] Free ICRIS search: confirm exact registered name, company number, and
+      true incorporation date.
+- [ ] Get employee count and Benny's title from Benny, needed for the D-U-N-S
+      application if one has to be filed.
+- [ ] Benny submits the Convert to Organization request himself once the
+      D-U-N-S exists (this agent prepares, does not submit).


### PR DESCRIPTION
## Summary
- Documents the plan to convert the Apple Developer account from Individual to Use Effect Limited: the D-U-N-S lookup/request path (Apple's fast track vs. D&B HK's ~30 working day route), the conversion request sequence, and what has to be redone under the company afterward (W-8BEN-E, bank account, Paid Apps Agreement).
- Flags two things that matter regardless of timing: the `identifierForVendor` reset on org name change (irreversible, gets worse the longer conversion waits), and that revenue earned pre-conversion stays personal income even after converting.
- Records the inaccurate treaty box on today's personal-account W-8BEN (HK has no US tax treaty) so it isn't a dropped thread — it's superseded by the eventual W-8BEN-E, not correctable in ASC today.
- D-U-N-S number itself is still TBD, pending an Apple lookup tool session — this doc has an open-items checklist to track it and the two still-missing inputs (employee count, Benny's title).

## Test plan
- [x] Doc only, no code changes — read-through for accuracy against Apple's published docs and the BR certificate on file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)