### PR TITLE
fix(mobile): instrument the home list to catch card overlap in the act

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -41,6 +41,7 @@ import {
   type SessionNode,
 } from "../src/omg/session-tree";
 import { AutoFindingCard } from "../src/omg/auto-agent-card";
+import { useOverlapWatch } from "../src/omg/list-overlap-watch";
 import { selectHomeAutoFindings, useAutoAgents, type AutoFindingRow } from "../src/omg/auto-agents";
 import { useComputerPicker } from "../src/omg/computer-picker";
 import { useDictation } from "../src/omg/dictation";
@@ -402,6 +403,27 @@ export default function SessionsScreen() {
   useEffect(() => {
     if (error) toast.show(error, { intent: "error" });
   }, [error, toast]);
+  /**
+   * DIAGNOSTIC, NOT A FIX — see list-overlap-watch.tsx.
+   *
+   * Benny has seen cards drawn on top of each other on his real device; it
+   * has not reproduced on a simulator despite real testing against his own
+   * large, actively-churning account. Rather than guess at a mechanism
+   * nobody has caught in the act, `OverlapRow` measures every top-level
+   * row's actual on-screen frame and flags it the moment two rows'
+   * positions genuinely intersect — turning "cannot reproduce" into "will
+   * know the instant it happens," with the exact pixel offsets, wherever it
+   * happens next.
+   *
+   * The toast is gated to Benny's own account (or a dev build) — this is a
+   * one-report diagnostic, not a feature, and firing a red "internal error"
+   * toast for some unrelated user's transient, self-correcting layout race
+   * would be a worse experience than the bug it exists to catch. Everyone
+   * still gets the console.error, which costs nothing with no debugger
+   * attached and is free evidence the moment one is.
+   */
+  const notifyUserOfOverlap = __DEV__ || user?.email === "itechbenny@gmail.com";
+  const { Row: OverlapRow } = useOverlapWatch(toast, notifyUserOfOverlap);
   /**
    * Live-socket health. The SDK's statuses are connecting | live | reconnecting
    * | offline — there is no "connected", and comparing against that string made
@@ -1119,13 +1141,14 @@ export default function SessionsScreen() {
                 {/* Each session is its own card now, so the rows need air
                     between them — see SessionCard. */}
                 <View style={{ gap: space.sm }}>
-                  {working.map((node) => (
-                    <SessionFamily
-                      key={sessionStableId(node.session)}
-                      node={node}
-                      onOpen={openSession}
-                    />
-                  ))}
+                  {working.map((node) => {
+                    const id = sessionStableId(node.session);
+                    return (
+                      <OverlapRow key={id} id={`working:${id}`}>
+                        <SessionFamily node={node} onOpen={openSession} />
+                      </OverlapRow>
+                    );
+                  })}
                 </View>
               </>
             ) : null}
@@ -1138,14 +1161,14 @@ export default function SessionsScreen() {
                   dotColor={colors.success}
                 />
                 <View style={{ gap: space.sm }}>
-                  {idle.map((node) => (
-                    <SessionFamily
-                      key={sessionStableId(node.session)}
-                      node={node}
-                      onOpen={openSession}
-                      onArchive={archiveSession}
-                    />
-                  ))}
+                  {idle.map((node) => {
+                    const id = sessionStableId(node.session);
+                    return (
+                      <OverlapRow key={id} id={`idle:${id}`}>
+                        <SessionFamily node={node} onOpen={openSession} onArchive={archiveSession} />
+                      </OverlapRow>
+                    );
+                  })}
                 </View>
               </>
             ) : null}
@@ -1185,19 +1208,20 @@ export default function SessionsScreen() {
                 <SectionHeader label="Auto" count={autoRows.length} dotColor={colors.primary} />
                 <View style={{ gap: space.sm }}>
                   {autoRows.map((row) => (
-                    <AutoFindingCard
-                      key={row.finding.id}
-                      row={row}
-                      expanded={expandedAuto === row.finding.id}
-                      onToggle={() =>
-                        setExpandedAuto((current) =>
-                          current === row.finding.id ? null : row.finding.id,
-                        )
-                      }
-                      onDismiss={() => dismissFinding(row.finding.id)}
-                      onStartSession={() => void startSessionFromFinding(row)}
-                      busy={startingFindingId === row.finding.id}
-                    />
+                    <OverlapRow key={row.finding.id} id={`auto:${row.finding.id}`}>
+                      <AutoFindingCard
+                        row={row}
+                        expanded={expandedAuto === row.finding.id}
+                        onToggle={() =>
+                          setExpandedAuto((current) =>
+                            current === row.finding.id ? null : row.finding.id,
+                          )
+                        }
+                        onDismiss={() => dismissFinding(row.finding.id)}
+                        onStartSession={() => void startSessionFromFinding(row)}
+                        busy={startingFindingId === row.finding.id}
+                      />
+                    </OverlapRow>
                   ))}
                 </View>
               </>
@@ -1220,19 +1244,20 @@ export default function SessionsScreen() {
                 <SectionHeader label="Recent" count={recent.length} dotColor={colors.textMuted} />
                 <View style={{ gap: space.sm }}>
                   {recent.map((session) => (
-                    <SessionCard
-                      key={session.sessionId}
-                      title={recentTitle(session)}
-                      // WHEN, then what was last said. A list called Recent
-                      // that never says when is asking you to guess, and these
-                      // rows span minutes to weeks.
-                      subtitle={[relativeTime(session.lastActivityAt), session.lastUserText?.trim()]
-                        .filter(Boolean)
-                        .join(" · ")}
-                      agent={session.agent}
-                      ended
-                      onPress={() => router.push(`/session/${session.sessionId}`)}
-                    />
+                    <OverlapRow key={session.sessionId} id={`recent:${session.sessionId}`}>
+                      <SessionCard
+                        title={recentTitle(session)}
+                        // WHEN, then what was last said. A list called Recent
+                        // that never says when is asking you to guess, and these
+                        // rows span minutes to weeks.
+                        subtitle={[relativeTime(session.lastActivityAt), session.lastUserText?.trim()]
+                          .filter(Boolean)
+                          .join(" · ")}
+                        agent={session.agent}
+                        ended
+                        onPress={() => router.push(`/session/${session.sessionId}`)}
+                      />
+                    </OverlapRow>
                   ))}
                 </View>
               </>

--- a/mobile/src/omg/list-overlap-watch.tsx
+++ b/mobile/src/omg/list-overlap-watch.tsx
@@ -1,0 +1,133 @@
+/**
+ * A geometric trip-wire for the home list, not a fix.
+ *
+ * Benny has hit session/finding cards drawn on top of each other, with large
+ * blank gaps elsewhere, on his real device — see the screenshot referenced in
+ * the bug this file was added for. The content was always correct; only the
+ * POSITIONS were wrong, which is the signature of a view left somewhere its
+ * data no longer says it should be. `motion.tsx` already root-caused and
+ * fixed one confirmed way that happens (a `exiting` animation stranding a
+ * view out of flow when a re-render interrupts it — see that file's
+ * "DO NOT ADD ONE" note) — but that fix has been reproduced, verified, and
+ * live on a large real account without reproducing Benny's report again, so
+ * either the fix is incomplete for some third path, or the failure needs
+ * real-device timing (a Mac-hosted simulator has far more UI-thread headroom
+ * than his phone) that a dev box cannot manufacture.
+ *
+ * Rather than guess at a fix for a mechanism nobody has caught in the act,
+ * this instruments the actual invariant: no two rows should ever occupy
+ * overlapping vertical space on screen. `Row` wraps each top-level list item,
+ * measures its own on-screen frame after every layout pass via
+ * `measureInWindow` (window coordinates, so rows in different sections —
+ * different parent Views — are still comparable), and a debounced check
+ * sorts all currently-mounted rows by their MEASURED top (not document
+ * order, which would need its own bookkeeping and isn't the thing that can
+ * go wrong here) and flags any pair whose vertical ranges intersect.
+ *
+ * On a hit: a console.error, unconditionally — harmless in a production
+ * build with nobody attached to Metro, and free evidence the moment anyone
+ * ever is. The TOAST is separate and deliberately gated: this is a
+ * diagnostic for one bug report, not a feature, and a red "internal error"
+ * toast firing on some unrelated user's phone for a transient, self-
+ * correcting, sub-second layout race would be a worse experience than the
+ * bug it is trying to catch. `notifyUser` decides whether the toast fires;
+ * callers should pass it only for the account that reported this (see
+ * `app/index.tsx`), or `__DEV__`, never unconditionally for everyone on the
+ * production channel.
+ *
+ * Fires at most once per screen mount — this is a smoke detector, not a
+ * running log, and a list that is actually broken will have plenty of other
+ * evidence once this alarm has gone off once.
+ *
+ * Deliberately NOT wired into SessionCard/AutoFindingCard themselves: `Row`
+ * is a plain, un-animated `View` wrapped one level OUTSIDE those components,
+ * so it cannot change anything about their own Reanimated `entering`/`layout`
+ * behaviour — it can only ever observe the frame Yoga already computed.
+ */
+
+import { useCallback, useMemo, useRef } from "react";
+import { View, type LayoutChangeEvent } from "react-native";
+
+import type { useToast } from "./toast";
+
+type RowMeasurement = { id: string; top: number; bottom: number };
+
+/** How much intersection counts as a real overlap, not float/rounding noise. */
+const OVERLAP_THRESHOLD = 6;
+/** Let a burst of layout passes settle before judging the result. */
+const CHECK_DEBOUNCE_MS = 400;
+
+export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: boolean) {
+  const measurements = useRef(new Map<string, RowMeasurement>());
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const runCheck = useCallback(() => {
+    if (firedRef.current) return;
+    const rows = Array.from(measurements.current.values()).sort((a, b) => a.top - b.top);
+    for (let i = 1; i < rows.length; i++) {
+      const prev = rows[i - 1];
+      const cur = rows[i];
+      const overlap = prev.bottom - cur.top;
+      if (overlap > OVERLAP_THRESHOLD) {
+        firedRef.current = true;
+        const message = `List rows overlap: "${prev.id}" over "${cur.id}" by ${Math.round(
+          overlap,
+        )}pt (${rows.length} rows on screen)`;
+        // eslint-disable-next-line no-console
+        console.error("[list-overlap-watch]", message, {
+          prev,
+          cur,
+          allRows: rows,
+        });
+        if (notifyUser) toast.show(message, { intent: "error" });
+        return;
+      }
+    }
+  }, [toast, notifyUser]);
+
+  const report = useCallback(
+    (id: string, top: number, bottom: number) => {
+      measurements.current.set(id, { id, top, bottom });
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(runCheck, CHECK_DEBOUNCE_MS);
+    },
+    [runCheck],
+  );
+
+  const unregister = useCallback((id: string) => {
+    measurements.current.delete(id);
+  }, []);
+
+  /**
+   * One top-level list row. `id` should be the same stable key already used
+   * for React reconciliation (`sessionStableId`, a finding id, …) — reusing
+   * it means a row that remounts under a new key is correctly treated as a
+   * new measurement, not compared against its own stale frame.
+   */
+  const Row = useMemo(() => {
+    return function OverlapWatchRow({ id, children }: { id: string; children: React.ReactNode }) {
+      const ref = useRef<View>(null);
+      const onLayout = useCallback(
+        (_e: LayoutChangeEvent) => {
+          // The layout event's own `nativeEvent.layout` is PARENT-relative,
+          // which is useless across sections (Working/Idle/Auto/Recent are
+          // separate parent Views). `measureInWindow` gives screen
+          // coordinates, so rows from different sections are still directly
+          // comparable — which is exactly the comparison this exists to make.
+          ref.current?.measureInWindow((_x, y, _width, height) => {
+            report(id, y, y + height);
+          });
+        },
+        [id],
+      );
+      return (
+        <View ref={ref} onLayout={onLayout}>
+          {children}
+        </View>
+      );
+    };
+  }, [report]);
+
+  return { Row, unregister };
+}


### PR DESCRIPTION
## Summary
- Benny hit session/finding cards drawn on top of each other on his real device (screenshot in the linked report), with correct content but wrong positions — the signature of a view left somewhere its data no longer says it should be.
- That signature has one confirmed root cause on this branch already (#112/#137: an `exiting` animation stranding a view out of flow on an interrupted re-render), but it's fully fixed here (zero `exiting` on the home list), and extensive live testing against Benny's own large, actively-churning account — the exact rows in his screenshot — did not reproduce it via normal scrolling, a forced pull-to-refresh, or expanding an Auto finding with a dozen siblings below it.
- Rather than guess at a third mechanism nobody has caught in the act, this lands a diagnostic: `useOverlapWatch` (new `list-overlap-watch.tsx`) wraps every top-level home-list row in a plain `View`, measures its real on-screen frame via `measureInWindow` after each layout pass, and flags the moment two rows' vertical ranges actually intersect — with the exact top/bottom of every row on screen.
- It fired on the first two things I tried it on: a cold load where an Auto row measured inside the Idle section's range, and a second cold load where two Recent rows overlapped each other by 21pt. Third cold load fired again. Different pairs, different sections, same class of failure, self-correcting within under a second on the simulator — consistent with dozens of rows across independently-fetched sections (`listSessions()` vs the separate `useAutoAgents()` findings pipeline) animating in at close to the same time on initial load, before combined layout settles.
- **Not yet proven to be the same event Benny's screenshot shows** — a slower real device under real load plausibly stretches that self-correcting window long enough to see and screenshot, but that's a theory this diagnostic is meant to close the gap on, not a claim.
- Pure diagnostic, **zero behaviour change** to the list itself. `Row` is a plain, un-animated wrapper one level *outside* `SessionCard`/`AutoFindingCard`, so it cannot perturb the Reanimated `entering`/`layout` animations it's observing.
- The toast is gated to Benny's own account (or a dev build) — this is a one-report diagnostic, not a feature, and a red "internal error" toast on an unrelated user's phone for a transient, self-correcting layout race would be worse than the bug. Everyone still gets the `console.error`, free the moment anyone is attached.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `expo export --platform ios` clean
- [x] Live on iPhone 17 Pro simulator against Benny's real account (10+ working, 12 idle, 15 auto, 6 recent, nested subagent trees) — detector fired on 3/3 cold loads, each with full row-by-row diagnostic payload in the console
- [ ] Confirm it also fires (or doesn't) on Benny's physical device next time the bug shows up — that's what this PR is for

🤖 Generated with [Claude Code](https://claude.com/claude-code)