### PR TITLE
feat(serve): report pending browser logins so a host can see this box is busy

### DIFF
--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -6,8 +6,10 @@ import {
   claudeConfigDirs,
   cleanAuthOutput,
   getCodingAgentAuth,
+  isLoginPending,
   listCodingAgents,
   parseAuthOutput,
+  pendingCodingAgentLogins,
   startCodingAgentAuth,
   startToolAuth,
   withCursorOmgMcp,
@@ -547,5 +549,53 @@ describe("pi provider sign-in", () => {
 
   test("agents with no browser login still say so", async () => {
     expect(startCodingAgentAuth("cursor")).rejects.toThrow(/does not support browser login/i);
+  });
+});
+
+/**
+ * A login is real work, and this box is the only thing that can see it.
+ *
+ * The host polls GET /api/sessions to decide whether this machine is idle
+ * enough to hibernate, and that answer used to describe agent sessions only. So
+ * a box with a half-finished Claude sign-in reported nothing to hold it up and
+ * was hibernated under the user. That is what happened to a paying customer on
+ * 2026-08-17: he clicked Login, his machine slept, and he never ran an agent.
+ *
+ * This box REPORTS; the host DECIDES. These tests pin the reporting contract,
+ * because it is the input every host-side idle rule is built on.
+ */
+describe("pending login reporting", () => {
+  const TTL = 15 * 60 * 1000;
+  const now = 1_000_000;
+  const live = { status: "waiting", expiresAt: now + TTL };
+
+  test("a login a user could still finish counts as work", () => {
+    expect(isLoginPending(live, now)).toBe(true);
+    // "starting" is the window before the authorization URL has been scraped.
+    // The customer's machine slept while he was mid-flow, so this window must
+    // count exactly as much as "waiting" does.
+    expect(isLoginPending({ status: "starting", expiresAt: now + TTL }, now)).toBe(true);
+  });
+
+  test("a finished login is not work", () => {
+    // Neither ending leaves anything for the user to come back to.
+    expect(isLoginPending({ status: "complete", expiresAt: now + TTL }, now)).toBe(false);
+    expect(isLoginPending({ status: "error", expiresAt: now + TTL }, now)).toBe(false);
+  });
+
+  test("an expired login is an abandoned tab, not work", () => {
+    // The self-limit. Without it a walked-away user could pin a machine awake
+    // indefinitely, which is the cost regression that makes any host-side
+    // policy unsafe to trust.
+    expect(isLoginPending({ ...live, expiresAt: now - 1 }, now)).toBe(false);
+
+    // Exactly at the deadline still counts: the boundary belongs to the user.
+    expect(isLoginPending({ ...live, expiresAt: now }, now)).toBe(true);
+  });
+
+  test("a quiet box reports no pending logins", () => {
+    // The default answer for the overwhelming majority of polls. If this were
+    // ever non-zero at rest, every machine would stop hibernating at all.
+    expect(pendingCodingAgentLogins(now)).toBe(0);
   });
 });

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -1071,6 +1071,50 @@ export function cancelCodingAgentAuth(id: string): void {
   authSessions.delete(id);
 }
 
+/**
+ * Is this login still one a person could come back and finish?
+ *
+ * Pure, and exported, so the rule can be tested without spawning a real CLI
+ * login. "complete" and "error" are over; an expired one is an abandoned tab,
+ * not work.
+ */
+export function isLoginPending(
+  session: { status: string; expiresAt: number },
+  now: number,
+): boolean {
+  if (session.status !== "starting" && session.status !== "waiting") return false;
+  return now <= session.expiresAt;
+}
+
+/**
+ * How many browser logins are still live and waiting for the user right now.
+ *
+ * WHY THIS EXISTS. A login is real work, but until now it was invisible from
+ * outside this process. The host asks this box "are you busy?" every ~45s and
+ * reads only agent sessions, so a box with a half-finished Claude login
+ * truthfully answered "no" and was hibernated mid-login. A paying customer hit
+ * exactly that on 2026-08-17: he clicked Login, his machine slept underneath
+ * him, and he never ran an agent at all.
+ *
+ * This REPORTS, it does not decide. The host owns the idle policy — how long a
+ * machine is held, and whether a pending login extends that — because a number
+ * baked into this process could never be tuned for boxes already in the field.
+ * All this box owes the host is the truth about what it is doing.
+ *
+ * Bounded regardless: AUTH_SESSION_TTL_MS already ends an abandoned login, so
+ * this cannot report "busy" forever even if a host chose to trust it forever.
+ *
+ * Counted, not a boolean, so a host can say "2 logins waiting" rather than just
+ * "busy", and so one stuck login is distinguishable from several.
+ */
+export function pendingCodingAgentLogins(now: number = Date.now()): number {
+  let count = 0;
+  for (const session of authSessions.values()) {
+    if (isLoginPending(session, now)) count += 1;
+  }
+  return count;
+}
+
 export function loginCommandFor(kind: CodingAgentKind): string | null {
   const parts = loginCommandPartsFor(kind);
   return parts ? parts.map(shellQuote).join(" ") : null;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -267,6 +267,7 @@ import {
   getCodingAgentAuth,
   getCodingAgentSetupLog,
   loginCommandFor,
+  pendingCodingAgentLogins,
   registerClaudeMcpForAccount,
   runCodingAgentSetup,
   runCodingAgentSetups,
@@ -4445,7 +4446,21 @@ a{color:#60a5fa}
         // sessionListRow for why the default leaves it out. The one caller
         // that wants it is omg_list_sessions with verbose:true.
         const full = url.searchParams.get("full") === "1";
-        return json({ sessions: full ? sessions : sessions.map(sessionListRow) });
+        // `pendingLogins` is how a HOST learns this box is mid-login.
+        //
+        // The control plane polls this route to decide whether the machine is
+        // idle enough to hibernate, and it only ever counted agent sessions. A
+        // browser login is real work that lives entirely in this process, so a
+        // box with a half-finished Claude sign-in answered "not busy" and was
+        // hibernated under the user (2026-08-17, a paying customer).
+        //
+        // ADDITIVE ON PURPOSE. An older host ignores the extra field, and a
+        // newer host reading an older box sees `undefined` and falls back to
+        // exactly today's behaviour. Neither side needs to ship first.
+        return json({
+          sessions: full ? sessions : sessions.map(sessionListRow),
+          pendingLogins: pendingCodingAgentLogins(),
+        });
       }
 
       if (path === "/api/install") {


### PR DESCRIPTION
## Why

A paying omg.dev customer clicked **Login** to connect Claude on 2026-08-17. His Computer hibernated underneath him 45 seconds later, while he was still clicking. He never ran a single agent.

The host polls `GET /api/sessions` to decide whether a machine is idle enough to hibernate, and that answer described **agent sessions only**. A box with a half-finished Claude sign-in reported nothing to hold it up, so it looked exactly like an idle box.

This box already tracked live logins in `authSessions` and already expired them via `AUTH_SESSION_TTL_MS`. It simply had no way to say so.

## What changed

`GET /api/sessions` now carries `pendingLogins`: a count of logins a user could still come back and finish.

**Reporting, not policy.** The host owns the idle rule — how long a machine is held, and whether a pending login extends that. A number baked in here could never be tuned for boxes already baked and in the field, so all this box owes the host is the truth about what it is doing.

It also cannot report "busy" forever: an abandoned login expires on this box's own clock.

## Backward compatible, both directions

Neither side has to ship first.

- An **older host** ignores the extra field.
- A **newer host** reading an **older box** sees `undefined` and falls back to exactly today's behaviour. Critically, `undefined` means *"cannot tell us"*, never *"no logins"*.

## Testing

- `isLoginPending` is split out as a pure function so the rule is testable without spawning a real CLI login: `starting` and `waiting` count, `complete` and `error` do not, an expired login does not, and the deadline instant itself belongs to the user.
- **Verified against a real server on `:8791`, not only in unit tests.** A quiet box reported `pendingLogins: 0`; starting a genuine `claude auth login` via `POST /api/coding-agents/aisdk/auth` returned a real authorization URL and moved it to **1**.
- 42 tests pass. Typecheck is clean for both changed files (the repo has one pre-existing unrelated error in `web/src/lib/omg-client.ts`, present on clean `main`).

## Host side

The matching control-plane change is BennyKok/vibes#1452, which counts `pendingLogins` as in-use and raises the idle grace from 45s to 5 minutes.
