### PR TITLE
fix(mobile): sign-out redirects to sign-in immediately

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -98,8 +98,63 @@ a screenshot pixel to a device point by dividing by the scale factor (3 on
 these devices). Raise the right window first (`AXRaise`) — clicks go to
 whatever is under the coordinate, not to a device id.
 
+**AXRaise before EVERY interaction, not once at the start.** This Mac runs
+several agents' simulators in parallel, and window focus (which window is
+*key*, not just which is visually on top) drifts between your taps as other
+agents' sessions raise their own windows. Calibrating the `group` origin once
+is fine — that geometry doesn't move — but skipping the `AXRaise` before a
+later tap is how a perfectly-computed coordinate lands on nothing: the tap
+event still posts, the screenshot still looks like your app, and there is no
+error, because your window is still visible, just not key. Re-raise
+immediately before every tap/drag/keystroke:
+
+```bash
+osascript -e '
+tell application "Simulator" to activate
+delay 0.15
+tell application "System Events" to tell process "Simulator"
+  perform action "AXRaise" of (first window whose name contains "YOUR_SIM_NAME")
+end tell
+' && python3 /tmp/tap.py $X $Y
+```
+
+**Typing text: `System Events`' `keystroke` silently no-ops over SSH.** It is
+the third variant of this trap (alongside `booted` and stale `AXRaise`) found
+in one session: `osascript -e 'tell application "System Events" to keystroke
+"..."'` returns success and produces no error, but nothing appears in the
+focused field — most likely missing Automation/TCC permission for the process
+running osascript over SSH (a separate permission bucket from Accessibility,
+which mouse clicks already have). Mouse taps via raw `CGEventPost` work fine
+because they never go through System Events at all. Use the same technique
+for keyboard input — `CGEventCreateKeyboardEvent` +
+`CGEventKeyboardSetUnicodeString` lets you post arbitrary Unicode text
+without needing a keycode table:
+
+```python
+import sys, Quartz
+text = sys.argv[1]
+down = Quartz.CGEventCreateKeyboardEvent(None, 0, True)
+Quartz.CGEventKeyboardSetUnicodeString(down, len(text), text)
+Quartz.CGEventPost(Quartz.kCGHIDEventTap, down)
+up = Quartz.CGEventCreateKeyboardEvent(None, 0, False)
+Quartz.CGEventKeyboardSetUnicodeString(up, len(text), text)
+Quartz.CGEventPost(Quartz.kCGHIDEventTap, up)
+```
+
+Tap the field (with a fresh `AXRaise` first) before sending text — this posts
+keys to whatever's focused, it doesn't focus anything itself.
+
 Fast refresh applies edits in a couple of seconds, so the probe-and-look loop
 below is cheap. Use it instead of reasoning about what UIKit "should" do.
+
+**Changes to `app/_layout.tsx` are the one place NOT to trust Fast Refresh
+for verification.** It restructures the root navigator, and edits there (a
+`key` prop, a new top-level effect) can silently fail to apply through
+incremental HMR while every other screen-level edit in the same session
+applies instantly and correctly — nothing errors, the old behavior just
+keeps running. If you're testing a `_layout.tsx` change and the result looks
+unchanged, do a full `simctl terminate` + `simctl launch` before concluding
+the fix doesn't work.
 
 ## Probe with colour when a layout is a mystery
 

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,6 +1,6 @@
-import { DarkTheme, DefaultTheme, Stack, ThemeProvider } from "expo-router";
+import { DarkTheme, DefaultTheme, router, Stack, ThemeProvider } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import Reanimated, {
   Easing,
@@ -149,6 +149,38 @@ function RootNavigator() {
    * exist yet.
    */
   useNotificationTapRouting(authStatus === "signed-in");
+  /**
+   * Land on sign-in the moment ANY path sets authStatus to "signed-out" —
+   * an explicit Sign out, a session that expired underneath the app, a
+   * future 401 handler, all of it. Centralized here instead of next to one
+   * call site (e.g. inside provider.tsx's signOut()) on purpose: a fix that
+   * only fires for the Settings sign-out button leaves every OTHER path to
+   * signed-out re-creating the exact bug this exists to close.
+   *
+   * Why this is needed at all, confirmed on-device: `Stack.Protected`
+   * changes which screens are REGISTERED per authStatus (see the
+   * signed-out Stack below — "settings" isn't declared there), but that is
+   * not the same as telling expo-router to NAVIGATE anywhere. Without this,
+   * a confirmed sign-out from Settings left Settings on screen rendering
+   * the now-cleared (signed-out) provider state — right values, wrong
+   * screen. `dismissTo` pops through whatever was pushed (Settings,
+   * Computers, a session, ...) back to sign-in in one step regardless of
+   * stack depth.
+   *
+   * Gated on the TRANSITION (previous render was "signed-in"), not just
+   * "authStatus is currently signed-out" — a cold start that resolves
+   * straight to signed-out already mounts the signed-out Stack fresh with
+   * sign-in as its only screen; there is no stale signed-in screen to
+   * escape from, so nothing here should run.
+   */
+  const previousAuthStatusRef = useRef(authStatus);
+  useEffect(() => {
+    const wasSignedIn = previousAuthStatusRef.current === "signed-in";
+    previousAuthStatusRef.current = authStatus;
+    if (wasSignedIn && authStatus === "signed-out") {
+      router.dismissTo("/sign-in");
+    }
+  }, [authStatus]);
   const { colors, isDark } = useTheme();
   // Shares the splash with auth, rather than flashing an icon-less bar for a
   // frame: the font resolves from a bundled asset, so this is never a wait
@@ -163,7 +195,32 @@ function RootNavigator() {
     return (
       <>
         <StatusBar style={isDark ? "light" : "dark"} />
-        <Stack screenOptions={{ contentStyle: { backgroundColor: colors.bg } }}>
+        {/*
+         * `key="signed-out"` — belt, not the actual buckle.
+         *
+         * This Stack and the signed-in one below declare two DIFFERENT sets
+         * of screens — "settings", "computers", etc. exist only in the
+         * signed-in tree. Without a key, React sees the same element type
+         * (Stack) in the same position across a signed-in -> signed-out
+         * render and reconciles it as an UPDATE to the existing navigator
+         * rather than a fresh mount: the native stack's navigation STATE
+         * can survive, including "the current route is settings", even
+         * though "settings" is no longer among this tree's declared
+         * screens.
+         *
+         * TESTED ALONE, ON-DEVICE, AND IT WAS NOT ENOUGH: adding just this
+         * key still left a real sign-out showing Settings with nulled-out
+         * data (account row fell back to "Signed in", computer to "None
+         * selected") instead of landing on sign-in — changing which screens
+         * are registered is still not the same as telling expo-router to
+         * navigate anywhere, key or no key. The actual fix is the
+         * `router.dismissTo("/sign-in")` effect above, which acts on
+         * expo-router's own href tracking directly. This key is kept as
+         * cheap, correct-anyway hygiene — it makes the signed-in/signed-out
+         * boundary an honest fresh mount instead of an in-place screen-list
+         * swap — not because it redirects anything by itself.
+         */}
+        <Stack key="signed-out" screenOptions={{ contentStyle: { backgroundColor: colors.bg } }}>
           <Stack.Protected guard>
             <Stack.Screen name="sign-in" options={{ headerShown: false }} />
           </Stack.Protected>
@@ -180,6 +237,7 @@ function RootNavigator() {
     <>
       <StatusBar style={isDark ? "light" : "dark"} />
       <Stack
+        key="signed-in"
         screenOptions={{
           /**
            * The nav bar is left to the system material.

--- a/mobile/src/omg/provider.tsx
+++ b/mobile/src/omg/provider.tsx
@@ -396,6 +396,12 @@ export function OmgProvider({ children }: PropsWithChildren) {
     setBindings([]);
     setCloud(null);
     setUser(null);
+    // The redirect to sign-in lives centrally in RootNavigator
+    // (app/_layout.tsx), keyed on this flip to "signed-out" — not here —
+    // so every path to signed-out lands on sign-in, not just this one.
+    // See that file for why a redirect is needed at all (Stack.Protected
+    // changing which screens are registered doesn't navigate anywhere by
+    // itself).
     setAuthStatus("signed-out");
   }, [client]);
 


### PR DESCRIPTION
## Summary
Read PR #146 first (sign-out was silently 403ing; fixed to fail closed — local state only clears once the server confirms revocation). This PR is downstream of that: **after** a confirmed sign-out, the app left whatever signed-in screen was up (e.g. Settings) stranded on screen instead of landing on sign-in.

**Confirmed actual pre-fix behavior** (not assumed) by driving a real sign-in/sign-out cycle against `appreview@omg.dev` on a throwaway simulator: `authStatus` and local state DID update correctly on confirmed revocation (Settings' own fields visibly fell back to their signed-out defaults — "Signed in" instead of the email, "None selected" instead of "Cloud computer"). The screen just never navigated away. Tell: the header title fell back to the lowercase route name `settings` instead of its configured `"Settings"`, because that screen's `options` only exist in the signed-in `Stack.Protected` tree, and swapping which screens are *registered* per `authStatus` is not the same as telling expo-router to *navigate* anywhere.

## Fix
Two parts in `app/_layout.tsx`:
- `key="signed-in"` / `key="signed-out"` on the two per-`authStatus` `<Stack>` trees — tested **alone** first and confirmed on-device it is **not** sufficient by itself (documented in the comment). Kept as correct-anyway hygiene.
- The actual fix: a `useEffect` gated on the `authStatus` transition from `signed-in` → `signed-out`, calling `router.dismissTo("/sign-in")`. Pops through whatever was pushed back to sign-in in one step, regardless of stack depth.

**Architectural note:** this lives centrally in `RootNavigator`, not next to the Settings sign-out button, specifically so every path to signed-out is covered (session expiry, a future 401 handler), not just this one entry point. First draft put `router.dismissTo` directly in `provider.tsx`'s `signOut()` — that also worked, but only for this one call site.

Respects #146's fail-closed contract: only reacts to `authStatus` already being `signed-out`, which only happens post-confirmation. Nothing here can move the UI ahead of a confirmed revocation.

Also updates `mobile/AGENTS.md` with two simulator-automation traps hit during verification: AXRaise needs to run before *every* interaction (window focus drifts on this shared Mac, not just once at calibration), and `System Events`' `keystroke` silently no-ops over SSH — use Quartz `CGEventPost` for keyboard input too.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Real sign-in (appreview@omg.dev) → Settings → Sign out → confirm: pre-fix repro'd (stale Settings, nulled data)
- [x] `key`-only attempt tested and confirmed insufficient
- [x] `dismissTo` fix: lands cleanly and immediately on sign-in, repeated 3x
- [x] Confirmed this only fires on confirmed revocation (fail-closed preserved)

OTA-shippable: pure JS/navigation change, no native code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)