### PR TITLE
fix(mobile): give the omg.dev launch envelope a dedicated display

### DIFF
--- a/mobile/src/omg/omg-prompt-envelope.ts
+++ b/mobile/src/omg/omg-prompt-envelope.ts
@@ -1,0 +1,66 @@
+// Ported from web/src/lib/omg-prompt-envelope.ts — keep the two in sync. If
+// the header/end/task markers ever change, update both, or (better) move this
+// into packages/ so mobile and web share one implementation instead of two
+// copies that can quietly drift.
+
+export type OmgPromptEnvelope = {
+  instructions: string;
+  task: string;
+  version: string | null;
+};
+
+// The envelope was branded "LFG", then "OMG", before settling on the company
+// name "omg.dev". All three spellings must parse forever: every transcript
+// recorded under an older brand still opens with that header, and those messages
+// are re-rendered every time the session is opened. Recognising only the current
+// one would regress them to showing the raw contract.
+const CONTRACT_HEADERS = [
+  "=== omg.dev RUNTIME CONTRACT",
+  "=== OMG RUNTIME CONTRACT",
+  "=== LFG RUNTIME CONTRACT",
+] as const;
+const CONTRACT_ENDS = [
+  "=== END omg.dev RUNTIME CONTRACT ===",
+  "=== END OMG RUNTIME CONTRACT ===",
+  "=== END LFG RUNTIME CONTRACT ===",
+] as const;
+const USER_TASK = "=== USER TASK ===";
+
+/**
+ * Splits omg.dev's agent-facing launch envelope for presentation only.
+ *
+ * The complete text remains in the transcript and is still sent to the agent;
+ * callers use this projection to keep the user's actual first message readable.
+ */
+export function parseOmgPromptEnvelope(text: string): OmgPromptEnvelope | null {
+  const header = CONTRACT_HEADERS.find((candidate) => text.startsWith(candidate));
+  if (!header) return null;
+
+  const headerEnd = text.indexOf("\n");
+  if (headerEnd < 0) return null;
+
+  // Pair the end marker to whichever spelling opened the envelope, but accept
+  // either: a prompt resumed across the rename can legitimately be mixed.
+  let contractEnd = -1;
+  let endMarker = "";
+  for (const candidate of CONTRACT_ENDS) {
+    const at = text.indexOf(candidate, headerEnd + 1);
+    if (at < 0) continue;
+    if (contractEnd < 0 || at < contractEnd) {
+      contractEnd = at;
+      endMarker = candidate;
+    }
+  }
+  if (contractEnd < 0) return null;
+
+  const taskMarker = text.indexOf(USER_TASK, contractEnd + endMarker.length);
+  if (taskMarker < 0) return null;
+
+  const headerLine = text.slice(0, headerEnd);
+  const version = headerLine.match(/\(capability version ([^)]+)\)/)?.[1] ?? null;
+  const instructions = text.slice(headerEnd + 1, contractEnd).trim();
+  const task = text.slice(taskMarker + USER_TASK.length).replace(/^\s*\n?/, "").trim();
+
+  if (!instructions || !task) return null;
+  return { instructions, task, version };
+}

--- a/mobile/src/omg/transcript.tsx
+++ b/mobile/src/omg/transcript.tsx
@@ -64,6 +64,7 @@ import {
   parseMessageAttachments,
   type MessageAttachment,
 } from "./message-attachments";
+import { parseOmgPromptEnvelope } from "./omg-prompt-envelope";
 import { AuthenticatedImage } from "./remote-image";
 import { Text } from "./text";
 import { useTheme } from "./theme";
@@ -1200,11 +1201,70 @@ function FallbackEntry({ message }: { message: Entry }) {
   );
 }
 
+/**
+ * omg.dev's launch contract travels inside the first user turn — several
+ * agent CLIs have no separate system-prompt channel for it — so without this,
+ * opening a session's first message meant reading past the whole runtime
+ * contract to find the one line the user actually typed. Web solves it with
+ * an inline disclosure; the phone already has an idiom for "auxiliary text
+ * that isn't the conversation" (`ToolRun`'s pill -> sheet), so this reuses
+ * that instead of an inline expand fighting the list's layout animation.
+ */
+function OmgInstructionsChip({ instructions, version }: { instructions: string; version: string | null }) {
+  const { colors, type, space, radius } = useTheme();
+  const [open, setOpen] = useState(false);
+  const symbol: Symbols = { ios: "scroll", android: "description" };
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          void Haptics.selectionAsync();
+          setOpen(true);
+        }}
+        accessibilityRole="button"
+        accessibilityLabel={`omg.dev instructions${version ? `, version ${version}` : ""}. Open`}
+        style={({ pressed }) => ({
+          alignSelf: "flex-end",
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 5,
+          minHeight: 26,
+          paddingHorizontal: space.sm,
+          paddingVertical: 3,
+          borderRadius: radius.pill,
+          borderWidth: 1,
+          borderColor: colors.border,
+          backgroundColor: pressed ? colors.cardPressed : colors.card,
+        })}
+      >
+        <Icon ios={symbol.ios} android={symbol.android} size={12} color={colors.textMuted} />
+        <Text style={{ ...type.caption, fontWeight: "500", color: colors.text }}>
+          omg.dev instructions
+        </Text>
+        {version ? (
+          <Text style={{ ...type.caption, fontFamily: MONO, color: colors.textMuted }}>
+            {version}
+          </Text>
+        ) : null}
+        <Icon ios="chevron.right" android="chevron_right" size={10} color={colors.textMuted} />
+      </Pressable>
+
+      <ToolSheet visible={open} title="omg.dev instructions" symbol={symbol} onClose={() => setOpen(false)}>
+        <Text selectable style={{ fontFamily: MONO, fontSize: 13, lineHeight: 19, color: colors.text }}>
+          {instructions}
+        </Text>
+      </ToolSheet>
+    </>
+  );
+}
+
 export function UserMessage({ message }: { message: Entry }) {
   const { colors, type, space, radius } = useTheme();
   const body = useBodyText();
   const [copied, setCopied] = useState(false);
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const envelope = useMemo(() => parseOmgPromptEnvelope(message.text ?? ""), [message.text]);
 
   useEffect(
     () => () => {
@@ -1213,13 +1273,19 @@ export function UserMessage({ message }: { message: Entry }) {
     [],
   );
 
+  // When this turn carries the omg.dev launch envelope, everything below —
+  // copy, attachment-splitting, the bubble itself — works from the user's
+  // actual task text, not the full contract. The raw `message.text` still
+  // goes to the agent; this is presentation only (see omg-prompt-envelope.ts).
+  const rawText = envelope?.task ?? message.text ?? "";
+
   const copy = () => {
-    if (!message.text) return;
+    if (!rawText) return;
     void Haptics.selectionAsync();
     // expo-clipboard, not RN's core Clipboard — the core one is deprecated and
     // slated for removal, and expo-clipboard is already a dependency (the
     // iMessage sign-in flow uses it to copy the code).
-    void Clipboard.setStringAsync(message.text);
+    void Clipboard.setStringAsync(rawText);
     setCopied(true);
     if (copyTimer.current) clearTimeout(copyTimer.current);
     copyTimer.current = setTimeout(() => setCopied(false), 1500);
@@ -1234,13 +1300,16 @@ export function UserMessage({ message }: { message: Entry }) {
   // line. COPY STILL TAKES THE RAW TEXT: what the agent saw is what gets
   // copied, exactly as on the web.
   const { body: text, attachments } = useMemo(
-    () => parseMessageAttachments(message.text ?? ""),
-    [message.text],
+    () => parseMessageAttachments(rawText),
+    [rawText],
   );
   const isLong = text.length > LONG_MESSAGE_CHARS;
 
   return (
     <View style={{ alignSelf: "stretch", gap: space.xs }}>
+      {envelope ? (
+        <OmgInstructionsChip instructions={envelope.instructions} version={envelope.version} />
+      ) : null}
       {attachments.length ? (
         <UserAttachments attachments={attachments} pending={message.pending} />
       ) : null}

--- a/test/mobile-omg-prompt-envelope.test.ts
+++ b/test/mobile-omg-prompt-envelope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseOmgPromptEnvelope } from "../mobile/src/omg/omg-prompt-envelope";
+import { parseOmgPromptEnvelope as parseOnWeb } from "../web/src/lib/omg-prompt-envelope";
+
+const SAMPLE = [
+  "=== omg.dev RUNTIME CONTRACT (capability version 2026-08-12.2) ===",
+  "- Narrate progress.",
+  "- Ship verified work.",
+  "=== END omg.dev RUNTIME CONTRACT ===",
+  "",
+  "=== USER TASK ===",
+  "Make the first message easy to read.",
+].join("\n");
+
+describe("the phone splits the omg.dev launch envelope off a user message", () => {
+  test("separates omg.dev instructions from the user's task", () => {
+    expect(parseOmgPromptEnvelope(SAMPLE)).toEqual({
+      instructions: "- Narrate progress.\n- Ship verified work.",
+      task: "Make the first message easy to read.",
+      version: "2026-08-12.2",
+    });
+  });
+
+  // Pre-rename transcripts are re-rendered every time an old session is opened,
+  // so every legacy header has to keep parsing indefinitely.
+  test("separates pre-rename OMG instructions from the user's task", () => {
+    expect(
+      parseOmgPromptEnvelope(
+        [
+          "=== OMG RUNTIME CONTRACT (capability version 2026-08-08.1) ===",
+          "- Narrate progress.",
+          "=== END OMG RUNTIME CONTRACT ===",
+          "",
+          "=== USER TASK ===",
+          "Make the first message easy to read.",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      instructions: "- Narrate progress.",
+      task: "Make the first message easy to read.",
+      version: "2026-08-08.1",
+    });
+  });
+
+  test("separates pre-rename LFG instructions from the user's task", () => {
+    expect(
+      parseOmgPromptEnvelope(
+        [
+          "=== LFG RUNTIME CONTRACT (capability version 2026-08-04.1) ===",
+          "- Narrate progress.",
+          "=== END LFG RUNTIME CONTRACT ===",
+          "",
+          "=== USER TASK ===",
+          "Make the first message easy to read.",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      instructions: "- Narrate progress.",
+      task: "Make the first message easy to read.",
+      version: "2026-08-04.1",
+    });
+  });
+
+  test("leaves ordinary and malformed messages alone", () => {
+    expect(parseOmgPromptEnvelope("Just a normal follow-up")).toBeNull();
+    expect(parseOmgPromptEnvelope("=== LFG RUNTIME CONTRACT ===\nNo closing marker")).toBeNull();
+  });
+
+  // The two copies (web/src/lib/omg-prompt-envelope.ts and this one) exist
+  // because mobile can't import from web/. This test is the tripwire: if a fix
+  // lands on one side and not the other, an old-brand transcript renders
+  // correctly on one platform and shows the raw contract on the other.
+  test("stays in lockstep with the web parser", () => {
+    expect(parseOmgPromptEnvelope(SAMPLE)).toEqual(parseOnWeb(SAMPLE));
+    expect(parseOmgPromptEnvelope("Just a normal follow-up")).toEqual(
+      parseOnWeb("Just a normal follow-up"),
+    );
+  });
+});

--- a/test/mobile-transcript-attachments.test.ts
+++ b/test/mobile-transcript-attachments.test.ts
@@ -89,7 +89,11 @@ describe("the transcript renders a user turn the way the web does", () => {
   );
 
   test("the bubble paints the split body, never the raw message text", () => {
-    expect(userMessage).toContain("parseMessageAttachments(message.text");
+    // Parsed from `rawText` (= the omg.dev envelope's task when the turn
+    // carries one, else message.text — see omg-prompt-envelope.ts), not the
+    // literal message.text, so a launch contract's attachments still split
+    // out correctly instead of being searched for in the un-stripped text.
+    expect(userMessage).toContain("parseMessageAttachments(rawText");
     expect(userMessage).toContain("{text}");
     expect(userMessage).not.toContain("{message.text}");
   });
@@ -102,7 +106,16 @@ describe("the transcript renders a user turn the way the web does", () => {
   });
 
   test("copy still yields the raw text the agent received", () => {
-    expect(userMessage).toContain("Clipboard.setStringAsync(message.text)");
+    // Except when the turn carries the omg.dev launch envelope: copy then
+    // yields just the user's task (rawText = envelope?.task ?? message.text),
+    // matching web's MessageActions — not the full runtime contract.
+    expect(userMessage).toContain("Clipboard.setStringAsync(rawText)");
+  });
+
+  test("an omg.dev launch envelope is detected and stripped to its task", () => {
+    expect(userMessage).toContain("parseOmgPromptEnvelope(message.text");
+    expect(userMessage).toContain("envelope?.task ?? message.text");
+    expect(userMessage).toContain("<OmgInstructionsChip");
   });
 
   test("an attachment with no caption draws no empty bubble", () => {


### PR DESCRIPTION
## Summary
Benny: *"We don't have the dedicated display for a separate message for the omg.dev instruction. We have that on the web, but we don't have it on the app."*

- Web splits the runtime-contract envelope out of the first user turn (`web/src/lib/omg-prompt-envelope.ts` → `parseOmgPromptEnvelope`) and shows a collapsed "omg.dev instructions" disclosure above the user's actual task bubble (`OmgInstructionsBlock` in `web/src/App.tsx`). Mobile had no equivalent — `UserMessage` rendered the entire raw envelope (headers, contract body, markers) as an ordinary chat bubble.
- Ports the parser to `mobile/src/omg/omg-prompt-envelope.ts` — kept as a synced copy rather than a shared package import, since `mobile/` isn't a workspace member; a parity test (`test/mobile-omg-prompt-envelope.test.ts`) imports both implementations and asserts they agree, so a fix on one side that misses the other fails CI instead of silently drifting.
- `UserMessage` now detects the envelope and renders the stripped task text as the bubble body, plus a collapsible "omg.dev instructions" chip above it. The chip opens a sheet with the raw instructions, reusing the app's existing pill → `ToolSheet` idiom (see `ToolRun`) rather than inline-expanding like web — matching web's information architecture (collapsed by default, label, version, expandable), not its pixels.
- Copy now yields the stripped task text (matching web's `MessageActions`), not the raw contract.

## Verification
- `tsc --noEmit` clean.
- `bun test` — new parity test passes; full suite has the same 10 pre-existing failures/6 errors as `origin/feat/mobile-omg-foundation` (confirmed via `git stash` before/after), none touching these files.
- Ran on a real iPhone 17 Pro simulator against a live Metro tunnel connected to this branch (not just typecheck) — other message kinds in the same file (tool badges, thinking blocks) rendered correctly through the same `Icon`/`ToolSheet`/pill-badge primitives this chip reuses, confirming the build is healthy. I was not able to get a live on-device screenshot of an actual envelope-carrying first message within the session (environment instability on a shared simulator — repeated OTA/dev-server fallbacks unrelated to this code — and a live session's `pinToEnd` fighting attempts to scroll to message #1). Compensated with a byte-for-byte faithful static reproduction of web's `OmgInstructionsBlock` (verified against its exact Tailwind classes and CSS custom properties) for visual reference, sent to Benny separately for comparison.

## Test plan
- [x] `tsc --noEmit`
- [x] `bun test`
- [ ] Benny: open a session whose first turn carries the omg.dev/OMG/LFG contract and confirm the chip renders instead of the raw contract text, and that copy yields just the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)