### PR TITLE
fix(mobile): the composer's glass had unglazed gaps, and the ghost-row fix never shipped to build-21

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -97,7 +97,7 @@ function SessionFamily({
         <View style={{ marginLeft: space.xl, marginTop: space.sm, gap: space.sm }}>
           {node.children.map((child, index) => (
             <SessionBranch
-              key={sessionStableId(child.session) || index}
+              key={sessionStableId(child.session)}
               node={child}
               depth={depth + 1}
               last={index === node.children.length - 1}
@@ -1081,9 +1081,9 @@ export default function SessionsScreen() {
                 {/* Each session is its own card now, so the rows need air
                     between them — see SessionCard. */}
                 <View style={{ gap: space.sm }}>
-                  {working.map((node, i) => (
+                  {working.map((node) => (
                     <SessionFamily
-                      key={sessionStableId(node.session) || i}
+                      key={sessionStableId(node.session)}
                       node={node}
                       onOpen={openSession}
                     />
@@ -1100,9 +1100,9 @@ export default function SessionsScreen() {
                   dotColor={colors.success}
                 />
                 <View style={{ gap: space.sm }}>
-                  {idle.map((node, i) => (
+                  {idle.map((node) => (
                     <SessionFamily
-                      key={sessionStableId(node.session) || i}
+                      key={sessionStableId(node.session)}
                       node={node}
                       onOpen={openSession}
                       onArchive={archiveSession}

--- a/mobile/src/components.tsx
+++ b/mobile/src/components.tsx
@@ -959,7 +959,38 @@ export function HomeComposer({
     borderColor: colors.borderSoft,
   };
   return (
-    <View
+    <GlassSurface
+      /**
+       * THE WHOLE COMPOSER IS THE GLASS NOW, not a transparent box with two
+       * glazed pills floating inside it.
+       *
+       * This used to be a plain `View` with `backgroundColor: "transparent"`
+       * under Liquid Glass — deliberately, so the two pills inside (the
+       * field, the caption row's buttons) had real content behind them for
+       * their OWN blur to sample. But the padding AROUND those pills — 8pt
+       * here, more at the safe-area edge, the full gap between the field row
+       * and the caption row — was never drawn at all: no blur, no fill,
+       * genuinely see-through. Scrolled under a tall list, a card's title
+       * landing in that gap read in full contrast, which is what "the
+       * composer is painted over cards" turned out to mean: not that a card
+       * sat on top of the composer, but that the composer had unglazed holes
+       * in it exactly the shape of its own padding.
+       *
+       * A `variant="clear"` sibling sized with `StyleSheet.absoluteFillObject`
+       * was tried first, to keep the pills as independent glass shapes on
+       * top of a full-bleed backing. It measured the composer's OWN first
+       * layout pass and then stayed that size — the same Host-sizing lag
+       * `ComposerCaptionButton` already has to work around for its menu (see
+       * that component) — so the backing covered the field row but fell
+       * short of the caption row a moment later, once the pills below it
+       * populated and the composer grew. Making the container itself the
+       * glass sidesteps that class of bug entirely: there is no second
+       * element trying to track this one's size after the fact, because
+       * there is only one, and Yoga sizes it the ordinary way — from its own
+       * children, including the pills nested inside it.
+       */
+      variant="clear"
+      fallbackColor={colors.bg}
       style={{
         paddingHorizontal: space.lg,
         paddingTop: space.sm,
@@ -969,9 +1000,6 @@ export function HomeComposer({
         // session composer — which adds them — floated correctly. Two
         // composers, two heights, on screens you swap between constantly.
         paddingBottom: bottomInset + space.sm,
-        // Transparent under glass so the blur has content to sample; opaque
-        // otherwise so list rows do not show through the composer.
-        backgroundColor: LIQUID_GLASS ? "transparent" : colors.bg,
       }}
     >
       {/* Liquid Glass on iOS 26+, a solid card everywhere else. */}
@@ -1311,7 +1339,7 @@ export function HomeComposer({
           ) : null}
         </ScrollView>
       </View>
-    </View>
+    </GlassSurface>
   );
 }
 

--- a/mobile/src/omg/motion.tsx
+++ b/mobile/src/omg/motion.tsx
@@ -201,9 +201,17 @@ export function PressableScale({
  * nothing owns the view any more — React is done with it and Reanimated has
  * stopped animating it — so it is stranded on screen at the coordinates it
  * had when it left. The rows still in flow then reflow past it (the list
- * polls every 10s and sections resize constantly), and the stranded frame is
- * left painting over whatever now occupies that space. Ghosts of the Recent
- * section on top of the live Idle rows is exactly what that looks like.
+ * polls every 10s and a busy/idle session can flip sections — Working to Idle
+ * and back — inside a single poll window), and the stranded frame is left
+ * painting over whatever now occupies that space. That stranded native view is
+ * held by the UI thread, not by React state, so it outlives whatever
+ * re-renders come after it and survives for as long as the app process does —
+ * which on iOS is however long the app sits suspended in the background, not
+ * merely until the next JS-level refresh. A session that flaps busy/idle
+ * repeatedly (an auto-reply persona firing on each inbound message, for
+ * instance) can strand several identical-looking copies of its own card, one
+ * per interrupted exit — indistinguishable rows piled on screen, which is
+ * exactly the "six identical cards" shape this bug was reported with.
  *
  * Reproduced on the simulator by dropping and restoring the Recent rows every
  * 120ms — inside `motion.fast` — which piled up stranded cards under a

--- a/mobile/src/omg/session-tree.ts
+++ b/mobile/src/omg/session-tree.ts
@@ -23,8 +23,50 @@ import type { OmgSession } from "@omg-dev/protocol";
 
 export type SessionNode = { session: OmgSession; children: SessionNode[] };
 
+/**
+ * A stable, non-empty React key for one session, even when the machine sends
+ * one with none of the three real identifiers.
+ *
+ * The three real ids come first and are preferred whenever any of them
+ * exists. When NONE do, this used to return `""` and every call site fell
+ * back to `|| index` — which is a key by POSITION, not by identity. Two
+ * id-less sessions then keyed as `0`, `1`, … by array order, so a poll that
+ * changed nothing but the order (or dropped a session earlier in the list)
+ * made React reconcile row N's old content into row N's new session, which
+ * reads as one row's card refusing to update, or two different sessions
+ * sharing a single animated row that flickers between their content.
+ *
+ * The fallback is a hash of whatever the session DOES carry — title, agent,
+ * cwd, last words said, parent — prefixed so it can never collide with a real
+ * id. It is not guaranteed unique (two genuinely identical, id-less sessions
+ * still collide), but it is deterministic across re-renders of the same
+ * underlying data, which `index` never was, and collisions now require two
+ * sessions to agree on every one of those fields rather than merely occupying
+ * the same array slot.
+ */
 export function sessionStableId(session: OmgSession): string {
-  return session.sessionId || session.nativeSessionId || session.tmuxName || "";
+  const real = session.sessionId || session.nativeSessionId || session.tmuxName;
+  if (real) return real;
+  return `anon:${hashFields([
+    session.title,
+    session.lastUserText,
+    session.agent,
+    session.agentLabel,
+    session.cwd,
+    session.project,
+    session.parentSessionId,
+    session.parentNativeSessionId,
+  ])}`;
+}
+
+/** A short, deterministic, non-cryptographic hash — good enough for a key. */
+function hashFields(fields: Array<string | null | undefined>): string {
+  let hash = 0;
+  const joined = fields.map((f) => f ?? "").join(" ");
+  for (let i = 0; i < joined.length; i++) {
+    hash = (Math.imul(31, hash) + joined.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
 }
 
 export function buildSessionTree(sessions: OmgSession[]): SessionNode[] {


### PR DESCRIPTION
## Summary

Three real-device screenshots (19 hours apart) showed an opaque stack of
session cards painted over a second list on the Welcome screen, with buried
rows readable in the gaps, and the composer / `opus · Medium · All projects`
toolbar also painted over cards.

Two distinct bugs, both real:

**1. A known, previously-fixed bug that never reached the branch this task
started from (`ship/build-21`).** `SessionCard`'s `exiting` animation
(Reanimated `FadeOut`) strands a native view at its last position whenever a
re-render interrupts it mid-exit. A session that flaps busy/idle (an
auto-reply persona firing per inbound message) can strand several
identical-looking copies of its own card — the reported "six identical
cards" and "orange-pause cards over hollow-circle cards." This was already
root-caused with a synthetic interrupt probe, fixed, and verified in #112 —
already on this branch (`feat/mobile-omg-foundation`) — but `ship/build-21`,
where three fresh device screenshots kept reproducing the bug, forked before
that PR landed and never picked it up. That's most of what this PR is: the
part of the diff touching `motion.tsx`/`components.tsx`'s `exiting` removal
and the poll-diffing fix mostly no-ops here (already present); it's included
so `ship/build-21` and this branch stop disagreeing about it, and the
richer "why this survives across the app's whole background life" reasoning
merges into the comment.

**2. A second, previously-undiagnosed bug: the composer's own glass had holes
in it.** The composer's outer container is deliberately transparent so its
child glass pills (the field, the caption pills) have real content behind
them to blur — that's the "list scrolls under the glass" design. But the
blur was only ever applied to the two pill *shapes*, not the padding around
and between them. That padding was genuinely unglazed: no blur, no fill, a
literal hole. A card scrolled to that position read in full contrast, which
is what "composer painted over cards" actually was. Confirmed live against
the team's own dogfooding account, in light mode. Fixed by making the
composer's own outer container the glass surface, so it's sized by Yoga from
its real children instead of a second element trying to track another's size
after the fact (the same Host-sizing lag already documented in
`ComposerCaptionButton`'s own comments).

Also:
- `sessionStableId` can no longer return a key-able empty string (falls back
  to a deterministic hash of the session's other fields instead of the
  position-based `|| index` every call site used).
- The composer's height reservation gets a real floor (`MIN_COMPOSER_HEIGHT`)
  and a never-shrink `onLayout`, so a cold open or a late pill-row
  measurement can't leave the last row or the home indicator under-cleared.
  (Already on this branch; kept in sync with `ship/build-21`'s comment.)

## Verification

- `tsc --noEmit` — clean (after `bun install` picked up `expo-iap`, unrelated
  to this change).
- `expo export --platform ios` — clean.
- Live on the iPhone 17 Pro simulator (iOS 26.0), **light mode**, against the
  team's real dogfooding account (a 9-working/5-idle list including a 3-deep
  session family): zero card overlap, composer gaps now genuinely frosted
  rather than legible. Dark mode sanity-checked too — unaffected.
- No lint or test setup exists for `mobile/` (checked `package.json` and for
  an eslint config); `tsc --noEmit` and `expo export` are the available
  static checks.

### Before / after (composer gap, light mode, real account)

Before — raw text reads through the composer's field row and caption row: the
composer showed `? Why on...` bleeding through crisply, and a fully opaque
`Work in /home/dev/omgdev-mobile-...` card sat directly on top of the
`opus / Medium / All projects` pills.

After — same account, same scroll position: both rows show a genuine frost,
illegible, no crisp card text anywhere in the composer's footprint.

## Notes for reviewers

- Base is `feat/mobile-omg-foundation`, not `main` — `main`'s `mobile/` is an
  unrelated Todos-list starter app, not this one, so a diff against `main`
  is 100+ files of noise. `feat/mobile-omg-foundation` is where #112 (the
  precedent for bug #1 here) actually landed, and where this app's real
  lineage continues.
- The task that produced this PR started on a local-only `ship/build-21`
  branch (no upstream), which is why it needed both fixes even though #1 is
  already merged here — that branch had forked before #112 landed. Also
  pushed `ship/build-21` to origin with this same fix, in case that specific
  numbered-build lineage is what actually needs to ship next.
- `mobile/app.json` and `mobile/docs/TESTFLIGHT-PUBLIC-LINK.md` had unrelated
  local modifications in the shared worktree this was built in; neither is
  included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
