### PR TITLE
fix(mobile): suppress list-row entering/layout motion during cold load

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -468,6 +468,14 @@ export default function SessionsScreen() {
    * point everything else has already settled — nothing left to race). Wide
    * enough to cover a slow fetch or a multi-wave subagent tree resolving,
    * short enough that it's not what a person notices as "the list is slow."
+   *
+   * 3500ms IS A GUESS, NOT A MEASUREMENT — tunable, not sacred. It's sized
+   * off simulator fetch timing on a fast Mac; a real device on real
+   * cellular could easily need longer, or a fast wifi connection could get
+   * away with less. list-overlap-watch.tsx is what would tell you which:
+   * if it starts firing again on real devices with this window in place,
+   * that's a signal to widen it before reaching for a different mechanism
+   * entirely, not a sign the whole approach is wrong.
    */
   const mountedAtRef = useRef(Date.now());
   const COLD_LOAD_WINDOW_MS = 3500;

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -75,11 +75,14 @@ function SessionFamily({
   depth = 0,
   onOpen,
   onArchive,
+  animateEntry = true,
 }: {
   node: SessionNode;
   depth?: number;
   onOpen: (id: string | null) => void;
   onArchive?: (id: string | null) => void;
+  /** See the identical prop on SessionCard/AutoFindingCard for why. */
+  animateEntry?: boolean;
 }) {
   const { colors, space } = useTheme();
   const session = node.session;
@@ -94,6 +97,7 @@ function SessionFamily({
         blocked={session.status === "blocked"}
         onPress={() => onOpen(session.sessionId)}
         onArchive={depth === 0 && onArchive ? () => onArchive(session.sessionId) : undefined}
+        animateEntry={animateEntry}
       />
 
       {node.children.length ? (
@@ -105,6 +109,7 @@ function SessionFamily({
               depth={depth + 1}
               last={index === node.children.length - 1}
               onOpen={onOpen}
+              animateEntry={animateEntry}
             />
           ))}
         </View>
@@ -132,11 +137,14 @@ function SessionBranch({
   depth,
   last,
   onOpen,
+  animateEntry = true,
 }: {
   node: SessionNode;
   depth: number;
   last: boolean;
   onOpen: (id: string | null) => void;
+  /** See the identical prop on SessionCard/AutoFindingCard for why. */
+  animateEntry?: boolean;
 }) {
   const { colors, space } = useTheme();
   const [cardHeight, setCardHeight] = useState(0);
@@ -202,7 +210,7 @@ function SessionBranch({
           />
         </>
       )}
-      <SessionFamily node={node} depth={depth} onOpen={onOpen} />
+      <SessionFamily node={node} depth={depth} onOpen={onOpen} animateEntry={animateEntry} />
     </View>
   );
 }
@@ -424,6 +432,46 @@ export default function SessionsScreen() {
    */
   const notifyUserOfOverlap = __DEV__ || user?.email === "itechbenny@gmail.com";
   const { Row: OverlapRow } = useOverlapWatch(toast, notifyUserOfOverlap);
+  /**
+   * THE FIX, once list-overlap-watch.tsx had a mechanism to point at:
+   * suppress BOTH `entering` and `layout` for a fixed window after this
+   * screen mounts, then never again.
+   *
+   * Both caught overlaps were on cold load, and both are consistent with the
+   * same race: Working/Idle rows come from `sessions` (client.listSessions())
+   * while Auto rows come from a SEPARATE fetch (useAutoAgents(), see above) —
+   * two independent sources that do not resolve on the same tick. Cold load
+   * is the one moment potentially dozens of rows across BOTH sources mount
+   * and start their own `entering: FadeInDown` within the same beat; the
+   * measured cross-row position corruption showed up between rows in
+   * DIFFERENT sections (idle vs. auto) and rows in the SAME section
+   * (recent vs. recent), which is what an entering-animation race predicts
+   * and a single stranded-view bug would not.
+   *
+   * `layout` ALSO SUPPRESSED, not just `entering` — first attempt left
+   * `layout: LinearTransition` live and still measured 1 overlap in 5 cold
+   * loads. Either source can straggle in across more than one wave (a
+   * session's subagent children resolving after its own row, a finding's
+   * `occurrences` bumping mid-load), and a `layout` reflow racing a sibling
+   * that is itself still settling is the same class of race `entering` is —
+   * animating FROM or TO a frame that is about to move again is exactly how
+   * a transiently-wrong position gets painted. During the window a row
+   * SNAPS directly to its current correct position with no animation,
+   * rather than risk animating relative to one.
+   *
+   * A FIXED WINDOW since mount, not an "is any section still empty" check,
+   * deliberately — the two sources resolving at different times is exactly
+   * the thing being raced, so gating on either one individually reintroduces
+   * the same asymmetry. A wall-clock window since this screen first rendered
+   * covers both regardless of which arrives first, second, or late (a
+   * source that lands after the window animates in on its own, by which
+   * point everything else has already settled — nothing left to race). Wide
+   * enough to cover a slow fetch or a multi-wave subagent tree resolving,
+   * short enough that it's not what a person notices as "the list is slow."
+   */
+  const mountedAtRef = useRef(Date.now());
+  const COLD_LOAD_WINDOW_MS = 3500;
+  const animateEntry = Date.now() - mountedAtRef.current >= COLD_LOAD_WINDOW_MS;
   /**
    * Live-socket health. The SDK's statuses are connecting | live | reconnecting
    * | offline — there is no "connected", and comparing against that string made
@@ -1145,7 +1193,7 @@ export default function SessionsScreen() {
                     const id = sessionStableId(node.session);
                     return (
                       <OverlapRow key={id} id={`working:${id}`}>
-                        <SessionFamily node={node} onOpen={openSession} />
+                        <SessionFamily node={node} onOpen={openSession} animateEntry={animateEntry} />
                       </OverlapRow>
                     );
                   })}
@@ -1165,7 +1213,12 @@ export default function SessionsScreen() {
                     const id = sessionStableId(node.session);
                     return (
                       <OverlapRow key={id} id={`idle:${id}`}>
-                        <SessionFamily node={node} onOpen={openSession} onArchive={archiveSession} />
+                        <SessionFamily
+                          node={node}
+                          onOpen={openSession}
+                          onArchive={archiveSession}
+                          animateEntry={animateEntry}
+                        />
                       </OverlapRow>
                     );
                   })}
@@ -1220,6 +1273,7 @@ export default function SessionsScreen() {
                         onDismiss={() => dismissFinding(row.finding.id)}
                         onStartSession={() => void startSessionFromFinding(row)}
                         busy={startingFindingId === row.finding.id}
+                        animateEntry={animateEntry}
                       />
                     </OverlapRow>
                   ))}
@@ -1256,6 +1310,7 @@ export default function SessionsScreen() {
                         agent={session.agent}
                         ended
                         onPress={() => router.push(`/session/${session.sessionId}`)}
+                        animateEntry={animateEntry}
                       />
                     </OverlapRow>
                   ))}

--- a/mobile/src/components.tsx
+++ b/mobile/src/components.tsx
@@ -657,6 +657,7 @@ export function SessionCard({
   ended,
   onPress,
   onArchive,
+  animateEntry = true,
 }: {
   title: string;
   subtitle?: string | null;
@@ -668,6 +669,20 @@ export function SessionCard({
   onPress: () => void;
   /** Omit to make the row unswipeable — a running session has nothing to archive. */
   onArchive?: () => void;
+  /**
+   * Skip BOTH the mount-in slide/fade AND the resettle-on-reflow transition
+   * — see the identical flag on `AutoFindingCard` for why. Suppressing only
+   * `entering` and leaving `layout` live still measured a residual overlap
+   * (1/5 cold loads in testing): the two independently-fetched sections
+   * (`listSessions()` vs `useAutoAgents()`) can straggle in more than one
+   * wave each, and a `layout` reflow racing a still-settling sibling is the
+   * same class of transient position corruption `entering` was. During the
+   * cold-load window this makes a row snap directly to its correct position
+   * with no animation at all rather than risk animating from/to a frame that
+   * is itself about to move. `app/index.tsx` passes `false` only for a fixed
+   * window after the home screen mounts.
+   */
+  animateEntry?: boolean;
 }) {
   const { colors, radius, type, space, motion } = useTheme();
   // Entering/exiting/layout live on this outer, style-less view rather than
@@ -695,8 +710,8 @@ export function SessionCard({
 
   return (
     <Reanimated.View
-      entering={listMotion.entering}
-      layout={listMotion.layout}
+      entering={animateEntry ? listMotion.entering : undefined}
+      layout={animateEntry ? listMotion.layout : undefined}
     >
       {swipeable ? (
         <Reanimated.View

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -145,6 +145,7 @@ export function AutoFindingCard({
   onDismiss,
   onStartSession,
   busy,
+  animateEntry = true,
 }: {
   row: AutoFindingRow;
   expanded: boolean;
@@ -155,6 +156,18 @@ export function AutoFindingCard({
   onStartSession: () => void;
   /** True while a session is being started FROM THIS finding. */
   busy?: boolean;
+  /**
+   * Skip BOTH the mount-in slide/fade AND the resettle-on-reflow transition
+   * — see the identical flag on `SessionCard` for why. Suppressing only
+   * `entering` and leaving `layout` live still measured a residual overlap
+   * (1/5 cold loads in testing): the two independently-fetched sections
+   * (`listSessions()` vs this hook's own `useAutoAgents()` fetch) can
+   * straggle in more than one wave each, and a `layout` reflow racing a
+   * still-settling sibling is the same class of transient position
+   * corruption `entering` was. `app/index.tsx` passes `false` only for a
+   * fixed window after the home screen mounts.
+   */
+  animateEntry?: boolean;
 }) {
   const { colors, radius, type, space, motion } = useTheme();
   const listMotion = useListItemMotion();
@@ -175,7 +188,10 @@ export function AutoFindingCard({
   });
 
   return (
-    <Reanimated.View entering={listMotion.entering} layout={listMotion.layout}>
+    <Reanimated.View
+      entering={animateEntry ? listMotion.entering : undefined}
+      layout={animateEntry ? listMotion.layout : undefined}
+    >
       <Reanimated.View
         pointerEvents="none"
         style={[


### PR DESCRIPTION
## STATUS UPDATE (after merge) — this is a mitigation, not the confirmed fix

Keeping this on record for the next person who finds "cold-load motion suppression" in the tree and might otherwise assume it solved the overlap bug: **it did not, on its own.**

Later evidence, after this merged and shipped in the same OTA as #149:
- The detector fired on Benny's real device with this fix active (idle over recent, 57pt, 37 rows).
- A definitive follow-up test — forcing `entering`/`layout` permanently off for every row, no suppression window, no animation involved at all — **still produced overlap candidates.** That rules out Reanimated animation timing as the (sole) mechanism this PR targeted.
- Separately, #149's own verification math had a bug (see #156) that could produce false "confirmed" overlaps, so some earlier readings — including possibly the real-device one above — are unverified, not proven.
- Current working theory (unconfirmed): rows — typically in the Auto section — can briefly measure at a wrong position before Yoga has the combined height of the sections above them, self-correcting shortly after. That's a data/layout-timing question, not an animation one. Investigation continuing in a follow-up PR (coalescing the three independent data sources feeding this list).

This PR is being kept rather than reverted — it's small, harmless, and plausibly still reduces *some* fraction of layout churn on cold load — but treat it as "a thing that happened to also be true," not as the fix for Benny's report. #149 (now #156-corrected) is what's actually watching for whether the real bug is gone.

---

## Summary
Stacked on #149 (list-overlap-watch.tsx) — not yet merged, so this diff includes both; the fix itself is the second commit. #149's detector is what made this a measured claim instead of a guess.

- **Mechanism**: on the home screen's cold load, Working/Idle rows come from `sessions` (`client.listSessions()`) while Auto rows come from a separate fetch (`useAutoAgents()`) — two independent sources that don't resolve on the same tick. When dozens of rows across both mount and start their own `entering`/`layout` Reanimated animation within the same beat, some rows' on-screen positions transiently don't match their settled neighbors.
- **Fix**: `animateEntry`, a new optional prop (default `true`, every other call site unaffected) threaded through `SessionCard`/`AutoFindingCard`/`SessionFamily`/`SessionBranch`. `app/index.tsx` computes it from a fixed 3.5s window since mount and passes it to all four sections. During that window rows snap directly to their correct position with no animation; afterward, motion is unchanged.
- **Both `entering` AND `layout` suppressed**, not just `entering` — first attempt left `layout: LinearTransition` live and still measured 1 overlap in 5 cold loads. A `layout` reflow racing a still-settling sibling is the same race class.
- **Fixed wall-clock window, not per-source "still empty" checks** — deliberately, since the two sources resolving asymmetrically is the thing being raced.

## Verification (measured, not asserted)
- 15 consecutive rapid-fire cold loads with the #149 detector watching: 0 new detections.
- 10 more with realistic pacing between launches (terminate → wait → relaunch → wait for full settle, not back-to-back): 0 new detections.
- **One relaunch in between those two tracked batches** (not part of either run, done for an unrelated visual check) **did trigger the detector once**, same signature as the original catches (idle-over-auto, 43pt). Net: 25/26 clean across both batches, 0/10 in the batch that matches how a person actually opens the app.
- I'm flagging that one data point rather than rounding it off the report. I haven't ruled out test-harness noise from rapid automated relaunching (Metro/simulator/tunnel state under repeated back-to-back terminate+reopen, not representative of a real cold open) versus a genuine rarer remaining race. #149 stays in the tree specifically so this keeps being watched after it ships either way.
- `tsc --noEmit` and `expo export --platform ios` both clean.

## Open question from review, answered here
- **Does cold load feel dead without per-row entering?** Subjectively, no — there's already a skeleton→content transition (`SessionListSkeleton`) covering the "nothing → something" moment, so losing the *additional* per-row slide/fade on top of that reveal was not obviously jarring in my own testing. This is a feel judgment though, and Benny should be the one to call it once he's on it. If it does read as flat, a single container-level `FadeIn` around the whole section block (one animated view, not 30) would restore arrival motion without reintroducing the per-row race — did not add this preemptively since it's a design call, not a correctness one.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `expo export --platform ios` clean
- [x] 25/26 cold loads clean against #149's detector across two batches (rapid-fire + realistic pacing)
- [ ] Confirm on Benny's device that the original bug is gone (or that #149 stops firing for him)
- [ ] Benny's call on whether cold load still feels right without per-row entering

🤖 Generated with [Claude Code](https://claude.com/claude-code)