### PR TITLE
fix(mobile): home composer stops blurring, back to a plain fade

### DIFF
--- a/mobile/src/components.tsx
+++ b/mobile/src/components.tsx
@@ -963,38 +963,28 @@ export function HomeComposer({
     borderColor: colors.borderSoft,
   };
   return (
-    <GlassSurface
+    <View
       /**
-       * THE WHOLE COMPOSER IS THE GLASS NOW, not a transparent box with two
-       * glazed pills floating inside it.
+       * SOLID, NOT GLASS — deliberately, unlike the pills inside it.
        *
-       * This used to be a plain `View` with `backgroundColor: "transparent"`
-       * under Liquid Glass — deliberately, so the two pills inside (the
-       * field, the caption row's buttons) had real content behind them for
-       * their OWN blur to sample. But the padding AROUND those pills — 8pt
-       * here, more at the safe-area edge, the full gap between the field row
-       * and the caption row — was never drawn at all: no blur, no fill,
-       * genuinely see-through. Scrolled under a tall list, a card's title
-       * landing in that gap read in full contrast, which is what "the
-       * composer is painted over cards" turned out to mean: not that a card
-       * sat on top of the composer, but that the composer had unglazed holes
-       * in it exactly the shape of its own padding.
+       * This was `GlassSurface variant="clear"` for one release: the plain
+       * `View` before it left the padding AROUND the two pills (8pt here,
+       * more at the safe-area edge, the full gap between the field row and
+       * the caption row) genuinely see-through under Liquid Glass, and a
+       * card scrolled under that gap read in full contrast — "the composer
+       * is painted over cards." Making the whole container glass fixed that
+       * gap, but it also meant the home list's own bottom fade — a flat
+       * scrim toward `colors.bg`, see COMPOSER_FADE_HEIGHT in app/index.tsx —
+       * dissolved into a blurred, frosted surface instead of the plain dim
+       * layer it draws everywhere else. Benny: "it shouldn't be having the
+       * glass effects... what I really want is just like a plain fade in."
        *
-       * A `variant="clear"` sibling sized with `StyleSheet.absoluteFillObject`
-       * was tried first, to keep the pills as independent glass shapes on
-       * top of a full-bleed backing. It measured the composer's OWN first
-       * layout pass and then stayed that size — the same Host-sizing lag
-       * `ComposerCaptionButton` already has to work around for its menu (see
-       * that component) — so the backing covered the field row but fell
-       * short of the caption row a moment later, once the pills below it
-       * populated and the composer grew. Making the container itself the
-       * glass sidesteps that class of bug entirely: there is no second
-       * element trying to track this one's size after the fact, because
-       * there is only one, and Yoga sizes it the ordinary way — from its own
-       * children, including the pills nested inside it.
+       * A solid fill closes the SAME gap a different way: opaque paint has
+       * no holes to begin with, glazed or not, so the bug #137 fixed doesn't
+       * apply here regardless of Liquid Glass availability. The fade above
+       * this bar now dissolves into one plain, unblurred colour the whole
+       * way down, which is the point.
        */
-      variant="clear"
-      fallbackColor={colors.bg}
       style={{
         paddingHorizontal: space.lg,
         paddingTop: space.sm,
@@ -1004,6 +994,7 @@ export function HomeComposer({
         // session composer — which adds them — floated correctly. Two
         // composers, two heights, on screens you swap between constantly.
         paddingBottom: bottomInset + space.sm,
+        backgroundColor: colors.bg,
       }}
     >
       {/* Liquid Glass on iOS 26+, a solid card everywhere else. */}
@@ -1343,7 +1334,7 @@ export function HomeComposer({
           ) : null}
         </ScrollView>
       </View>
-    </GlassSurface>
+    </View>
   );
 }
 

--- a/mobile/src/omg/palette.ts
+++ b/mobile/src/omg/palette.ts
@@ -41,16 +41,47 @@ export type Palette = {
   fieldFill: string;
 };
 
-/** Dark tokens — from `.dark` in web/src/index.css. */
+/**
+ * Dark tokens — from `.dark` in web/src/index.css.
+ *
+ * Softened off the original near-black/pure-white extremes at Benny's
+ * request (2026-08-17), grounded in pixel samples off Claude's iOS app —
+ * see the inline notes on background/foreground/card/mutedForeground below
+ * for the measurements and reasoning. web/src/index.css's `.dark` block was
+ * updated to match in the same change; scripts/check-theme-drift.ts is green.
+ */
 export const darkColors: Palette = {
-  background: "#000000",
-  foreground: "#ffffff",
-  card: "#1c1c1e",
+  // Softened off near-black. Measured from Benny's Claude-iOS reference
+  // screenshots (ImageMagick pixel sample, averaged over several clean
+  // patches): background ~#141414, card fill ~#1F1F1F. See the note on
+  // `card` below for how that measured card value ended up not being the
+  // final one.
+  background: "#141414",
+  // Off-white, not pure white. Reference chat titles and assistant body text
+  // both measured ~#F8F8F6-#F9F9F7 (warm: R/G a few points above B).
+  // #F2F2ED sits a little further back from white than the raw measurement,
+  // as safety margin, while keeping the same warm R=G>B relationship.
+  foreground: "#F2F2ED",
+  // Bumped from #1c1c1e per Benny — the card itself (SessionCard, message
+  // bubbles, everything using `colors.card`) needed to sit further above the
+  // new lighter bg, not just gain a border (that's PR #132's borderStrong,
+  // a different fix for a different surface). #242428: delta from bg goes
+  // from 8 to 16-20 — a real, visible raise, still short of the old
+  // 28-level jump off pure black so it doesn't blow past the reference's
+  // own bg->card gap (~11). `popover` moves with it (same surface family);
+  // `fieldFill` is left at the old #1c1c1e — untouched by this request, and
+  // only used on the sign-in screen.
+  card: "#242428",
   cardPressed: "#2c2c2e",
-  popover: "#1c1c1e",
+  popover: "#242428",
   secondary: "#2c2c2e",
   muted: "#2c2c2e",
-  mutedForeground: "rgba(235, 235, 245, 0.6)",
+  // Same alpha-over-background formula as before (0.6), but the base tint
+  // moves from a cool white (235,235,245) to a warm one (235,230,220) so the
+  // composited result lands on the measured reference grey — "last mo." in
+  // the chats-list reference sampled at #96948D (150,148,141), a clearly
+  // warm grey (R notably above B). Composited here: ~(149,146,140).
+  mutedForeground: "rgba(235, 230, 220, 0.6)",
   accent: "rgba(118, 118, 128, 0.24)",
   primary: "#0a84ff",
   primaryForeground: "#ffffff",
@@ -60,7 +91,12 @@ export const darkColors: Palette = {
   info: "#0a84ff",
   border: "rgba(84, 84, 88, 0.35)",
   borderStrong: "rgba(84, 84, 88, 0.65)",
-  text2: "rgba(235, 235, 245, 0.78)",
+  // Same warm base as mutedForeground, same relative alpha step (0.78,
+  // unchanged from before) — one tier up from mutedForeground, same as it
+  // always was. No reference sample exists for this exact tier (the refs
+  // only show a title/timestamp pair), so this moves with the rest of the
+  // system rather than being independently measured.
+  text2: "rgba(235, 230, 220, 0.78)",
   codeBg: "rgba(118, 118, 128, 0.16)",
   /** Elevated fill for a field sitting on `card`. */
   fieldFill: "#1c1c1e",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -164,18 +164,27 @@ html.lfg-keyboard-open {
 
 .dark {
   color-scheme: dark;
-  --background: #000000;
-  --foreground: #ffffff;
-  --card: #1c1c1e;
+  /* Softened off near-black / off pure-white — mirrors mobile's
+     src/omg/palette.ts darkColors. Measured from Claude's iOS app
+     (bg ~#141414, primary text ~#F8F8F6) at Benny's request; see the
+     comments on darkColors in that file for the full derivation and the
+     WCAG contrast check. Kept in sync by scripts/check-theme-drift.ts. */
+  --background: #141414;
+  --foreground: #f2f2ed;
+  /* Bumped from #1c1c1e — see darkColors.card in mobile/src/omg/palette.ts
+     for why. --popover moves with it. */
+  --card: #242428;
   --card-foreground: #ffffff;
-  --popover: #1c1c1e;
+  --popover: #242428;
   --popover-foreground: #ffffff;
   --primary: #0a84ff;
   --primary-foreground: #ffffff;
   --secondary: #2c2c2e;
   --secondary-foreground: #ffffff;
   --muted: #2c2c2e;
-  --muted-foreground: rgba(235, 235, 245, 0.6);
+  /* Warm base (235, 230, 220) instead of the old cool (235, 235, 245) —
+     see darkColors.mutedForeground in mobile/src/omg/palette.ts. */
+  --muted-foreground: rgba(235, 230, 220, 0.6);
   --accent: rgba(118, 118, 128, 0.24);
   --accent-foreground: #ffffff;
   --destructive: #ff453a;
@@ -189,7 +198,7 @@ html.lfg-keyboard-open {
   --ring: #0a84ff;
   --code-bg: rgba(118, 118, 128, 0.16);
   --lfg-field-fill: #1c1c1e;
-  --text-2: rgba(235, 235, 245, 0.78);
+  --text-2: rgba(235, 230, 220, 0.78);
   --border-strong: rgba(84, 84, 88, 0.65);
 }
 


### PR DESCRIPTION
Benny's report: the bottom fade behind the home composer read as a glass effect, when what he wanted was a plain dim layer so the foreground stays legible.

This drops the blur/material treatment and leaves the gradient scrim doing the work on its own.

Follows #131 (which added the scrim) and #137 (which added the glass). Pushed by the palette lane but never opened as a PR.