### PR TITLE
Fix hosted input question ownership

### DIFF
--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -273,6 +273,27 @@ async function activeSessionId(input?: string): Promise<string> {
   return await resolveSid(sessionId);
 }
 
+/**
+ * Resolve the owner of a question from the session that will receive its answer.
+ *
+ * A stdio MCP child inherits OMG_USER, but the shared HTTP MCP server belongs
+ * to no user. Its request only carries the calling session id. Reading the
+ * shared server's environment there stores the question as unassigned, and a
+ * signed-in device then removes it from its user-scoped pending feed. The
+ * session row is the durable owner in both transports, so use it when no
+ * explicit or ambient user exists.
+ */
+async function questionUser(explicit: string | undefined, sessionId: string): Promise<string | null> {
+  const direct = explicit?.trim() || envValue("USER");
+  if (direct) return direct;
+
+  const { sessions } = await api<{ sessions: SessionRow[] }>("/api/sessions");
+  const session = sessions.find(
+    (row) => row.sessionId === sessionId || row.nativeSessionId === sessionId,
+  );
+  return session?.assignedUser?.trim() || null;
+}
+
 export async function closeOmgSession(sessionIdInput: string) {
   if (!sessionIdInput.trim()) throw new Error("sessionId required");
   // Resolve before the self-close check so a short id can't slip past it.
@@ -725,7 +746,7 @@ export function buildOmgMcpServer(): McpServer {
     },
     async ({ question, options, sessionId, user }) => {
       const sid = await activeSessionId(sessionId);
-      const who = user?.trim() || envValue("USER") || null;
+      const who = await questionUser(user, sid);
       const data = await api<{ id: string; status: string }>("/api/ask", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1155,7 +1176,7 @@ export function buildOmgMcpServer(): McpServer {
     },
     async ({ prompt, options, sessionId, user }) => {
       const sid = await activeSessionId(sessionId);
-      const who = user?.trim() || envValue("USER") || null;
+      const who = await questionUser(user, sid);
       const data = await api<{ id: string; status: string }>("/api/ask", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/mcp-http.test.ts
+++ b/src/mcp-http.test.ts
@@ -20,6 +20,8 @@ const OTHER = "99999999-2222-4222-8222-222222222222";
 const originalFetch = globalThis.fetch;
 const originalBase = process.env.LFG_BASE;
 const originalSessionId = process.env.LFG_SESSION_ID;
+const originalLfgUser = process.env.LFG_USER;
+const originalOmgUser = process.env.OMG_USER;
 
 /** Outbound API calls the tool made, in order. */
 let calls: string[] = [];
@@ -29,6 +31,8 @@ beforeEach(() => {
   process.env.LFG_BASE = "http://127.0.0.1:9876";
   // The serve process answers every session and belongs to none of them.
   delete process.env.LFG_SESSION_ID;
+  delete process.env.LFG_USER;
+  delete process.env.OMG_USER;
   globalThis.fetch = (async (url: string | URL | Request) => {
     calls.push(String(url));
     return Response.json({ artifact: { id: "art-1" }, sessions: [] });
@@ -41,6 +45,10 @@ afterEach(() => {
   else process.env.LFG_BASE = originalBase;
   if (originalSessionId === undefined) delete process.env.LFG_SESSION_ID;
   else process.env.LFG_SESSION_ID = originalSessionId;
+  if (originalLfgUser === undefined) delete process.env.LFG_USER;
+  else process.env.LFG_USER = originalLfgUser;
+  if (originalOmgUser === undefined) delete process.env.OMG_USER;
+  else process.env.OMG_USER = originalOmgUser;
 });
 
 type ToolReply = { text: string; isError: boolean };
@@ -80,6 +88,57 @@ async function callTool(
 }
 
 describe("caller identity over the shared MCP endpoint", () => {
+  test("input questions inherit the calling session owner", async () => {
+    const requests: Array<{ url: string; method: string; body: unknown }> = [];
+    globalThis.fetch = (async (
+      url: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const href = String(url);
+      requests.push({
+        url: href,
+        method: init?.method ?? "GET",
+        body: typeof init?.body === "string" ? JSON.parse(init.body) : null,
+      });
+      if (href.endsWith("/api/sessions")) {
+        return Response.json({
+          sessions: [{ sessionId: SESSION, assignedUser: "owner@example.com" }],
+        });
+      }
+      if (href.endsWith("/api/ask")) {
+        return Response.json({ id: "question-1", status: "open" });
+      }
+      return Response.json({}, { status: 404 });
+    }) as typeof fetch;
+
+    const reply = await callTool(
+      "omg_input",
+      { prompt: "Which release should I deploy?", options: ["Stable", "Canary"] },
+      { session: SESSION },
+    );
+
+    expect(reply.isError).toBe(false);
+    expect(requests).toEqual([
+      {
+        url: "http://127.0.0.1:9876/api/sessions",
+        method: "GET",
+        body: null,
+      },
+      {
+        url: "http://127.0.0.1:9876/api/ask",
+        method: "POST",
+        body: {
+          question: "Which release should I deploy?",
+          options: ["Stable", "Canary"],
+          sessionId: SESSION,
+          user: "owner@example.com",
+          pushback: true,
+          wait: false,
+        },
+      },
+    ]);
+  });
+
   test("display_image publishes to the calling session named on the request", async () => {
     const reply = await callTool(
       "omg_display_image",


### PR DESCRIPTION
## What changed

- Resolve the user for `omg_input` and `omg_ask_user` from the owning session when the shared MCP server has no user environment.
- Add a regression test for the hosted HTTP MCP path.

## Root cause

The shared MCP server receives the session ID in each request, but it does not inherit that session user. It wrote `user: null`, and the hosted pending feed removed the question from the signed-in user view.

## Validation

- `bun test src/mcp-http.test.ts` — 6 passed
- `bun run typecheck` — passed after `bun run build:packages`
- `bun run test` — one unrelated existing failure in `test/session-list-payload.test.ts`, reproduced on clean `main`
