### PR TITLE
docs(mobile): record the two 2026-08-18 OTA publishes in TESTFLIGHT.md

### DIFF
--- a/mobile/docs/TESTFLIGHT.md
+++ b/mobile/docs/TESTFLIGHT.md
@@ -16,7 +16,21 @@ read off the EAS docs.
 | iOS credentials | distribution certificate + provisioning profile, on EAS |
 | ASC API key | `P37PJ5VSHN`, issuer `8e538491-9c7f-4ddf-88ba-4bf3e4f81fa6`, ADMIN |
 | Latest TestFlight build | `1.0.2 (29)` — submitted, Waiting for Review |
-| EAS Update | live, branch `production`, runtimeVersion policy `appVersion`; last group `b6c8a104` (2026-08-18, `gitCommitHash b5dcde4`, `#149`+`#150`) |
+| EAS Update | live, branch `production`, runtimeVersion policy `appVersion`; last group `2ddf6471` (2026-08-18, `gitCommitHash 276b1e2`, `#152`+`#153`) — see the publish log below |
+
+## Publish log (`production` channel)
+
+The channel's real history, so it's legible from the repo instead of only
+`eas update:list`. Add a row here on every publish — commit hash and group id,
+both independently confirmed with `eas update:view <group-id>`, not just "the
+command didn't error."
+
+| Date | Group | `gitCommitHash` | Carries | Native-compat gate |
+|---|---|---|---|---|
+| 2026-08-16 | `7c6c1c91` | `9367263` (`#114`) | No in-app links to an external purchase, plus the composer/session-list fixes before it | Last publish before the `expo-iap` (`#115`) native-module gap — see below |
+| *(stalled ~2 days)* | | | `#115`–`#148` merged but held: `expo-iap` landed as a new native dependency and nothing had verified build 24 could take it | — this is the gap the 2026-08-18 gate procedure exists to close |
+| 2026-08-18 | `b6c8a104` | `b5dcde4` (`#149`+`#150`) | List-overlap detector (diagnostic, Benny's account only), cold-load list-motion fix | Cleared: `expo-iap` confirmed guarded (`requireOptionalNativeModule`, no top-level import) and safe on build 24 despite the module being genuinely absent from that binary; `expo-linear-gradient` confirmed already compiled into build 24 pre-dating `#131`. Both verified with `strings` on the actual build-24/26 IPAs, not inferred. Full writeup: `#151`. |
+| 2026-08-18 | `2ddf6471` | `276b1e2` (`#152`+`#153`) | Sign-in submit button alignment (Yoga centring fix) + "omg.dev" branding on the welcome screen; sign-out now redirects to sign-in on every signed-out path (fail-closed, after confirmed server-side revocation — see `#146`) | `mobile/package.json` and `mobile/app.json` confirmed byte-identical to the already-cleared `b5dcde4` state — no new native surface, nothing to re-verify beyond the diff itself |
 
 ## Which change needs which pipeline
 


### PR DESCRIPTION
## Summary
- Closes out the doc work started in #151: adds a "Publish log" table to `mobile/docs/TESTFLIGHT.md` recording the `production` channel's actual history — group id, commit hash, what it carried, and how the native-compat gate was cleared for each publish — so it's legible from the repo rather than only `eas update:list`.
- Records both of today's publishes: `b6c8a104` (#149 + #150) and `2ddf6471` (#152 + #153).

## Test plan
- [x] Doc-only change.
- [x] Group ids and commit hashes cross-checked against `eas update:view` output captured during both publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)