### PR TITLE
mobile: give the transcript's cards a border you can actually see

### DIFF
--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -1347,7 +1347,12 @@ export default function SessionScreen() {
             backgroundColor: colors.card,
             borderRadius: radius.lg,
             borderWidth: StyleSheet.hairlineWidth,
-            borderColor: colors.border,
+            // borderStrong: this is a card the transcript can hand you at any
+            // moment, asking for a tap that unblocks the agent — it needs to
+            // read as a distinct surface immediately, not the .35-alpha
+            // border that "reads as a rumour against black" everywhere else
+            // it was tried (see SessionCard's own note on the home screen).
+            borderColor: colors.borderStrong,
             gap: space.sm,
           }}
         >
@@ -1368,7 +1373,7 @@ export default function SessionScreen() {
                   borderRadius: radius.pill,
                   backgroundColor: pressed ? colors.cardPressed : colors.secondary,
                   borderWidth: StyleSheet.hairlineWidth,
-                  borderColor: colors.border,
+                  borderColor: colors.borderStrong,
                 })}
               >
                 <Text style={{ ...type.footnote, color: colors.text }}>{opt.label}</Text>

--- a/mobile/src/omg/transcript.tsx
+++ b/mobile/src/omg/transcript.tsx
@@ -1144,7 +1144,12 @@ export function AttachmentEntry({ message }: { message: Entry }) {
         backgroundColor: colors.card,
         borderRadius: radius.lg,
         borderWidth: StyleSheet.hairlineWidth,
-        borderColor: colors.border,
+        // borderStrong, not border: this chip is a card sitting directly on
+        // the transcript's near-black background, same as SessionCard on the
+        // home screen — the .35-alpha `border` "reads as a rumour against
+        // black" there (see that component's own note), and the rumour is
+        // just as true here.
+        borderColor: colors.borderStrong,
       }}
     >
       <Icon
@@ -1189,7 +1194,9 @@ function FallbackEntry({ message }: { message: Entry }) {
         backgroundColor: colors.card,
         borderRadius: radius.md,
         borderWidth: StyleSheet.hairlineWidth,
-        borderColor: colors.border,
+        // Same reasoning as AttachmentEntry just above: a card on black earns
+        // the stronger border, not the .35-alpha one.
+        borderColor: colors.borderStrong,
       }}
     >
       <Icon ios="questionmark.circle" android="help" size={14} color={colors.textMuted} />
@@ -1262,7 +1269,13 @@ export function UserMessage({ message }: { message: Entry }) {
             backgroundColor: colors.card,
             borderRadius: radius.xl,
             borderWidth: StyleSheet.hairlineWidth,
-            borderColor: colors.border,
+            // borderStrong. The comment above says it plainly: this border is
+            // the ONLY thing telling a sent message apart from the reply
+            // under it. `border` at .35 alpha is SessionCard's old "rumour
+            // against black" mistake, and here it is load-bearing rather than
+            // decorative — the one card in the whole app that most needs the
+            // edge you can actually see.
+            borderColor: colors.borderStrong,
             paddingHorizontal: space.lg,
             paddingVertical: space.md,
             // Both states are "not acted on yet", so both sit back a little.
@@ -1443,7 +1456,8 @@ function AttachmentChip({ name }: { name: string }) {
         paddingVertical: 6,
         borderRadius: radius.lg,
         borderWidth: StyleSheet.hairlineWidth,
-        borderColor: colors.border,
+        // Same card-on-black reasoning as AttachmentEntry/UserMessage.
+        borderColor: colors.borderStrong,
         backgroundColor: colors.card,
       }}
     >


### PR DESCRIPTION
## Summary
- Bumps four transcript surfaces from `colors.border` (rgba .35) to `colors.borderStrong` (rgba .65) — the same upgrade `SessionCard` already made on the home screen, whose own comment says the weaker token "reads as a rumour against black."
- Surfaces touched: the user's own sent-message bubble (`UserMessage` — the border is the *only* thing distinguishing a sent message from the reply under it, per the existing comment there), the attachment card (`AttachmentEntry`), the unrenderable-attachment fallback (`FallbackEntry`), the named-attachment chip (`AttachmentChip`), all in `src/omg/transcript.tsx`, plus the agent's tappable "answer this" prompt card in `app/session/[id].tsx`.
- No new colors — both tokens already exist in `src/omg/palette.ts` and are drift-checked against `web/src/index.css`.
- Deliberately left alone: the tool-call badge (has its own comment saying it matches the web's `border-border/80` on purpose), the chat composer's own input-field border (matches the home composer's intentional restraint), and a couple of low-stakes transient chips (typing indicator, "jump to latest" pill) — kept this surgical rather than recoloring every hairline in the file.

## Verification
- `bun run typecheck` clean on both worktrees (rebased onto `151e4ac`).
- Before/after on iPhone 17 Pro Max, dark mode: the sent-message bubble border goes from barely perceptible to a clearly separated card edge.
- Light mode checked too — see the PR thread for that comparison and whether `borderStrong` needs a lighter-mode-specific value.

## Test plan
- [ ] Open a session with at least one sent message, one tool call, and one attachment
- [ ] Confirm the sent-message bubble reads as a distinct card from the assistant reply under it, dark and light mode
- [ ] Confirm the tool-call badge is unchanged (still the weaker border, matching web)
- [ ] Confirm the agent's "answer this" prompt card (if you can trigger one) is clearly bordered and its option pills are tappable