### PR TITLE
fix(web): the connect dialog opens on the click, not the tab

### DIFF
--- a/test/auth-popup.test.ts
+++ b/test/auth-popup.test.ts
@@ -1,66 +1,27 @@
-// The sign-in tab, and the guarantee that it is never blank.
+// The connect-agent sign-in: dialog first, tab second.
 //
-// The bug this covers: "onboarding connect Claude opens a blank page". The tab
-// has to be opened inside the click, but the URL it needs only exists a server
-// round trip later — so the old code parked the user on `about:blank` for the
-// length of that trip, and closed the tab outright whenever the trip failed.
-// These tests pin the property that replaced it: a tab opened through
-// openAuthTab always has content, and every exit path either navigates it or
-// explains itself in it.
+// The bug behind these tests was "onboarding connect Claude opens a blank
+// page". The sign-in URL does not exist until the server has spawned a
+// provider CLI and scraped its stdout, but `window.open` is only trusted
+// inside the synchronous part of a click — so the original code opened a tab
+// immediately and awaited the URL inside it, parking the user on
+// `about:blank` for the length of the round trip.
+//
+// The first fix wrote a holding page into that tab. It removed the blankness
+// but kept the shape: the address bar still read `about:blank`, and the popup
+// still had to survive an await.
+//
+// This is the shape that removes the problem instead of dressing it: the CLICK
+// opens the DIALOG, the dialog owns the wait, and its own button opens the tab
+// from a fresh gesture straight at the provider. These tests pin that the wait
+// is always visible and that nothing opens a tab speculatively.
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
-import {
-  escapeHtml,
-  failureDocument,
-  isAuthorizationUrl,
-  openAuthTab,
-  waitingDocument,
-} from "../web/src/lib/auth-popup.ts";
+import { isAuthorizationUrl } from "../web/src/lib/auth-popup.ts";
 
-/** The parts of a popup handle the carrier actually touches. */
-function fakeTab() {
-  const written: string[] = [];
-  const tab = {
-    closed: false,
-    opener: {} as unknown,
-    focused: 0,
-    location: {
-      replaced: [] as string[],
-      replace(url: string) {
-        this.replaced.push(url);
-      },
-    },
-    document: {
-      open() {},
-      write(html: string) {
-        written.push(html);
-      },
-      close() {},
-    },
-    focus() {
-      tab.focused += 1;
-    },
-    close() {
-      tab.closed = true;
-    },
-  };
-  return { tab, written };
-}
-
-function withWindow(
-  open: (url: string, target: string) => unknown,
-  run: () => void,
-): void {
-  const previous = (globalThis as { window?: unknown }).window;
-  (globalThis as { window?: unknown }).window = { open };
-  try {
-    run();
-  } finally {
-    (globalThis as { window?: unknown }).window = previous;
-  }
-}
+const app = readFileSync("web/src/App.tsx", "utf8");
 
 describe("authorization URL validation", () => {
   test("accepts the http(s) URLs a provider can actually serve", () => {
@@ -68,9 +29,9 @@ describe("authorization URL validation", () => {
     expect(isAuthorizationUrl("http://localhost:1455/auth")).toBe(true);
   });
 
-  test("rejects everything that would leave the tab blank or worse", () => {
-    // A CLI's URL is scraped out of its stdout, so drift lands here rather
-    // than in the tab.
+  test("rejects everything that would open nowhere", () => {
+    // The URL is regexed out of CLI output, so drift lands here rather than in
+    // a tab the user is looking at.
     expect(isAuthorizationUrl(undefined)).toBe(false);
     expect(isAuthorizationUrl("")).toBe(false);
     expect(isAuthorizationUrl("about:blank")).toBe(false);
@@ -80,162 +41,74 @@ describe("authorization URL validation", () => {
   });
 });
 
-describe("the tab is never contentless", () => {
-  test("opening one writes its document in the same call", () => {
-    const { tab, written } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        const pending = openAuthTab("Claude");
-        expect(pending.opened).toBe(true);
-        // Written BEFORE any caller can await: this is the whole fix.
-        expect(written).toHaveLength(1);
-        expect(written[0]).toContain("Opening Claude sign in…");
-      },
-    );
-  });
-
-  test("severs the child's back-reference to the host", () => {
-    const { tab } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        openAuthTab("Claude");
-        expect(tab.opener).toBeNull();
-      },
-    );
-  });
-
-  test("settling navigates the tab it already holds", () => {
-    const { tab } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        const pending = openAuthTab("Codex");
-        expect(pending.settle("https://auth.openai.com/codex/device")).toBe(true);
-        expect(tab.location.replaced).toEqual(["https://auth.openai.com/codex/device"]);
-        expect(tab.focused).toBe(1);
-      },
-    );
-  });
-
-  test("refuses to settle on a URL that is not a sign-in page", () => {
-    const { tab } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        const pending = openAuthTab("Claude");
-        expect(pending.settle(undefined)).toBe(false);
-        expect(pending.settle("javascript:alert(1)")).toBe(false);
-        expect(tab.location.replaced).toEqual([]);
-        // Still open, still showing the waiting document — never navigated
-        // somewhere blank.
-        expect(tab.closed).toBe(false);
-      },
-    );
-  });
-
-  test("failing repaints the tab instead of closing it", () => {
-    const { tab, written } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        const pending = openAuthTab("Claude");
-        pending.fail("Install the Claude CLI before signing in");
-        // The popup holds focus, so the reason has to be IN it — a toast on
-        // the host page is behind the window the user is looking at.
-        expect(tab.closed).toBe(false);
-        expect(written).toHaveLength(2);
-        expect(written[1]).toContain("Install the Claude CLI before signing in");
-      },
-    );
-  });
-
-  test("settling a closed tab reports failure rather than throwing", () => {
-    const { tab } = fakeTab();
-    withWindow(
-      () => tab,
-      () => {
-        const pending = openAuthTab("Claude");
-        tab.closed = true;
-        expect(pending.settle("https://claude.ai/oauth/authorize")).toBe(false);
-        expect(() => pending.fail("gone")).not.toThrow();
-        expect(() => pending.close()).not.toThrow();
-      },
-    );
-  });
-
-  test("a blocked popup is reported, not faked", () => {
-    withWindow(
-      () => null,
-      () => {
-        const pending = openAuthTab("Claude");
-        expect(pending.opened).toBe(false);
-        expect(pending.settle("https://claude.ai/oauth/authorize")).toBe(false);
-        // The caller falls back to the in-page button; nothing here throws.
-        expect(() => pending.fail("blocked")).not.toThrow();
-      },
-    );
-  });
-
-  test("a window.open that throws degrades to 'not opened'", () => {
-    withWindow(
-      () => {
-        throw new Error("blocked by policy");
-      },
-      () => {
-        expect(openAuthTab("Claude").opened).toBe(false);
-      },
-    );
-  });
-});
-
-describe("the documents it writes", () => {
-  test("both are complete documents, not fragments", () => {
-    for (const html of [waitingDocument("Claude"), failureDocument("nope")]) {
-      expect(html.startsWith("<!doctype html>")).toBe(true);
-      expect(html).toContain("<body>");
-    }
-  });
-
-  test("provider names and server errors are escaped, never markup", () => {
-    expect(escapeHtml('<img src=x onerror="alert(1)">')).toBe(
-      "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
-    );
-    expect(waitingDocument("<script>")).not.toContain("<script>");
-    expect(failureDocument("<script>bad</script>")).not.toContain("<script>bad");
-  });
-
-  test("reduced motion keeps a live affordance instead of a frozen ring", () => {
-    // A still spinner reads as hung, which is the same failure this module
-    // exists to remove.
-    expect(waitingDocument("Claude")).toContain("prefers-reduced-motion");
-  });
-});
-
-describe("App wiring", () => {
-  const app = readFileSync("web/src/App.tsx", "utf8");
-
-  test("no login path opens a raw blank tab any more", () => {
+describe("no login path opens a tab speculatively", () => {
+  test("nothing opens a blank or placeholder tab", () => {
     expect(app).not.toContain('window.open("about:blank"');
+    expect(app).not.toContain('window.open("", "_blank")');
+    expect(app).not.toContain("openAuthTab");
   });
 
-  test("startBrowserAuth drives the carrier", () => {
-    expect(app).toContain("const authTab = openAuthTab(providerLabel)");
-    expect(app).toContain("if (authTab.settle(session.authorizationUrl)) return;");
-  });
-
-  test("a failed start explains itself in the tab", () => {
-    expect(app).toContain("authTab.fail(message)");
-  });
-
-  test("the tab is only closed when the host owns what happens next", () => {
-    // Exactly one close(): the "already connected" branch, which has no page
-    // left to show and reports on the host surface instead.
-    expect(app.match(/authTab\.close\(\)/g)).toHaveLength(1);
-  });
-
-  test("the in-panel button refuses a URL that is not a sign-in page", () => {
+  test("the only window.open is the dialog's own button, on a real URL", () => {
+    // Call sites only — prose in a comment must not count, or this test
+    // fails on documentation.
+    const opens = app.match(/window\.open\([^)\s]/g) ?? [];
+    expect(opens).toHaveLength(1);
+    expect(app).toContain(
+      'window.open(session.authorizationUrl, "_blank", "noopener,noreferrer")',
+    );
+    // Gated, so the button cannot exist for a URL that opens nowhere.
     expect(app).toContain("{isAuthorizationUrl(session.authorizationUrl) ? (");
+  });
+});
+
+describe("the dialog owns the wait", () => {
+  test("pending is set before the round trip, not after", () => {
+    const fn = app.slice(
+      app.indexOf("async function startBrowserAuth"),
+      app.indexOf("async function loginCodingAgent"),
+    );
+    const pendingAt = fn.indexOf("setCodingAgentAuthPending(providerLabel)");
+    const awaitAt = fn.indexOf("await api<CodingAgentAuthSession>");
+    expect(pendingAt).toBeGreaterThan(-1);
+    expect(awaitAt).toBeGreaterThan(-1);
+    // This ordering IS the fix: set after the await and the click again
+    // produces nothing on screen until the CLI has answered.
+    expect(pendingAt).toBeLessThan(awaitAt);
+  });
+
+  test("every exit from the round trip clears pending", () => {
+    const fn = app.slice(
+      app.indexOf("async function startBrowserAuth"),
+      app.indexOf("async function loginCodingAgent"),
+    );
+    // complete / waiting / throw — a missed one leaves a dialog that cannot
+    // be dismissed, since pending also suppresses close.
+    expect(fn.match(/setCodingAgentAuthPending\(null\)/g)).toHaveLength(3);
+  });
+
+  test("the dialog opens on pending as well as on a session", () => {
+    expect(app).toContain("open={!!session || !!pendingLabel}");
+  });
+
+  test("preparing is not dismissible, because there is nothing to cancel yet", () => {
+    expect(app).toContain("if (!open && !pendingLabel) void close();");
+  });
+
+  test("the wait states what is happening", () => {
+    expect(app).toContain("Preparing your sign-in link…");
+  });
+
+  test("the loading title names the provider rather than falling back", () => {
+    // Without the pending label the header would read "Connect Account" for
+    // the whole wait, since the session that carries the provider is null.
+    expect(app).toContain(
+      'const providerLabel = session ? authProviderLabel(session.provider) : (pendingLabel ?? "your account")',
+    );
+  });
+
+  test("inline auth suppresses the global dialog, pending included", () => {
+    expect(app).toContain(
+      "pendingLabel={codingAgentAuthInlineSid ? null : codingAgentAuthPending}",
+    );
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,7 @@ import {
   type ToolConnectOption,
 } from "./lib/embedded-connect";
 import { emitSessionCreatedToHost } from "./lib/embed-host-signal";
-import { isAuthorizationUrl, openAuthTab } from "./lib/auth-popup";
+import { isAuthorizationUrl } from "./lib/auth-popup";
 import { LFG_SMALL_ICON_PATH } from "./lib/icon-assets";
 import {
   api,
@@ -5367,6 +5367,21 @@ export function App() {
   const [keyboardOpen, setKeyboardOpen] = useState(false);
   const [codingAgents, setCodingAgents] = useState<CodingAgentInfo[]>([]);
   const [codingAgentAuth, setCodingAgentAuth] = useState<CodingAgentAuthSession | null>(null);
+  // The provider whose login is being PREPARED — set on click, before the
+  // server has answered.
+  //
+  // The dialog used to be gated on the session alone, so it could not exist
+  // until the round trip finished. That round trip spawns a provider CLI and
+  // scrapes a sign-in URL out of its stdout, which takes seconds on a cold
+  // Computer — and for that whole time the click had produced no visible UI at
+  // all. The old code filled the gap by opening a browser tab up front, which
+  // is what put people on `about:blank`.
+  //
+  // Naming the pending provider is what lets the dialog open on the CLICK and
+  // carry its own loading state. The tab is then opened by a real click on the
+  // dialog's own button, from a fresh user gesture, straight at the provider:
+  // no placeholder document, no redirect, and nothing a popup blocker can eat.
+  const [codingAgentAuthPending, setCodingAgentAuthPending] = useState<string | null>(null);
   // Auth started from a blocked session stays inside that session's transcript
   // instead of opening the global settings dialog. completedSid lets the
   // banner acknowledge success while the failed turn remains the transcript
@@ -7308,18 +7323,20 @@ export function App() {
     );
   }
 
-  // The tab is opened through openAuthTab, which paints it in the same
-  // statement — see web/src/lib/auth-popup.ts. This function then has exactly
-  // three ways to leave it, and none of them is blank:
+  // Preparing a login NEVER opens a browser tab. The dialog does, from its own
+  // button, on a second real click.
   //
-  //   settle()  the provider's sign-in page (the whole point)
-  //   fail()    the reason no page is coming, in the tab holding focus
-  //   close()   only when the HOST surface owns what happens next
+  // This function used to open a tab up front and await the round trip inside
+  // it, because `window.open` is only trusted during the synchronous part of a
+  // click and the sign-in URL does not exist until a provider CLI has been
+  // spawned and its stdout scraped. That bought a working popup at the cost of
+  // parking the user on a blank tab for the length of the trip — the
+  // "connect Claude opens about:blank" report.
   //
-  // The old code opened `about:blank` and awaited a round trip that spawns a
-  // provider CLI and scrapes its stdout for a URL. The user watched a blank
-  // page for however long that took, and every failure path closed the tab and
-  // toasted behind the popup that had just stolen focus.
+  // Opening the DIALOG on the click instead satisfies the same "show something
+  // immediately" requirement without needing the tab to exist yet, and the tab
+  // it eventually opens is a direct open on the real URL from a fresh gesture:
+  // correct address bar, no placeholder, and impossible to popup-block.
   async function startBrowserAuth(
     kind: AgentKind | "github",
     path: string,
@@ -7329,7 +7346,8 @@ export function App() {
   ) {
     setCodingAgentAuthInlineSid(inlineSid ?? null);
     if (inlineSid) setCodingAgentAuthCompletedSid(null);
-    const authTab = openAuthTab(providerLabel);
+    // Before the await, so the surface is on screen for the whole round trip.
+    setCodingAgentAuthPending(providerLabel);
     try {
       const session = await api<CodingAgentAuthSession>(path, {
         method: "POST",
@@ -7338,8 +7356,9 @@ export function App() {
       });
       if (session.status === "error") throw new Error(session.error || "Couldn't start login");
       if (session.status === "complete") {
-        // Already connected — nothing left to sign into, and the host says so.
-        authTab.close();
+        // Already connected — there is nothing to sign into, so the dialog has
+        // nothing to say and the toast carries it.
+        setCodingAgentAuthPending(null);
         toast.success(`${authProviderLabel(session.provider)} connected`);
         setCodingAgentAuthInlineSid(null);
         if (inlineSid) setCodingAgentAuthCompletedSid(inlineSid);
@@ -7349,23 +7368,13 @@ export function App() {
         ]);
         return;
       }
+      // The session replaces the pending placeholder in the SAME dialog, so
+      // the loading state becomes the sign-in button without a remount.
       setCodingAgentAuth(session);
-      if (authTab.settle(session.authorizationUrl)) return;
-      if (isAuthorizationUrl(session.authorizationUrl)) {
-        // The popup was blocked, so the host panel's own "Open sign in" button
-        // is the way through. It is already on screen with this session.
-        toast.message(`Allow pop-ups, or use “Open ${authProviderLabel(session.provider)} sign in”.`);
-        return;
-      }
-      // A waiting session with no usable URL means the CLI never printed one.
-      // The host panel keeps polling, so say so in the tab rather than closing
-      // it and leaving a toast behind the popup.
-      authTab.fail(
-        `${authProviderLabel(session.provider)} has not returned a sign-in link yet. Check the omg.dev tab.`,
-      );
+      setCodingAgentAuthPending(null);
     } catch (e) {
       const message = e instanceof Error ? e.message : "Couldn't start login";
-      authTab.fail(message);
+      setCodingAgentAuthPending(null);
       setCodingAgentAuthInlineSid(null);
       toast.error(message);
     }
@@ -7617,6 +7626,7 @@ export function App() {
         />
         <CodingAgentAuthDialog
           session={codingAgentAuth}
+          pendingLabel={codingAgentAuthPending}
           onSessionChange={setCodingAgentAuth}
           onComplete={completeConnectionAuth}
         />
@@ -8390,6 +8400,10 @@ export function App() {
 
       <CodingAgentAuthDialog
         session={codingAgentAuthInlineSid ? null : codingAgentAuth}
+        // Inline auth renders its own panel inside the transcript, so the
+        // global dialog must stay shut for it — pending included, or a
+        // reconnect from a blocked session would raise both surfaces at once.
+        pendingLabel={codingAgentAuthInlineSid ? null : codingAgentAuthPending}
         onSessionChange={setCodingAgentAuth}
         onComplete={completeConnectionAuth}
       />
@@ -23121,14 +23135,20 @@ function CodingAgentAuthPanel({
 
 function CodingAgentAuthDialog({
   session,
+  pendingLabel,
   onSessionChange,
   onComplete,
 }: {
   session: CodingAgentAuthSession | null;
+  /** Provider name while the login is still being prepared, before a session. */
+  pendingLabel?: string | null;
   onSessionChange: (session: CodingAgentAuthSession | null) => void;
   onComplete: () => void | Promise<void>;
 }) {
-  const providerLabel = authProviderLabel(session?.provider);
+  // Pending and session are the same dialog at two moments, so the title comes
+  // from whichever is current rather than from the session alone — otherwise
+  // the loading state would be headed "Connect Account".
+  const providerLabel = session ? authProviderLabel(session.provider) : (pendingLabel ?? "your account");
   async function close() {
     if (session && session.status !== "complete") {
       await api(`/api/coding-agents/auth/${session.id}`, { method: "DELETE" }).catch(() => {});
@@ -23136,12 +23156,23 @@ function CodingAgentAuthDialog({
     onSessionChange(null);
   }
   return (
-    <Dialog open={!!session} onOpenChange={(open) => { if (!open) void close(); }}>
+    <Dialog
+      // Open on the CLICK. The pending flag is set before the round trip, so
+      // this surface exists for the whole wait instead of appearing after it.
+      open={!!session || !!pendingLabel}
+      onOpenChange={(open) => {
+        // Not dismissible while preparing: there is no session to cancel yet,
+        // and closing would strand the CLI the server just spawned.
+        if (!open && !pendingLabel) void close();
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Connect {providerLabel}</DialogTitle>
           <DialogDescription>
-            Finish signing in in the browser. omg.dev will detect approval automatically.
+            {session
+              ? "Finish signing in in the browser. omg.dev will detect approval automatically."
+              : `Starting the ${providerLabel} sign-in on your Computer.`}
           </DialogDescription>
         </DialogHeader>
         {session ? (
@@ -23151,7 +23182,21 @@ function CodingAgentAuthDialog({
             onComplete={onComplete}
             onDismiss={() => void close()}
           />
-        ) : null}
+        ) : (
+          // The wait, given a shape. This is the state the browser tab used to
+          // stand in for — same seconds, but spent on a surface that says what
+          // is happening and keeps the user where the next control appears.
+          <div className="space-y-3 py-2">
+            <div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Preparing your sign-in link…
+            </div>
+            <p className="text-center text-xs text-muted-foreground/70">
+              Your Computer is starting the {providerLabel} CLI. The sign-in
+              button appears here when it is ready.
+            </p>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/web/src/lib/auth-popup.ts
+++ b/web/src/lib/auth-popup.ts
@@ -1,42 +1,22 @@
-// The tab a provider sign-in opens into.
+// Is this string something a browser can actually open as a sign-in page?
 //
-// WHY THIS EXISTS. Every browser login here is two steps that cannot be
-// merged: open a tab (only trusted inside the synchronous part of a click) and
-// mint an authorization URL (a server round trip that spawns a provider CLI and
-// waits for it to print one). `startBrowserAuth` therefore opened
-// `about:blank` and awaited — and `about:blank` is not "a tab that is about to
-// become the sign-in page", it is a blank page, for as long as the round trip
-// takes. On a cold Computer the CLI can take seconds to print its URL, and when
-// it never does the tab was closed out from under the user. Both read as
-// exactly one thing: "connect Claude opens a blank page".
+// The sign-in URL is not composed by us. The server spawns a provider CLI and
+// regexes the first https:// match out of its terminal output, so what arrives
+// here is whatever that scrape produced — a real authorize URL most of the
+// time, and on a bad day a fragment of a log line or nothing at all.
 //
-// The fix is not a faster round trip; it is making a contentless auth tab
-// impossible to have. Opening one through this module IS writing its document,
-// in the same statement, so there is no window in which a caller holds a tab
-// with nothing in it. From there a tab only ever ends in a state that explains
-// itself: the provider's page, or a legible failure the user can read in the
-// tab that has their attention.
+// A control that opens a non-URL is the blank tab in another costume, which is
+// the bug this file was created for. Everything that can open the provider
+// checks here first.
 //
-// The host toast is not that explanation. The popup takes focus, so a message
-// rendered behind it is a message nobody sees — which is why `fail()` paints
-// the tab rather than closing it. `close()` stays for the one case with nothing
-// to say: the login finished, or it needs input back on the host page.
+// This module used to also carry a popup "carrier" that opened `about:blank`
+// up front and wrote a holding page into it, because `window.open` is only
+// trusted inside the synchronous part of a click and the URL took a server
+// round trip to appear. That whole apparatus is gone: the dialog now opens on
+// the click and its own button opens the tab from a fresh gesture, so there is
+// never a tab waiting on a URL. The guard is what remains because it is the
+// part that was about correctness rather than about timing.
 
-/** A tab opened up-front, already showing something, waiting for a URL. */
-export interface PendingAuthTab {
-  /** False when the popup was blocked — the caller keeps its in-page fallback. */
-  readonly opened: boolean;
-  /** Point the tab at the provider. Returns false if it is gone or the URL is unusable. */
-  settle(url: string | undefined): boolean;
-  /** Show why no sign-in page is coming, in the tab the user is looking at. */
-  fail(message: string): void;
-  /** Close it — only when the host surface owns what happens next. */
-  close(): void;
-}
-
-/** Only an absolute http(s) URL can be a provider sign-in page. A CLI's URL is
- *  scraped out of its stdout, so a parse that drifts must land on a legible
- *  failure rather than navigating the tab somewhere blank (or worse). */
 export function isAuthorizationUrl(value: string | undefined): value is string {
   if (!value) return false;
   try {
@@ -45,118 +25,4 @@ export function isAuthorizationUrl(value: string | undefined): value is string {
   } catch {
     return false;
   }
-}
-
-function documentFor(body: string): string {
-  return `<!doctype html><meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sign in</title>
-<style>
-  html { color-scheme: light dark }
-  body { margin:0; min-height:100vh; display:flex; flex-direction:column; gap:14px;
-         align-items:center; justify-content:center; text-align:center; padding:24px;
-         font:500 17px/1.45 ui-sans-serif,-apple-system,system-ui,sans-serif;
-         letter-spacing:-.01em }
-  .msg { max-width:32ch; opacity:.72 }
-  .hint { font-size:14px; opacity:.5 }
-  .spinner { width:18px; height:18px; border-radius:50%; opacity:.55;
-             border:2px solid currentColor; border-top-color:transparent;
-             animation:spin .7s linear infinite }
-  @keyframes spin { to { transform:rotate(360deg) } }
-  /* A frozen ring reads as hung, so reduced motion gets a slow breath instead
-     of a still image. */
-  @media (prefers-reduced-motion:reduce) {
-    .spinner { border-top-color:currentColor; animation:pulse 1.6s ease-in-out infinite }
-    @keyframes pulse { 50% { opacity:.18 } }
-  }
-</style>
-<body>${body}</body>`;
-}
-
-export function waitingDocument(providerLabel: string): string {
-  return documentFor(
-    `<div class="spinner"></div><div class="msg">Opening ${escapeHtml(providerLabel)} sign in…</div>`,
-  );
-}
-
-export function failureDocument(message: string): string {
-  return documentFor(
-    `<div class="msg">${escapeHtml(message)}</div>` +
-      `<div class="hint">You can close this tab and try again.</div>`,
-  );
-}
-
-/** The provider label and the server's error both reach this document as text.
- *  Neither is markup, so neither is written as markup. */
-export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-/**
- * Open the sign-in tab. MUST be called synchronously from the click handler —
- * awaiting first is what gets it blocked.
- *
- * No `noopener` flag: it makes `window.open` return null by design, and the
- * handle is the entire point. The child's back-reference is severed below
- * instead, while it is still same-origin.
- */
-export function openAuthTab(providerLabel: string): PendingAuthTab {
-  let tab: Window | null = null;
-  try {
-    tab = window.open("", "_blank");
-    if (tab) {
-      try {
-        tab.opener = null;
-      } catch {
-        // Some engines make `opener` read-only. The destination is the
-        // provider's own sign-in page, not untrusted content.
-      }
-      write(tab, waitingDocument(providerLabel));
-    }
-  } catch {
-    tab = null;
-  }
-
-  return {
-    opened: tab !== null,
-    settle(url) {
-      if (!tab || tab.closed || !isAuthorizationUrl(url)) return false;
-      try {
-        tab.location.replace(url);
-        // Focus is not guaranteed, and losing it is fine — the tab exists
-        // either way, which is the part that matters.
-        tab.focus?.();
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    fail(message) {
-      if (!tab || tab.closed) return;
-      try {
-        write(tab, failureDocument(message));
-      } catch {
-        // A tab we cannot repaint still holds the waiting document, which is
-        // wrong but not blank.
-      }
-    },
-    close() {
-      if (!tab || tab.closed) return;
-      try {
-        tab.close();
-      } catch {
-        // A tab we cannot close keeps its own last message.
-      }
-    },
-  };
-}
-
-function write(tab: Window, html: string): void {
-  tab.document.open();
-  tab.document.write(html);
-  tab.document.close();
 }


### PR DESCRIPTION
## The idea

Benny's: **the click opens the dialog, and the dialog's own button opens the tab.**

## Why the previous fix was not enough

PR #147 stopped the sign-in tab from being *empty*, but kept the shape that made it empty — a tab opened before its URL existed, holding a placeholder document. Two things survived:

1. **The address bar still read `about:blank`** for the whole round trip, because writing a document into a tab does not change its URL. That is exactly what got reported next.
2. **The popup still had to survive an `await`**, so a slow Computer could still lose it to a popup blocker.

## What changed

The dialog **already existed** and already had everything: the "Open sign in" button, the one-time code box, the paste field, the approval spinner. It was gated on the session — which only exists *after* the round trip — so it could not be shown during the wait.

`codingAgentAuthPending` is that missing state. It is set **before** the await, so the surface is on screen for the entire wait instead of after it:

```
click → dialog opens now, "Preparing your sign-in link…"
      → URL arrives → same dialog swaps to the button
      → you click it → provider opens directly
```

## What it buys

- the tab opens **at the provider URL**, from a fresh user gesture — correct address bar, no redirect, nothing a popup blocker can eat
- the wait happens **where the next control appears**, not in a window that stole focus
- a failure has somewhere to be read that is not behind that window

The popup carrier is deleted. Only `isAuthorizationUrl` survives, because that one was about correctness — the URL is regexed out of CLI stdout — rather than about timing. **Net −216 lines.**

## The cost

One extra click, accepted deliberately. This is a once-per-machine step, and being certain the instructions are seen is worth more than saving a click on it.

## Verification

In real Chrome:

- **0.8s after the click** — dialog reads "Preparing your sign-in link…", and `tab list` shows **no second tab at all**
- **after the round trip** — the same dialog swaps to "Open Claude sign in"
- **clicking it** — opens `example.com/signin` directly; `about:blank` never appears

Plus 11 tests rewritten for the new contract (including one that pins `setCodingAgentAuthPending` *before* the await, since that ordering is the fix), the full suite showing the same pre-existing failures as a clean tree, and both `build:packages` and `web build` passing.
