### PR TITLE
Fix mobile bot navigation and thread selection

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,10 +35,13 @@ import {
 import { cacheProjectFilter, readCachedProjectFilter } from "./lib/project-filter";
 import {
   MOBILE_BOT_ROSTER_ROW_CLASS,
+  mobileSurfaceDockBottom,
   mobileSurfaceToggleActive,
+  shouldShowBotsInSessionList,
   shouldShowInlineBotsSurfaceToggle,
   shouldShowMobileSurfaceToggle,
 } from "./lib/mobile-bots-nav";
+import { findBotMainSession } from "./lib/bot-session";
 import { resolveRosterUser } from "./lib/roster-user";
 import {
   botVisibleUserText as botVisibleUserTextFor,
@@ -7750,7 +7753,9 @@ export function App() {
   // clear the composer. The visual fade overlays the scroll surface and must
   // not also become blank layout space.
   const mainBottomPadding = mobileComposerVisible
-    ? "pb-[var(--lfg-inline-composer-height,var(--lfg-composer-clear))] [scroll-padding-bottom:var(--lfg-inline-composer-height,var(--lfg-composer-clear))]"
+    ? "pb-[calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+var(--lfg-mobile-surface-dock-height))] [scroll-padding-bottom:calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+var(--lfg-mobile-surface-dock-height))]"
+    : isMobile && tab === "bots"
+      ? "pb-[calc(var(--lfg-mobile-surface-dock-height)+var(--lfg-device-safe-bottom))] [scroll-padding-bottom:calc(var(--lfg-mobile-surface-dock-height)+var(--lfg-device-safe-bottom))]"
     : tab === "live"
       ? keyboardOpen
         ? "pb-[calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+0.75rem)] md:pb-3"
@@ -8058,28 +8063,6 @@ export function App() {
       </header>
       )}
 
-      {/* Bots as a top-level page alongside Chat: a direct Chat/Bot toggle in
-          the pinned mobile chrome, mirroring the desktop rail's SurfaceToggle
-          instead of leaving Bots reachable only through the PagesMenu
-          overflow. Lower-frequency pages (Notifications, Artifacts, Settings)
-          stay in that overflow — this adds one control, not a second nav
-          model. Sits below whichever header variant rendered above so it
-          stays pinned (not scrolled away) on both Live and Bots. */}
-      {shouldShowMobileSurfaceToggle(isMobile, tab) ? (
-        <div
-          className={cn(
-            "shrink-0 pb-2",
-            embedded ? "pl-3 pr-[calc(0.75rem+var(--lfg-host-top-inset))]" : "px-2",
-          )}
-        >
-          <SurfaceToggle
-            active={mobileSurfaceToggleActive(tab)}
-            onOpenSessions={() => setTab("live")}
-            onOpenBots={() => setTab("bots")}
-          />
-        </div>
-      ) : null}
-
       {embedded ? null : <PwaInstallCallout />}
 
       {error ? (
@@ -8373,6 +8356,15 @@ export function App() {
         ) : null}
         </>}
       </main>
+
+      {shouldShowMobileSurfaceToggle(isMobile, tab) ? (
+        <MobileSurfaceDock
+          active={mobileSurfaceToggleActive(tab)}
+          aboveComposer={mobileComposerVisible}
+          onOpenSessions={() => setTab("live")}
+          onOpenBots={() => setTab("bots")}
+        />
+      ) : null}
 
       {!bare ? (
         <>
@@ -10568,6 +10560,7 @@ function LiveView({
   focus?: { sid: string; n: number } | null;
 }) {
   const isWide = useIsWide();
+  const isMobile = useIsMobile();
   const recentShipped = useRecentShippedSessions(
     projectFilter,
     !!onOpenRecentShipped,
@@ -10656,13 +10649,19 @@ function LiveView({
   const pinnedSet = new Set(topPinned);
   const nodeContainsPin = (node: SessionTreeNode): boolean =>
     pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
-  const pinnedNodes = tree.roots.filter(nodeContainsPin);
+  const nodeIsBot = (node: SessionTreeNode): boolean => !!node.session.botId;
+  // Mobile has a dedicated Bots surface. Keep bot-owned families out of Chat,
+  // even when a bot session or one of its delegated children was pinned.
+  const pinnedNodes = tree.roots.filter(
+    (node) => nodeContainsPin(node) && (!isMobile || !nodeIsBot(node)),
+  );
   // Remaining roots keep the familiar working → idle grouping. A parent is
   // considered working if any child is working.
   // Bots are their own category here too — see the rail's note: a bot you have
   // not spoken to in a week is not "idle" the way a finished session is.
-  const nodeIsBot = (node: SessionTreeNode): boolean => !!node.session.botId;
-  const botNodes = tree.roots.filter((node) => !nodeContainsPin(node) && nodeIsBot(node));
+  const botNodes = shouldShowBotsInSessionList(isMobile)
+    ? tree.roots.filter((node) => !nodeContainsPin(node) && nodeIsBot(node))
+    : [];
   const workingNodes = tree.roots.filter(
     (node) => !nodeContainsPin(node) && !nodeIsBot(node) && tree.effectiveBusy(node),
   );
@@ -10674,8 +10673,8 @@ function LiveView({
   const working = tree.flatten(workingNodes);
   const idle = tree.flatten(idleNodes);
 
-  // On-screen order: pinned, bots, then working, then idle. Drives both sheet
-  // navigation and which transcripts we warm ahead of the user opening them.
+  // On-screen order: pinned, bots, then working, then idle. Mobile's bot list
+  // is empty by design because Bots owns those persistent conversations.
   const screenOrder = [...pinned, ...botSessions, ...working, ...idle]
     .map((s) => s.sessionId)
     .filter((id): id is string => !!id);
@@ -10692,7 +10691,10 @@ function LiveView({
   // live list empties and refills.
   if (
     !isWide &&
-    !sessions.length &&
+    !pinned.length &&
+    !botSessions.length &&
+    !working.length &&
+    !idle.length &&
     !findings.length &&
     !shippedReview &&
     !recentShipped.length
@@ -11435,10 +11437,7 @@ function RailStage({
   const botsBySid = useMemo(() => {
     const map = new Map<string, PersistentBot>();
     for (const bot of bots) {
-      const backing = sessions.find(
-        (session) =>
-          session.botId === bot.id || (!!bot.sessionId && session.sessionId === bot.sessionId),
-      );
+      const backing = findBotMainSession(bot, sessions);
       const sid = backing?.sessionId ?? bot.sessionId ?? null;
       if (sid) map.set(sid, bot);
     }
@@ -24018,25 +24017,61 @@ function SurfaceToggle({
   active,
   onOpenSessions,
   onOpenBots,
+  compact = false,
 }: {
   active: "sessions" | "chat";
   onOpenSessions: () => void;
   onOpenBots: () => void;
+  compact?: boolean;
 }) {
   // This is the one segmented-toggle component both the desktop rail header
   // (RailStage, isWide-only) and the mobile Chat/Bots header render — one
   // navigation idiom, two mount points, instead of a second control. It used
   // to hard-hide at mobile widths (docs/design/bot-mode/spec.md §2.1 predates
   // the mobile primary-nav toggle); callers now decide where it mounts.
+  const barRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLSpanElement>(null);
+  const initializedRef = useRef(false);
+  const movePill = useCallback((animate: boolean) => {
+    const bar = barRef.current;
+    const pill = pillRef.current;
+    const tab = bar?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]');
+    if (!bar || !pill || !tab) return;
+    const previousTransition = pill.style.transition;
+    if (!animate) pill.style.transition = "none";
+    pill.style.transform = `translateX(${tab.offsetLeft}px)`;
+    pill.style.width = `${tab.offsetWidth}px`;
+    if (!animate) {
+      void pill.offsetWidth;
+      pill.style.transition = previousTransition;
+    }
+  }, []);
+  useLayoutEffect(() => {
+    movePill(initializedRef.current);
+    initializedRef.current = true;
+  }, [active, movePill]);
+  useEffect(() => {
+    const sync = () => movePill(false);
+    window.addEventListener("resize", sync);
+    return () => window.removeEventListener("resize", sync);
+  }, [movePill]);
+
   return (
     <div
-      className="flex gap-0.5 rounded-full bg-muted p-[3px]"
+      ref={barRef}
+      className={cn(
+        "t-tabs lfg-surface-toggle",
+        compact
+          ? "lfg-surface-toggle--dock w-[13rem] max-w-[calc(100vw-2rem)]"
+          : "w-full",
+      )}
       role="tablist"
       aria-label="Switch surface"
     >
+      <span ref={pillRef} className="t-tabs-pill" aria-hidden="true" />
       {([
         ["sessions", "Chat", onOpenSessions],
-        ["chat", "Bot", onOpenBots],
+        ["chat", "Bots", onOpenBots],
       ] as const).map(([value, label, onClick]) => (
         <button
           key={value}
@@ -24044,16 +24079,40 @@ function SurfaceToggle({
           role="tab"
           aria-selected={active === value}
           onClick={onClick}
-          className={cn(
-            "flex h-[26px] flex-1 items-center justify-center rounded-full px-3 text-xs font-semibold transition-[background-color,color,box-shadow] duration-150",
-            active === value
-              ? "bg-card text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
+          className="t-tab flex flex-1 items-center justify-center gap-1.5 text-xs font-semibold"
         >
+          {compact ? (
+            value === "sessions" ? <MessageSquare className="size-3.5" /> : <Bot className="size-3.5" />
+          ) : null}
           {label}
         </button>
       ))}
+    </div>
+  );
+}
+
+function MobileSurfaceDock({
+  active,
+  aboveComposer,
+  onOpenSessions,
+  onOpenBots,
+}: {
+  active: "sessions" | "chat";
+  aboveComposer: boolean;
+  onOpenSessions: () => void;
+  onOpenBots: () => void;
+}) {
+  return (
+    <div
+      className="pointer-events-none fixed inset-x-0 z-[56] flex justify-center px-4 pb-2"
+      style={{ bottom: mobileSurfaceDockBottom(aboveComposer) }}
+    >
+      <SurfaceToggle
+        compact
+        active={active}
+        onOpenSessions={onOpenSessions}
+        onOpenBots={onOpenBots}
+      />
     </div>
   );
 }
@@ -24344,9 +24403,7 @@ function BotsView({
   }, [bot, isMobile]);
 
   if (bot) {
-    const backingSession = sessions.find(
-      (session) => session.botId === bot.id || (!!bot.sessionId && session.sessionId === bot.sessionId),
-    );
+    const backingSession = findBotMainSession(bot, sessions);
     const sid = backingSession?.sessionId ?? bot.sessionId ?? null;
     const session: Session | null = sid
       ? backingSession ?? {
@@ -24495,9 +24552,7 @@ function BotsView({
         <span className="truncate">New bot</span>
       </button>
       {bots.length ? bots.map((item) => {
-        const session = sessions.find(
-          (candidate) => candidate.botId === item.id || (!!item.sessionId && candidate.sessionId === item.sessionId),
-        );
+        const session = findBotMainSession(item, sessions);
         const working = !!(session?.sessionId && busyBySid[session.sessionId]);
         const rawPreview = session?.last?.text || session?.lastUserText || item.lastMessagePreview || "";
         // See the rail roster: a `[subagent …]` report is not preview material.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -87,6 +87,76 @@
   --lfg-mobile-header-height: calc(3.5rem + env(safe-area-inset-top, 0px));
   --lfg-mobile-header-fade-height: 1.25rem;
   --lfg-mobile-composer-fade-height: var(--lfg-mobile-header-fade-height);
+  --lfg-mobile-surface-dock-height: 3.25rem;
+  --tabs-dur: 250ms;
+  --tabs-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  --tabs-text-muted: rgba(15, 15, 15, 0.8);
+  --tabs-text-active: #0f0f0f;
+  --tabs-bar-bg: #f1f1f1;
+  --tabs-pill-bg: #ffffff;
+}
+
+/* Sliding segmented control from transitions.dev. */
+.t-tabs {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px;
+  border-radius: 48px;
+  background: var(--tabs-bar-bg);
+}
+.t-tab {
+  position: relative;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  height: 30px;
+  padding: 4px 12px;
+  color: var(--tabs-text-muted);
+  cursor: pointer;
+  border-radius: 48px;
+  z-index: 1;
+  transition: color var(--tabs-dur) var(--tabs-ease);
+}
+.t-tab:not([aria-selected="true"]):hover,
+.t-tab[aria-selected="true"] {
+  color: var(--tabs-text-active);
+}
+
+.t-tabs-pill {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  height: 30px;
+  width: 0;
+  background: var(--tabs-pill-bg);
+  border-radius: 48px;
+  transform: translateX(0);
+  transition:
+    transform var(--tabs-dur) var(--tabs-ease),
+    width     var(--tabs-dur) var(--tabs-ease);
+  will-change: transform, width;
+  z-index: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-tabs-pill, .t-tab { transition: none !important; }
+}
+
+.lfg-surface-toggle {
+  --tabs-text-muted: var(--muted-foreground);
+  --tabs-text-active: var(--foreground);
+  --tabs-bar-bg: color-mix(in srgb, var(--muted) 88%, transparent);
+  --tabs-pill-bg: var(--card);
+  pointer-events: auto;
+}
+
+.lfg-surface-toggle--dock {
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+  backdrop-filter: blur(18px);
 }
 
 /* Framed inside omg Computer (`?embed=1` / iframe): cancel the device

--- a/web/src/lib/bot-session.test.ts
+++ b/web/src/lib/bot-session.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { findBotMainSession } from "./bot-session";
+
+describe("findBotMainSession", () => {
+  test("prefers the bot's exact saved session over an earlier child", () => {
+    const child = {
+      sessionId: "child",
+      botId: "bot-1",
+      parentSessionId: "main",
+      subagentDepth: 1,
+    };
+    const main = { sessionId: "main", botId: "bot-1" };
+
+    expect(findBotMainSession({ id: "bot-1", sessionId: "main" }, [child, main])).toBe(main);
+  });
+
+  test("uses a top-level bot session when the bot has no saved session yet", () => {
+    const child = {
+      sessionId: "child",
+      botId: "bot-1",
+      parentNativeSessionId: "main",
+    };
+    const main = { sessionId: "main", botId: "bot-1" };
+
+    expect(findBotMainSession({ id: "bot-1" }, [child, main])).toBe(main);
+  });
+
+  test("never falls back to a child-only match", () => {
+    const child = {
+      sessionId: "child",
+      botId: "bot-1",
+      subagentDepth: 1,
+    };
+
+    expect(findBotMainSession({ id: "bot-1" }, [child])).toBeUndefined();
+  });
+});

--- a/web/src/lib/bot-session.ts
+++ b/web/src/lib/bot-session.ts
@@ -1,0 +1,29 @@
+type BotSessionRef = {
+  id: string;
+  sessionId?: string | null;
+};
+
+type SessionRef = {
+  sessionId?: string | null;
+  nativeSessionId?: string | null;
+  botId?: string | null;
+  parentSessionId?: string | null;
+  parentNativeSessionId?: string | null;
+  subagentDepth?: number | null;
+};
+
+/**
+ * Resolve only the persistent bot's main conversation.
+ *
+ * Child sessions inherit botId for attribution. A broad botId match can
+ * therefore open a delegated task instead of the bot's saved conversation.
+ */
+export function findBotMainSession<T extends SessionRef>(bot: BotSessionRef, sessions: T[]): T | undefined {
+  const savedSessionId = bot.sessionId?.trim();
+  if (savedSessionId) {
+    const exact = sessions.find((session) => session.sessionId === savedSessionId || session.nativeSessionId === savedSessionId);
+    if (exact) return exact;
+  }
+
+  return sessions.find((session) => session.botId === bot.id && !session.parentSessionId && !session.parentNativeSessionId && !session.subagentDepth);
+}

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   MOBILE_BOT_ROSTER_ROW_CLASS,
+  mobileSurfaceDockBottom,
   mobileSurfaceToggleActive,
+  shouldShowBotsInSessionList,
   shouldShowInlineBotsSurfaceToggle,
   shouldShowMobileSurfaceToggle,
 } from "./mobile-bots-nav";
@@ -48,12 +50,32 @@ describe("mobileSurfaceToggleActive", () => {
   });
 });
 
+describe("shouldShowBotsInSessionList", () => {
+  test("keeps bot families out of mobile Chat", () => {
+    expect(shouldShowBotsInSessionList(true)).toBe(false);
+  });
+
+  test("preserves the desktop rail grouping", () => {
+    expect(shouldShowBotsInSessionList(false)).toBe(true);
+  });
+});
+
+describe("mobileSurfaceDockBottom", () => {
+  test("sits above the Live composer", () => {
+    expect(mobileSurfaceDockBottom(true)).toContain("--lfg-inline-composer-height");
+  });
+
+  test("uses the safe-area edge on the Bots roster", () => {
+    expect(mobileSurfaceDockBottom(false)).toBe("var(--lfg-safe-bottom)");
+  });
+});
+
 describe("shouldShowInlineBotsSurfaceToggle", () => {
-  test("hidden at real mobile widths (persistent header toggle covers it)", () => {
+  test("hidden at real mobile widths (persistent bottom toggle covers it)", () => {
     expect(shouldShowInlineBotsSurfaceToggle(true)).toBe(false);
   });
 
-  test("shown in the tablet band, where there is no persistent header toggle", () => {
+  test("shown in the tablet band, where there is no persistent bottom toggle", () => {
     expect(shouldShowInlineBotsSurfaceToggle(false)).toBe(true);
   });
 });

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -2,12 +2,9 @@
  * Pure decision logic for the mobile "Chat | Bot" surface toggle.
  *
  * Desktop reaches the bots surface through `SurfaceToggle` in the rail
- * header (`RailStage`), which only mounts at `isWide` widths. Mobile had no
- * equivalent direct control — Bots was reachable only through the `PagesMenu`
- * overflow. This module is the (testable) gating logic for the mobile
- * equivalent: a persistent toggle in the mobile header that mirrors the
- * desktop rail's Chat/Bot switch, without inventing a second navigation
- * idiom (no bottom tab bar, no drawer).
+ * header (`RailStage`), which only mounts at `isWide` widths. Mobile uses one
+ * compact dock above the composer instead, with strict data separation between
+ * Chat sessions and persistent Bots.
  *
  * Kept as pure functions, imported by App.tsx, so the render logic and the
  * unit-tested logic are the same source instead of two copies that can
@@ -25,8 +22,8 @@ export const MOBILE_BOT_ROSTER_ROW_CLASS =
   "flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted";
 
 /**
- * The persistent mobile header toggle (Live header + Bots header) shows only
- * at real mobile widths, and only on the two tabs it switches between. Other
+ * The persistent mobile bottom toggle shows only at real mobile widths, and
+ * only on the two tabs it switches between. Other
  * pages (Notifications, Artifacts, Settings, extension tabs) stay reachable
  * through the existing `PagesMenu` overflow — this keeps exactly one
  * additional navigation affordance, not a competing tab-bar model.
@@ -43,12 +40,22 @@ export function mobileSurfaceToggleActive(tab: string): SurfaceToggleActive {
   return tab === "bots" ? "chat" : "sessions";
 }
 
+/** Mobile Chat and Bots are strict, mutually exclusive data surfaces. */
+export function shouldShowBotsInSessionList(isMobile: boolean): boolean {
+  return !isMobile;
+}
+
+export function mobileSurfaceDockBottom(aboveComposer: boolean): string {
+  return aboveComposer
+    ? "var(--lfg-inline-composer-height, var(--lfg-composer-clear))"
+    : "var(--lfg-safe-bottom)";
+}
+
 /**
  * `BotsView`'s roster page carries its own inline `SurfaceToggle` (used by
- * the tablet band, where `!isWide && !isMobile`). Once the persistent mobile
- * header toggle exists, real mobile would otherwise show both — the pinned
- * header one and the inline one scrolling in the page content. This keeps
- * the inline copy tablet-only so mobile shows exactly one toggle.
+ * the tablet band, where `!isWide && !isMobile`). The persistent mobile dock
+ * would otherwise duplicate this inline control. This keeps the inline copy
+ * tablet-only so mobile shows exactly one toggle.
  */
 export function shouldShowInlineBotsSurfaceToggle(isMobile: boolean): boolean {
   return !isMobile;


### PR DESCRIPTION
## What changed

- moves the mobile Chat/Bots switch into a compact bottom dock above the composer
- keeps persistent bot families out of the mobile Chat session list
- resolves bot conversations by their exact saved main session
- adds a sliding active pill with reduced-motion support
- preserves the existing desktop session grouping

## Why

Mobile Chat mixed bot conversations with delegated child sessions. A broad `botId` lookup could also open a child task instead of the bot's persistent conversation.

## Validation

- `bun test ./src/lib/mobile-bots-nav.test.ts ./src/lib/bot-session.test.ts ./src/mobile-copy-button.test.ts`
- `bun run typecheck`
- `bun run build`
