### PR TITLE
feat(mobile): Bots roster screen, phase 1 port

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -373,6 +373,11 @@ function RootNavigator() {
             name="notifications"
             options={{ title: "Notifications", headerLargeTitle: true }}
           />
+          {/* Bots roster. `bots/[id]` (bot chat) is a later phase — see
+              app/bots/index.tsx's own doc comment for the navigation
+              reasoning and why this is a header icon button, not a rail
+              toggle. */}
+          <Stack.Screen name="bots/index" options={{ title: "Bots", headerLargeTitle: true }} />
           {/* In-app purchase. Pushed from the blocked cloud computer and from
               Settings — the two places someone learns they need to pay. It is
               a normal pushed screen rather than a modal so the back gesture

--- a/mobile/app/bots/index.tsx
+++ b/mobile/app/bots/index.tsx
@@ -27,11 +27,11 @@
  * phase (bot chat); this file is the roster half only.
  *
  * "+ New bot" is visually present (both the header action and, empty-roster
- * only, the dashed row — §3.4) because leaving the roster's own create
- * affordance out would read as broken chrome, not as scope control. Tapping
- * either is a placeholder toast until the New/Edit Bot sheet exists — see
- * the PR description for why that sheet and bot chat are both held for a
- * separate steer.
+ * only, EmptyState's action slot — same pattern as home's "Choose a computer")
+ * because leaving the roster's own create affordance out would read as broken
+ * chrome, not as scope control. Tapping either is a placeholder toast until
+ * the New/Edit Bot sheet exists — see the PR description for why that sheet
+ * and bot chat are both held for a separate steer.
  */
 
 import { useFocusEffect, useNavigation, useRouter } from "expo-router";
@@ -156,32 +156,33 @@ export default function BotsScreen() {
       </Text>
 
       {bots.length === 0 && loading ? null : bots.length === 0 ? (
-        <>
-          <EmptyState
-            title="No bots yet"
-            detail="Give a persona a name and a memory — it'll be there next time you open this."
-          />
-          <PressableScale
-            onPress={createBot}
-            scale={0.98}
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: space.sm,
-              marginHorizontal: space.lg,
-              marginTop: space.sm,
-              paddingVertical: space.md,
-              borderRadius: 18,
-              borderWidth: 1,
-              borderStyle: "dashed",
-              borderColor: colors.borderStrong,
-            }}
-          >
-            <Icon ios="plus" android="add" size={14} color={colors.textMuted} />
-            <Text style={{ ...type.subhead, color: colors.textMuted }}>New bot</Text>
-          </PressableScale>
-        </>
+        <EmptyState
+          title="No bots yet"
+          detail="A bot is a persistent agent you talk to, not a task you launch."
+          action={
+            <PressableScale
+              onPress={createBot}
+              scale={0.98}
+              accessibilityRole="button"
+              accessibilityLabel="New bot"
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: space.sm,
+                paddingHorizontal: space.lg,
+                paddingVertical: space.md,
+                borderRadius: 18,
+                borderWidth: 1,
+                borderStyle: "dashed",
+                borderColor: colors.borderStrong,
+              }}
+            >
+              <Icon ios="plus" android="add" size={14} color={colors.textMuted} />
+              <Text style={{ ...type.subhead, color: colors.textMuted }}>New bot</Text>
+            </PressableScale>
+          }
+        />
       ) : (
         <View style={{ gap: space.sm }}>
           {bots.map((bot) => (

--- a/mobile/app/bots/index.tsx
+++ b/mobile/app/bots/index.tsx
@@ -1,0 +1,200 @@
+/**
+ * Bots roster — persistent agents you talk to, not tasks you launch.
+ *
+ * Phase 1 native port of the web's Bots page (docs/design/bot-mode/spec.md
+ * §3, superseded in the details noted in bot-avatar.tsx and bot-roster-row.tsx
+ * by the shipped web implementation this mirrors instead:
+ * web/src/App.tsx's `BotsView` roster branch, web/src/lib/mobile-bots-nav.ts).
+ *
+ * NAVIGATION: REACHED BY A HEADER ICON BUTTON, NOT A RAIL TOGGLE.
+ *
+ * The spec's navigation section (§0.2-0.3, §2) is written entirely against
+ * web furniture this app does not have — `PagesMenu`'s dropdown radio group
+ * and a `Sessions | Chat` segmented toggle stacked in a left rail header.
+ * This app has neither a rail nor a page-switcher menu: app/index.tsx already
+ * reaches every cross-cutting destination (Notifications, Computers,
+ * Settings) through a plain icon button in the home screen's nav bar that
+ * pushes a full screen — bell -> /notifications, monitor -> the computer
+ * picker, gear -> /settings. That is the app's own established idiom for
+ * "a surface next to sessions, one tap away," and it already solves the
+ * exact problem the web's toggle exists for (a persistent, always-visible
+ * way to switch), so Bots gets the same treatment: a lucide `bot` glyph
+ * button next to the existing three, pushing this screen. See app/index.tsx.
+ *
+ * Master-detail lives under the same route family the web uses (`/bots`
+ * roster, `/bots/[id]` chat) rather than two unrelated tabs — mirrors how
+ * `session/[id]` nests under the sessions surface. `[id].tsx` is the next
+ * phase (bot chat); this file is the roster half only.
+ *
+ * "+ New bot" is visually present (both the header action and, empty-roster
+ * only, the dashed row — §3.4) because leaving the roster's own create
+ * affordance out would read as broken chrome, not as scope control. Tapping
+ * either is a placeholder toast until the New/Edit Bot sheet exists — see
+ * the PR description for why that sheet and bot chat are both held for a
+ * separate steer.
+ */
+
+import { useFocusEffect, useNavigation, useRouter } from "expo-router";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { RefreshControl, ScrollView, View } from "react-native";
+import type { OmgSession } from "@omg-dev/protocol";
+
+import { EmptyState, Icon, IconButton } from "../../src/components";
+import { PressableScale } from "../../src/omg/motion";
+import { Text } from "../../src/omg/text";
+import { useTheme } from "../../src/omg/theme";
+import { useToast } from "../../src/omg/toast";
+import { useOmg } from "../../src/omg/provider";
+import { useBots, type Bot } from "../../src/omg/bots";
+import { BotRosterRow } from "../../src/omg/bot-roster-row";
+
+/** A session carries `botId` once it is bot-driven — see bot-mode-design.md's
+ * `Session` type extension. Not yet in @omg-dev/protocol's OmgSession, same
+ * situation as `nativeSessionId` in app/index.tsx, so it is read off the
+ * wire value with a narrow cast rather than left untyped. */
+type BotDrivenSession = OmgSession & { botId?: string; busy?: boolean };
+
+export default function BotsScreen() {
+  const navigation = useNavigation();
+  const router = useRouter();
+  const { colors, type, space } = useTheme();
+  const { client } = useOmg();
+  const toast = useToast();
+
+  const { bots, loading, refresh } = useBots();
+  const [pulling, setPulling] = useState(false);
+
+  // Which bots are working right now, cross-referenced from the live
+  // sessions list the same way the web does (`busyBySid` keyed through
+  // `session.botId` in BotsView). A bot with no live session is simply not
+  // in this set, which is the correct "idle" answer whether it has never
+  // been messaged or its backing session just is not running at the moment.
+  const [busyBotIds, setBusyBotIds] = useState<Set<string>>(new Set());
+  const loadBusy = useCallback(async () => {
+    if (!client) return;
+    try {
+      const sessions = (await client.listSessions()) as BotDrivenSession[];
+      setBusyBotIds(new Set(sessions.filter((s) => s.busy && s.botId).map((s) => s.botId!)));
+    } catch {
+      // A failed poll leaves the previous working-state read rather than
+      // wiping every dot — the roster itself still renders.
+    }
+  }, [client]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadBusy();
+      const timer = setInterval(() => void loadBusy(), 10_000);
+      return () => clearInterval(timer);
+    }, [loadBusy]),
+  );
+
+  // Same cold-load settle window as SessionCard/AutoFindingCard — see the
+  // long note on `animateEntry` in auto-agent-card.tsx. This screen fetches
+  // bots and sessions independently, the same shape of race that motivated
+  // that fix on the home screen.
+  const mountedAtRef = useRef(Date.now());
+  const COLD_LOAD_WINDOW_MS = 3500;
+  const animateEntry = Date.now() - mountedAtRef.current >= COLD_LOAD_WINDOW_MS;
+
+  const openBot = (bot: Bot) => {
+    // TODO(bot chat): route to /bots/[id] once that screen exists.
+    void bot;
+    toast.show("Bot chat is coming soon.");
+  };
+
+  const createBot = () => {
+    // TODO(New/Edit Bot sheet): open the create sheet once it exists.
+    toast.show("Creating bots is coming soon.");
+  };
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: "Bots",
+      headerLargeTitle: true,
+      headerRight: () => (
+        <IconButton
+          ios="plus"
+          android="add"
+          accessibilityLabel="New bot"
+          onPress={createBot}
+          size={20}
+          color={colors.primary}
+        />
+      ),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigation, colors]);
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ paddingBottom: space.xxl }}
+      contentInsetAdjustmentBehavior="automatic"
+      refreshControl={
+        <RefreshControl
+          refreshing={pulling}
+          onRefresh={() => {
+            setPulling(true);
+            refresh();
+            void Promise.all([loadBusy()]).finally(() => setPulling(false));
+          }}
+          tintColor={colors.textMuted}
+        />
+      }
+    >
+      <Text
+        style={{
+          ...type.footnote,
+          color: colors.textMuted,
+          paddingHorizontal: space.lg,
+          paddingTop: space.xs,
+          paddingBottom: space.md,
+        }}
+      >
+        Persistent agents you talk to, not tasks you launch.
+      </Text>
+
+      {bots.length === 0 && loading ? null : bots.length === 0 ? (
+        <>
+          <EmptyState
+            title="No bots yet"
+            detail="Give a persona a name and a memory — it'll be there next time you open this."
+          />
+          <PressableScale
+            onPress={createBot}
+            scale={0.98}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: space.sm,
+              marginHorizontal: space.lg,
+              marginTop: space.sm,
+              paddingVertical: space.md,
+              borderRadius: 18,
+              borderWidth: 1,
+              borderStyle: "dashed",
+              borderColor: colors.borderStrong,
+            }}
+          >
+            <Icon ios="plus" android="add" size={14} color={colors.textMuted} />
+            <Text style={{ ...type.subhead, color: colors.textMuted }}>New bot</Text>
+          </PressableScale>
+        </>
+      ) : (
+        <View style={{ gap: space.sm }}>
+          {bots.map((bot) => (
+            <BotRosterRow
+              key={bot.id}
+              bot={bot}
+              working={busyBotIds.has(bot.id)}
+              onPress={() => openBot(bot)}
+              animateEntry={animateEntry}
+            />
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1034,6 +1034,20 @@ export default function SessionsScreen() {
             size={19}
             color={colors.textSecondary}
           />
+          {/* Bots. Same idiom as the bell/computer/gear beside it — a plain
+              bar button pushing a full screen — rather than the web's rail
+              toggle, which this app has no rail to hang. See
+              app/bots/index.tsx for the navigation reasoning. Lucide, not an
+              SF Symbol: `person.and.background.dotted` and friends read as
+              "people," not "a bot," and this app already reaches for Lucide
+              exactly when SF Symbols has no honest equivalent (lucide.tsx). */}
+          <IconButton
+            lucide="bot"
+            accessibilityLabel="Bots"
+            onPress={() => router.push("/bots")}
+            size={19}
+            color={colors.textSecondary}
+          />
           {/* TWO BUTTONS, NOT ONE CHIP.
               The machine name and the gear used to share a single pill, which
               read as one control and made the name look pressable-adjacent

--- a/mobile/src/omg/bot-avatar.tsx
+++ b/mobile/src/omg/bot-avatar.tsx
@@ -1,0 +1,125 @@
+/**
+ * A bot's avatar — deliberately NOT the web's mark.
+ *
+ * The web's `BotAvatar` (web/src/components/BotAvatar.tsx) is a hand-rolled
+ * SVG creature: a 12-point radial silhouette that morphs between five shapes
+ * (circle/squircle/teardrop/pebble/hexagon) and breathes on a shared rAF
+ * loop, painted with one of five gradient "colorways." It supersedes the
+ * older emoji-avatar design in docs/design/bot-mode/spec.md, which is why
+ * this file exists instead of an emoji box.
+ *
+ * PORTING THE SILHOUETTE ITSELF IS OUT OF SCOPE, ON PURPOSE. It needs
+ * arbitrary SVG path drawing, and this app has no `react-native-svg` and
+ * cannot take on a native module without an EAS rebuild — see
+ * agent-icons.ts's identical reasoning for why agent marks ship as PNGs
+ * instead of the web's SVGs. `expo-linear-gradient` IS already a dependency
+ * (used by the home composer's fade), so the colorway half of the identity
+ * survives losslessly; the shape half — five distinct silhouettes — does
+ * not, and is deliberately deferred rather than faked with a worse-looking
+ * stand-in. `shape` still round-trips through bots.ts so no data is lost;
+ * only the rendering is simplified. Revisit if Benny wants the five shapes
+ * distinguished on native — the honest options then are a small bundled PNG
+ * per shape (same trick as agent-icons.ts) or taking the react-native-svg
+ * native-module cost deliberately, not a pure-RN geometry hack standing in
+ * for five hand-tuned silhouettes.
+ *
+ * THE SHAPE THAT SURVIVES THE PORT IS THE ONE THAT CARRIES MEANING: a bot
+ * reads as a bot, not a session, at a glance. On the web that meaning is
+ * "circular vs. `rounded-md`" (spec.md §0.5). On THIS app every session/agent
+ * mark (`AgentAvatar`, components.tsx) is already circular — full
+ * `borderRadius: size / 2` — so a circular bot avatar would carry no
+ * distinguishing signal here at all; it would look identical to a session
+ * row. The break has to run the other way on this surface: a bot avatar is a
+ * ROUNDED SQUARE (a "squircle" corner radius, not a full round), which is
+ * the one shape no existing avatar in this app uses. The meaning survives —
+ * bot rows are still shape-distinct from session rows on sight — even though
+ * the specific shape is inverted from the web's choice.
+ *
+ * The colorway gradient runs diagonally (top-left to bottom-right), matching
+ * the web's `gradientUnits="userSpaceOnUse" x1=18 y1=18 x2=182 y2=182` on a
+ * 200x200 viewBox — the same corner-to-corner direction, just without the
+ * silhouette clipping it.
+ */
+
+import { View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import Reanimated, { useAnimatedStyle, useSharedValue, withRepeat, withTiming } from "react-native-reanimated";
+
+import { useTheme } from "./theme";
+import type { BotColorway } from "./bots";
+
+/** Mirrors COLORWAYS in web/src/components/BotAvatar.tsx — literal design values, not CSS. */
+const COLORWAY_STOPS: Record<BotColorway, [string, string]> = {
+  warm: ["#f0a04b", "#b4451f"],
+  brand: ["#4d7cff", "#06b6d4"],
+  violet: ["#8b5cf6", "#ec4899"],
+  forest: ["#14b8a6", "#84cc16"],
+  midnight: ["#7b8ba6", "#2b3446"],
+};
+
+/** Same default the web falls back to for a bot with no colorway chosen yet. */
+const DEFAULT_COLORWAY: BotColorway = "warm";
+
+/**
+ * The corner radius that reads as "rounded square" rather than "circle" or
+ * "sharp card" at avatar sizes — proportional to size so it holds up at both
+ * the roster's 44pt and the chat header's smaller mark.
+ */
+const SQUIRCLE_RATIO = 0.32;
+
+export function BotAvatar({
+  colorway = DEFAULT_COLORWAY,
+  size = 44,
+  working = false,
+  style,
+}: {
+  colorway?: BotColorway;
+  size?: number;
+  /** Same warning-amber pulsing dot as SessionStatusDot's busy state. */
+  working?: boolean;
+  style?: object;
+}) {
+  const { colors } = useTheme();
+  const [start, end] = COLORWAY_STOPS[colorway] ?? COLORWAY_STOPS[DEFAULT_COLORWAY];
+  const radius = Math.round(size * SQUIRCLE_RATIO);
+
+  const pulse = useSharedValue(1);
+  if (working) {
+    pulse.value = withRepeat(withTiming(0.5, { duration: 1000 }), -1, true);
+  } else {
+    pulse.value = 1;
+  }
+  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }));
+
+  const dotSize = Math.max(10, Math.round(size * 0.27));
+
+  return (
+    <View style={[{ width: size, height: size }, style]}>
+      <LinearGradient
+        colors={[start, end]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{ width: size, height: size, borderRadius: radius }}
+      />
+      {working ? (
+        <Reanimated.View
+          pointerEvents="none"
+          style={[
+            {
+              position: "absolute",
+              right: -1,
+              bottom: -1,
+              width: dotSize,
+              height: dotSize,
+              borderRadius: dotSize / 2,
+              backgroundColor: colors.warning,
+              borderWidth: 2,
+              borderColor: colors.card,
+            },
+            pulseStyle,
+          ]}
+        />
+      ) : null}
+    </View>
+  );
+}

--- a/mobile/src/omg/bot-avatar.tsx
+++ b/mobile/src/omg/bot-avatar.tsx
@@ -63,13 +63,13 @@ const DEFAULT_COLORWAY: BotColorway = "warm";
 /**
  * The corner radius that reads as "rounded square" rather than "circle" or
  * "sharp card" at avatar sizes — proportional to size so it holds up at both
- * the roster's 44pt and the chat header's smaller mark.
+ * the roster's 28pt mark and a later chat-header size.
  */
 const SQUIRCLE_RATIO = 0.32;
 
 export function BotAvatar({
   colorway = DEFAULT_COLORWAY,
-  size = 44,
+  size = 28,
   working = false,
   style,
 }: {

--- a/mobile/src/omg/bot-roster-row.tsx
+++ b/mobile/src/omg/bot-roster-row.tsx
@@ -1,0 +1,138 @@
+/**
+ * One bot, as a roster row — the Bots screen's equivalent of SessionCard.
+ *
+ * WHY A BORDERED CARD, NOT THE WEB'S FLAT ROW. The web's mobile roster
+ * (`MOBILE_BOT_ROSTER_ROW_CLASS`, web/src/lib/mobile-bots-nav.ts) is a flat
+ * hover row with no border — it deliberately matches the desktop RAIL's list
+ * item shell, because on web the roster sits right next to that rail. This
+ * app has no rail. Its own home list (SessionCard, components.tsx) tried the
+ * flat/grouped-list shape first and moved to a bordered card per row after
+ * real on-device testing — see the long comment on SessionCard for why: "a
+ * session IS a separate object... the list is short enough that it was never
+ * a scanning problem." A bot is the same kind of object (its own identity,
+ * its own state), so it gets the app's own established row shape rather than
+ * importing the web's, which was tuned for a different navigation context.
+ *
+ * Otherwise this mirrors AutoFindingCard/SessionCard closely on purpose:
+ * same card shell, same avatar-left/text-middle/state-right anatomy, same
+ * `useListItemMotion`/`animateEntry` contract for cold-load list settling
+ * (see the long note on that flag in auto-agent-card.tsx — Bots gets a
+ * second independently-fetched section on a future combined home surface,
+ * so the same suppression window will matter there too, even though this
+ * screen is not that home surface yet).
+ */
+
+import { View } from "react-native";
+import Reanimated from "react-native-reanimated";
+
+import { Icon } from "../components";
+import { Text } from "./text";
+import { BotAvatar } from "./bot-avatar";
+import { PressableScale, useListItemMotion } from "./motion";
+import { useTheme } from "./theme";
+import { relativeTime } from "./format";
+import { botPreviewText, type Bot } from "./bots";
+
+export function BotRosterRow({
+  bot,
+  working,
+  onPress,
+  animateEntry = true,
+}: {
+  bot: Bot;
+  /** Whether the bot's backing session is currently busy. */
+  working?: boolean;
+  onPress: () => void;
+  /** See the identical prop on SessionCard/AutoFindingCard for why. */
+  animateEntry?: boolean;
+}) {
+  const { colors, radius, type, space } = useTheme();
+  const listMotion = useListItemMotion();
+  const disabled = !bot.enabled;
+
+  const preview = botPreviewText(bot);
+
+  return (
+    <Reanimated.View
+      entering={animateEntry ? listMotion.entering : undefined}
+      layout={animateEntry ? listMotion.layout : undefined}
+    >
+      <PressableScale
+        onPress={onPress}
+        scale={0.97}
+        accessibilityRole="button"
+        accessibilityLabel={`${bot.name}${disabled ? ", disabled" : ""}`}
+        style={({ pressed }) => ({
+          flexDirection: "row",
+          alignItems: "center",
+          gap: space.md,
+          marginHorizontal: space.lg,
+          paddingHorizontal: space.lg,
+          paddingVertical: 10,
+          minHeight: 60,
+          borderRadius: radius.xl,
+          borderWidth: 1,
+          borderColor: colors.borderStrong,
+          backgroundColor: pressed ? colors.cardPressed : colors.card,
+          opacity: disabled ? 0.7 : 1,
+        })}
+      >
+        <View style={disabled ? { opacity: 0.45 } : undefined}>
+          <BotAvatar colorway={bot.colorway} size={44} working={!disabled && !!working} />
+        </View>
+
+        <View style={{ flex: 1, gap: 1, minWidth: 0 }}>
+          <Text
+            numberOfLines={1}
+            style={{
+              ...type.callout,
+              fontWeight: "600",
+              color: disabled ? colors.textMuted : colors.text,
+            }}
+          >
+            {bot.name}
+          </Text>
+          <Text
+            numberOfLines={1}
+            style={{
+              ...type.caption,
+              fontWeight: "400",
+              color: colors.textMuted,
+            }}
+          >
+            {disabled ? preview : working ? `Working — ${preview}` : preview}
+          </Text>
+        </View>
+
+        {bot.lastMessageAt ? (
+          <Text
+            style={{
+              ...type.caption,
+              fontSize: 10,
+              fontVariant: ["tabular-nums"],
+              color: colors.textMuted,
+              opacity: 0.7,
+            }}
+          >
+            {relativeTime(bot.lastMessageAt)}
+          </Text>
+        ) : null}
+
+        {disabled ? (
+          <View
+            style={{
+              paddingHorizontal: 8,
+              paddingVertical: 2,
+              borderRadius: 999,
+              backgroundColor: colors.secondary,
+            }}
+          >
+            <Text style={{ ...type.caption, fontSize: 10, color: colors.textMuted }}>Disabled</Text>
+          </View>
+        ) : null}
+
+        <Icon ios="chevron.right" android="chevron_right" size={14} color={colors.textMuted} />
+      </PressableScale>
+    </Reanimated.View>
+  );
+}

--- a/mobile/src/omg/bot-roster-row.tsx
+++ b/mobile/src/omg/bot-roster-row.tsx
@@ -14,23 +14,25 @@
  * importing the web's, which was tuned for a different navigation context.
  *
  * Otherwise this mirrors AutoFindingCard/SessionCard closely on purpose:
- * same card shell, same avatar-left/text-middle/state-right anatomy, same
+ * same card shell, same 16h/10v padding and minHeight 60, same
  * `useListItemMotion`/`animateEntry` contract for cold-load list settling
  * (see the long note on that flag in auto-agent-card.tsx — Bots gets a
  * second independently-fetched section on a future combined home surface,
  * so the same suppression window will matter there too, even though this
  * screen is not that home surface yet).
+ *
+ * Working is one signal: the avatar's corner dot. The subtitle is the last
+ * message preview only — no "Working —" prefix, no timestamp, no Disabled
+ * pill, no chevron. A disabled bot dims the avatar, not the card.
  */
 
 import { View } from "react-native";
 import Reanimated from "react-native-reanimated";
 
-import { Icon } from "../components";
 import { Text } from "./text";
 import { BotAvatar } from "./bot-avatar";
 import { PressableScale, useListItemMotion } from "./motion";
 import { useTheme } from "./theme";
-import { relativeTime } from "./format";
 import { botPreviewText, type Bot } from "./bots";
 
 export function BotRosterRow({
@@ -74,11 +76,10 @@ export function BotRosterRow({
           borderWidth: 1,
           borderColor: colors.borderStrong,
           backgroundColor: pressed ? colors.cardPressed : colors.card,
-          opacity: disabled ? 0.7 : 1,
         })}
       >
         <View style={disabled ? { opacity: 0.45 } : undefined}>
-          <BotAvatar colorway={bot.colorway} size={44} working={!disabled && !!working} />
+          <BotAvatar colorway={bot.colorway} size={28} working={!disabled && !!working} />
         </View>
 
         <View style={{ flex: 1, gap: 1, minWidth: 0 }}>
@@ -87,7 +88,7 @@ export function BotRosterRow({
             style={{
               ...type.callout,
               fontWeight: "600",
-              color: disabled ? colors.textMuted : colors.text,
+              color: colors.text,
             }}
           >
             {bot.name}
@@ -100,38 +101,9 @@ export function BotRosterRow({
               color: colors.textMuted,
             }}
           >
-            {disabled ? preview : working ? `Working — ${preview}` : preview}
+            {preview}
           </Text>
         </View>
-
-        {bot.lastMessageAt ? (
-          <Text
-            style={{
-              ...type.caption,
-              fontSize: 10,
-              fontVariant: ["tabular-nums"],
-              color: colors.textMuted,
-              opacity: 0.7,
-            }}
-          >
-            {relativeTime(bot.lastMessageAt)}
-          </Text>
-        ) : null}
-
-        {disabled ? (
-          <View
-            style={{
-              paddingHorizontal: 8,
-              paddingVertical: 2,
-              borderRadius: 999,
-              backgroundColor: colors.secondary,
-            }}
-          >
-            <Text style={{ ...type.caption, fontSize: 10, color: colors.textMuted }}>Disabled</Text>
-          </View>
-        ) : null}
-
-        <Icon ios="chevron.right" android="chevron_right" size={14} color={colors.textMuted} />
       </PressableScale>
     </Reanimated.View>
   );

--- a/mobile/src/omg/bots.ts
+++ b/mobile/src/omg/bots.ts
@@ -1,0 +1,125 @@
+/**
+ * Bots — persistent agents you talk to, not tasks you launch.
+ *
+ * Mirrors `Bot` in `src/bots/store.ts` on the machine, plus the two fields
+ * `GET /api/bots` computes server-side from the transcript index
+ * (`lastMessagePreview`/`lastMessageTs` — see the route handler's own
+ * comment: "the roster line comes from the index, not from a live session,"
+ * because a bot is idle between turns by definition and its harness may not
+ * be running at all). Reading straight off the bot record's own
+ * `lastMessageAt` for the roster's timestamp is deliberate for the same
+ * reason: it does not need a live session to be true.
+ *
+ * `shape`/`colorway` are kept as data even though `BotAvatar` (bot-avatar.tsx)
+ * does not yet render five distinct silhouettes — see that file's own doc
+ * comment for why, and for what would unlock it. Round-tripping the fields
+ * here means nothing is lost server-side while the native avatar stays a
+ * fixed shape; a future avatar upgrade only has to change rendering, not
+ * plumb the data through again.
+ *
+ * Degrades to an empty roster on any error, the same way resumable.ts and
+ * auto-agents.ts degrade — an older machine with no `/api/bots` yet should
+ * not surface a red error banner on a screen someone opened to see who they
+ * can talk to.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useFocusEffect } from "expo-router";
+
+import { useOmg } from "./provider";
+
+/** Mirrors BOT_SHAPES in src/bots/store.ts. Not yet distinguished on native — see bot-avatar.tsx. */
+export const BOT_SHAPES = ["circle", "squircle", "teardrop", "pebble", "hexagon"] as const;
+export type BotShape = (typeof BOT_SHAPES)[number];
+
+/** Mirrors BOT_COLORWAYS in src/bots/store.ts. */
+export const BOT_COLORWAYS = ["warm", "brand", "violet", "forest", "midnight"] as const;
+export type BotColorway = (typeof BOT_COLORWAYS)[number];
+
+/** Mirrors `Bot` in src/bots/store.ts, plus the roster-only preview fields. */
+export type Bot = {
+  id: string;
+  name: string;
+  shape?: BotShape;
+  colorway?: BotColorway;
+  persona: string;
+  description?: string;
+  capabilities?: string[];
+  agent: string;
+  model?: string;
+  thinkingLevel?: string;
+  cwd?: string;
+  owner?: string;
+  enabled: boolean;
+  sessionId?: string;
+  createdAt: number;
+  lastMessageAt?: number;
+  runtimeRefreshPending?: boolean;
+  /** Server-computed, GET /api/bots only. Absent when the bot has never been messaged. */
+  lastMessagePreview?: string;
+  lastMessageTs?: number | null;
+};
+
+/**
+ * Bare-minimum text for a roster row's preview line.
+ *
+ * The web strips a `[subagent …]` background-task report from the preview
+ * (`isSubagentUpdateText`/`plainPreviewText` in web/src/lib/bot-transcript.ts)
+ * because that text is not something a bot "said" in a way worth previewing.
+ * Phase 1 native keeps this simple — collapse whitespace, cap length — and
+ * leaves the subagent-report filter for a follow-up once bot chat itself
+ * exists here to make that distinction meaningful.
+ */
+export function botPreviewText(bot: Pick<Bot, "lastMessagePreview">): string {
+  const raw = bot.lastMessagePreview?.trim();
+  if (!raw) return "Say hi to get started.";
+  return raw.replace(/\s+/g, " ").slice(0, 140);
+}
+
+export function useBots(): {
+  bots: Bot[];
+  loading: boolean;
+  refresh: () => void;
+} {
+  const { client, bindingId } = useOmg();
+  const [bots, setBots] = useState<Bot[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => setTick((n) => n + 1), []);
+
+  // A machine switch invalidates the roster outright — same reasoning as
+  // useResumable: these are that box's bots, and showing the previous
+  // machine's rows would offer to talk to something this machine never
+  // heard of.
+  useEffect(() => {
+    setBots([]);
+  }, [bindingId]);
+
+  const load = useCallback(async () => {
+    if (!client) return;
+    setLoading(true);
+    try {
+      const payload = await client.transport.request<{ bots?: Bot[] }>("/api/bots");
+      setBots(payload.bots ?? []);
+    } catch {
+      // Older machine with no /api/bots, or a transient failure. No section,
+      // rather than an error on a screen someone opened to see their roster.
+      setBots([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [client]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load]),
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load, tick]);
+
+  return { bots, loading, refresh };
+}

--- a/mobile/src/omg/lucide.tsx
+++ b/mobile/src/omg/lucide.tsx
@@ -36,6 +36,7 @@ export const LUCIDE_FONT_FAMILY = "Lucide";
 export const LUCIDE = {
   monitor: 0xe11d,
   settings: 0xe154,
+  bot: 0xe1bb,
 } as const;
 
 export type LucideName = keyof typeof LUCIDE;


### PR DESCRIPTION
## Summary

Phase 1 port of Bot Mode's **roster screen** (docs/design/bot-mode/spec.md §3) into the native iOS app. This is the first of two checkpoints requested for this port — bot chat, the New/Edit Bot sheet, and the "driven by \<bot>" badge are deliberately not in this PR; see "Not in this PR" below.

- New "Bots" header icon button on the sessions screen (`app/index.tsx`), next to Notifications/Computer/Settings, pushing `/bots`.
- New `app/bots/index.tsx`: roster list, empty state, pull-to-refresh, working-state cross-referenced from the live sessions list.
- New `src/omg/bots.ts`: `Bot` type (mirrors `src/bots/store.ts`) + `useBots()` data hook, following the same degrade-to-empty pattern as `useResumable`/`useAutoAgents`.
- New `src/omg/bot-avatar.tsx`, `src/omg/bot-roster-row.tsx`: avatar + row components.
- `src/omg/lucide.tsx`: added the `bot` glyph codepoint (font already bundled — no new asset).

## Two decisions that needed judgment (write-up, not silent choices)

**Navigation.** The spec's nav section is written entirely against web furniture (`PagesMenu`, a rail-header `Sessions | Chat` segmented toggle) this app has none of. The app's own established idiom for "a surface next to sessions, reachable in one tap" is already a plain header icon button that pushes a full screen — bell → `/notifications`, monitor → the computer picker, gear → `/settings`. Bots gets the same treatment rather than an invented tab bar or a forced copy of the rail toggle.

**Avatar.** The web's actual shipped bot avatar (`web/src/components/BotAvatar.tsx`, merged to main — supersedes the emoji design in spec.md §3.2/§5.2) is a hand-rolled animated SVG "mascot": 5 morphing shapes × 5 gradient colorways. This app has no `react-native-svg` and the OTA constraint rules out adding it (same reasoning `agent-icons.ts` already documents for why agent marks ship as PNGs instead of SVGs). `expo-linear-gradient` **is** already a dependency, so the colorway gradient survives losslessly; the 5-way shape morph is deferred (data still round-trips through `Bot.shape`, just not yet rendered distinctly).

More load-bearing: the spec's "bots are circular, sessions are `rounded-md`" rule (the one shape-break called out as must-survive) doesn't port literally, because **this app's session/agent avatars are already circular** (`AgentAvatar`, `components.tsx`) — a circular bot avatar here would look identical to a session row and carry no signal at all. Bot avatars are rounded squares instead, inverting the web's specific mapping while preserving the actual thing that mapping exists for: a bot row reads as a bot, not a session, at a glance.

**Row shell.** Bordered card (`SessionCard`/`AutoFindingCard` idiom), not the web's flat rail-style row — that flat shell was tuned for sitting next to a rail this app doesn't have, and the app's own home list already moved to bordered cards per-row after real on-device testing (see the comment history on `SessionCard`).

## Not in this PR

- Bot chat (`/bots/[id]`) — tapping a roster row shows a placeholder toast.
- New/Edit Bot sheet — the header "+" and the empty-state dashed row show a placeholder toast.
- The "driven by \<bot>" badge on session rows.

All per the original ask: stop and report after the roster screen for a steer before building bot chat.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx expo export --platform ios` — clean (1761 modules bundled, no Metro errors)
- [ ] On-device/simulator visual check — **not done**. Benny's Mac had 4 simulators already booted for other agents' sessions and the disk is documented as near-full; given this checkpoint's explicit bar was typecheck + export + PR, I held off rather than add a 5th booted device and a dev-client install/sign-in cycle on a shared, constrained machine. Flagging per `mobile/AGENTS.md`'s own warning that a broken nav bar can pass both checks clean — recommend an on-device look (mine or yours) before this merges, especially given the header/`_layout.tsx` Stack.Screen change.
- [x] `mobile/package.json` untouched — no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)