### PR TITLE
fix(mobile): don't paint Auto/Recent until Sessions has had its turn (meaningfully fewer, not eliminated)

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -390,6 +390,22 @@ export default function SessionsScreen() {
   const projectPicker = useProjectPicker();
 
   const [sessions, setSessions] = useState<OmgSession[]>([]);
+  /**
+   * HAS SESSIONS HAD ITS TURN YET — see the long note on `SESSIONS_SETTLE_TIMEOUT_MS`
+   * below for what this exists to prevent. Kept as its own flag rather than
+   * derived from `loading`/`sessions.length`, because neither means the right
+   * thing here: `loading` starts false before the first fetch has even been
+   * attempted (indistinguishable from "already resolved"), and an EMPTY
+   * `sessions` result is a fully valid, resolved answer, not an unresolved one.
+   */
+  const [sessionsSettled, setSessionsSettled] = useState(false);
+  // A machine switch invalidates this the same way it invalidates `sessions`
+  // itself (see the load() effect) — the new machine's Auto/Recent rows must
+  // wait their turn behind the new machine's OWN session list, not ride in on
+  // however settled the PREVIOUS machine's flag happened to be.
+  useEffect(() => {
+    setSessionsSettled(false);
+  }, [bindingId]);
   const [loading, setLoading] = useState(false);
   /**
    * ONLY A PULL SPINS THE SPINNER.
@@ -592,10 +608,66 @@ export default function SessionsScreen() {
         if (!quiet) setError(e instanceof Error ? e.message : String(e));
       } finally {
         if (!quiet) setLoading(false);
+        // Resolved — success OR failure, both count. An empty or errored
+        // result is a fully answered question, not an unanswered one; see
+        // `sessionsSettled`'s own doc comment for why this can't be derived
+        // from `loading` or `sessions.length` instead. This line is only
+        // reached once the `!client || !ready` guard above has already been
+        // passed, so a machine that's still waking never marks itself
+        // settled by accident — see the timeout below for what covers a
+        // machine that never finishes waking at all.
+        setSessionsSettled(true);
       }
     },
     [client, ready],
   );
+
+  /**
+   * WHY AUTO/RECENT CAN PAINT BEFORE WORKING/IDLE, AND WHY THAT IS THE BUG.
+   *
+   * `load()` above gates on `ready` — the machine's own wake/probe round
+   * trip has to finish before it even ATTEMPTS `client.listSessions()`.
+   * `useAutoAgents()` and `useResumable()` (both above) gate their own
+   * fetches on nothing but the API client existing — no readiness check —
+   * so on a machine that needs waking, Auto and Recent's requests are
+   * already in flight, and often already answered, while Sessions hasn't
+   * started yet. The result: on the first render where `ready` flips true,
+   * Auto/Recent can already have rows to show while Working/Idle are still
+   * empty — and then Sessions resolves a beat later and mounts a batch of
+   * rows ABOVE Auto, shoving it down mid-settle. list-overlap-watch.tsx
+   * caught this live, twice identically: Idle mounting late while Auto had
+   * already-settled rows re-measuring, not newly mounting ones.
+   *
+   * THE FIX: Auto and Recent do not render their rows until Sessions has
+   * had its own turn — `sessionsSettled`, set above once `load()` resolves
+   * (success OR failure both count; see that flag's doc comment). This
+   * removes the ordering bug directly — nothing above a section can shove
+   * it late if the section waits for everything above it — rather than
+   * papering over its consequences with animation suppression, which
+   * #150 already tried and which did not hold up under real-device
+   * evidence.
+   *
+   * THE TIMEOUT IS WHAT MAKES THIS SAFE. `sessionsSettled` becoming true
+   * depends on `load()` actually running to completion, and `load()`
+   * refuses to run at all while `!ready` — so a machine that never finishes
+   * waking, or a `listSessions()` call that hangs, would leave Auto and
+   * Recent hidden FOREVER without this. `SESSIONS_SETTLE_TIMEOUT_MS` forces
+   * `sessionsSettled` true regardless once it elapses, trading one
+   * old-fashioned reflow (Auto/Recent appearing, then Sessions arriving
+   * even later and pushing them down the ORIGINAL way) for never blocking
+   * indefinitely. 2500ms is a guess, not a measurement, sized as "longer
+   * than a `listSessions()` call should ever reasonably take once the
+   * machine is confirmed awake" — this hook only starts counting once
+   * `ready` is true, so it is not timing the wake itself, only the session
+   * fetch that follows it. Tunable the same way COLD_LOAD_WINDOW_MS was —
+   * list-overlap-watch.tsx would show it if this needs to move.
+   */
+  const SESSIONS_SETTLE_TIMEOUT_MS = 2500;
+  useEffect(() => {
+    if (!ready || sessionsSettled) return;
+    const timer = setTimeout(() => setSessionsSettled(true), SESSIONS_SETTLE_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [ready, sessionsSettled]);
 
   /**
    * TITLES AND SUBTITLES GO STALE WHILE YOU WATCH THEM, so this polls.
@@ -1263,8 +1335,15 @@ export default function SessionsScreen() {
              * Blue, matching the tint the web gives findings ("N open" in
              * `text-primary`) and staying clear of the amber/green/grey the
              * three session sections have already claimed.
+             *
+             * GATED ON `sessionsSettled`, ALONGSIDE `autoRows.length` — see
+             * the long note by that flag's `useEffect` above. Auto's own
+             * data is very often ready before Working/Idle's is (no
+             * readiness gate on its fetch), and rendering it the moment it
+             * arrives is exactly what let it paint, settle, and then get
+             * shoved down when Sessions mounted its own rows late.
              */}
-            {autoRows.length ? (
+            {sessionsSettled && autoRows.length ? (
               <>
                 <SectionHeader label="Auto" count={autoRows.length} dotColor={colors.primary} />
                 <View style={{ gap: space.sm }}>
@@ -1300,8 +1379,11 @@ export default function SessionsScreen() {
              *
              * Tapping one READS it. Resuming costs an agent process and is
              * asked for by sending a message, not by opening a row.
+             *
+             * Same `sessionsSettled` gate as Auto, same reason — `resumable`
+             * has no readiness gate on its own fetch either.
              */}
-            {recent.length ? (
+            {sessionsSettled && recent.length ? (
               <>
                 <SectionHeader label="Recent" count={recent.length} dotColor={colors.textMuted} />
                 <View style={{ gap: space.sm }}>

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -249,9 +249,48 @@ export function AutoFindingCard({
               <View style={{ marginTop: 5 }}>
                 <SeverityDot severity={finding.severity} />
               </View>
+              {/**
+               * COLLAPSED HEIGHT IS FIXED AT TWO LINES, NOT "UP TO TWO."
+               *
+               * `numberOfLines={2}` alone caps wrapping but does not RESERVE
+               * the space — a one-line title sizes to one line, a two-line
+               * title sizes to two, and which one you get depends on the
+               * text's actual measured width against the row's available
+               * width. That measurement is a SECOND layout pass Yoga has to
+               * run after resolving this row's flex width, which every other
+               * home-list row (SessionCard's `numberOfLines={1}` title and
+               * subtitle, always exactly one line) never needs. This
+               * two-pass convergence is what list-overlap-watch.tsx's
+               * diagnostics caught: when a section above this one grows late
+               * (see the ordering fix in app/index.tsx), Session rows
+               * resettle in one pass and this row needed a second — the
+               * asymmetry that made Auto specifically the one that showed a
+               * transient wrong position rather than Working/Idle/Recent.
+               *
+               * `height: lineHeight * 2` while collapsed makes the box a
+               * CONSTANT regardless of whether the title needs one line or
+               * two — no text measurement required to know this row's
+               * height before Yoga can place it, same one-pass shape as
+               * every other row. Expanded stays auto-sized (`numberOfLines`
+               * already goes to `undefined` there) since a tap is a
+               * deliberate, one-row-at-a-time action, not a burst of many
+               * rows settling at once — the case this addresses.
+               *
+               * THE COST, ON PURPOSE, NOT HIDDEN: a one-line title now
+               * leaves visible blank space below it where a second line
+               * would have gone. That is a real visual change for short
+               * findings, not a free win — Benny should see it before/after
+               * rather than have it decided for him.
+               */}
               <Text
                 numberOfLines={expanded ? undefined : 2}
-                style={{ ...type.footnote, color: colors.textSecondary, flex: 1, lineHeight: 18 }}
+                style={{
+                  ...type.footnote,
+                  color: colors.textSecondary,
+                  flex: 1,
+                  lineHeight: 18,
+                  ...(expanded ? null : { height: 18 * 2 }),
+                }}
               >
                 {finding.title}
               </Text>


### PR DESCRIPTION
## UPDATE — second commit added: the fixed-height title (both halves now in this PR)

The ordering fix alone (first commit, original PR description below) tested at 2/9 candidates under simulated slow wake — meaningfully fewer than before, but not zero. Per review feedback, added a second, complementary fix rather than tuning another timing constant:

**`AutoFindingCard`'s collapsed finding title is now `height: 36` (fixed), not just `numberOfLines={2}` (variable).** `SessionCard` rows (Working/Idle/Recent) are always exactly one line — constant height, no text-measurement pass needed. Auto's title could be one OR two lines depending on content width — a second layout pass every other row skips, and the diagnostics from #158 showed Auto was consistently the section with the transient wrong position after a reflow, never the others. Structural fix, not temporal: no constant to tune, no device-speed dependence. Full reasoning and the visual tradeoff (a short title now leaves ~18pt of blank space beneath it) are in the second commit's message.

**Combined verification, same protocol as before (temporary 3s simulated-slow-wake delay inside `load()`, reverted before testing what ships, against the corrected #156 detector):**
- Warm, 9 cold loads: 0 candidates.
- Simulated slow wake, 9 cold loads: **0 candidates.**

18/18 clean combined, versus 2/9 with the ordering fix alone — the strongest simulator signal either fix has produced. Still simulator-only; not a substitute for Benny's device, and still labelled honestly rather than as "the fix" for the reasons in the original description below.

**Could not capture a live before/after screenshot of the fixed-height tradeoff** — Benny's real account churns fast enough that repeated scroll/relaunch cycles kept landing on different data before framing the shot. Confirmed the mechanism at the data layer via a temporary console.log instead (removed before commit). Happy to try again, or this can be judged from the code + description alone — a short finding title will show ~18pt of blank space beneath it where a second line would have gone.

---

## Summary
**Meaningfully fewer, not eliminated — read the verification section before treating this as solved.**

Mechanism, derived from `list-overlap-watch.tsx`'s diagnostics (#158), not guessed: `load()` (feeds Working/Idle) gates on `ready` — the machine's own wake/probe round-trip has to finish before it even attempts `client.listSessions()`. `useAutoAgents()` and `useResumable()` gate their own fetches on the API client existing, nothing else. On a machine that needs waking, Auto and Recent's requests are already in flight — often already answered — while Sessions hasn't started. The diagnostics caught this live, twice identically: Idle mounting 16 rows for the first time while Auto had 9 reports and **zero** new mounts — an already-settled section getting shoved down by a section that arrived late above it, not a batch-mount problem in Auto itself.

**The fix**: sections stack vertically, so a section can only be painted safely once everything above it has resolved. `sessionsSettled` (new state, set in `load()`'s `finally` — success OR failure both count, an empty or errored result is a fully answered question, not an unresolved one) gates Auto and Recent's rendering. Resets on `bindingId` change so switching machines doesn't let the new machine's Auto/Recent ride in ahead of its own session list.

A **2500ms timeout** forces `sessionsSettled` true regardless if Sessions never resolves — a machine that never finishes waking, or a hung `listSessions()` call, must not hide Auto/Recent forever. The bound is a guess ("longer than a `listSessions()` call should reasonably take once the machine is confirmed awake" — the timer only starts once `ready` is true, so it isn't timing the wake itself), tunable, not measured — same caveat `COLD_LOAD_WINDOW_MS` carried in #150.

`archiveSession`/`dismissFinding` are untouched — they mutate state directly, never touch this gate, so optimistic actions stay instant.

## Verification — read this before merging
Can't reproduce a genuinely slow machine wake from here, so the slow path was **simulated**: a temporary 3s delay inside `load()` before `client.listSessions()` (gated to the first, non-quiet call only), run against `list-overlap-watch.tsx`'s corrected, verified detector, then **reverted before anything here was tested or committed** — the numbers below are against the code that actually ships.

- **Warm (no simulated delay), 9 cold loads: 0 candidates.**
- **Simulated slow wake, 9 cold loads: 2 candidates (~22%)** — same shape as before (Idle mounting a large batch late, a Recent or Auto row measuring ~1200pt off before settling).

That's meaningfully fewer than before this PR (candidates on every few loads, sometimes every load) but **not zero** under the condition that matters most. Working theory for why: gating Auto/Recent on the same flag Idle's data arrives with means when the gate opens, Idle's fresh batch and the previously-blocked Auto/Recent can land in one *larger* combined commit — this removes "settled section gets shoved" but may still leave "large simultaneous mount," which is the broader pattern behind both failure shapes seen so far.

**Do not read "2/9 under simulated slow wake" as a measurement of production behavior** — it's a lower bound on how often this can still happen, from a condition approximated on a fast simulator, not reproduced against Benny's actual hardware.

A follow-up addressing the *other* half of the mechanism — making Auto's rows converge in one layout pass instead of two, via a fixed-height collapsed title rather than a temporal fix — is the next thing being tried, not this PR.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `expo export --platform ios` clean
- [x] 0/9 warm cold loads clean against the corrected detector
- [x] 2/9 candidates under simulated slow-wake — disclosed, not hidden
- [ ] Real-device signal from Benny's phone (the detector, now with diagnostics, is what would confirm whether this moved the needle in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)