### PR TITLE
fix(bot-chat): dedupe stale streaming drafts, tighten spacing, fix narrow-bubble wrap

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -124,6 +124,7 @@ import {
   OmgChatStreamOwnership,
   OmgChatTransport,
   appendOmgTranscriptEvent,
+  mergeHistoryPage,
   omgMessagesToUIMessages,
   omgUIMessagesToMessages,
   type OmgChatMessage,
@@ -263,7 +264,12 @@ import { useProjectListPrefs, setProjectListPrefs } from "@/lib/project-list-pre
 import { useSendMorph } from "@/lib/use-send-morph";
 import { reportError } from "./lib/report-error";
 import { lazyWithReload } from "./lib/lazy-with-reload";
-import { buildChatRenderItems, splitQueuedRenderItems, toolGroupLabel } from "./lib/chat-render-items";
+import {
+  buildChatRenderItems,
+  splitQueuedRenderItems,
+  toolGroupLabel,
+  type ChatRenderItem,
+} from "./lib/chat-render-items";
 import {
   parseMessageAttachments,
   type MessageAttachment,
@@ -2532,6 +2538,14 @@ function autoAgentProject(agent: AutoAgent, repos: Repo[]): string {
 
 function sessionReference(sessionId: string): string {
   return `LFG session reference: ${sessionId}`;
+}
+
+// Which "speaker" a chat row reads as, for grouping consecutive same-speaker
+// rows closer together than a change of speaker (see the transcript render
+// loop). Tool calls/results and any non-user message all read as the
+// assistant talking, same as MessageBubble's own user/assistant split.
+function chatRenderItemSpeaker(item: ChatRenderItem<Message>): "user" | "assistant" {
+  return item.type === "msg" && item.message.role === "user" ? "user" : "assistant";
 }
 
 // The most recent activity condensed to one line — used as the collapsed-card
@@ -13722,17 +13736,10 @@ function SessionChatBody({
               Math.max(0, cached.messages.findIndex((message) => historyIds.has(message.id))),
             )
           : [];
-        const keptIds = new Set(olderKept.map((message) => message.id));
         let settled: OmgChatMessage[] = history;
         setMessages((current) => {
-          // Messages that landed live while this fetch was in flight and aren't
-          // in the page yet — they're newest, so they belong at the end.
-          const liveOnly = current.filter(
-            (message) => !historyIds.has(message.id) && !keptIds.has(message.id),
-          );
           const cachedIds = new Set(cached?.messages.map((message) => message.id) ?? []);
-          const trailing = liveOnly.filter((message) => !cachedIds.has(message.id));
-          return (settled = [...olderKept, ...history, ...trailing]);
+          return (settled = mergeHistoryPage(current, history, olderKept, cachedIds));
         });
         // Keep the deeper cursor when we preserved paged-in history above.
         const settledBefore = olderKept.length
@@ -16364,24 +16371,29 @@ const ChatStream = memo(function ChatStream({
               Loading older messages
             </div>
           ) : null}
-          {items.map((item, index) =>
-            item.type === "tools" ? (
-              <ToolGroup
-                key={item.key}
-                items={item.items}
-                live={busy && index === items.length - 1}
-              />
-            ) : (
-              <MessageBubble
-                key={item.key}
-                message={item.message}
-                live={busy && index === items.length - 1}
-                entering={!!item.message.id && enteringIdsRef.current.has(item.message.id)}
-                onRetryQueued={onRetryQueued}
-                bot={bot}
-              />
-            ),
-          )}
+          {items.map((item, index) => {
+            // A speaker change gets visible breathing room; a same-speaker
+            // follow-up sits close to the turn before it, the way a real chat
+            // reads. ConversationContent's own gap is the tight same-speaker
+            // baseline — this only adds the extra space on top of it.
+            const speakerChanged =
+              index > 0 && chatRenderItemSpeaker(items[index - 1]) !== chatRenderItemSpeaker(item);
+            return (
+              <div key={item.key} className={speakerChanged ? "pt-2.5" : undefined}>
+                {item.type === "tools" ? (
+                  <ToolGroup items={item.items} live={busy && index === items.length - 1} />
+                ) : (
+                  <MessageBubble
+                    message={item.message}
+                    live={busy && index === items.length - 1}
+                    entering={!!item.message.id && enteringIdsRef.current.has(item.message.id)}
+                    onRetryQueued={onRetryQueued}
+                    bot={bot}
+                  />
+                )}
+              </div>
+            );
+          })}
           <TypingIndicator visible={showTypingIndicator} bot={bot} />
           {/* Pinned below the working indicator: what the agent is doing now,
               then what it will read next. */}
@@ -17390,20 +17402,25 @@ function MessageBubble({
     <MessageActions text={message.text || ""} isUser={false}>
         {/* Assistant turns render markdown from the raw source via Streamdown,
             which tolerates half-finished markdown mid-stream (no html injection). */}
-        {/* max-w-full, not MessageContent's default 92%: the cap already lives
-            on MessageActions, whose content div is content-sized (flex-col +
-            items-start). A second 92% here resolves against that shrink-to-fit
-            width, i.e. 92% of the text's own max-content width, so any reply
-            that would fit on one line gets its last word pushed onto a second
-            line ("Hi Benny!" wraps to "Hi" / "Benny!"). Long replies hit the
-            available width first and hid this until bots started replying in
-            one-liners. */}
+        {/* max-w-full, not MessageContent's default 92% (or a second, tighter
+            percentage for the bot bubble): the cap already lives on
+            MessageActions, whose content div is content-sized (flex-col +
+            items-start). A second percentage here resolves against that
+            shrink-to-fit width, i.e. N% of the text's own max-content width,
+            so any reply that would fit on one line gets pushed onto a second
+            line — "Hi Benny!" wrapped to "Hi" / "Benny!", and a single short
+            word like "Waiting." wrapped mid-word ("Waiti" / "ng."). Long
+            replies hit the available width first and hid this until bots
+            started replying in one-liners. A bot bubble still reads narrower
+            than a full-width row because MessageActions already caps
+            non-user turns at 92% — this doesn't need its own tighter cap on
+            top of that one. */}
       <MessageContent
         className={cn(
           "max-w-full",
           // The card row shell every surface in the app uses, with a taller
           // corner so it reads as a chat bubble rather than a list row.
-          botBubble && "max-w-[84%] rounded-[18px] border border-border bg-card px-3.5 py-2.5 text-[14.5px] leading-[1.55]",
+          botBubble && "rounded-[18px] border border-border bg-card px-3.5 py-2.5 text-[14.5px] leading-[1.55]",
         )}
       >
         {message.text ? (

--- a/web/src/components/ai-elements/conversation.tsx
+++ b/web/src/components/ai-elements/conversation.tsx
@@ -23,7 +23,13 @@ Conversation.displayName = "Conversation";
 export type ConversationContentProps = ComponentProps<"div">;
 
 export function ConversationContent({ className, ...props }: ConversationContentProps) {
-  return <div className={cn("flex flex-col gap-3", className)} {...props} />;
+  // Tight base gap between every row. The visible breathing room between a
+  // speaker change and a same-speaker follow-up comes from each row's own
+  // top margin (see the chat-render loop's speaker-change spacing), not from
+  // this container gap — a flat gap-3 here made every row equally far apart
+  // regardless of who was talking, which read as mostly empty screen on a
+  // tall/narrow viewport like an iPad.
+  return <div className={cn("flex flex-col gap-1", className)} {...props} />;
 }
 
 export type ConversationEmptyStateProps = ComponentProps<"div"> & {

--- a/web/src/components/ai-elements/message.tsx
+++ b/web/src/components/ai-elements/message.tsx
@@ -40,7 +40,18 @@ export function MessageContent({ className, ...props }: MessageContentProps) {
         // Default cap for assistant content that is a direct Message child.
         // User turns cap width on MessageActions instead (so the percentage
         // resolves against Message's definite width and stays right-aligned).
-        "min-w-0 max-w-[92%] text-sm leading-relaxed",
+        //
+        // min-w-0 (not min-w-auto, the flex-item default) is needed so long
+        // unbroken text can still shrink to the max-width cap above — without
+        // it a min-content-sized item can refuse to shrink below one long
+        // word. A small min-width floor guards the other direction: a caller
+        // that ends up shrink-constrained for any reason (a stacked
+        // percentage max-width resolving against an unexpectedly narrow
+        // ancestor is the shape that hit bot chat — see MessageBubble's
+        // bot-bubble className comment for the actual "Waiting." -> "Waiti" /
+        // "ng." bug) shouldn't be able to squeeze a bubble narrower than a
+        // single short word can fit in.
+        "min-w-[3.5rem] max-w-[92%] text-sm leading-relaxed",
         className,
       )}
       {...props}

--- a/web/src/lib/omg-chat-transport-history-merge.test.ts
+++ b/web/src/lib/omg-chat-transport-history-merge.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { mergeHistoryPage, type OmgChatMessage } from "./omg-chat-transport";
+
+// Regression test for the bot-chat duplicate-bubble bug: a message rendering
+// TWICE, back to back, with identical text.
+//
+// Root cause (see mergeHistoryPage's own doc comment): useChat's state is
+// keyed by session id and survives navigating away and back to the same
+// session (e.g. reopening a bot's conversation). If a turn was still
+// streaming when the app lost focus — an iPad backgrounding Safari mid-turn
+// is the concrete case Benny hit — the live subscription event that would
+// normally clear the local streaming-draft bubble never arrives before the
+// session's history effect re-fetches `/api/sessions/:sid/messages`. That
+// fetch comes back with the SAME turn already finalized under its own real
+// id, and the old merge logic had no rule dropping the stale draft, so both
+// rendered: the finalized bubble and the untouched streaming duplicate.
+
+function streamingDraft(sid: string, text: string, ts: number): OmgChatMessage {
+  return {
+    id: `draft-${sid}`,
+    role: "assistant",
+    metadata: {
+      omgMessage: { id: `draft-${sid}`, role: "assistant", kind: "text", text, ts },
+    },
+    parts: [{ type: "text", text, state: "streaming" }],
+  };
+}
+
+function finalAssistantText(id: string, text: string, ts: number): OmgChatMessage {
+  return {
+    id,
+    role: "assistant",
+    metadata: { omgMessage: { id, role: "assistant", kind: "text", text, ts } },
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+function userText(id: string, text: string, ts: number): OmgChatMessage {
+  return {
+    id,
+    role: "user",
+    metadata: { omgMessage: { id, role: "user", kind: "text", text, ts } },
+    parts: [{ type: "text", text, state: "done" }],
+  };
+}
+
+describe("mergeHistoryPage", () => {
+  test("drops a stale streaming draft once the fetched history already has it finalized", () => {
+    const TEXT = "Screenshot worked quickly this time, so the Mac/SSH is responsive. Let's pull it down and look.";
+    const sid = "bot-session-1";
+    const current: OmgChatMessage[] = [
+      userText("row-1", "Waiting.", 1000),
+      streamingDraft(sid, TEXT, 2000),
+    ];
+    const history: OmgChatMessage[] = [
+      userText("row-1", "Waiting.", 1000),
+      finalAssistantText("row-2", TEXT, 2050),
+    ];
+
+    const merged = mergeHistoryPage(current, history, [], new Set());
+
+    const copies = merged.filter((message) => message.role === "assistant" && message.id !== `draft-${sid}`);
+    expect(copies).toHaveLength(1);
+    expect(copies[0]?.parts.find((part) => part.type === "text")?.text).toBe(TEXT);
+    // The stale draft bubble must not survive alongside the finalized row.
+    expect(merged.some((message) => message.id === `draft-${sid}`)).toBe(false);
+    expect(merged.filter((message) => message.role === "assistant")).toHaveLength(1);
+  });
+
+  test("a live-landed, already-finalized message during the fetch's flight still appears once", () => {
+    const history: OmgChatMessage[] = [userText("row-1", "hello", 1000)];
+    const liveArrived = finalAssistantText("row-2", "hi there", 1500);
+    const current: OmgChatMessage[] = [userText("row-1", "hello", 1000), liveArrived];
+
+    const merged = mergeHistoryPage(current, history, [], new Set());
+
+    expect(merged.filter((message) => message.id === "row-2")).toHaveLength(1);
+    expect(merged.map((message) => message.id)).toEqual(["row-1", "row-2"]);
+  });
+
+  test("older paged-in history is preserved ahead of the fresh page", () => {
+    const older = [userText("row-0", "older turn", 500)];
+    const history: OmgChatMessage[] = [userText("row-1", "hello", 1000)];
+    const current: OmgChatMessage[] = [...older, ...history];
+
+    const merged = mergeHistoryPage(current, history, older, new Set());
+
+    expect(merged.map((message) => message.id)).toEqual(["row-0", "row-1"]);
+  });
+});

--- a/web/src/lib/omg-chat-transport.ts
+++ b/web/src/lib/omg-chat-transport.ts
@@ -265,6 +265,60 @@ function upsertOmgUIMessage(current: OmgChatMessage[], incoming: OmgChatMessage)
   return out;
 }
 
+function isStreamingAssistantText(message: OmgChatMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    message.parts.some((part) => part.type === "text" && part.state === "streaming")
+  );
+}
+
+/**
+ * Merge a freshly-fetched history page (the authoritative persisted read
+ * model) with whatever the chat's local state already holds, on session
+ * mount / re-entry.
+ *
+ * `current` can hold a streaming-draft assistant bubble left over from an
+ * earlier visit to this same session id (useChat's state is keyed by id and
+ * survives navigating away and back — see SessionChat). Normally that draft
+ * is cleared the instant the turn's real "message" event arrives, via
+ * upsertOmgUIMessage's own drop-stale-draft rule below. But if the app was
+ * backgrounded (or the live subscription otherwise missed a beat) while the
+ * turn finished, that clearing event never reached this client, so the stale
+ * draft is still sitting in `current` when this history page lands — and the
+ * page's `history` now contains the SAME turn, fully finalized, under its own
+ * real id. Without this drop, both rendered: the finalized bubble from
+ * `history` and the untouched streaming duplicate from `current`, back to
+ * back, with identical text — this was bug 1's actual cause on iPad, where
+ * Safari suspends a backgrounded tab's JS mid-turn.
+ *
+ * Dropping every local streaming draft here (not just ones matched to a
+ * specific history row) mirrors upsertOmgUIMessage's own rule and is safe:
+ * if a turn is still genuinely in progress, the live subscription's next
+ * `ai_part` delta recreates the draft within moments — a brief gap beats a
+ * permanent duplicate.
+ */
+export function mergeHistoryPage(
+  current: OmgChatMessage[],
+  history: OmgChatMessage[],
+  olderKept: OmgChatMessage[],
+  cachedIds: Set<string>,
+): OmgChatMessage[] {
+  const historyIds = new Set(history.map((message) => message.id));
+  const keptIds = new Set(olderKept.map((message) => message.id));
+  // Messages that landed live while this fetch was in flight and aren't in
+  // the page yet — they're newest, so they belong at the end. A stale
+  // streaming draft is never "newest": either its turn is already reflected
+  // in `history` (duplicate) or the live subscription will repaint it.
+  const liveOnly = current.filter(
+    (message) =>
+      !historyIds.has(message.id) &&
+      !keptIds.has(message.id) &&
+      !isStreamingAssistantText(message),
+  );
+  const trailing = liveOnly.filter((message) => !cachedIds.has(message.id));
+  return [...olderKept, ...history, ...trailing];
+}
+
 function omgQueueReconcileRow(message: OmgChatMessage): QueueReconcileMessage {
   return { id: message.id, role: message.role, ...message.metadata?.omgMessage };
 }


### PR DESCRIPTION
## Summary

Three rendering/streaming bugs in the bot chat UI, reported by Benny from an iPad screenshot of the "iOS Manager" bot conversation.

**1. Duplicated streamed message** ("Screenshot worked quickly this time..." rendering twice)

Root cause is client-side, not a stored-transcript duplicate. I audited `deliverBotMessage` (the recently-unified bot message delivery path, squash commit `3b08ffb`) and the transcript-index dedupe-by-message-uuid path — both are sound. I also swept the entire local `transcript_messages` table for genuine duplicate rows; every match found was independent LLM regeneration minutes apart (e.g. "Still pending. Let's wait a bit more." said 3x with 3 different message ids, ~6-27 min apart), not a stored duplicate.

The actual bug: `useChat`'s state is keyed by session id and persists across navigating away and back to the same conversation (`SessionChat`'s `id={sid}`). If a turn was still streaming when the app lost focus — Safari suspending a backgrounded iPad tab mid-turn is the concrete case — the live "message" event that normally clears the local streaming-draft bubble (via `upsertOmgUIMessage`'s drop-stale-draft rule) never arrives before `SessionChatBody`'s history effect refetches `/api/sessions/:sid/messages` on re-entry. That fetch returns the same turn already finalized under its own real id, and the old fetch-vs-live merge had no equivalent rule, so both rendered: the finalized bubble and the untouched streaming duplicate, with identical text.

Fix: extracted the merge into `mergeHistoryPage` (`web/src/lib/omg-chat-transport.ts`) and made it drop stale local streaming drafts, mirroring the same rule `upsertOmgUIMessage` already applies on the live path.

**2. Excessive vertical spacing**

`ConversationContent` used a flat `gap-3` between every row regardless of speaker. Tightened the base gap to `gap-1` and added `pt-2.5` only on a speaker change in the render loop, so consecutive same-speaker turns sit close together and a speaker change gets the breathing room.

**3. Degenerate narrow bubble** ("Waiting." → "Waiti" / "ng.")

The bot-bubble branch of `MessageBubble` stacked a second `max-w-[84%]` on top of `MessageContent`'s own `max-w-full` — the exact "double percentage" shape a comment two lines above already documents fixing once, for "Hi Benny!" wrapping to "Hi" / "Benny!". The percentage resolved against `MessageActions`' already shrink-to-fit width instead of the bubble's own content, so a single short word could get squeezed onto two lines. Removed the redundant percentage (MessageActions' existing 92% cap is enough) and added a small `min-w-[3.5rem]` floor on `MessageContent` as a defensive backstop.

## Test plan

- [x] Regression test added at the layer the bug 1 duplication actually occurs: `web/src/lib/omg-chat-transport-history-merge.test.ts` tests `mergeHistoryPage` directly — verified it fails without the fix and passes with it.
- [x] `bun run typecheck` — clean.
- [x] `bun run test` — 1797 pass / 2 fail / 1 skip, matching main's baseline exactly (the 2 known pre-existing brittle text-slice tests: `settings rendering > mobile secondary chrome...` and `which responses drop cmd > /api/sessions keeps a full=1 opt-in`). Zero regressions from this branch.
- [x] `bun run build:packages` — clean.
- [x] `cd web && bun run build` — clean.
- [x] Visual verification against the real, live "iOS Manager" bot conversation via a temporary `vite dev` server + ego-browser (pixel screenshots were blocked by a confirmed ego-browser Mac-side pull-back issue — retried multiple times, tried format variants, and sanity-checked against a trivial external page, all timing out identically; the pairing tool itself flags pull-back as unverified). Used DOM/computed-style measurement instead, before vs. after, on the real bot conversation:
  - Bug 3: bubble width 74px → 89px; "Waiting." text height 48px (wrapped, 2 lines) → 24px (single line, matches line-height).
  - Bug 2: row gaps uniform 12px → 4px between same-speaker rows / 14px on speaker change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)