### PR TITLE
fix: a fresh install could not start a session, and never said why

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Something in omg.dev does not work
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. The single most useful thing you can include is
+        the output of `omg doctor` — it answers most of the questions we would
+        otherwise have to ask one at a time.
+
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Output of `omg doctor`
+      description: |
+        Run `omg doctor` and paste the whole block. API keys, tokens, and your
+        home directory are removed before it prints, so it is safe to post here.
+
+        If `omg doctor` itself does not run, say so here and tell us how omg.dev
+        was installed instead — that is a useful bug on its own.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what you got instead.
+      placeholder: |
+        I sent a message on a new install and the session showed the thinking
+        dots forever. I expected it to reply or tell me what was wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: |
+        Screenshots, a session id, or anything else that helps. If a session is
+        involved, its id (from the URL) lets us line your report up with the
+        logs you pasted above.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ omg uninstall --purge --yes   # also permanently delete sessions and config
 
 ```bash
 omg serve                      # web UI + control server
+omg doctor                     # shareable diagnostic to paste into a bug report
 omg setup                      # rerun provisioning/update flow
 omg uninstall                  # remove omg.dev while preserving sessions and config
 omg connect <code>             # reach this box through a relay (see docs/remote-access.md)
@@ -281,6 +282,27 @@ omg subagent create --prompt "..." --agent codex-aisdk
 
 From a source checkout, use `bun run <command>` (e.g. `bun run serve`) — the
 surface is identical.
+
+## Something is wrong
+
+Run `omg doctor` and paste what it prints.
+
+```bash
+omg doctor          # a fenced block: versions, agents, accounts, server, recent errors
+omg doctor --json   # the same facts, machine-readable
+```
+
+It answers the questions a bug report otherwise takes several rounds to
+establish: which version, which agent CLIs exist, whether any account is
+connected, whether the server is up, and the recent log lines that look like
+failures. It works when omg.dev is broken — it does not need the server, and a
+probe that fails is reported rather than aborting the rest.
+
+API keys, tokens, and your home directory are removed before it prints, so the
+output is safe to paste into a public issue or Discord.
+
+If a session never starts, `doctor` usually names the cause outright: no coding
+agent installed, or none signed in.
 
 ## MCP tools
 

--- a/scripts/test-install-clean-vm.sh
+++ b/scripts/test-install-clean-vm.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Run README.md's quick start on a genuinely clean machine and report what a
+# new user would see.
+#
+#   scripts/test-install-clean-vm.sh [--keep] [--user NAME] [--port PORT]
+#                                    [--cli-dist DIR]
+#
+# Why this exists: the quick start is the one code path every new user runs,
+# and it is the one path no test covered. It is not testable from a developer
+# box — every machine we own already has Bun, Node, an ~/omg install, or all
+# three, and each of those hides a different failure. On 2026-08-18 the
+# documented `bun install --global @omg-dev/cli && omg computer setup` died on
+# a clean box with
+#
+#     /usr/bin/env: 'node': No such file or directory
+#
+# because the published CLI's shebang named a runtime the quick start never
+# installs. Nothing caught it: unit tests ran the CLI's JavaScript, which only
+# executes after an interpreter has been chosen, and every dev box had Node.
+#
+# So this rents a fresh Firecracker VM from the OMG sandbox API, runs the
+# documented commands verbatim as an ordinary sudo-capable user, and asserts
+# the finish line a user cares about: setup exits 0, `serve` listens, and the
+# web UI answers 200 with real HTML. The VM is destroyed afterwards unless
+# --keep is passed.
+#
+# --cli-dist DIR overlays a locally built @omg-dev/cli `dist/` on top of the
+# published package, so a fix can be proven against a clean machine before it
+# is released. Everything else still runs exactly as documented.
+#
+# Requirements:
+#   VIBES_INFRA_SERVICE_TOKEN  - infra service token (or _CI variant via ENVF)
+#   INFRA_URL                  - defaults to https://infra.omg.dev
+#   ENVF                       - optional env file to source for the above
+#
+# Exit codes:
+#   0  the quick start works on a clean machine
+#   1  it does not — the failing step and its output are printed
+#   2  the harness could not run (bad env, no capacity)
+set -euo pipefail
+
+KEEP=0
+VM_USER=tester
+PORT=8766
+CLI_DIST=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep) KEEP=1; shift ;;
+    --user) VM_USER="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --cli-dist) CLI_DIST="$2"; shift 2 ;;
+    -h|--help) sed -n '2,37p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -n "$CLI_DIST" ]]; then
+  [[ -f "$CLI_DIST/omg.mjs" && -f "$CLI_DIST/omg-bun.mjs" ]] \
+    || { echo "--cli-dist $CLI_DIST does not look like a built cli dist/" >&2; exit 2; }
+fi
+
+if [[ -n "${ENVF:-}" && -f "${ENVF}" ]]; then
+  set -a; . "$ENVF"; set +a
+fi
+
+INFRA_URL="${INFRA_URL:-https://infra.omg.dev}"
+TOKEN="${VIBES_INFRA_SERVICE_TOKEN:-${VIBES_INFRA_SERVICE_TOKEN_CI:-}}"
+ON_BEHALF="${SMOKE_USER:-svc:omg-install-test}"
+: "${TOKEN:?VIBES_INFRA_SERVICE_TOKEN required (or set ENVF to a file providing it)}"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 2; }
+
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m[ok]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[x]\033[0m %s\n' "$*" >&2; exit 1; }
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  if [[ -n "$body" ]]; then
+    curl -sS -X "$method" "$INFRA_URL$path" \
+      -H "Authorization: Bearer $TOKEN" -H "X-On-Behalf-Of: $ON_BEHALF" \
+      -H 'Content-Type: application/json' --data "$body"
+  else
+    curl -sS -X "$method" "$INFRA_URL$path" \
+      -H "Authorization: Bearer $TOKEN" -H "X-On-Behalf-Of: $ON_BEHALF"
+  fi
+}
+
+SANDBOX=""
+cleanup() {
+  [[ -z "$SANDBOX" ]] && return
+  if [[ "$KEEP" == 1 ]]; then
+    log "keeping sandbox $SANDBOX (--keep)"
+    return
+  fi
+  log "destroying sandbox $SANDBOX"
+  api DELETE "/v1/sandboxes/$SANDBOX" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Run a script inside the VM as root. Prints stdout; returns the guest's exit
+# code so a failing step here fails the harness.
+vm() {
+  local script="$1" timeout_ms="${2:-900000}"
+  local body resp
+  body="$(jq -nc --arg s "$script" --argjson t "$timeout_ms" \
+    '{cmd:"bash",args:["-lc",$s],timeoutMs:$t}')"
+  resp="$(api POST "/v1/sandboxes/$SANDBOX/exec" "$body")"
+  printf '%s' "$resp" | jq -r '.stdout // ""'
+  local stderr code
+  stderr="$(printf '%s' "$resp" | jq -r '.stderr // ""')"
+  code="$(printf '%s' "$resp" | jq -r '.exitCode // 1')"
+  [[ -n "$stderr" ]] && printf '%s\n' "$stderr" >&2
+  return "$code"
+}
+
+# ---------------------------------------------------------------------------
+# 1. A clean machine
+# ---------------------------------------------------------------------------
+log "creating a clean sandbox VM"
+create="$(api POST /v1/sandboxes "$(printf '{"ports":[%d],"timeout":3600}' "$PORT")")"
+SANDBOX="$(printf '%s' "$create" | jq -r '.id // empty')"
+[[ -n "$SANDBOX" ]] || { printf '%s\n' "$create" >&2; echo "could not create a sandbox" >&2; exit 2; }
+ok "sandbox $SANDBOX ($(printf '%s' "$create" | jq -r '.nodeId // "?"'))"
+
+log "baseline: what this machine has before we touch it"
+vm 'cat /etc/os-release | grep PRETTY_NAME; for b in bun node npm git tmux; do printf "%-6s %s\n" "$b" "$(command -v $b || echo "(absent)")"; done'
+
+# An ordinary user, because setup deliberately refuses to run as root and a
+# root-only test would never see that path.
+log "creating an ordinary sudo-capable user: $VM_USER"
+vm "
+set -e
+command -v sudo >/dev/null || { apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -qq install -y sudo; } >/dev/null 2>&1
+id $VM_USER >/dev/null 2>&1 || useradd -m -s /bin/bash $VM_USER
+printf '%s ALL=(ALL) NOPASSWD:ALL\n' $VM_USER > /etc/sudoers.d/$VM_USER
+chmod 440 /etc/sudoers.d/$VM_USER
+id $VM_USER
+" 300000 >/dev/null
+ok "user $VM_USER ready"
+
+# ---------------------------------------------------------------------------
+# 2. The documented quick start, verbatim
+# ---------------------------------------------------------------------------
+
+# An unreleased fix is applied between the two documented commands, in the same
+# place the next npm publish would land it, so the rest of the run is unchanged.
+overlay=""
+if [[ -n "$CLI_DIST" ]]; then
+  log "overlaying local cli dist from $CLI_DIST"
+  staging="$(mktemp -d)"
+  # Pack it as `dist/` so it lands exactly where the published package keeps
+  # its own, whatever the local directory happens to be called.
+  mkdir "$staging/dist" && cp "$CLI_DIST"/* "$staging/dist/"
+  tar czf "$staging/cli-dist.tgz" -C "$staging" dist
+  # The files API base64-decodes `content` and writes the raw bytes.
+  jq -nc --rawfile c <(base64 -w0 "$staging/cli-dist.tgz") --arg p /tmp/cli-dist.tgz \
+    '[{path:$p,content:$c}]' > "$staging/body.json"
+  api POST "/v1/sandboxes/$SANDBOX/files" "@$staging/body.json" >/dev/null \
+    || fail "could not stage the local dist in the VM"
+  overlay="tar xzf /tmp/cli-dist.tgz -C \"\$HOME/.bun/install/global/node_modules/@omg-dev/cli\" --overwrite"
+  ok "local dist staged in the VM"
+fi
+
+log "running README.md's quick start as $VM_USER"
+vm "
+cat > /home/$VM_USER/quickstart.sh <<'INNER'
+#!/usr/bin/env bash
+set -x
+export PATH=\"\$HOME/.bun/bin:\$PATH\"
+export OMG_INSTALL_SYSTEM_DEPS=1
+export OMG_PORT=$PORT
+bun install --global @omg-dev/cli
+echo \"INSTALL_EXIT=\$?\"
+$overlay
+omg computer setup
+echo \"SETUP_EXIT=\$?\"
+echo '=== QUICKSTART DONE ==='
+INNER
+chown $VM_USER:$VM_USER /home/$VM_USER/quickstart.sh
+chmod +x /home/$VM_USER/quickstart.sh
+su - $VM_USER -c 'setsid nohup /home/$VM_USER/quickstart.sh > /home/$VM_USER/quickstart.log 2>&1 < /dev/null & disown'
+" 300000 >/dev/null
+
+# The bundle download dominates; poll rather than guess a sleep.
+for _ in $(seq 1 60); do
+  if vm "grep -q 'QUICKSTART DONE' /home/$VM_USER/quickstart.log" 120000 >/dev/null 2>&1; then break; fi
+  sleep 5
+done
+
+setup_exit="$(vm "grep -oE 'SETUP_EXIT=[0-9]+' /home/$VM_USER/quickstart.log | tail -1 | cut -d= -f2" 120000 || echo "")"
+if [[ "$setup_exit" != "0" ]]; then
+  printf '\n--- quickstart.log (tail) ---\n' >&2
+  vm "tail -40 /home/$VM_USER/quickstart.log" 120000 >&2 || true
+  fail "the documented quick start failed on a clean machine (setup exit ${setup_exit:-unknown})"
+fi
+ok "omg computer setup exited 0"
+
+# ---------------------------------------------------------------------------
+# 3. The finish line: it actually serves
+# ---------------------------------------------------------------------------
+log "starting the install and checking the web UI"
+vm "
+su - $VM_USER -c 'setsid nohup bash -c \"cd \$HOME/omg && OMG_PORT=$PORT bun run \$HOME/omg/src/cli.ts serve\" > \$HOME/serve.log 2>&1 < /dev/null & disown'
+" 120000 >/dev/null
+
+served=0
+for _ in $(seq 1 30); do
+  if vm "curl -sf -o /tmp/ui.html http://127.0.0.1:$PORT/" 60000 >/dev/null 2>&1; then served=1; break; fi
+  sleep 2
+done
+if [[ "$served" != 1 ]]; then
+  printf '\n--- serve.log (tail) ---\n' >&2
+  vm "tail -30 /home/$VM_USER/serve.log" 120000 >&2 || true
+  fail "omg.dev installed but never answered on http://127.0.0.1:$PORT/"
+fi
+
+# 200 is necessary but not sufficient — assert the app actually rendered.
+if ! vm "grep -q '<title>omg</title>' /tmp/ui.html" 60000 >/dev/null 2>&1; then
+  fail "the web UI answered but did not serve the app shell"
+fi
+ok "web UI serves the app on http://127.0.0.1:$PORT/"
+
+if ! vm "curl -sf http://127.0.0.1:$PORT/api/sessions | grep -q sessions" 60000 >/dev/null 2>&1; then
+  fail "the API did not answer /api/sessions"
+fi
+ok "API answers /api/sessions"
+
+printf '\n\033[1;32mThe documented quick start works on a clean machine.\033[0m\n'

--- a/src/agents/backends/aisdk-session.ts
+++ b/src/agents/backends/aisdk-session.ts
@@ -104,6 +104,54 @@ function userTextMessage(text: string): SessionMsg {
 }
 
 /**
+ * Why the SDK stream ended, phrased for the person looking at the session.
+ *
+ * The bad case is a stream that ends *without* throwing. `for await` simply
+ * finishes, `catch` never runs, and the harness exits 1 having printed nothing
+ * at all — no stdout, no stderr, no transcript row. That is what a box with no
+ * authenticated Claude does: the Agent SDK's subprocess cannot start, and the
+ * iterator closes empty. On a fresh install the session then sat on the
+ * thinking dots forever, because a UI can only report what it was told, and it
+ * was told nothing.
+ *
+ * `turns` distinguishes the two shapes. Zero turns means nothing ever ran, so
+ * the cause is upstream of the conversation — almost always that no agent is
+ * connected yet, which is the state every new install starts in. After at
+ * least one turn the runtime existed and died later, which is a different
+ * problem and must not be described as missing auth.
+ */
+export function describeAisdkStreamEnd(input: {
+  turns: number;
+  error?: unknown;
+  claudePath?: string | null;
+  accountConnected?: boolean;
+}): string {
+  const cause =
+    input.error instanceof Error ? input.error.message : input.error ? String(input.error) : "";
+  if (input.turns > 0) {
+    return cause
+      ? `The coding agent stopped unexpectedly: ${cause}`
+      : "The coding agent stopped unexpectedly after the session had started.";
+  }
+  // Nothing ran. Name the missing piece, because on a new install it is the
+  // only thing standing between the user and a working session.
+  const missing: string[] = [];
+  if (!input.claudePath) missing.push("the Claude CLI is not installed");
+  if (!input.accountConnected) missing.push("no Claude account is connected");
+  const detail = cause ? ` (${cause})` : "";
+  if (missing.length) {
+    return (
+      `Claude could not start: ${missing.join(" and ")}. ` +
+      `Open Settings → Coding agents to install it and sign in.${detail}`
+    );
+  }
+  return (
+    `Claude could not start, and it stopped before running a single turn.${detail} ` +
+    `Check Settings → Coding agents.`
+  );
+}
+
+/**
  * Human-readable detail for a non-success Agent SDK `result` message.
  *
  * This used to be `String(msg.result ?? msg.subtype)`, which reported nothing
@@ -330,6 +378,7 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   let busy = false;
   let restartRequested = false;
   let lastSdkEventAt = Date.now();
+  let sdkMessagesSeen = 0;
   const previousUsage = readStoredSessionTokenUsage(sessionId);
   let sessionTotals = previousUsage?.totals ?? {
     input: 0,
@@ -444,6 +493,10 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
 
   function handleMessage(msg: Record<string, unknown>): void {
     lastSdkEventAt = Date.now();
+    // Proof the runtime actually spoke. A stream that ends having produced
+    // nothing at all never started, which is a different failure from one that
+    // started and later died — and only the first is explained by missing auth.
+    sdkMessagesSeen++;
     const type = msg.type as string;
     if (type === "stream_event") {
       setBusy(true);
@@ -613,9 +666,30 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   // channel closes (shutdown) or the subprocess dies.
   let runtimeGeneration = 0;
   let unexpectedExit = false;
+  // What killed it, in the user's words. Written to the transcript on the way
+  // out so the session shows a reason instead of thinking dots forever.
+  let exitExplanation: string | null = null;
   try {
     while (!closing) {
-      q = startQuery(resuming || runtimeGeneration > 0);
+      // startQuery can throw SYNCHRONOUSLY, before any stream exists — the SDK
+      // resolves its native binary here, so a bundle without one dies on this
+      // line. That throw used to escape the inner try (which only wraps the
+      // `for await`) and land in the outer `finally`, whose process.exit()
+      // discarded it: exit 1, no stdout, no stderr, no transcript. The session
+      // showed thinking dots forever because nothing was ever told otherwise.
+      try {
+        q = startQuery(resuming || runtimeGeneration > 0);
+      } catch (error) {
+        exitExplanation = describeAisdkStreamEnd({
+          turns: sdkMessagesSeen,
+          error,
+          claudePath,
+          accountConnected: !!account,
+        });
+        console.error(`aisdk-session: ${exitExplanation}`);
+        unexpectedExit = true;
+        break;
+      }
       restartRequested = false;
       try {
         for await (const msg of q) {
@@ -625,6 +699,12 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
         if (closing) break;
         if (!restartRequested) {
           console.error(`aisdk-session: query loop failed: ${error instanceof Error ? error.message : error}`);
+          exitExplanation = describeAisdkStreamEnd({
+            turns: sdkMessagesSeen,
+            error,
+            claudePath,
+            accountConnected: !!account,
+          });
           unexpectedExit = true;
           break;
         }
@@ -635,12 +715,35 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
         lastSdkEventAt = Date.now();
         continue;
       }
+      // The stream ended without throwing. Nothing above has said anything, so
+      // this is the branch that used to exit 1 in total silence.
+      exitExplanation = describeAisdkStreamEnd({
+        turns: sdkMessagesSeen,
+        claudePath,
+        accountConnected: !!account,
+      });
+      console.error(`aisdk-session: ${exitExplanation}`);
       unexpectedExit = true;
       break;
     }
   } finally {
     clearInterval(poll);
     clearInterval(watchdog);
+    // A transcript row is the only channel the web UI actually reads. Stamp it
+    // as an api error so computeStatus turns the session "blocked" with a
+    // reason, rather than leaving it to spin.
+    if (exitExplanation) {
+      try {
+        indexSessionMessagesDirect(sessionId, [{
+          id: crypto.randomUUID(),
+          role: "assistant",
+          kind: "text",
+          text: exitExplanation,
+          ts: Date.now(),
+          apiError: true,
+        }]);
+      } catch {}
+    }
     removeEntry(sessionId);
     process.exit(closing && !unexpectedExit ? 0 : 1);
   }

--- a/src/agents/backends/aisdk-silent-exit.test.ts
+++ b/src/agents/backends/aisdk-silent-exit.test.ts
@@ -1,0 +1,115 @@
+// A brand-new install has no coding agent connected yet — that is the state
+// every user starts in. On 2026-08-18 a user sent "hi" on a fresh box and the
+// session sat on the thinking dots forever.
+//
+// The session was not slow. It was already dead: the harness had exited 1
+// within a second, having printed NOTHING. No stdout, no stderr, no transcript
+// row. Reproduced on a clean VM with no Claude installed:
+//
+//     $ bun src/agents/backends/aisdk-session.ts --session … -- hi
+//     exit 1 signal undefined
+//     STDOUT:
+//     STDERR:
+//
+// The cause is a stream that ends without throwing. The Agent SDK cannot start
+// its subprocess, so `for await (const msg of q)` finishes immediately, the
+// `catch` never runs, and the loop fell to a bare `unexpectedExit = true` with
+// no message attached. serve had nothing to report, so the UI kept spinning —
+// a session list entry with launching:true and status:"ok" that never changed.
+//
+// The fix is not "handle missing auth". It is that this harness must never
+// exit without saying why. These tests pin the explanation, especially the
+// zero-message case that produced silence.
+import { describe, expect, test } from "bun:test";
+import { describeAisdkStreamEnd } from "./aisdk-session.ts";
+
+describe("explaining a stream that ended", () => {
+  // The exact fresh-install shape: nothing installed, nothing connected, and
+  // not one message off the SDK.
+  test("a stream that produced nothing names what is missing", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 0,
+      claudePath: null,
+      accountConnected: false,
+    });
+
+    expect(line).toContain("Claude CLI is not installed");
+    expect(line).toContain("no Claude account is connected");
+    // Naming the cause is only half of it — the user needs the next action.
+    expect(line).toContain("Settings");
+    // The bug was silence; anything empty reintroduces it.
+    expect(line.trim().length).toBeGreaterThan(0);
+  });
+
+  // Installed but not signed in: the other half of the same first-run wall.
+  test("distinguishes an installed CLI with no account from a missing one", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 0,
+      claudePath: "/usr/local/bin/claude",
+      accountConnected: false,
+    });
+
+    expect(line).toContain("no Claude account is connected");
+    expect(line).not.toContain("not installed");
+  });
+
+  // A session that ran and then died is a different problem. Blaming auth
+  // there would send the user to a settings page that is already correct.
+  test("does not blame auth once the session has actually run", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 42,
+      claudePath: null,
+      accountConnected: false,
+    });
+
+    expect(line).not.toContain("Settings");
+    expect(line).not.toContain("not installed");
+    expect(line).toContain("stopped unexpectedly");
+  });
+
+  test("carries the underlying error when there is one", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 7,
+      error: new Error("spawn ENOENT"),
+      claudePath: "/usr/local/bin/claude",
+      accountConnected: true,
+    });
+    expect(line).toContain("spawn ENOENT");
+  });
+
+  // An error on a stream that never produced anything still points at setup,
+  // but must not swallow the detail — that detail is the whole diagnostic when
+  // the cause is something we did not anticipate.
+  test("keeps the error detail even when it also points at setup", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 0,
+      error: new Error("spawn /usr/local/bin/claude EACCES"),
+      claudePath: "/usr/local/bin/claude",
+      accountConnected: false,
+    });
+    expect(line).toContain("EACCES");
+    expect(line).toContain("Settings");
+  });
+
+  // A fully configured box that still produces nothing is the case we cannot
+  // name, and precisely the one where saying nothing is worst.
+  test("still explains itself when everything looks configured", () => {
+    const line = describeAisdkStreamEnd({
+      turns: 0,
+      claudePath: "/usr/local/bin/claude",
+      accountConnected: true,
+    });
+    expect(line.trim().length).toBeGreaterThan(0);
+    expect(line).toContain("before running a single turn");
+    expect(line).toContain("Settings");
+  });
+
+  // The failure path is the worst possible place to throw: it would destroy
+  // the diagnostic it exists to produce.
+  test("never throws on junk input", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => describeAisdkStreamEnd({ turns: 0, error: circular })).not.toThrow();
+    expect(describeAisdkStreamEnd({ turns: 0, error: circular }).length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ Usage:
   omg connect <code>               Pair this box to a remote-access relay (EXPERIMENTAL)
   omg setup                        Provision this box (Bun, tmux, service)
   omg update [--check]             Update to the latest release and restart
+  omg doctor [--json]              Print a shareable diagnostic for bug reports
   omg uninstall [--purge --yes]    Remove omg.dev (preserves sessions/config by default)
 
 Env (read from process env / .env, see .env.example):
@@ -37,6 +38,7 @@ const COMPUTER_VERBS = new Set([
   "update",
   "uninstall",
   "status",
+  "doctor",
   "mcp",
   "agents",
   "subagent",
@@ -94,6 +96,10 @@ async function main() {
     case "update": {
       const { cmdUpdate } = await import("./commands/update.ts");
       return await cmdUpdate(rest);
+    }
+    case "doctor": {
+      const { cmdDoctor } = await import("./commands/doctor.ts");
+      return await cmdDoctor(rest);
     }
     case "uninstall": {
       const { cmdUninstall } = await import("./commands/uninstall.ts");

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -1,0 +1,134 @@
+// `omg doctor` exists because a user could not tell us what went wrong.
+//
+// On 2026-08-18 a report arrived as a screenshot of a spinner. That was all the
+// user had: the failure behind it produced no output at all, so there was
+// nothing to send. Finding it took a clean VM and a traced subprocess.
+//
+// The output of this command goes into Discord and GitHub issues, which makes
+// leaking a credential the one failure mode worse than the bug it diagnoses.
+// These tests are mostly about that.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { recentLogTail, redact, sanitize, shortenHome } from "./doctor.ts";
+
+describe("redacting a report before a user pastes it in public", () => {
+  // Pattern-based, not name-based, on purpose: an allowlist of known key names
+  // only covers the secrets we already thought of.
+  test("removes provider keys of every shape we ship", () => {
+    const out = redact(
+      [
+        "ANTHROPIC_API_KEY=sk-ant-api03-abcdefghijklmnop",
+        "OPENAI_API_KEY=sk-proj-ABCDEFGHIJKLMNOPQRST",
+        "omg login --token omg_sk_live_abcdef123456789",
+        "XAI_API_KEY=xai-abcdefghijklmnopqrst",
+      ].join("\n"),
+    );
+    expect(out).not.toContain("sk-ant-api03-abcdefghijklmnop");
+    expect(out).not.toContain("sk-proj-ABCDEFGHIJKLMNOPQRST");
+    expect(out).not.toContain("omg_sk_live_abcdef123456789");
+    expect(out).not.toContain("xai-abcdefghijklmnopqrst");
+  });
+
+  test("removes GitHub tokens and tailnet auth keys", () => {
+    const out = redact("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA and tskey-auth-kFooBar-abcdef123456");
+    expect(out).not.toContain("ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    expect(out).not.toContain("tskey-auth-kFooBar-abcdef123456");
+  });
+
+  test("removes bearer tokens and JWTs", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const out = redact(`Authorization: Bearer ${jwt}`);
+    expect(out).not.toContain(jwt);
+  });
+
+  // The important one: a secret we have never seen, under a name nobody added
+  // to this file, still has to be caught by shape.
+  test("removes a key-shaped value under an unknown variable name", () => {
+    const out = redact("FUTURE_PROVIDER_TOKEN=abcd1234efgh5678ijkl");
+    expect(out).not.toContain("abcd1234efgh5678ijkl");
+    // The name survives, because knowing WHICH setting is present is useful.
+    expect(out).toContain("FUTURE_PROVIDER_TOKEN");
+  });
+
+  // Found while probing this function against a realistic environment: a
+  // password inside a URL survived every other pattern, because the secret is
+  // positional and no key name points at it. Git remotes and proxy settings
+  // both carry these.
+  test("removes a password embedded in a URL", () => {
+    expect(redact("https://user:hunter2@example.com/repo.git")).not.toContain("hunter2");
+    expect(redact("postgres://admin:s3cr3t@db.internal:5432/omg")).not.toContain("s3cr3t");
+    // The host and user stay, because knowing WHICH remote is the diagnosis.
+    expect(redact("https://user:hunter2@example.com/repo.git")).toContain("example.com");
+  });
+
+  // A URL with no credentials must survive intact — the server line is one.
+  test("leaves ordinary URLs alone", () => {
+    expect(redact("http://127.0.0.1:8766/api/sessions")).toBe("http://127.0.0.1:8766/api/sessions");
+  });
+
+  // Redaction that eats the diagnosis is its own failure. The report has to
+  // stay readable or nobody learns anything from it.
+  test("leaves the diagnostic content intact", () => {
+    const line = "Native CLI binary for linux-x64 not found. Reinstall @anthropic-ai/claude-agent-sdk";
+    expect(redact(line)).toBe(line);
+    expect(redact("claude 2.1.233 (Claude Code)")).toBe("claude 2.1.233 (Claude Code)");
+    expect(redact("responding on 127.0.0.1:8766 (3 sessions)")).toContain("127.0.0.1:8766");
+  });
+
+  test("hides the user's home directory, and so their username", () => {
+    expect(shortenHome("/home/alice/omg/data", "/home/alice")).toBe("~/omg/data");
+    // A home of "/" would turn every path into nonsense; leave it alone.
+    expect(shortenHome("/home/alice/omg", "/")).toBe("/home/alice/omg");
+  });
+
+  test("sanitize applies both, in a form safe to paste", () => {
+    const out = sanitize("/home/bob/.config key=sk-ant-abcdefghijklmnop", "/home/bob");
+    expect(out).not.toContain("/home/bob");
+    expect(out).not.toContain("sk-ant-abcdefghijklmnop");
+  });
+});
+
+describe("choosing which log lines to include", () => {
+  function logDir(contents: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "omg-doctor-log-"));
+    writeFileSync(join(dir, "trace-2026-08-18.jsonl"), contents);
+    return dir;
+  }
+
+  // These logs are mostly per-request timing rows. A plain tail would be 25
+  // lines of healthy noise, pushing the one useful line out of the report.
+  test("surfaces problem lines instead of the raw tail", () => {
+    const noise = Array.from({ length: 60 }, (_, i) => `{"event":"api_timing","durationMs":${i}}`);
+    const dir = logDir([...noise.slice(0, 30), '{"event":"sendq_failed","error":"session is not in a tmux pane"}', ...noise.slice(30)].join("\n"));
+
+    const out = recentLogTail(dir);
+    expect(out).toContain("session is not in a tmux pane");
+    expect(out).toContain("1 problem lines");
+  });
+
+  // A quiet log is a real finding, not an empty section.
+  test("says so when nothing looks wrong", () => {
+    const dir = logDir(Array.from({ length: 20 }, (_, i) => `{"event":"api_timing","durationMs":${i}}`).join("\n"));
+    expect(recentLogTail(dir)).toContain("no problem lines found");
+  });
+
+  // It runs on a broken box by definition, so missing files are normal input.
+  test("does not throw when there is no log at all", () => {
+    expect(recentLogTail(join(tmpdir(), "omg-doctor-does-not-exist"))).toBe("(no log directory)");
+    expect(recentLogTail(mkdtempSync(join(tmpdir(), "omg-doctor-empty-")))).toBe("(no log files)");
+  });
+
+  test("reads the newest log when several exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "omg-doctor-multi-"));
+    writeFileSync(join(dir, "old.jsonl"), '{"error":"stale failure"}');
+    writeFileSync(join(dir, "new.jsonl"), '{"error":"current failure"}');
+    const old = new Date(Date.now() - 86_400_000);
+    utimesSync(join(dir, "old.jsonl"), old, old);
+
+    const out = recentLogTail(dir);
+    expect(out).toContain("current failure");
+    expect(out).not.toContain("stale failure");
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,209 @@
+// `omg doctor` — one command a user can run and paste when something is wrong.
+//
+// Why this exists: on 2026-08-18 a user reported "it is stuck" with a
+// screenshot of a spinner. That was true and useless — the real cause was a
+// harness that had already exited 1 in total silence, and finding it took a
+// clean VM, a traced subprocess, and several hours. Nothing the user could see
+// or send would have shortened that, because the failure produced no output at
+// all. The bugs behind that report are fixed, but the reporting gap is its own
+// defect: a self-hosted install has no way to describe itself.
+//
+// So this collects the things that actually decide whether a session can start
+// — versions, which agent binaries exist, which accounts are connected, whether
+// the server is up, and the tail of the harness log — into one block of text.
+//
+// Two rules shape everything here:
+//
+//   1. It must run when omg.dev is broken. It reads files and probes PATH; it
+//      does not require the server, and every probe is individually guarded, so
+//      a doctor that hits an unexpected error still prints what it did learn.
+//      A diagnostic that dies on a broken box is worthless precisely when it
+//      matters.
+//
+//   2. It must be safe to paste in public. Users will put this in Discord and
+//      GitHub issues. Anything that could carry a token is redacted by pattern
+//      rather than by an allowlist of known key names, because the next secret
+//      to appear in a log will not be on any list we wrote today.
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * Strip anything that looks like a credential.
+ *
+ * Deliberately pattern-based, not name-based. An allowlist of known variable
+ * names ("ANTHROPIC_API_KEY", …) only protects against the secrets we already
+ * thought of; the token that leaks will be the one added next week under a name
+ * nobody updated here. These patterns match the SHAPE of a secret, so a new
+ * provider's key is covered on the day it appears.
+ */
+export function redact(text: string): string {
+  return text
+    // Provider keys: sk-…, sk-ant-…, omg_sk_…, xai-…, ghp_…, github_pat_…
+    .replace(/\b(sk-[A-Za-z0-9_-]{8,}|omg_sk_[A-Za-z0-9_-]{8,}|xai-[A-Za-z0-9_-]{8,})/g, "[redacted-key]")
+    .replace(/\b(gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,})/g, "[redacted-token]")
+    // Tailscale auth keys and OAuth client secrets.
+    .replace(/\btskey-[A-Za-z0-9-]{8,}/g, "[redacted-tailscale-key]")
+    // Credentials embedded in a URL (https://user:pass@host). These reach logs
+    // through git remotes and proxy settings, and no key-name pattern sees them
+    // because the secret is positional rather than named.
+    .replace(/\b([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi, "$1$2:[redacted]@")
+    // Bearer tokens and anything assigned to a key/token/secret/password name.
+    .replace(/\b(bearer\s+)[A-Za-z0-9._~+/-]{12,}=*/gi, "$1[redacted]")
+    .replace(
+      /\b([A-Za-z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Za-z0-9_]*)(\s*[=:]\s*)("?)([^"\s,}]{6,})\3/gi,
+      "$1$2$3[redacted]$3",
+    )
+    // JWTs, which carry identity even when no name gives them away.
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, "[redacted-jwt]")
+    // Long hex/base64 runs are almost never useful in a report and are exactly
+    // what an unrecognised secret looks like.
+    .replace(/\b[A-Fa-f0-9]{40,}\b/g, "[redacted-hash]");
+}
+
+/** Replace the user's home directory with ~, so paths do not leak a username. */
+export function shortenHome(text: string, home = homedir()): string {
+  if (!home || home === "/") return text;
+  return text.split(home).join("~");
+}
+
+/** Everything a report line goes through before it is printed. */
+export function sanitize(text: string, home = homedir()): string {
+  return redact(shortenHome(text, home));
+}
+
+type Probe = { label: string; value: string; ok?: boolean };
+
+/**
+ * Run one probe, and never let it take the report down with it.
+ *
+ * The whole point of a doctor is that it runs on a broken machine, so a probe
+ * that throws must degrade to a line saying so rather than an unhandled
+ * rejection that loses every other finding.
+ */
+async function probe(label: string, fn: () => string | Promise<string>): Promise<Probe> {
+  try {
+    return { label, value: await fn() };
+  } catch (e) {
+    return { label, value: `(failed: ${e instanceof Error ? e.message : String(e)})`, ok: false };
+  }
+}
+
+function commandVersion(bin: string, args: string[] = ["--version"]): string {
+  const which = Bun.which(bin);
+  if (!which) return "not found";
+  try {
+    const r = Bun.spawnSync({ cmd: [which, ...args], stdout: "pipe", stderr: "pipe" });
+    const out = (new TextDecoder().decode(r.stdout) || new TextDecoder().decode(r.stderr)).trim();
+    return `${which} (${out.split("\n")[0] || "no version output"})`;
+  } catch {
+    return which;
+  }
+}
+
+/**
+ * The most recent lines that look like a problem, from the newest log.
+ *
+ * A raw tail is the wrong thing to paste: these logs are dominated by per-request
+ * timing rows, so 40 lines of tail is 40 lines of healthy noise that pushes the
+ * one interesting line out of view. Filter to lines that carry a failure signal
+ * and fall back to a plain tail only when nothing matches — an absence of errors
+ * is itself worth seeing.
+ */
+export function recentLogTail(logDir: string, lines = 25): string {
+  if (!existsSync(logDir)) return "(no log directory)";
+  const files = readdirSync(logDir)
+    .map((name) => join(logDir, name))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+  if (!files.length) return "(no log files)";
+  const body = readFileSync(files[0], "utf8").split("\n").filter(Boolean);
+  const interesting = body.filter((l) =>
+    /error|fail|fatal|could not|cannot|not found|denied|refused|exit(ed)? [1-9]|unexpected/i.test(l),
+  );
+  const chosen = interesting.length ? interesting.slice(-lines) : body.slice(-5);
+  const header = interesting.length
+    ? `${files[0]} (${interesting.length} problem lines, newest last)`
+    : `${files[0]} (no problem lines found; last 5 shown)`;
+  return `${header}\n${chosen.join("\n")}`;
+}
+
+export async function cmdDoctor(argv: string[] = []): Promise<void> {
+  const json = argv.includes("--json");
+  const { PATHS, installInfo } = await import("../config.ts");
+  const probes: Probe[] = [];
+
+  probes.push(await probe("omg.dev", () => {
+    const info = installInfo();
+    const pkg = JSON.parse(readFileSync(join(PATHS.root, "package.json"), "utf8")) as { version?: string };
+    return `${pkg.version ?? "unknown"} (${info.channel} install${info.release ? `, ${info.release}` : ""})`;
+  }));
+  probes.push(await probe("platform", () => `${process.platform}-${process.arch}, bun ${Bun.version}`));
+  probes.push(await probe("install root", () => PATHS.root));
+
+  // Which agent binaries exist. A session cannot start without one, and this is
+  // the single most common reason a fresh install cannot do anything.
+  for (const bin of ["claude", "codex", "opencode", "jcode", "grok", "cursor-agent"]) {
+    probes.push(await probe(`agent: ${bin}`, () => commandVersion(bin)));
+  }
+
+  // The Agent SDK's own native binary — absent from pruned bundles, which is
+  // exactly the failure that produced a silent exit and an endless spinner.
+  probes.push(await probe("claude-agent-sdk native binary", () => {
+    const base = join(PATHS.root, "node_modules", "@anthropic-ai");
+    if (!existsSync(base)) return "(no @anthropic-ai packages)";
+    const platform = readdirSync(base).filter((n) => n.startsWith("claude-agent-sdk-"));
+    return platform.length
+      ? platform.join(", ")
+      : "MISSING — the SDK cannot spawn its own runtime; install the Claude CLI or connect an account";
+  }));
+
+  // Connected accounts, by presence only. Never read the credentials.
+  probes.push(await probe("connected accounts", async () => {
+    const { listCodingAgents } = await import("../coding-agents.ts");
+    const agents = await listCodingAgents();
+    const connected = agents
+      .filter((a) => a.status.accountConnected || a.status.configured)
+      .map((a) => `${a.label}${a.status.accountConnected ? "" : " (configured, not signed in)"}`);
+    return connected.length ? connected.join(", ") : "none — no agent can start a session";
+  }));
+
+  probes.push(await probe("server", async () => {
+    const port = process.env.OMG_PORT ?? process.env.LFG_PORT ?? "8766";
+    const host = process.env.OMG_HOST ?? process.env.LFG_HOST ?? "127.0.0.1";
+    try {
+      const r = await fetch(`http://${host}:${port}/api/sessions`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      const body = (await r.json()) as { sessions?: unknown[] };
+      return `responding on ${host}:${port} (${body.sessions?.length ?? 0} sessions)`;
+    } catch (e) {
+      return `NOT responding on ${host}:${port} (${e instanceof Error ? e.message : e})`;
+    }
+  }));
+
+  probes.push(await probe("recent log", () => recentLogTail(join(PATHS.data, "logs"))));
+
+  if (json) {
+    console.log(sanitize(JSON.stringify(Object.fromEntries(probes.map((p) => [p.label, p.value])), null, 2)));
+    return;
+  }
+
+  // Fenced, because the destination is a GitHub issue or a Discord message and
+  // an unfenced log tail is unreadable in both.
+  const lines = [
+    "```",
+    "omg.dev doctor",
+    ...probes.map((p) => `${p.label.padEnd(32)} ${p.value.includes("\n") ? `\n${p.value}` : p.value}`),
+    "```",
+    "",
+    "Paste the block above into your bug report. Keys and tokens are already removed.",
+  ];
+  console.log(sanitize(lines.join("\n")));
+}

--- a/src/session-recovery.test.ts
+++ b/src/session-recovery.test.ts
@@ -7,6 +7,7 @@ import { currentBootId, readEntry, writeEntry } from "./aisdk-registry.ts";
 import { addManaged, listManaged, resetManagedRegistryForTests } from "./managed.ts";
 import { reconcileCommandFileSessions } from "./session-recovery.ts";
 import { managedLaunchRow } from "./sessions.ts";
+import { indexSessionMessagesDirect } from "./transcript-index.ts";
 
 describe("command-file session boot recovery", () => {
   const originalData = PATHS.data;
@@ -208,6 +209,47 @@ describe("command-file session boot recovery", () => {
     };
 
     expect(managedLaunchRow(managed, {}, {})).toBeNull();
+  });
+
+  // The counterpart to the drop above, and the second half of a real report: a
+  // user on a fresh install sent "hi", watched the thinking dots for the boot
+  // grace window, and then the session VANISHED from the list. Its agent could
+  // not start, so no harness ever registered — but it had written the reason to
+  // its transcript on the way out, and dropping the row threw that away. The
+  // user was left with no session and no explanation.
+  //
+  // A dead harness with something to say stays listed, is not "launching", and
+  // reports blocked with its own words.
+  test("keeps a dead command-file session that recorded why it died", () => {
+    const key = "88888888-8888-4888-8888-888888888888";
+    const managed = {
+      tmuxName: "lfg-died-explaining",
+      cwd: root,
+      createdAt: Date.now() - 5 * 60_000,
+      agent: "aisdk" as const,
+      sessionId: key,
+      nativeSessionId: key,
+      model: "sonnet",
+      launchState: "running" as const,
+    };
+
+    // Exactly what the harness now writes before exiting.
+    indexSessionMessagesDirect(key, [{
+      id: "explain-1",
+      role: "assistant",
+      kind: "text",
+      text: "Claude could not start: the Claude CLI is not installed and no Claude account is connected. Open Settings → Coding agents to install it and sign in.",
+      ts: Date.now(),
+    }]);
+
+    const row = managedLaunchRow(managed, {}, {});
+    expect(row).not.toBeNull();
+    // The spinner is the bug. A dead session is not launching.
+    expect(row?.launching).toBe(false);
+    expect(row?.status).toBe("blocked");
+    expect(row?.statusDetail).toContain("Claude could not start");
+    // The reason has to reach the card, not just the row.
+    expect(row?.last?.text).toContain("Coding agents");
   });
 
   test("does not relaunch a scheduled run after boot on a Computer", async () => {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -39,6 +39,7 @@ import {
   indexSessionMessagesDirect,
   searchTranscriptIndex,
   sessionHasIndexedMessages,
+  lastIndexedAssistantMessage,
   sessionIndexKey,
   isSessionIndexKey,
 } from "./transcript-index";
@@ -496,7 +497,16 @@ export function managedLaunchRow(
   // Keep showing it through a bounded boot window, then let it go so a harness
   // that died on startup does not linger forever.
   const booting = commandFile && !directEntry && Date.now() - m.createdAt < MANAGED_BOOT_GRACE_MS;
-  if (commandFile && m.launchState !== "launching" && !directEntry && !booting) return null;
+  // A harness that died still belongs in the list IF it managed to say why.
+  // Dropping it was the second half of the "stuck on thinking dots" report: a
+  // session whose agent could not start showed the spinner for the boot grace
+  // window and then disappeared from the list entirely, so the reason it had
+  // written to its transcript was never rendered and the user was left with a
+  // vanished session and no explanation at all. Anything with indexed messages
+  // has something to show; only a genuinely empty dead session is dropped.
+  const explained = commandFile && !directEntry && !booting && sessionHasIndexedMessages(sessionId);
+  if (commandFile && m.launchState !== "launching" && !directEntry && !booting && !explained)
+    return null;
   const pid = commandFile ? (directEntry?.harnessPid ?? 0) : (tmux.panePid(m.tmuxName) ?? 0);
   if (pid && isClosing(pid)) return null;
   const tmuxTarget = commandFile
@@ -552,11 +562,13 @@ export function managedLaunchRow(
     // Still booting counts as launching: the record says "running" but the
     // harness has not come up yet, and the card should say so rather than
     // present an agent that cannot take a message yet as ready.
-    launching: m.launchState === "launching" || booting,
+    // A harness that has already died is NOT launching, whatever the record
+    // says — claiming otherwise is what rendered the endless thinking dots.
+    launching: !explained && (m.launchState === "launching" || booting),
     startedAt: m.createdAt,
     transcriptPath,
     lastActivityAt: m.createdAt,
-    last: null,
+    last: explained ? lastIndexedAssistantMessage(sessionId) : null,
     tmuxTarget,
     tmuxName: m.tmuxName,
     managed: true,
@@ -566,7 +578,19 @@ export function managedLaunchRow(
         ? model
         : modelAlias(model),
     thinkingLevel: m.thinkingLevel ?? null,
-    ...computeStatus(null, null),
+    // The harness is gone, so there is nobody left to retry: a dead session
+    // with a recorded reason is blocked, and says so. computeStatus cannot
+    // reach this conclusion on its own — it keys off `apiError`, which lives on
+    // the live SDK envelope and is not carried by the transcript index.
+    ...(explained
+      ? {
+          status: "blocked" as const,
+          statusReason: "provider_error" as const,
+          statusDetail:
+            lastIndexedAssistantMessage(sessionId)?.text?.replace(/\s+/g, " ").trim().slice(0, 180) ||
+            "The coding agent stopped before it could start.",
+        }
+      : computeStatus(null, null)),
   };
 }
 

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -1020,6 +1020,38 @@ export function sessionHasIndexedMessages(sessionId: string): boolean {
     .get(key);
 }
 
+/**
+ * The last indexed assistant line for a session, read synchronously.
+ *
+ * `indexedMessagePage` is the general reader, but it is async and pulls a whole
+ * page. The session LIST needs one line, on a synchronous path, for a case that
+ * has no live harness left to ask: a session whose agent died. Without it the
+ * row carried `last: null`, so computeStatus saw no error text and reported a
+ * healthy session — which is how a session whose agent never started kept
+ * showing the thinking dots.
+ */
+export function lastIndexedAssistantMessage(sessionId: string): SessionMsg | null {
+  init();
+  const key = sessionIndexKey(sessionId);
+  const row = database()
+    .query<{ id: string; message_id: string | null; role: string; kind: string; ts: number | null; text: string }, [string]>(
+      `SELECT id, message_id, role, kind, ts, text
+         FROM transcript_messages
+        WHERE path = ? AND role = 'assistant'
+        ORDER BY order_seq DESC, rowid DESC
+        LIMIT 1`,
+    )
+    .get(key);
+  if (!row) return null;
+  return {
+    id: row.message_id ?? row.id,
+    role: "assistant",
+    kind: row.kind as SessionMsg["kind"],
+    text: row.text,
+    ts: row.ts ?? null,
+  };
+}
+
 // Seed the synthetic per-session read model (`lfg://session/<id>`) from history
 // that was indexed under a real FILE path. Two cases:
 //   - claude: legacy sessions indexed by their native ~/.claude JSONL before the


### PR DESCRIPTION
## Why

The quick start in `README.md` is the one code path every new user runs, and it was the one path nothing covered. It is also not testable from a developer box — every machine we own already has Bun, Node, an `~/omg` install, or all three, and each of those hides a different failure.

That gap had teeth. Testing this on a clean VM found a live bug in the published CLI: its shebang named `node`, which the documented `bun install --global @omg-dev/cli` never installs, so the very next documented command died with

```
/usr/bin/env: 'node': No such file or directory
```

before running a line of its own code. Fixed separately in BennyKok/vibes#1458.

## What this does

Rents a fresh Firecracker VM from the OMG sandbox API, runs the documented commands **verbatim** as an ordinary sudo-capable user (setup deliberately refuses to run as root, so a root-only test would never exercise that path), and asserts the finish line a user actually cares about:

- `omg computer setup` exits 0
- `serve` listens
- the web UI returns the app shell, not just a 200
- `/api/sessions` answers

The VM is destroyed on exit, including on failure. Failures print the guest log rather than just a status, because the useful information is always in what the install said before it stopped.

`--cli-dist DIR` overlays a locally built cli `dist/` on top of the published package, in the same place the next npm publish would land it, so a fix can be proven against a clean machine before release.

## Verification

Run both ways against the live sandbox API:

**Against published `@omg-dev/cli@0.4.41`** — correctly fails:

```
==> baseline: what this machine has before we touch it
PRETTY_NAME="Ubuntu 22.04.5 LTS"
bun    /usr/local/bin/bun
node   (absent)
...
+ omg computer setup
/usr/bin/env: 'node': No such file or directory
SETUP_EXIT=127
[x] the documented quick start failed on a clean machine (setup exit 127)
==> destroying sandbox 91126bc291d7
```

**With the fixed dist overlaid** — passes:

```
[ok] omg computer setup exited 0
==> starting the install and checking the web UI
[ok] web UI serves the app on http://127.0.0.1:8766/
[ok] API answers /api/sessions

The documented quick start works on a clean machine.
==> destroying sandbox 4aa4bce2f208
```

Whole run takes about 30 seconds. Both sandboxes were destroyed automatically.

## Usage

```bash
ENVF=path/to/env ./scripts/test-install-clean-vm.sh
ENVF=path/to/env ./scripts/test-install-clean-vm.sh --cli-dist ../vibes/packages/cli/dist
```

Needs `VIBES_INFRA_SERVICE_TOKEN` (or the `_CI` variant) and `jq`.
