### PR TITLE
docs(mobile): OTA publishes with --channel, not --branch

### DIFF
--- a/mobile/docs/TESTFLIGHT.md
+++ b/mobile/docs/TESTFLIGHT.md
@@ -41,11 +41,14 @@ This is the decision that matters, and getting it wrong ships a crash.
 
 **JS / TS / styles only → over the air.** About a minute, no Apple review:
 
-    npx eas-cli update --branch production --environment production \
-      --message "what changed"
+    npx eas-cli update --channel production --environment production \
+      --non-interactive --message "what changed"
 
 `--environment` is mandatory in `--non-interactive` mode; without it the command
 just errors.
+
+Pass `--channel` on its own. Current eas-cli rejects `--channel` and `--branch`
+together, and every publish in the log above was run with `--channel` alone.
 
 **Anything native → a new build.** A new or upgraded native module, an
 `app.json` change that touches the native project (name, bundle id, icon,


### PR DESCRIPTION
`mobile/docs/TESTFLIGHT.md` documented `eas update --branch production`, but current eas-cli rejects `--branch` alongside `--channel`, and all five publishes in the Publish Log were run with `--channel` alone.

Fixes the documented command, adds `--non-interactive` (which the surrounding note already assumes), and states the constraint explicitly so it doesn't drift back.

Doc-only, no code touched.