### PR TITLE
Surface existing hosted input questions

### DIFF
--- a/src/ask/store.ts
+++ b/src/ask/store.ts
@@ -36,6 +36,22 @@ export type AskQuestion = {
   answeredAt?: number | null;
 };
 
+/**
+ * Decide whether a user-scoped feed may show one question.
+ *
+ * New questions carry `user` directly. Older shared-MCP questions can be
+ * unassigned even though their owning session is assigned, so fall back to
+ * the session relationship without exposing a truly ownerless question.
+ */
+export function questionVisibleToUser(
+  question: Pick<AskQuestion, "user" | "sessionId">,
+  user: string,
+  ownedSessionIds: ReadonlySet<string>,
+): boolean {
+  if (question.user) return question.user === user;
+  return !!question.sessionId && ownedSessionIds.has(question.sessionId);
+}
+
 const dir = () => join(PATHS.data, "ask");
 const path = () => join(dir(), "questions.jsonl");
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -106,6 +106,7 @@ import {
   waitForAnswer,
   sweepExpiredQuestions,
   formatPushbackAnswerText,
+  questionVisibleToUser,
 } from "../ask/store.ts";
 import {
   listSessions,
@@ -3980,7 +3981,19 @@ a{color:#60a5fa}
         const notification = endpoint ? await takePushNotification(endpoint) : null;
         await sweepExpiredQuestions();
         const openQs = await listQuestions("open");
-        const questions = me ? openQs.filter((q) => q.user === me) : openQs;
+        let questions = openQs;
+        if (me) {
+          const sessions = await listSessionsCached();
+          const ownedSessionIds = new Set<string>();
+          for (const session of sessions) {
+            if (session.assignedUser !== me) continue;
+            if (session.sessionId) ownedSessionIds.add(session.sessionId);
+            if (session.nativeSessionId) ownedSessionIds.add(session.nativeSessionId);
+          }
+          questions = openQs.filter((question) =>
+            questionVisibleToUser(question, me, ownedSessionIds)
+          );
+        }
         // Findings are global (not user-private), so they pass through as-is.
         const findings = await listFindings("open");
         return json({ user: me, notification, questions, findings });

--- a/test/ask-store.test.ts
+++ b/test/ask-store.test.ts
@@ -20,6 +20,7 @@ import {
   sweepExpiredQuestions,
   waitForAnswer,
   formatPushbackAnswerText,
+  questionVisibleToUser,
   ASK_TTL_MS,
 } from "../src/ask/store.ts";
 
@@ -40,6 +41,36 @@ beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "lfg-ask-"));
   await mkdir(join(dir, "ask"), { recursive: true });
   PATHS.data = dir;
+});
+
+describe("questionVisibleToUser", () => {
+  const owned = new Set(["session-owned"]);
+
+  test("uses the explicit question owner when present", () => {
+    expect(questionVisibleToUser({ user: "me@example.com" }, "me@example.com", owned)).toBe(true);
+    expect(questionVisibleToUser({ user: "other@example.com" }, "me@example.com", owned)).toBe(false);
+  });
+
+  test("recovers an old unassigned question through its assigned session", () => {
+    expect(
+      questionVisibleToUser(
+        { user: null, sessionId: "session-owned" },
+        "me@example.com",
+        owned,
+      ),
+    ).toBe(true);
+  });
+
+  test("does not expose a truly ownerless or foreign question", () => {
+    expect(questionVisibleToUser({ user: null, sessionId: null }, "me@example.com", owned)).toBe(false);
+    expect(
+      questionVisibleToUser(
+        { user: null, sessionId: "session-foreign" },
+        "me@example.com",
+        owned,
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("dismissQuestion", () => {


### PR DESCRIPTION
## What changed

- Recover existing unassigned questions through the assigned session owner.
- Keep truly ownerless and foreign questions hidden.

## Why

v0.1.400 fixes ownership for new questions. Questions created before that release still have `user: null` and stay hidden from subscribed devices without this compatibility read.

## Validation

- `bun test test/ask-store.test.ts src/mcp-http.test.ts` — 23 passed
- `bun run typecheck` — passed
