### PR TITLE
fix(mobile): add tiebreaker diagnostics to the overlap detector

### DIFF
--- a/mobile/src/omg/list-overlap-watch.tsx
+++ b/mobile/src/omg/list-overlap-watch.tsx
@@ -41,6 +41,20 @@
  * a fast Mac. It means don't trust a raw "overlap found" line from before
  * this fix, on this device or his, as a confirmed finding on its own.
  *
+ * A VERIFIED hit is real, but on its own it still can't tell apart the two
+ * live theories for WHY: (a) one section mounted a large batch of new rows
+ * in one commit and an early row measured before the batch finished, or (b)
+ * two independently-timed data sources (sessions vs. auto findings vs.
+ * resumable) changed close enough together to race each other. Both predict
+ * a verified overlap; they don't predict the same SHAPE of one. So a
+ * confirmed hit's payload also carries `diagnostics`: which sections had any
+ * row report in the `ACTIVITY_WINDOW_MS` before the hit, how many rows in
+ * each were mounting for the first time, and how long the screen had been up
+ * — a big new-mount count in ONE section supports (a); meaningful activity
+ * in TWO sections at once supports (b); and time-since-mount says whether
+ * this is cold-load-adjacent or recurs well into a session. This turns the
+ * next real hit into a tiebreaker instead of just more confirmation.
+ *
  * On a hit: a console.error, unconditionally — harmless in a production
  * build with nobody attached to Metro, and free evidence the moment anyone
  * ever is. The TOAST is separate and deliberately gated: this is a
@@ -71,10 +85,28 @@ import type { useToast } from "./toast";
 
 type RowMeasurement = { id: string; top: number; bottom: number };
 
+/**
+ * `id` is always `"<section>:<key>"` (see app/index.tsx's four call sites —
+ * `working:`, `idle:`, `auto:`, `recent:`). Splitting it back out is what
+ * lets a hit's diagnostic answer "was this cross-section or one section
+ * mounting a big batch" without adding a second prop just to carry it.
+ */
+function sectionOf(id: string): string {
+  return id.split(":", 1)[0] ?? id;
+}
+
 /** How much intersection counts as a real overlap, not float/rounding noise. */
 const OVERLAP_THRESHOLD = 6;
 /** Let a burst of layout passes settle before judging the result. */
 const CHECK_DEBOUNCE_MS = 400;
+/**
+ * How far back to look, from the moment a candidate is found, when building
+ * "what else was mounting or reporting around the same time" context. Wide
+ * enough to catch a batch that mounted over several of this file's own
+ * CHECK_DEBOUNCE_MS-spaced passes, not so wide it drags in unrelated churn
+ * from a different poll cycle entirely.
+ */
+const ACTIVITY_WINDOW_MS = 1500;
 /**
  * `measureInWindow` is itself async — its callback resolves on a later tick,
  * not synchronously with the `onLayout` that requested it. Under a burst of
@@ -96,6 +128,49 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
   const rowRefs = useRef(new Map<string, React.RefObject<View | null>>());
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const firedRef = useRef(false);
+  /** When this hook itself first ran — a proxy for "screen mounted." */
+  const hookMountedAt = useRef(Date.now());
+  /** First time EACH id was ever reported — answers "is this row new." */
+  const firstSeenAt = useRef(new Map<string, number>());
+  /**
+   * Every report, kept for `ACTIVITY_WINDOW_MS` and no longer — this is what
+   * lets a hit's diagnostic say which sections were active and how many rows
+   * newly mounted in the run-up to it, discriminating "one section mounted a
+   * big batch" from "two sections changed close together" without needing a
+   * second catch to guess between them.
+   */
+  const activityLog = useRef<{ id: string; section: string; at: number; isNewMount: boolean }[]>(
+    [],
+  );
+
+  /**
+   * What was happening in the `ACTIVITY_WINDOW_MS` before `now` — the
+   * tiebreaker data. Answers, for a confirmed hit: which section(s) had
+   * ANY row report during the run-up (cross-section activity, or just the
+   * two offending rows' own section), how many rows in each section were
+   * mounting for the FIRST time (a large count in one section supports
+   * "big single-section mount batch"; a small count across two sections
+   * supports "cross-source coalescing"; neither points at growth from row
+   * height changes, e.g. an expanding finding), and how long the screen had
+   * been up (cold-load-adjacent vs. happens well into a session too).
+   */
+  const buildDiagnostics = useCallback((now: number) => {
+    const cutoff = now - ACTIVITY_WINDOW_MS;
+    const recent = activityLog.current.filter((r) => r.at >= cutoff);
+    const newMountsBySection: Record<string, number> = {};
+    const reportsBySection: Record<string, number> = {};
+    for (const r of recent) {
+      reportsBySection[r.section] = (reportsBySection[r.section] ?? 0) + 1;
+      if (r.isNewMount) newMountsBySection[r.section] = (newMountsBySection[r.section] ?? 0) + 1;
+    }
+    return {
+      timeSinceScreenMountMs: now - hookMountedAt.current,
+      activityWindowMs: ACTIVITY_WINDOW_MS,
+      sectionsActiveInWindow: Object.keys(reportsBySection).sort(),
+      reportsBySectionInWindow: reportsBySection,
+      newMountsBySectionInWindow: newMountsBySection,
+    };
+  }, []);
 
   const measureNow = useCallback(
     (id: string): Promise<RowMeasurement | null> =>
@@ -139,21 +214,28 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
           // of which one ended up on top the second time.
           const freshOverlap =
             Math.min(freshPrev.bottom, freshCur.bottom) - Math.max(freshPrev.top, freshCur.top);
+          const diagnostics = buildDiagnostics(Date.now());
           if (freshOverlap <= OVERLAP_THRESHOLD) {
             // eslint-disable-next-line no-console
             console.warn("[list-overlap-watch] candidate did not survive verification — measurement race, not a real overlap", {
               candidate: { prev, cur, overlap },
               reverified: { freshPrev, freshCur, freshOverlap },
+              diagnostics,
             });
             return;
           }
           if (firedRef.current) return;
           firedRef.current = true;
+          const prevSection = sectionOf(prev.id);
+          const curSection = sectionOf(cur.id);
           const message = `List rows overlap: "${prev.id}" over "${cur.id}" by ${Math.round(
             freshOverlap,
-          )}pt (${rows.length} rows on screen) — VERIFIED twice`;
+          )}pt (${rows.length} rows on screen, ${
+            prevSection === curSection ? `same section: ${prevSection}` : `${prevSection} x ${curSection}`
+          }, ${diagnostics.timeSinceScreenMountMs}ms since mount) — VERIFIED twice`;
           // eslint-disable-next-line no-console
           console.error("[list-overlap-watch]", message, {
+            diagnostics,
             firstMeasurement: { prev, cur, overlap },
             reverified: { freshPrev, freshCur, freshOverlap },
             allRows: rows,
@@ -167,6 +249,17 @@ export function useOverlapWatch(toast: ReturnType<typeof useToast>, notifyUser: 
 
   const report = useCallback(
     (id: string, top: number, bottom: number) => {
+      const now = Date.now();
+      const isNewMount = !firstSeenAt.current.has(id);
+      if (isNewMount) firstSeenAt.current.set(id, now);
+      activityLog.current.push({ id, section: sectionOf(id), at: now, isNewMount });
+      // Trim from the front — entries are pushed in chronological order, so
+      // this is the oldest-first end, and this can't grow unbounded over a
+      // long-running screen.
+      const cutoff = now - ACTIVITY_WINDOW_MS;
+      while (activityLog.current.length && activityLog.current[0].at < cutoff) {
+        activityLog.current.shift();
+      }
       measurements.current.set(id, { id, top, bottom });
       if (timer.current) clearTimeout(timer.current);
       timer.current = setTimeout(runCheck, CHECK_DEBOUNCE_MS);


### PR DESCRIPTION
## Summary
A VERIFIED hit from #156 is real, but on its own it can't distinguish the two live theories for why:
- **(a) batch-mount**: one section mounted a large batch of new rows in one commit and an early row measured before the batch finished.
- **(b) cross-source race**: two independently-timed data sources (`sessions`, `useAutoAgents()`, `resumable`) changed close enough together to race each other.

Both predict a verified overlap; they don't predict the same *shape* of one. This adds the data needed to tell them apart from a single real-device hit, without touching any list behavior — pure instrumentation, same as #149/#156.

## What's new
A confirmed hit's payload now also carries `diagnostics`:
- `sectionsActiveInWindow` — which sections had any row report in the 1.5s before the hit
- `newMountsBySectionInWindow` — how many rows in each section were mounting for the first time vs. just re-reporting an existing row
- `timeSinceScreenMountMs` — cold-load-adjacent, or does this recur well into a session

The confirmed console/toast message itself now also states whether the pair was same-section or cross-section and how long since mount, so the headline alone is informative without opening the payload.

## Already informative from unverified candidates
Two identical rejected candidates on the simulator this session showed `idle` mounting 16 rows for the first time in the window while `auto` had 9 reports but **zero** new mounts — the Auto rows involved were not newly mounting, they were already-settled rows re-measuring during a reflow triggered by Idle's late-arriving batch above them.

That's a real refinement on the working theory: Auto isn't necessarily special on its own (its variable-height finding-title text — `numberOfLines={2}` vs. `SessionCard`'s fixed `numberOfLines={1}` — remains a plausible contributing factor for why *it* is the one that shows the transient mismatch rather than converging instantly) — Idle mounting late is the trigger, and whatever sits immediately below the section that just grew is the one at risk during the cascade.

Two identical simulator repros isn't a verified hit, so this stays a lead, not a conclusion — the point of shipping this is to get that same diagnostic data from a genuine real-device hit next.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `expo export --platform ios` clean
- [x] Zero behavior change to the list — diagnostics only affect the detector's own console.error/toast payload
- [ ] Next verified real-device hit carries useful `diagnostics` to arbitrate batch-mount vs. cross-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)