### PR TITLE
fix(mobile): "Continue with" collapses into a submenu, marks intact

### DIFF
--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -881,24 +881,28 @@ export default function SessionScreen() {
           : [];
       if (launchableAgents.length > 1) {
         /**
-         * A flat section, not a submenu row — see the `submenu` doc on
-         * `MenuOption` in menu.tsx. A submenu's own trigger row is a UIMenu
-         * header, and UIKit draws a header's image at the image's own pixel
-         * size rather than scaling it, so a bundled agent mark on a submenu
-         * row lands as an oversized slab hanging off the menu (photographed
-         * on device, IMG_1316 — the incident this file's convention exists
-         * to prevent). Agents are exactly the brand-marked case the doc calls
-         * out by name, so each one is its own row here, grouped by `section`
-         * instead of nested behind one.
+         * A submenu, not a flat section — build 26 feedback: with the
+         * account's full roster this flattened into 6+ rows sharing one
+         * overflow menu with Rename/Fork/Copy/Archive, which read as too
+         * long. `menu.tsx`'s own doc on `MenuOption.submenu` says a
+         * submenu's TRIGGER row cannot carry a bundled image (confirmed
+         * still true 2026-08-17 on iPhone 17 Pro Simulator / iOS 26.0 —
+         * see the retest note in renderRows, IMG_1316) — but says nothing
+         * against the rows behind it. So the trigger here is text + an SF
+         * Symbol only, never `image`, and each agent keeps its own mark on
+         * its own leaf row inside the submenu, same as the flat version
+         * carried. Verified clean with the full 6-agent roster, light and
+         * dark mode, before shipping this.
          */
-        for (const agent of launchableAgents) {
-          options.push({
+        options.push({
+          label: "Continue with",
+          icon: "arrow.forward.circle",
+          submenu: launchableAgents.map((agent) => ({
             label: agent.label || agentDisplayName(agent.key),
             image: agentIcon(agent.key),
-            section: "Continue with",
             onPress: () => continueWithAgent(agent.key),
-          });
-        }
+          })),
+        });
       } else {
         options.push({
           label: launchableAgents[0]?.label

--- a/mobile/src/omg/menu.tsx
+++ b/mobile/src/omg/menu.tsx
@@ -81,10 +81,13 @@ export type MenuOption = {
   /**
    * Rows behind this one. A SwiftUI `Menu` nested in a menu is a submenu.
    *
-   * PREFER `section` FOR A SET OF ALTERNATIVES. A submenu row cannot carry a
-   * bundled image (see renderRows), so anything whose identity is a brand mark
-   * — agents, above all — belongs in a section of this menu rather than behind
-   * a row of it.
+   * THIS OPTION'S OWN `image` IS IGNORED (see renderRows) — a submenu
+   * TRIGGER cannot carry a bundled image, confirmed still true as of
+   * 2026-08-17 (see renderRows for the retest). The rows BEHIND it are
+   * unaffected: give them `image` freely, same as any leaf row. A `section`
+   * is still the simpler choice for a short, flat set of alternatives; reach
+   * for `submenu` when the list is long enough that collapsing it behind one
+   * row earns its extra tap (see "Continue with" in session/[id].tsx).
    */
   submenu?: MenuOption[];
   /**
@@ -266,9 +269,27 @@ export function DropdownMenu({
      *
      * The mark stays on every LEAF row, which is where it was earning its
      * place; a submenu row is already labelled by the name of the thing it
-     * opens. If the marks are wanted back on agents, the fix is to flatten
-     * models into a second Section of the same menu rather than to make this
-     * header carry a picture it cannot size.
+     * opens. The image-sizing bug below is specific to the TRIGGER's own
+     * label — a `submenu` whose trigger carries no image is otherwise
+     * unrestricted here. (Separately, `session-options.ts` avoided nesting
+     * models behind agents for a DIFFERENT reason — press-and-drag-to-select
+     * not surviving a sideways step into a second layer — which this file
+     * has not retested and does not claim to have resolved.)
+     *
+     * RETESTED 2026-08-17, iPhone 17 Pro Simulator, iOS 26.0, Expo SDK 57,
+     * @expo/ui 57.0.10: still reproduces, unchanged from the original
+     * report. Forced `option.image` onto this trigger's label (bypassing
+     * this guard) with the full 6-row agent roster open behind it — the
+     * mark rendered natively at its asset's own pixel size, a slab several
+     * hundred points wide overlapping the header text, the row list below
+     * it, and the page underneath the menu. The SAME roster behind a
+     * text-only trigger (this code, unmodified) renders clean in both
+     * light and dark mode (tap-to-select only — drag was not tested). So:
+     * still true, still enforced here, not a one-time incident. See
+     * `mobile/app/session/[id].tsx`'s "Continue with" for a submenu built
+     * the safe way — trigger unmarked, leaves marked — which is the
+     * pattern to copy, not the flat `section` that shipped before this
+     * retest.
      */
     if (option.submenu?.length) {
       return (


### PR DESCRIPTION
## Summary
- Build 26 feedback: every launchable agent under the session overflow's "Continue with" rendered flat (up to 6 rows, sharing space with Rename/Fork/Copy/Archive). Benny's instinct — "needs a submenu" — is exactly what PR #124 tried and reverted, because `menu.tsx`'s own doc says a submenu trigger can't carry a bundled image (UIKit draws the open submenu's header at the image's native pixel size, not the SwiftUI-scaled size — IMG_1316).
- Retested rather than trusted the comment: reproduced the documented bug live (iPhone 17 Pro Simulator, iOS 26.0, Expo SDK 57, `@expo/ui` 57.0.10, 2026-08-17), with the full 6-agent roster, using a submenu trigger that carries an `image`. Still broken, unchanged from the original report.
- But the restriction is narrower than the flat rewrite assumed: it's the **trigger's own image** that breaks, not nesting itself, and not the leaf rows behind it. A submenu whose trigger is text + an SF Symbol, with each agent keeping its own mark on its own leaf row, renders clean — verified with the full roster, light and dark mode.
- `menu.tsx`'s doc comments are updated in place (not silently overwritten) to record the retest — device, iOS version, date, result — and to correct the doc's own overstatement that a marked list has to be flattened to keep its marks.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] On-device (iPhone 17 Pro Simulator, iOS 26.0): confirmed current shipped flat list
- [x] On-device: reproduced the documented sizing bug with a marked submenu trigger + full 6-agent roster (screenshot: giant native-pixel mark bleeding over the menu and page)
- [x] On-device: confirmed the safe pattern (unmarked trigger, marked leaves) renders clean with the same full roster, light and dark mode
- [x] On-device: confirmed final shipped code ("Continue with", no debug labels) renders identically to the verified safe pattern

Not attributed to #137 — that PR is closed and authored by @BennyKok, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
