### PR TITLE
fix(web): the connect-agent tab is never blank

### DIFF
--- a/test/auth-popup.test.ts
+++ b/test/auth-popup.test.ts
@@ -1,0 +1,241 @@
+// The sign-in tab, and the guarantee that it is never blank.
+//
+// The bug this covers: "onboarding connect Claude opens a blank page". The tab
+// has to be opened inside the click, but the URL it needs only exists a server
+// round trip later — so the old code parked the user on `about:blank` for the
+// length of that trip, and closed the tab outright whenever the trip failed.
+// These tests pin the property that replaced it: a tab opened through
+// openAuthTab always has content, and every exit path either navigates it or
+// explains itself in it.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  escapeHtml,
+  failureDocument,
+  isAuthorizationUrl,
+  openAuthTab,
+  waitingDocument,
+} from "../web/src/lib/auth-popup.ts";
+
+/** The parts of a popup handle the carrier actually touches. */
+function fakeTab() {
+  const written: string[] = [];
+  const tab = {
+    closed: false,
+    opener: {} as unknown,
+    focused: 0,
+    location: {
+      replaced: [] as string[],
+      replace(url: string) {
+        this.replaced.push(url);
+      },
+    },
+    document: {
+      open() {},
+      write(html: string) {
+        written.push(html);
+      },
+      close() {},
+    },
+    focus() {
+      tab.focused += 1;
+    },
+    close() {
+      tab.closed = true;
+    },
+  };
+  return { tab, written };
+}
+
+function withWindow(
+  open: (url: string, target: string) => unknown,
+  run: () => void,
+): void {
+  const previous = (globalThis as { window?: unknown }).window;
+  (globalThis as { window?: unknown }).window = { open };
+  try {
+    run();
+  } finally {
+    (globalThis as { window?: unknown }).window = previous;
+  }
+}
+
+describe("authorization URL validation", () => {
+  test("accepts the http(s) URLs a provider can actually serve", () => {
+    expect(isAuthorizationUrl("https://claude.ai/oauth/authorize?code=true")).toBe(true);
+    expect(isAuthorizationUrl("http://localhost:1455/auth")).toBe(true);
+  });
+
+  test("rejects everything that would leave the tab blank or worse", () => {
+    // A CLI's URL is scraped out of its stdout, so drift lands here rather
+    // than in the tab.
+    expect(isAuthorizationUrl(undefined)).toBe(false);
+    expect(isAuthorizationUrl("")).toBe(false);
+    expect(isAuthorizationUrl("about:blank")).toBe(false);
+    expect(isAuthorizationUrl("Opening browser…")).toBe(false);
+    expect(isAuthorizationUrl("javascript:alert(1)")).toBe(false);
+    expect(isAuthorizationUrl("/api/coding-agents")).toBe(false);
+  });
+});
+
+describe("the tab is never contentless", () => {
+  test("opening one writes its document in the same call", () => {
+    const { tab, written } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        const pending = openAuthTab("Claude");
+        expect(pending.opened).toBe(true);
+        // Written BEFORE any caller can await: this is the whole fix.
+        expect(written).toHaveLength(1);
+        expect(written[0]).toContain("Opening Claude sign in…");
+      },
+    );
+  });
+
+  test("severs the child's back-reference to the host", () => {
+    const { tab } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        openAuthTab("Claude");
+        expect(tab.opener).toBeNull();
+      },
+    );
+  });
+
+  test("settling navigates the tab it already holds", () => {
+    const { tab } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        const pending = openAuthTab("Codex");
+        expect(pending.settle("https://auth.openai.com/codex/device")).toBe(true);
+        expect(tab.location.replaced).toEqual(["https://auth.openai.com/codex/device"]);
+        expect(tab.focused).toBe(1);
+      },
+    );
+  });
+
+  test("refuses to settle on a URL that is not a sign-in page", () => {
+    const { tab } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        const pending = openAuthTab("Claude");
+        expect(pending.settle(undefined)).toBe(false);
+        expect(pending.settle("javascript:alert(1)")).toBe(false);
+        expect(tab.location.replaced).toEqual([]);
+        // Still open, still showing the waiting document — never navigated
+        // somewhere blank.
+        expect(tab.closed).toBe(false);
+      },
+    );
+  });
+
+  test("failing repaints the tab instead of closing it", () => {
+    const { tab, written } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        const pending = openAuthTab("Claude");
+        pending.fail("Install the Claude CLI before signing in");
+        // The popup holds focus, so the reason has to be IN it — a toast on
+        // the host page is behind the window the user is looking at.
+        expect(tab.closed).toBe(false);
+        expect(written).toHaveLength(2);
+        expect(written[1]).toContain("Install the Claude CLI before signing in");
+      },
+    );
+  });
+
+  test("settling a closed tab reports failure rather than throwing", () => {
+    const { tab } = fakeTab();
+    withWindow(
+      () => tab,
+      () => {
+        const pending = openAuthTab("Claude");
+        tab.closed = true;
+        expect(pending.settle("https://claude.ai/oauth/authorize")).toBe(false);
+        expect(() => pending.fail("gone")).not.toThrow();
+        expect(() => pending.close()).not.toThrow();
+      },
+    );
+  });
+
+  test("a blocked popup is reported, not faked", () => {
+    withWindow(
+      () => null,
+      () => {
+        const pending = openAuthTab("Claude");
+        expect(pending.opened).toBe(false);
+        expect(pending.settle("https://claude.ai/oauth/authorize")).toBe(false);
+        // The caller falls back to the in-page button; nothing here throws.
+        expect(() => pending.fail("blocked")).not.toThrow();
+      },
+    );
+  });
+
+  test("a window.open that throws degrades to 'not opened'", () => {
+    withWindow(
+      () => {
+        throw new Error("blocked by policy");
+      },
+      () => {
+        expect(openAuthTab("Claude").opened).toBe(false);
+      },
+    );
+  });
+});
+
+describe("the documents it writes", () => {
+  test("both are complete documents, not fragments", () => {
+    for (const html of [waitingDocument("Claude"), failureDocument("nope")]) {
+      expect(html.startsWith("<!doctype html>")).toBe(true);
+      expect(html).toContain("<body>");
+    }
+  });
+
+  test("provider names and server errors are escaped, never markup", () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
+      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+    );
+    expect(waitingDocument("<script>")).not.toContain("<script>");
+    expect(failureDocument("<script>bad</script>")).not.toContain("<script>bad");
+  });
+
+  test("reduced motion keeps a live affordance instead of a frozen ring", () => {
+    // A still spinner reads as hung, which is the same failure this module
+    // exists to remove.
+    expect(waitingDocument("Claude")).toContain("prefers-reduced-motion");
+  });
+});
+
+describe("App wiring", () => {
+  const app = readFileSync("web/src/App.tsx", "utf8");
+
+  test("no login path opens a raw blank tab any more", () => {
+    expect(app).not.toContain('window.open("about:blank"');
+  });
+
+  test("startBrowserAuth drives the carrier", () => {
+    expect(app).toContain("const authTab = openAuthTab(providerLabel)");
+    expect(app).toContain("if (authTab.settle(session.authorizationUrl)) return;");
+  });
+
+  test("a failed start explains itself in the tab", () => {
+    expect(app).toContain("authTab.fail(message)");
+  });
+
+  test("the tab is only closed when the host owns what happens next", () => {
+    // Exactly one close(): the "already connected" branch, which has no page
+    // left to show and reports on the host surface instead.
+    expect(app.match(/authTab\.close\(\)/g)).toHaveLength(1);
+  });
+
+  test("the in-panel button refuses a URL that is not a sign-in page", () => {
+    expect(app).toContain("{isAuthorizationUrl(session.authorizationUrl) ? (");
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
   type ToolConnectOption,
 } from "./lib/embedded-connect";
 import { emitSessionCreatedToHost } from "./lib/embed-host-signal";
+import { isAuthorizationUrl, openAuthTab } from "./lib/auth-popup";
 import { LFG_SMALL_ICON_PATH } from "./lib/icon-assets";
 import {
   api,
@@ -71,6 +72,7 @@ import {
   AGENT_ICON_VERSION,
   ArtifactViewerContext,
   BROWSER_AUTH_KINDS,
+  BROWSER_AUTH_PROVIDER_LABELS,
   ClaudeAccountBadge,
   CodingAgentsContext,
   SessionAgentIcon,
@@ -7267,15 +7269,28 @@ export function App() {
     );
   }
 
+  // The tab is opened through openAuthTab, which paints it in the same
+  // statement — see web/src/lib/auth-popup.ts. This function then has exactly
+  // three ways to leave it, and none of them is blank:
+  //
+  //   settle()  the provider's sign-in page (the whole point)
+  //   fail()    the reason no page is coming, in the tab holding focus
+  //   close()   only when the HOST surface owns what happens next
+  //
+  // The old code opened `about:blank` and awaited a round trip that spawns a
+  // provider CLI and scrapes its stdout for a URL. The user watched a blank
+  // page for however long that took, and every failure path closed the tab and
+  // toasted behind the popup that had just stolen focus.
   async function startBrowserAuth(
     kind: AgentKind | "github",
     path: string,
     inlineSid?: string,
     body: Record<string, unknown> = {},
+    providerLabel = "the provider",
   ) {
     setCodingAgentAuthInlineSid(inlineSid ?? null);
     if (inlineSid) setCodingAgentAuthCompletedSid(null);
-    const authWindow = window.open("about:blank", "_blank");
+    const authTab = openAuthTab(providerLabel);
     try {
       const session = await api<CodingAgentAuthSession>(path, {
         method: "POST",
@@ -7284,7 +7299,8 @@ export function App() {
       });
       if (session.status === "error") throw new Error(session.error || "Couldn't start login");
       if (session.status === "complete") {
-        authWindow?.close();
+        // Already connected — nothing left to sign into, and the host says so.
+        authTab.close();
         toast.success(`${authProviderLabel(session.provider)} connected`);
         setCodingAgentAuthInlineSid(null);
         if (inlineSid) setCodingAgentAuthCompletedSid(inlineSid);
@@ -7295,16 +7311,24 @@ export function App() {
         return;
       }
       setCodingAgentAuth(session);
-      if (session.authorizationUrl && authWindow) {
-        authWindow.location.replace(session.authorizationUrl);
-        authWindow.focus();
-      } else if (!session.authorizationUrl) {
-        authWindow?.close();
+      if (authTab.settle(session.authorizationUrl)) return;
+      if (isAuthorizationUrl(session.authorizationUrl)) {
+        // The popup was blocked, so the host panel's own "Open sign in" button
+        // is the way through. It is already on screen with this session.
+        toast.message(`Allow pop-ups, or use “Open ${authProviderLabel(session.provider)} sign in”.`);
+        return;
       }
+      // A waiting session with no usable URL means the CLI never printed one.
+      // The host panel keeps polling, so say so in the tab rather than closing
+      // it and leaving a toast behind the popup.
+      authTab.fail(
+        `${authProviderLabel(session.provider)} has not returned a sign-in link yet. Check the omg.dev tab.`,
+      );
     } catch (e) {
-      authWindow?.close();
+      const message = e instanceof Error ? e.message : "Couldn't start login";
+      authTab.fail(message);
       setCodingAgentAuthInlineSid(null);
-      toast.error(e instanceof Error ? e.message : "Couldn't start login");
+      toast.error(message);
     }
   }
 
@@ -7334,11 +7358,12 @@ export function App() {
       `/api/coding-agents/${kind}/auth`,
       inlineSid,
       { claudeAccountId },
+      BROWSER_AUTH_PROVIDER_LABELS[kind],
     );
   }
 
   async function loginTool(key: ToolConnectOption["key"]) {
-    return startBrowserAuth(key, `/api/connections/${key}/auth`);
+    return startBrowserAuth(key, `/api/connections/${key}/auth`, undefined, {}, "GitHub");
   }
 
   // pi and OpenCode both sign in per model provider, so the request carries
@@ -7354,9 +7379,13 @@ export function App() {
       toast.error(`Connect ${provider.label} with \`opencode auth login\` in a terminal`);
       return;
     }
-    return startBrowserAuth("pi", "/api/coding-agents/pi/auth", undefined, {
-      provider: provider.id,
-    });
+    return startBrowserAuth(
+      "pi",
+      "/api/coding-agents/pi/auth",
+      undefined,
+      { provider: provider.id },
+      provider.label,
+    );
   }
 
   async function connectApiKeyProvider(kind: AgentKind, provider: PiProviderInfo) {
@@ -22902,7 +22931,12 @@ function CodingAgentAuthPanel({
             </div>
           ) : null}
 
-          {session.authorizationUrl ? (
+          {/* The URL is already in hand here, so this opens straight at the
+              provider — no placeholder step. It is gated on the URL being a
+              real http(s) one for the same reason the popup carrier is: the
+              CLI's URL is scraped from its stdout, and a button that opens
+              nowhere is the blank tab wearing a different hat. */}
+          {isAuthorizationUrl(session.authorizationUrl) ? (
             <Button
               variant="brand"
               className="w-full"

--- a/web/src/lib/auth-popup.ts
+++ b/web/src/lib/auth-popup.ts
@@ -1,0 +1,162 @@
+// The tab a provider sign-in opens into.
+//
+// WHY THIS EXISTS. Every browser login here is two steps that cannot be
+// merged: open a tab (only trusted inside the synchronous part of a click) and
+// mint an authorization URL (a server round trip that spawns a provider CLI and
+// waits for it to print one). `startBrowserAuth` therefore opened
+// `about:blank` and awaited — and `about:blank` is not "a tab that is about to
+// become the sign-in page", it is a blank page, for as long as the round trip
+// takes. On a cold Computer the CLI can take seconds to print its URL, and when
+// it never does the tab was closed out from under the user. Both read as
+// exactly one thing: "connect Claude opens a blank page".
+//
+// The fix is not a faster round trip; it is making a contentless auth tab
+// impossible to have. Opening one through this module IS writing its document,
+// in the same statement, so there is no window in which a caller holds a tab
+// with nothing in it. From there a tab only ever ends in a state that explains
+// itself: the provider's page, or a legible failure the user can read in the
+// tab that has their attention.
+//
+// The host toast is not that explanation. The popup takes focus, so a message
+// rendered behind it is a message nobody sees — which is why `fail()` paints
+// the tab rather than closing it. `close()` stays for the one case with nothing
+// to say: the login finished, or it needs input back on the host page.
+
+/** A tab opened up-front, already showing something, waiting for a URL. */
+export interface PendingAuthTab {
+  /** False when the popup was blocked — the caller keeps its in-page fallback. */
+  readonly opened: boolean;
+  /** Point the tab at the provider. Returns false if it is gone or the URL is unusable. */
+  settle(url: string | undefined): boolean;
+  /** Show why no sign-in page is coming, in the tab the user is looking at. */
+  fail(message: string): void;
+  /** Close it — only when the host surface owns what happens next. */
+  close(): void;
+}
+
+/** Only an absolute http(s) URL can be a provider sign-in page. A CLI's URL is
+ *  scraped out of its stdout, so a parse that drifts must land on a legible
+ *  failure rather than navigating the tab somewhere blank (or worse). */
+export function isAuthorizationUrl(value: string | undefined): value is string {
+  if (!value) return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function documentFor(body: string): string {
+  return `<!doctype html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sign in</title>
+<style>
+  html { color-scheme: light dark }
+  body { margin:0; min-height:100vh; display:flex; flex-direction:column; gap:14px;
+         align-items:center; justify-content:center; text-align:center; padding:24px;
+         font:500 17px/1.45 ui-sans-serif,-apple-system,system-ui,sans-serif;
+         letter-spacing:-.01em }
+  .msg { max-width:32ch; opacity:.72 }
+  .hint { font-size:14px; opacity:.5 }
+  .spinner { width:18px; height:18px; border-radius:50%; opacity:.55;
+             border:2px solid currentColor; border-top-color:transparent;
+             animation:spin .7s linear infinite }
+  @keyframes spin { to { transform:rotate(360deg) } }
+  /* A frozen ring reads as hung, so reduced motion gets a slow breath instead
+     of a still image. */
+  @media (prefers-reduced-motion:reduce) {
+    .spinner { border-top-color:currentColor; animation:pulse 1.6s ease-in-out infinite }
+    @keyframes pulse { 50% { opacity:.18 } }
+  }
+</style>
+<body>${body}</body>`;
+}
+
+export function waitingDocument(providerLabel: string): string {
+  return documentFor(
+    `<div class="spinner"></div><div class="msg">Opening ${escapeHtml(providerLabel)} sign in…</div>`,
+  );
+}
+
+export function failureDocument(message: string): string {
+  return documentFor(
+    `<div class="msg">${escapeHtml(message)}</div>` +
+      `<div class="hint">You can close this tab and try again.</div>`,
+  );
+}
+
+/** The provider label and the server's error both reach this document as text.
+ *  Neither is markup, so neither is written as markup. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Open the sign-in tab. MUST be called synchronously from the click handler —
+ * awaiting first is what gets it blocked.
+ *
+ * No `noopener` flag: it makes `window.open` return null by design, and the
+ * handle is the entire point. The child's back-reference is severed below
+ * instead, while it is still same-origin.
+ */
+export function openAuthTab(providerLabel: string): PendingAuthTab {
+  let tab: Window | null = null;
+  try {
+    tab = window.open("", "_blank");
+    if (tab) {
+      try {
+        tab.opener = null;
+      } catch {
+        // Some engines make `opener` read-only. The destination is the
+        // provider's own sign-in page, not untrusted content.
+      }
+      write(tab, waitingDocument(providerLabel));
+    }
+  } catch {
+    tab = null;
+  }
+
+  return {
+    opened: tab !== null,
+    settle(url) {
+      if (!tab || tab.closed || !isAuthorizationUrl(url)) return false;
+      try {
+        tab.location.replace(url);
+        // Focus is not guaranteed, and losing it is fine — the tab exists
+        // either way, which is the part that matters.
+        tab.focus?.();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    fail(message) {
+      if (!tab || tab.closed) return;
+      try {
+        write(tab, failureDocument(message));
+      } catch {
+        // A tab we cannot repaint still holds the waiting document, which is
+        // wrong but not blank.
+      }
+    },
+    close() {
+      if (!tab || tab.closed) return;
+      try {
+        tab.close();
+      } catch {
+        // A tab we cannot close keeps its own last message.
+      }
+    },
+  };
+}
+
+function write(tab: Window, html: string): void {
+  tab.document.open();
+  tab.document.write(html);
+  tab.document.close();
+}

--- a/web/src/lib/session-ui.tsx
+++ b/web/src/lib/session-ui.tsx
@@ -89,15 +89,29 @@ export function titleForSession(session: Session): string {
   );
 }
 
-/** Agent kinds whose CLI login can be driven from the browser (see
- *  authProviderFor in src/coding-agents.ts). Everything else is terminal-only. */
-export const BROWSER_AUTH_KINDS = new Set<string>([
-  "claude",
-  "aisdk",
-  "codex",
-  "codex-aisdk",
-  "grok",
-]);
+/**
+ * Agent kinds whose CLI login can be driven from the browser, and the account
+ * each one signs into (see authProviderFor in src/coding-agents.ts). Everything
+ * else is terminal-only.
+ *
+ * The provider name lives HERE, beside the kind, because the sign-in tab has to
+ * name it BEFORE the server answers — the tab opens inside the click, the
+ * server's `provider` arrives a round trip later, and a tab that cannot say
+ * what it is opening is the blank tab this map exists to prevent. Keeping it in
+ * one table means a new browser-loginable agent cannot be added to the login
+ * path while leaving its tab unlabelled.
+ */
+export const BROWSER_AUTH_PROVIDER_LABELS: Record<string, string> = {
+  claude: "Claude",
+  aisdk: "Claude",
+  codex: "Codex",
+  "codex-aisdk": "Codex",
+  grok: "Grok",
+};
+
+export const BROWSER_AUTH_KINDS = new Set<string>(
+  Object.keys(BROWSER_AUTH_PROVIDER_LABELS),
+);
 
 export const CodingAgentsContext = createContext<CodingAgentInfo[] | undefined>(undefined);
 


### PR DESCRIPTION
## The report

"Onboarding → connect Claude opens a blank page."

## Why it happened

A browser login is two steps that cannot be merged:

1. **open a tab** — only trusted inside the synchronous part of a click
2. **mint an authorization URL** — a server round trip that spawns the provider CLI and scrapes a URL out of its stdout

`startBrowserAuth` opened `about:blank` and then awaited step 2. So `about:blank` **was** the product for the whole duration of that trip — seconds on a cold Computer, where the CLI still has to start. Worse, every failure path called `authWindow?.close()` and reported with a toast on the *host* page, behind the popup that had just taken focus. A failed login therefore looked like a blank tab that disappeared.

## The fix

Not a faster round trip — removing the state. `openAuthTab()` writes the tab's document in the same statement that opens it, so no caller can hold a contentless auth tab. From there the tab has exactly three exits, and none of them is blank:

| exit | when | what the user sees |
|---|---|---|
| `settle(url)` | the URL arrived | the provider's sign-in page |
| `fail(msg)` | no page is coming | the reason, in the tab holding focus |
| `close()` | the host owns what is next | closes (only the already-connected branch) |

Two supporting changes follow from the same principle:

- **`BROWSER_AUTH_KINDS` now derives from `BROWSER_AUTH_PROVIDER_LABELS`.** The tab must name its provider *before* the server replies, so kind→provider lives in one table rather than a set plus a second lookup that can drift apart.
- **Both open paths gate on `isAuthorizationUrl()`.** The URL is regexed out of CLI output; a button that opens a non-URL is the same bug wearing a hat.

## Verification

Reproduced and fixed in real Chrome, against a harness that mimics the round trip:

- **old path** — tab parks on `about:blank` (bug reproduced)
- **new path, same moment** — tab is titled "Sign in" and reads "Opening Claude sign in…", then navigates to the provider
- **failure path** — tab stays open and reads "Install the Claude CLI before signing in"
- dark mode confirmed with `prefers-color-scheme: dark` emulation

Plus 18 new unit tests (carrier behaviour, popup blocking, HTML escaping, App wiring), the full `bun test` suite showing the same 10 pre-existing failures as a clean tree, and both `build:packages` and `web build` passing.
