### PR TITLE
fix(mobile): correct the overlap detector's own measurement math

### DIFF
--- a/mobile/src/omg/list-overlap-watch.tsx
+++ b/mobile/src/omg/list-overlap-watch.tsx
@@ -5,18 +5,7 @@
  * blank gaps elsewhere, on his real device — see the screenshot referenced in
  * the bug this file was added for. The content was always correct; only the
  * POSITIONS were wrong, which is the signature of a view left somewhere its
- * data no longer says it should be. `motion.tsx` already root-caused and
- * fixed one confirmed way that happens (a `exiting` animation stranding a
- * view out of flow when a re-render interrupts it — see that file's
- * "DO NOT ADD ONE" note) — but that fix has been reproduced, verified, and
- * live on a large real account without reproducing Benny's report again, so
- * either the fix is incomplete for some third path, or the failure needs
- * real-device timing (a Mac-hosted simulator has far more UI-thread headroom
- * than his phone) that a dev box cannot manufacture.
- *
- * Rather than guess at a fix for a mechanism nobody has caught in the act,
- * this instruments the actual invariant: no two rows should ever occupy
- * overlapping vertical space on screen. `Row` wraps each top-level list item,
+ * data no longer says it should be. `Row` wraps each top-level list item,
  * measures its own on-screen frame after every layout pass via
  * `measureInWindow` (window coordinates, so rows in different sections —
  * different parent Views — are still comparable), and a debounced check
@@ -24,20 +13,50 @@
  * order, which would need its own bookkeeping and isn't the thing that can
  * go wrong here) and flags any pair whose vertical ranges intersect.
  *
+ * THIS FILE HAD A BUG, AND IT MATTERS WHO IT REACHED. The original
+ * verification math was `prevBottom - curTop`, which silently assumes prev
+ * is still above cur. A re-measurement does not guarantee that: if prev has
+ * since settled somewhere well below cur, that formula turns a huge
+ * SEPARATION into a huge fake OVERLAP. This shipped to Benny's device (the
+ * real report that read "idle over recent, 57pt, 37 rows" is unverified —
+ * it may be a genuine catch or it may be exactly this bug) before the fix
+ * below existed. Fixed to the symmetric interval formula — `min(bottoms) -
+ * max(tops)` — which is correct regardless of which row ends up on top the
+ * second time.
+ *
+ * THE VERIFICATION ITSELF, added after a wave of suppressing every
+ * Reanimated `entering`/`layout` animation on the list (see app/index.tsx)
+ * still did not stop this from firing: a candidate hit schedules a SECOND,
+ * independent `measureInWindow` pass on just the two offending rows after
+ * `VERIFY_DELAY_MS`, and only reports if the SAME overlap survives. This is
+ * what turned "two numbers that didn't match once" into "did this settle,"
+ * and what proved — once the formula above was also fixed — that on this
+ * simulator every candidate the detector has caught since has been a row
+ * mid-relocation (typically an Auto row, moving 900-2000pt to its true
+ * position), not a sustained overlap. That does not mean the bug is
+ * imaginary — Benny's original screenshot, taken before this file existed,
+ * is real, undebatable photographic evidence, and this simulator resolving
+ * every candidate within `VERIFY_DELAY_MS` is consistent with the same
+ * transient simply taking longer to settle on a loaded real device than on
+ * a fast Mac. It means don't trust a raw "overlap found" line from before
+ * this fix, on this device or his, as a confirmed finding on its own.
+ *
  * On a hit: a console.error, unconditionally — harmless in a production
  * build with nobody attached to Metro, and free evidence the moment anyone
  * ever is. The TOAST is separate and deliberately gated: this is a
  * diagnostic for one bug report, not a feature, and a red "internal error"
  * toast firing on some unrelated user's phone for a transient, self-
- * correcting, sub-second layout race would be a worse experience than the
- * bug it is trying to catch. `notifyUser` decides whether the toast fires;
- * callers should pass it only for the account that reported this (see
+ * correcting layout race would be a worse experience than the bug it is
+ * trying to catch. `notifyUser` decides whether the toast fires; callers
+ * should pass it only for the account that reported this (see
  * `app/index.tsx`), or `__DEV__`, never unconditionally for everyone on the
  * production channel.
  *
- * Fires at most once per screen mount — this is a smoke detector, not a
- * running log, and a list that is actually broken will have plenty of other
- * evidence once this alarm has gone off once.
+ * Fires at most once per screen mount, ONCE VERIFIED — this is a smoke
+ * detector, not a running log, and a list that is actually broken will have
+ * plenty of other evidence once this alarm has gone off once. An unverified
+ * candidate that fails its re-check logs a `console.warn` and the check
+ * keeps running — a later, genuine hit is still caught.
  *
  * Deliberately NOT wired into SessionCard/AutoFindingCard themselves: `Row`
  * is a plain, un-animated `View` wrapped one level OUTSIDE those components,
@@ -56,11 +75,42 @@ type RowMeasurement = { id: string; top: number; bottom: number };
 const OVERLAP_THRESHOLD = 6;
 /** Let a burst of layout passes settle before judging the result. */
 const CHECK_DEBOUNCE_MS = 400;
+/**
+ * `measureInWindow` is itself async — its callback resolves on a later tick,
+ * not synchronously with the `onLayout` that requested it. Under a burst of
+ * concurrent layout passes (many rows re-laying-out close together), two
+ * rows' callbacks can resolve out of order relative to the actual native
+ * tree, so the FIRST detection may be comparing one row's fresh frame
+ * against another's already-stale one — a measurement race in this file,
+ * not necessarily a real simultaneous overlap on screen. Before reporting,
+ * re-measure the two offending rows fresh after a short quiet beat and only
+ * report if the SAME overlap still holds. This is what turns "two numbers
+ * that didn't match once" into "two rows genuinely occupying the same
+ * pixels," which matters because both are real findings but only one is a
+ * bug in the app rather than in this instrument.
+ */
+const VERIFY_DELAY_MS = 200;
 
 export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: boolean) {
   const measurements = useRef(new Map<string, RowMeasurement>());
+  const rowRefs = useRef(new Map<string, React.RefObject<View | null>>());
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const firedRef = useRef(false);
+
+  const measureNow = useCallback(
+    (id: string): Promise<RowMeasurement | null> =>
+      new Promise((resolve) => {
+        const ref = rowRefs.current.get(id);
+        if (!ref?.current) {
+          resolve(null);
+          return;
+        }
+        ref.current.measureInWindow((_x, y, _width, height) => {
+          resolve({ id, top: y, bottom: y + height });
+        });
+      }),
+    [],
+  );
 
   const runCheck = useCallback(() => {
     if (firedRef.current) return;
@@ -70,21 +120,50 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
       const cur = rows[i];
       const overlap = prev.bottom - cur.top;
       if (overlap > OVERLAP_THRESHOLD) {
-        firedRef.current = true;
-        const message = `List rows overlap: "${prev.id}" over "${cur.id}" by ${Math.round(
-          overlap,
-        )}pt (${rows.length} rows on screen)`;
-        // eslint-disable-next-line no-console
-        console.error("[list-overlap-watch]", message, {
-          prev,
-          cur,
-          allRows: rows,
-        });
-        if (notifyUser) toast.show(message, { intent: "error" });
+        // Candidate hit — verify before committing to it. Nothing else in
+        // this pass can fire while a verification is in flight (firedRef
+        // only gets set once the verification actually confirms), so a
+        // real, sustained overlap will simply be re-caught on the next
+        // debounced check if this particular candidate turns out stale.
+        void (async () => {
+          await new Promise((r) => setTimeout(r, VERIFY_DELAY_MS));
+          const [freshPrev, freshCur] = await Promise.all([measureNow(prev.id), measureNow(cur.id)]);
+          if (!freshPrev || !freshCur) return;
+          // SYMMETRIC interval overlap, not `freshPrev.bottom - freshCur.top`
+          // — that formula silently assumes prev is still above cur, which
+          // the first pass guarantees (rows are sorted by top before this
+          // runs) but a re-measurement does NOT: if prev has since settled
+          // to a position well below cur, `prev.bottom - cur.top` is a huge
+          // POSITIVE number that means "far apart, wrong order," not
+          // "overlapping" — min(bottoms) - max(tops) is correct regardless
+          // of which one ended up on top the second time.
+          const freshOverlap =
+            Math.min(freshPrev.bottom, freshCur.bottom) - Math.max(freshPrev.top, freshCur.top);
+          if (freshOverlap <= OVERLAP_THRESHOLD) {
+            // eslint-disable-next-line no-console
+            console.warn("[list-overlap-watch] candidate did not survive verification — measurement race, not a real overlap", {
+              candidate: { prev, cur, overlap },
+              reverified: { freshPrev, freshCur, freshOverlap },
+            });
+            return;
+          }
+          if (firedRef.current) return;
+          firedRef.current = true;
+          const message = `List rows overlap: "${prev.id}" over "${cur.id}" by ${Math.round(
+            freshOverlap,
+          )}pt (${rows.length} rows on screen) — VERIFIED twice`;
+          // eslint-disable-next-line no-console
+          console.error("[list-overlap-watch]", message, {
+            firstMeasurement: { prev, cur, overlap },
+            reverified: { freshPrev, freshCur, freshOverlap },
+            allRows: rows,
+          });
+          if (notifyUser) toast.show(message, { intent: "error" });
+        })();
         return;
       }
     }
-  }, [toast, notifyUser]);
+  }, [toast, notifyUser, measureNow]);
 
   const report = useCallback(
     (id: string, top: number, bottom: number) => {
@@ -97,6 +176,7 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
 
   const unregister = useCallback((id: string) => {
     measurements.current.delete(id);
+    rowRefs.current.delete(id);
   }, []);
 
   /**
@@ -108,6 +188,7 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
   const Row = useMemo(() => {
     return function OverlapWatchRow({ id, children }: { id: string; children: React.ReactNode }) {
       const ref = useRef<View>(null);
+      rowRefs.current.set(id, ref);
       const onLayout = useCallback(
         (_e: LayoutChangeEvent) => {
           // The layout event's own `nativeEvent.layout` is PARENT-relative,


### PR DESCRIPTION
## Summary
The verification math added to `list-overlap-watch.tsx` was itself wrong, and it shipped to Benny's device (in the same OTA as #149/#150) before this fix existed — **the real-device report ("idle over recent, 57pt, 37 rows") that prompted this fix is now unverified, not confirmed.**

- **The bug**: the re-check compared `prevBottom - curTop`, which silently assumes `prev` is still above `cur`. It isn't guaranteed to be — a row can relocate 1000+pt between the first candidate measurement and the verification pass (this build's own data showed exactly that: an Auto row jumping from `top=879` to `top=2072`). When that happens, `prev.bottom - cur.top` is a huge POSITIVE number meaning "far apart, wrong order," not "overlapping" — and the old formula reported it as a confirmed hit anyway.
- **The fix**: symmetric interval-overlap formula — `min(bottoms) - max(tops)` — correct regardless of which row ends up on top the second time.
- **What this reveals**: with the formula fixed, and separately with every Reanimated `entering`/`layout` animation on the list forced permanently off (to rule out animation timing entirely — it does not explain this), every candidate the detector has caught on the simulator since has failed re-verification: the "overlap" was a row still finding its on-screen position (typically an Auto row, mid-relocation by 900-2000pt), not a sustained visual bug.
- **This does not mean the bug is imaginary.** Benny's original screenshot, taken before any of this instrumentation existed, is real photographic evidence and stands on its own. It means a raw "overlap found" console line from *before* this fix — on this simulator or his phone — was never confirmed evidence, only a candidate.

## Why this is the priority
Until this lands (OTA), any further real-device report from the detector is untrustworthy, and Benny is the only person who can currently see this bug live. This is the highest-value thing to ship before the next investigation step (coalescing the three independent data sources feeding the list, which is the current working theory for the actual mechanism).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `expo export --platform ios` clean
- [x] Zero behavior change beyond the verification pass itself — same console.error/toast contract, same gating (Benny's account or `__DEV__`), same one-shot-per-mount semantics (now keyed to a VERIFIED hit rather than a raw candidate)
- [ ] Confirm on Benny's device that a future report comes with `— VERIFIED twice` in the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)