### PR TITLE
fix(mobile): sign-out silently 403s, leaves the session live for 30 days

### DIFF
--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -168,10 +168,37 @@ export default function SettingsScreen() {
     [client, pushBusy, user?.email],
   );
 
+  /**
+   * signOut() now throws SignOutFailedError instead of silently no-oping
+   * when the server didn't confirm the session was revoked (see auth.ts) —
+   * `void signOut()` would have turned that into an unhandled rejection
+   * with nothing shown on screen, which is its own version of the original
+   * bug: the person taps Sign out, nothing visibly happens, and they have
+   * no idea whether they're still signed in. signingOutRef guards against a
+   * second tap firing a second request while the first is in flight.
+   */
+  const [signingOut, setSigningOut] = useState(false);
   const confirmSignOut = () => {
     Alert.alert("Sign out?", "You'll need a new sign-in code to get back in.", [
       { text: "Cancel", style: "cancel" },
-      { text: "Sign out", style: "destructive", onPress: () => void signOut() },
+      {
+        text: "Sign out",
+        style: "destructive",
+        onPress: () => {
+          if (signingOut) return;
+          setSigningOut(true);
+          void signOut()
+            .catch((err) => {
+              Alert.alert(
+                "Couldn't sign out",
+                err instanceof Error
+                  ? err.message
+                  : "Something went wrong. Try again.",
+              );
+            })
+            .finally(() => setSigningOut(false));
+        },
+      },
     ]);
   };
 
@@ -348,7 +375,9 @@ export default function SettingsScreen() {
       <View style={{ marginTop: space.xl }}>
         <Card>
           <Row onPress={confirmSignOut}>
-            <Text style={{ ...type.callout, color: colors.danger, flex: 1 }}>Sign out</Text>
+            <Text style={{ ...type.callout, color: colors.danger, flex: 1 }}>
+              {signingOut ? "Signing out…" : "Sign out"}
+            </Text>
           </Row>
           <Row onPress={confirmDeleteAccount}>
             <Text style={{ ...type.callout, color: colors.danger, flex: 1 }}>Delete account</Text>

--- a/mobile/src/omg/auth.ts
+++ b/mobile/src/omg/auth.ts
@@ -22,7 +22,7 @@
  * OTP flow simply runs again.
  */
 
-import { AUTH_APP_ID, AUTH_ORIGIN } from "./config";
+import { AUTH_APP_ID, AUTH_ORIGIN, AUTH_REQUEST_ORIGIN } from "./config";
 
 export class OmgAuthError extends Error {
   readonly status: number;
@@ -30,6 +30,19 @@ export class OmgAuthError extends Error {
     super(message);
     this.name = "OmgAuthError";
     this.status = status;
+  }
+}
+
+/**
+ * Thrown when the server did not confirm the session was revoked. Distinct
+ * from OmgAuthError so callers can tell "sign-out failed, the account may
+ * still be signed in server-side" apart from an ordinary sign-in failure —
+ * the caller must NOT treat this the same as a successful sign-out.
+ */
+export class SignOutFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SignOutFailedError";
   }
 }
 
@@ -45,7 +58,7 @@ async function authFetch(path: string, body: unknown): Promise<unknown> {
   try {
     response = await fetch(`${AUTH_ORIGIN}${BETTER_AUTH_BASE}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Origin: AUTH_REQUEST_ORIGIN },
       body: JSON.stringify(body),
     });
   } catch {
@@ -103,7 +116,7 @@ export async function verifySignInCode(
 export async function getSession(): Promise<SignedInUser | null> {
   try {
     const response = await fetch(`${AUTH_ORIGIN}${BETTER_AUTH_BASE}/get-session`, {
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Origin: AUTH_REQUEST_ORIGIN },
     });
     if (!response.ok) return null;
     const data = (await response.json().catch(() => null)) as {
@@ -115,10 +128,47 @@ export async function getSession(): Promise<SignedInUser | null> {
   }
 }
 
+/**
+ * Ask the server to revoke the session, and throw SignOutFailedError if it
+ * did not confirm that. Every prior version of this function did
+ * `fetch(...).catch(() => {})` and cleared local state unconditionally — a
+ * missing Origin header (see AUTH_REQUEST_ORIGIN) made the server 403 this
+ * on every single call, and the swallowed rejection meant the app declared
+ * "signed out" while the session, and its cookie, stayed valid for up to 30
+ * days. That is worse than an error the caller has to handle: it is a false
+ * claim about account state. So this throws instead of swallowing, and the
+ * caller (provider.tsx) is required to leave local state untouched when it
+ * does — showing "signed out" is only correct once the server agrees.
+ *
+ * Fails closed on purpose: a network-unreachable sign-out attempt throws the
+ * same as a server rejection, rather than clearing local state as a
+ * fallback. The alternative — clear locally whenever the server can't be
+ * reached — reopens exactly this bug for anyone offline at the moment they
+ * sign out (bad wifi, airplane mode, a lost device with connectivity cut).
+ * Being stuck showing "signed in" while offline is a recoverable annoyance;
+ * being shown "signed out" while a token is still live is not.
+ */
 export async function signOut(): Promise<void> {
-  await fetch(`${AUTH_ORIGIN}${BETTER_AUTH_BASE}/sign-out`, {
-    method: "POST",
-  }).catch(() => {});
+  let response: Response;
+  try {
+    response = await fetch(`${AUTH_ORIGIN}${BETTER_AUTH_BASE}/sign-out`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: AUTH_REQUEST_ORIGIN },
+    });
+  } catch {
+    throw new SignOutFailedError(
+      "Couldn't reach omg to sign out. Check your connection and try again.",
+    );
+  }
+  // 401 means better-auth already considers this session gone (expired,
+  // already revoked elsewhere) — nothing left to revoke, so this is a
+  // success, not a failure: the goal state ("this device holds no valid
+  // session") already holds.
+  if (!response.ok && response.status !== 401) {
+    throw new SignOutFailedError(
+      `Sign-out was rejected (${response.status}). Your session may still be active — try again.`,
+    );
+  }
   cachedToken = null;
   inFlight = null;
 }

--- a/mobile/src/omg/config.ts
+++ b/mobile/src/omg/config.ts
@@ -20,6 +20,21 @@
 export const AUTH_ORIGIN =
   process.env.EXPO_PUBLIC_OMG_AUTH_URL ?? "https://auth.omg.dev";
 
+/**
+ * Origin header sent on every request to AUTH_ORIGIN.
+ *
+ * better-auth's origin-check middleware (trustedOrigins in
+ * apps/auth/src/auth.ts) rejects state-changing requests that arrive with no
+ * Origin header at all — a browser always sends one on a cross-origin fetch,
+ * but React Native's fetch never does, native apps have no origin. Without
+ * this, POST /api/auth/sign-out 403s with MISSING_OR_NULL_ORIGIN on every
+ * call: the session is never revoked, sign-out silently no-ops server-side,
+ * and the app has no way to know because the error is swallowed. The value
+ * just needs to be one of the server's fixed trustedOrigins entries — it
+ * does not need to describe this app.
+ */
+export const AUTH_REQUEST_ORIGIN = "https://omg.dev";
+
 /** Control plane: account, machine bindings, cloud Computer lifecycle. */
 export const CONTROLPLANE_ORIGIN =
   process.env.EXPO_PUBLIC_OMG_CONTROLPLANE_URL ?? "https://backend.omg.dev";

--- a/mobile/src/omg/provider.tsx
+++ b/mobile/src/omg/provider.tsx
@@ -378,6 +378,13 @@ export function OmgProvider({ children }: PropsWithChildren) {
     if (client) {
       await unregisterForPushNotifications(client.transport).catch(() => {});
     }
+    // authSignOut throws SignOutFailedError if the server did not confirm
+    // the session was revoked (see auth.ts) — on purpose, this propagates
+    // and everything below does NOT run. Clearing local state here anyway
+    // would recreate the exact bug being fixed: showing "signed out" while
+    // the account is still live server-side. Let it throw; the caller
+    // (Settings' confirmSignOut) is responsible for telling the person it
+    // failed and that they should retry.
     await authSignOut();
     forgetAllTransports();
     // The presence keys stay on purpose: the server-side lease can outlive a


### PR DESCRIPTION
## Summary

Benny reported he's unable to fully log out on iOS. Reproduced the root cause directly against the real auth server (not just in-app):

- `mobile/src/omg/auth.ts`'s `signOut()` does `fetch(AUTH_ORIGIN + "/api/auth/sign-out", {method:"POST"}).catch(() => {})` — no headers, and no check of `response.ok`.
- React Native's `fetch` never sends an `Origin` header (unlike browser fetch). better-auth's origin-check middleware (`trustedOrigins` in `apps/auth/src/auth.ts`) rejects `POST /api/auth/sign-out` with **403 `MISSING_OR_NULL_ORIGIN`** when one is missing.
- The `.catch(() => {})` only catches network-level failures, never inspects the response — so this 403 was completely invisible. `provider.tsx`'s `signOut()` then unconditionally cleared local state and declared the user signed out.
- The session cookie (`session_token`, 30-day expiry, daily rolling refresh) was **never revoked server-side**. It lives in the OS's persistent, keychain-backed cookie jar, so it survives every app restart — and the next `getSession()` call (next launch, foreground, etc.) silently re-authenticates as the "signed out" account. Only an uninstall (which wipes the app's cookie storage) breaks the illusion, matching the symptom a sibling session hit earlier today (stale account resurrecting after sign-in, unfixable by restart).

This is a security issue, not just a UX one: a user who taps "Sign out" on a shared or lost device is shown a false "signed out" state while their session stays live and reusable for up to 30 days.

**Verified against the live server with curl**, replicating the mobile client's exact request:
```
POST /api/auth/sign-out, no Origin header  → 403 {"message":"Missing or null Origin"}
                                              (session still valid afterward — confirmed via get-session)
POST /api/auth/sign-out, Origin: https://omg.dev → 200 {"success":true}
                                              (all 3 cookies cleared, get-session → null)
```

Sign-in and session reads (`/sign-in/email-otp`, `/get-session`) work fine without an `Origin` header — it's specifically the origin-check gating `/sign-out` that traps this.

## Changes

- **`config.ts`**: adds `AUTH_REQUEST_ORIGIN = "https://omg.dev"` — a fixed value already in the server's `trustedOrigins` list, sent as the `Origin` header on every better-auth request (not just sign-out, since the same trap could resurface on another route tomorrow).
- **`auth.ts`**: `signOut()` now throws `SignOutFailedError` instead of swallowing a rejection. A `401` (already-revoked/expired) is treated as success; anything else — including a genuine network failure — throws. This fails *closed* on purpose: clearing local state whenever the server can't be confirmed reachable would silently reopen this exact bug for anyone offline at the moment they sign out. Being stuck showing "signed in" while offline is a recoverable annoyance; being shown "signed out" while a token is still live is not.
- **`provider.tsx`**: lets that error propagate — local state (transports, bindings, `authStatus`) is only cleared once the server confirms revocation.
- **`settings.tsx`**: the sign-out row now catches the rejection and shows an `Alert` instead of firing `void signOut()` into an unhandled rejection (previously: tap "Sign out", nothing visibly happens, no feedback either way).

## Shippability

Pure JS change, no native module touched — **OTA-shippable via EAS Update**, does not need to ride build 29.

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] Verified against the live `auth.omg.dev` server end-to-end with curl (appreview@omg.dev test account): sign in → session live → sign-out → session confirmed revoked (`get-session` → `null`)
- [x] Confirmed the *old* code path (no Origin header) reproduces the 403 and leaves the session live, using the same account
- [ ] On-device confirmation on a simulator/TestFlight build recommended before wide rollout, if anyone gets a spare simulator — I was not able to complete the in-app repro (see note below) but the server-side behavior is the entire bug, and it's fully verified

Note: I could not get the email sign-in `TextInput` to accept synthetic taps on a fresh isolated simulator (buttons/Pressables on the same screen responded fine to identical tooling, so this reads as a Simulator/CGEvent quirk specific to native text-field focus, not an app bug) — no simulator repro video captured for that reason. Bypassed by testing the actual HTTP contract directly, which is the entire surface area of this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)