### PR TITLE
fix(web): show agent questions on hosted surfaces

### DIFF
--- a/test/live-header-context.test.ts
+++ b/test/live-header-context.test.ts
@@ -76,7 +76,9 @@ describe("contextual mobile Live header", () => {
     expect(source).toContain("const { questions } = useAsk();");
     expect(source).toContain("Tap to open notifications");
     expect(source).toContain("const showCard = intro;");
-    expect(source).toContain("embedded ? null : isMobile ? null");
+    expect(source).toMatch(
+      /\{isMobile \? null : \(\s*<>\s*\{embedded \? null : <UpdateNavButton \/>\}\s*<AskNavButton/,
+    );
   });
 });
 

--- a/test/pages-nav.test.ts
+++ b/test/pages-nav.test.ts
@@ -67,14 +67,24 @@ describe("page navigation reachability", () => {
     expect(app).toContain(") : liveDesktopWorkspace ? null : (");
   });
 
-  test("host-owned chrome stays out of the embedded header", () => {
-    // Un-suppressing the header must not leak omg's own concerns back in.
-    for (const guarded of ["<AskNavButton", "<UserFilterMenu"]) {
-      const at = app.indexOf(guarded, app.indexOf(") : liveDesktopWorkspace ? null : ("));
+  test("the embedded header keeps questions but hides host-owned chrome", () => {
+    const headerStart = app.indexOf(") : liveDesktopWorkspace ? null : (");
+    const askAt = app.indexOf("<AskNavButton", headerStart);
+    expect(askAt, "AskNavButton not found in the header").toBeGreaterThan(0);
+    expect(app).toMatch(
+      /\{embedded \? null : <UpdateNavButton \/>\}\s*<AskNavButton/,
+    );
+
+    for (const guarded of ["<UpdateNavButton", "<UserFilterMenu"]) {
+      const at = app.indexOf(guarded, headerStart);
       expect(at, `${guarded} not found in the header`).toBeGreaterThan(0);
-      // Each is preceded by an `embedded ? null :` guard within a few lines.
       const before = app.slice(Math.max(0, at - 200), at);
       expect(before, `${guarded} is not gated on embedded`).toContain("embedded ? null :");
     }
+  });
+
+  test("the hosted rail can open its question inbox", () => {
+    expect(app).toContain('onOpenAsk={() => setTab("notifications")}');
+    expect(app).not.toContain('onOpenAsk={embedded ? undefined : () => setTab("ask")}');
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7989,9 +7989,9 @@ export function App() {
                 )}
               </>
             ) : null}
-            {embedded ? null : isMobile ? null : (
+            {isMobile ? null : (
               <>
-                <UpdateNavButton />
+                {embedded ? null : <UpdateNavButton />}
                 <AskNavButton
                   active={tab === "notifications"}
                   onOpen={() => setTab("notifications")}
@@ -8087,12 +8087,11 @@ export function App() {
               // header is hidden. The host owns identity/settings chrome, not
               // the LFG workspace's project scope.
               onProjectChange={changeProjectFilter}
-              // Embed: host owns identity/settings — no user picker, settings,
-              // or ask chrome inside the iframe. LFG still owns its Live,
-              // Shipped, and Artifacts pages, so their navigation remains.
+              // Embed: the host owns identity and settings. LFG still owns agent
+              // questions, so the hosted rail must keep their entry point.
               onUserChange={embedded ? undefined : changeUserFilter}
               onOpenSettings={embedded ? undefined : () => setTab("settings")}
-              onOpenAsk={embedded ? undefined : () => setTab("ask")}
+              onOpenAsk={() => setTab("notifications")}
               onOpenBots={() => setTab("bots")}
               onOpenSessions={() => setTab("live")}
               railSurface={tab === "bots" ? "chat" : "sessions"}
@@ -12131,7 +12130,7 @@ function RailStage({
               <div className="ml-auto flex items-center gap-1">
                 {onOpenAsk ? (
                   <>
-                    <UpdateNavButton />
+                    {hosted ? null : <UpdateNavButton />}
                     <AskNavButton active={false} onOpen={onOpenAsk} />
                   </>
                 ) : null}


### PR DESCRIPTION
## Summary
- keep the agent-question button visible in hosted and embedded layouts
- route the hosted rail to the Notifications inbox
- keep update controls hidden when the host owns them

## Verification
- `bun test test/pages-nav.test.ts test/live-header-context.test.ts` (14 pass)
- `bun run build:packages && bun run typecheck`
- full suite: 1663 pass, 1 skip, 2 unrelated existing source-text failures