### PR TITLE
fix(picker): recover from missing folders

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -4296,7 +4296,10 @@ a{color:#60a5fa}
           if (!requestedPath) await mkdir(REPOS_ROOT, { recursive: true });
           current = await realpath(resolve(requested.replace(/^~(?=\/|$)/, home)));
         } catch {
-          return err(400, "folder does not exist");
+          return err(
+            400,
+            `Folder “${requested}” does not exist. It may have moved or been deleted. Choose another folder.`,
+          );
         }
         if (current !== home && !current.startsWith(`${home}/`)) {
           return err(403, "folder browsing is limited to your home directory");

--- a/test/project-folder-browser-fallback.test.ts
+++ b/test/project-folder-browser-fallback.test.ts
@@ -1,42 +1,66 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
+import {
+  browseFolderWithRecovery,
+  folderRecoveryNotice,
+} from "../web/src/lib/folder-browser-recovery.ts";
 
-// The picker opens on the last-used project path, which is remembered in
-// localStorage ("lfg_v2_repo") and never revalidated. Once that folder is
-// deleted or renamed (a pruned worktree, say), /api/filesystem/directories
-// answers 400 "folder does not exist" — and before the fallback below that
-// left the drawer stranded: header stuck on "Opening…", no listing, and both
-// "New Folder" and "Use This Folder" disabled, because they gate on `browser`
-// being non-null. Close was the only way out, and reopening hit the same path.
-async function projectFolderBrowser() {
-  const app = await readFile("web/src/App.tsx", "utf8");
-  const start = app.indexOf("function ProjectFolderBrowser(");
-  expect(start).toBeGreaterThan(-1);
-  const end = app.indexOf("\nfunction ", start + 1);
-  return app.slice(start, end === -1 ? undefined : end);
-}
+describe("project folder browser recovery", () => {
+  test("recovers to the parent when a listed folder is deleted before navigation", async () => {
+    const requested = "/home/user/repos/Test/Test";
+    const attempts: (string | undefined)[] = [];
+    const existing = new Set(["/home/user/repos/Test"]);
 
-describe("project folder browser: unavailable starting folder", () => {
-  test("falls back to the default root when the remembered folder is gone", async () => {
-    const component = await projectFolderBrowser();
+    const result = await browseFolderWithRecovery(requested, async (path) => {
+      attempts.push(path);
+      if (!path || !existing.has(path)) throw new Error("folder does not exist");
+      return { current: path };
+    });
 
-    // The initial open opts into the fallback...
-    expect(component).toMatch(/void browse\(initialPath,\s*true\)/);
-    // ...and the failure path re-requests the endpoint with no path, which the
-    // server answers with the repos root.
-    const cat = component.indexOf("} catch (e) {");
-    const handler = component.slice(cat, component.indexOf("} finally {", cat));
-    expect(handler).toMatch(/api<FolderBrowserPayload>\("\/api\/filesystem\/directories"\)/);
-    expect(handler).toContain("setBrowser(");
+    expect(attempts).toEqual([requested, "/home/user/repos/Test"]);
+    expect(result).toEqual({
+      payload: { current: "/home/user/repos/Test" },
+      unavailablePath: requested,
+      recoveryLocation: "parent",
+    });
   });
 
-  test("keeps the fallback opt-in so manual navigation still reports failure", async () => {
-    const component = await projectFolderBrowser();
+  test("falls back from a missing parent to projects root, then home", async () => {
+    const requested = "/home/user/repos/Test/Test";
+    const attempts: (string | undefined)[] = [];
 
-    // Clicking into a folder must not silently teleport the user to the root —
-    // only the initial open passes the flag.
-    expect(component).toMatch(/const browse = useCallback\(\s*async \(path\?: string, fallbackToRoot = false\)/);
-    expect(component).toMatch(/onClick=\{\(\) => void browse\(browser\.parent!\)\}/);
-    expect(component).toMatch(/onClick=\{\(\) => void browse\(directory\.path\)\}/);
+    const result = await browseFolderWithRecovery(requested, async (path) => {
+      attempts.push(path);
+      if (path !== "~") throw new Error("not found");
+      return { current: "/home/user" };
+    });
+
+    expect(attempts).toEqual([
+      requested,
+      "/home/user/repos/Test",
+      undefined,
+      "~",
+    ]);
+    expect(result.recoveryLocation).toBe("home");
+    expect(result.payload.current).toBe("/home/user");
+  });
+
+  test("names the missing path and tells the user what to do", () => {
+    expect(folderRecoveryNotice("/home/user/repos/Test/Test", "projects")).toBe(
+      "Folder “/home/user/repos/Test/Test” is no longer available. Choose another folder. Showing your projects folder instead.",
+    );
+  });
+
+  test("clears the stale payload and disables folder actions on an unrecovered error", async () => {
+    const app = await readFile("web/src/App.tsx", "utf8");
+    const start = app.indexOf("function ProjectFolderBrowser(");
+    const end = app.indexOf("\nfunction ", start + 1);
+    const component = app.slice(start, end);
+
+    expect(component.indexOf("setBrowser(null)")).toBeLessThan(
+      component.indexOf("browseFolderWithRecovery(path"),
+    );
+    expect(component).toContain("disabled={loading || !!error || !folderName.trim() || !browser}");
+    expect(component).toContain("disabled={!browser || loading || !!error}");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -154,6 +154,10 @@ import {
 import { findingReference } from "./lib/finding-reference";
 import { buildAutoTriagePrompt, resolveAutoTriageCwd } from "./lib/auto-triage";
 import { resolveComposerRepo } from "./lib/composer-repo";
+import {
+  browseFolderWithRecovery,
+  folderRecoveryNotice,
+} from "./lib/folder-browser-recovery";
 import { setThemePreference, THEME_CHANGE_EVENT } from "./lib/theme";
 import { startsInBottomSystemGestureZone } from "./lib/touch-gestures";
 import {
@@ -9742,6 +9746,9 @@ function OnboardingFlow({
                   ]);
                   setCwd(project.cwd);
                 }}
+                onUnavailablePath={(path) => {
+                  setCwd((current) => (current === path ? "" : current));
+                }}
                 onReposChanged={(deletedPath) => {
                   // Onboarding holds the list locally (no bootstrap refetch on
                   // this step), so drop the row here and un-select it if it was
@@ -12174,6 +12181,9 @@ function RailStage({
             onSelected={async (repo) => {
               onProjectChange?.(repoProject(repo));
               await onReposChanged?.();
+            }}
+            onUnavailablePath={(path) => {
+              if (filterRepo?.cwd === path) onProjectChange?.("__all");
             }}
             onReposChanged={onReposChanged}
           />
@@ -17447,6 +17457,7 @@ function ProjectFolderBrowser({
   onOpenChange,
   onSelected,
   onReposChanged,
+  onUnavailablePath,
 }: {
   open: boolean;
   initialPath?: string;
@@ -17458,13 +17469,20 @@ function ProjectFolderBrowser({
    *  deleted path so callers holding a local list can drop the row without a
    *  round trip; callers that refetch can ignore it. */
   onReposChanged?: (deletedPath: string) => void | Promise<void>;
+  /** Clear an in-memory selection that still names a path which disappeared. */
+  onUnavailablePath?: (path: string) => void;
 }) {
   const [browser, setBrowser] = useState<FolderBrowserPayload | null>(null);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [folderName, setFolderName] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ path: string; name: string } | null>(null);
+  const onUnavailablePathRef = useRef(onUnavailablePath);
+  useEffect(() => {
+    onUnavailablePathRef.current = onUnavailablePath;
+  }, [onUnavailablePath]);
 
   // `browser?.directories` only guards the null payload, not a payload that
   // came back without the list (an error envelope, an older/proxied backend, a
@@ -17473,29 +17491,30 @@ function ProjectFolderBrowser({
   // the router crash boundary over a folder list. Default to empty instead.
   const directories = browser?.directories ?? [];
 
-  const browse = useCallback(async (path?: string, fallbackToRoot = false) => {
+  const browse = useCallback(async (path?: string) => {
     setLoading(true);
     setError(null);
+    setNotice(null);
+    // Never leave the previous path actionable while the server is deciding
+    // whether the requested path still exists.
+    setBrowser(null);
     try {
-      const query = path ? `?path=${encodeURIComponent(path)}` : "";
-      setBrowser(await api<FolderBrowserPayload>(`/api/filesystem/directories${query}`));
+      const result = await browseFolderWithRecovery(path, async (candidate) => {
+        const query = candidate ? `?path=${encodeURIComponent(candidate)}` : "";
+        return api<FolderBrowserPayload>(`/api/filesystem/directories${query}`);
+      });
+      setBrowser(result.payload);
+      if (result.unavailablePath && result.recoveryLocation) {
+        if (localStorage.getItem("lfg_v2_repo") === result.unavailablePath) {
+          localStorage.removeItem("lfg_v2_repo");
+        }
+        onUnavailablePathRef.current?.(result.unavailablePath);
+        setNotice(folderRecoveryNotice(result.unavailablePath, result.recoveryLocation));
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : "Couldn't open this folder";
-      // The picker opens on the last-used project path, which may have since
-      // been deleted or moved (a pruned worktree, a renamed repo). Without a
-      // fallback that 400 strands the drawer on an empty list with every
-      // action disabled — no listing, no way back, only Close. Drop to the
-      // default root so the user can still navigate somewhere real.
-      if (path && fallbackToRoot) {
-        try {
-          setBrowser(await api<FolderBrowserPayload>("/api/filesystem/directories"));
-          setError(`${path} is unavailable (${message}) — showing your projects folder instead.`);
-          return;
-        } catch {
-          // Root is unreachable too; report the original failure below.
-        }
-      }
-      setError(message);
+      const target = path ?? "your projects folder";
+      setError(`Folder “${target}” could not be opened (${message}). Close this picker and check that the Computer is online.`);
     } finally {
       setLoading(false);
     }
@@ -17506,7 +17525,7 @@ function ProjectFolderBrowser({
     setCreating(startCreating);
     setFolderName("");
     setDeleteTarget(null);
-    void browse(initialPath, true);
+    void browse(initialPath);
   }, [browse, initialPath, open, startCreating]);
 
   async function finish(endpoint: string, body: object) {
@@ -17629,6 +17648,7 @@ function ProjectFolderBrowser({
             ) : null}
           </div>
 
+          {notice ? <p className="mt-2 text-sm text-muted-foreground">{notice}</p> : null}
           {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
           {creating ? (
             <div className="mt-3 flex gap-2">
@@ -17641,7 +17661,7 @@ function ProjectFolderBrowser({
               />
               <Button
                 type="button"
-                disabled={loading || !folderName.trim() || !browser}
+                disabled={loading || !!error || !folderName.trim() || !browser}
                 onClick={() => browser && void finish("/api/projects/create-folder", { parent: browser.current, name: folderName })}
               >
                 Create
@@ -17649,12 +17669,12 @@ function ProjectFolderBrowser({
             </div>
           ) : (
             <div className="mt-3 grid grid-cols-2 gap-2">
-              <Button type="button" variant="outline" onClick={() => setCreating(true)} disabled={!browser || loading}>
+              <Button type="button" variant="outline" onClick={() => setCreating(true)} disabled={!browser || loading || !!error}>
                 <Plus className="size-4" /> New Folder
               </Button>
               <Button
                 type="button"
-                disabled={!browser || loading}
+                disabled={!browser || loading || !!error}
                 onClick={() => browser && void finish("/api/projects/use-folder", { path: browser.current })}
               >
                 <Check className="size-4" /> Use This Folder
@@ -19169,6 +19189,9 @@ function NewSessionDialog({
         onSelected={async (project) => {
           chooseComposerRepo(project);
           await onReposChanged();
+        }}
+        onUnavailablePath={(path) => {
+          setRepo((current) => (current === path ? "" : current));
         }}
         onReposChanged={onReposChanged}
       />

--- a/web/src/lib/folder-browser-recovery.ts
+++ b/web/src/lib/folder-browser-recovery.ts
@@ -1,0 +1,69 @@
+export type FolderRecoveryLocation = "parent" | "projects" | "home";
+
+export type FolderBrowseResult<T> = {
+  payload: T;
+  unavailablePath: string | null;
+  recoveryLocation: FolderRecoveryLocation | null;
+};
+
+function parentFolder(path: string): string | null {
+  const normalized = path.replace(/\/+$/, "");
+  const separator = normalized.lastIndexOf("/");
+  if (separator <= 0) return null;
+  return normalized.slice(0, separator);
+}
+
+/**
+ * Open a folder and recover from a path that disappeared between listings.
+ *
+ * A directory row can become stale at any time. Try the nearest useful place
+ * first, then the configured projects root, then the user's home directory.
+ */
+export async function browseFolderWithRecovery<T>(
+  path: string | undefined,
+  load: (path?: string) => Promise<T>,
+): Promise<FolderBrowseResult<T>> {
+  try {
+    return {
+      payload: await load(path),
+      unavailablePath: null,
+      recoveryLocation: null,
+    };
+  } catch (originalError) {
+    const attempts: { path: string | undefined; location: FolderRecoveryLocation }[] = [];
+    const parent = path ? parentFolder(path) : null;
+    if (parent) attempts.push({ path: parent, location: "parent" });
+    attempts.push({ path: undefined, location: "projects" });
+    attempts.push({ path: "~", location: "home" });
+
+    const seen = new Set<string>();
+    for (const attempt of attempts) {
+      const key = attempt.path ?? "<projects>";
+      if (seen.has(key) || attempt.path === path) continue;
+      seen.add(key);
+      try {
+        return {
+          payload: await load(attempt.path),
+          unavailablePath: path ?? "your projects folder",
+          recoveryLocation: attempt.location,
+        };
+      } catch {
+        // Keep trying from the nearest location to the broadest safe one.
+      }
+    }
+
+    throw originalError;
+  }
+}
+
+export function folderRecoveryNotice(
+  unavailablePath: string,
+  recoveryLocation: FolderRecoveryLocation,
+): string {
+  const destination = recoveryLocation === "parent"
+    ? "its parent folder"
+    : recoveryLocation === "projects"
+      ? "your projects folder"
+      : "your home folder";
+  return `Folder “${unavailablePath}” is no longer available. Choose another folder. Showing ${destination} instead.`;
+}


### PR DESCRIPTION
## What changed

- Recover every folder navigation failure to the nearest valid parent.
- Fall back to the projects root, then the home folder.
- Clear stale remembered and in-memory project selections.
- Clear stale browser payloads while navigation is validated.
- Disable folder creation and selection when no valid payload exists.
- Name the missing path and give the user a clear next action.
- Add regression coverage for a folder deleted between listing and navigation.

## Root cause

The initial picker open opted into recovery, but Back, folder-row navigation, and post-delete refresh did not. A failed request also retained the previous browser payload. This combination could strand the sheet and leave actions enabled for a folder the server rejected.

The bare `not found` text is not emitted by the current filesystem handler. That handler returned `folder does not exist`. The bare text matches the generic route or an upstream/older runtime response. The client now replaces either response with path-specific guidance.

## Impact

A missing or machine-specific remembered path no longer blocks session creation. The picker lands on a real folder and asks the user to choose another location.

## Validation

- `bun run typecheck`
- `bun run --cwd web typecheck`
- `bun run build:packages`
- `bun test`: 1,591 passed, 1 skipped, 0 failed
- `git diff --check`
- This repository has no configured lint script.
