### PR TITLE
feat(mobile): guest side of shared Computers

### DIFF
--- a/mobile/app/computers.tsx
+++ b/mobile/app/computers.tsx
@@ -24,6 +24,7 @@ import { useTheme } from "../src/omg/theme";
 import { useToast } from "../src/omg/toast";
 import { bindingLabel, cloudStatusLabel, machineSpec, relativeTime } from "../src/omg/format";
 import { CLOUD_BINDING_ID } from "../src/omg/config";
+import { sharedBindingLabel } from "../src/omg/computer-shared-binding";
 
 const BLOCKED_CLOUD_STATUSES = new Set(["upgrade_required", "recycled"]);
 
@@ -70,6 +71,7 @@ export default function ComputersScreen() {
   const { colors, type, space } = useTheme();
   const {
     bindings,
+    sharedComputers,
     cloud,
     bindingId,
     selectBinding,
@@ -209,6 +211,53 @@ export default function ComputersScreen() {
           </>
         ) : null}
       </Card>
+
+      {/**
+       * Machines someone else shared with this account — never in `bindings`,
+       * relay only ever reports machines you own. Its own section, same as
+       * "Your machines" above: these are reachable and selectable exactly the
+       * same way, but they are not this account's machines, and saying so
+       * plainly is the whole point (see `sharedBindingLabel`).
+       *
+       * Not rendered at all for the (overwhelming majority) account nothing
+       * has been shared with — an empty "Shared with you" heading over
+       * nothing would be a section that exists to say "no".
+       */}
+      {sharedComputers.length > 0 ? (
+        <>
+          <SectionLabel>Shared with you</SectionLabel>
+          <Card>
+            {sharedComputers.map((c, i) => {
+              const selected = c.id === bindingId;
+              return (
+                <View key={c.id}>
+                  {i > 0 ? <Separator inset="text" /> : null}
+                  <Row onPress={() => void choose(c.id)}>
+                    <StatusDot busy={c.online ?? true} />
+                    <View style={{ flex: 1, gap: 2 }}>
+                      <Text style={{ ...type.callout, color: colors.text, fontWeight: "600" }}>
+                        {sharedBindingLabel(c.ownerLabel)}
+                      </Text>
+                      <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted }}>
+                        {c.online === false ? "Offline" : `Shared by ${c.ownerLabel}`}
+                      </Text>
+                    </View>
+                    {selected ? (
+                      <Icon
+                        ios="checkmark"
+                        android="check"
+                        size={16}
+                        weight="semibold"
+                        color={colors.primary}
+                      />
+                    ) : null}
+                  </Row>
+                </View>
+              );
+            })}
+          </Card>
+        </>
+      ) : null}
 
       <Text
         style={{

--- a/mobile/app/computers.tsx
+++ b/mobile/app/computers.tsx
@@ -24,7 +24,7 @@ import { useTheme } from "../src/omg/theme";
 import { useToast } from "../src/omg/toast";
 import { bindingLabel, cloudStatusLabel, machineSpec, relativeTime } from "../src/omg/format";
 import { CLOUD_BINDING_ID } from "../src/omg/config";
-import { sharedBindingLabel } from "../src/omg/computer-shared-binding";
+import { sharedBindingLabel, sharedComputerSubtitle } from "../src/omg/computer-shared-binding";
 
 const BLOCKED_CLOUD_STATUSES = new Set(["upgrade_required", "recycled"]);
 
@@ -127,7 +127,10 @@ export default function ComputersScreen() {
                   <Row onPress={() => void choose(b.id)}>
                     <StatusDot busy={b.online} />
                     <View style={{ flex: 1, gap: 2 }}>
-                      <Text style={{ ...type.callout, color: colors.text, fontWeight: "600" }}>
+                      <Text
+                        numberOfLines={1}
+                        style={{ ...type.callout, color: colors.text, fontWeight: "600" }}
+                      >
                         {bindingLabel(b)}
                       </Text>
                       <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted }}>
@@ -161,7 +164,10 @@ export default function ComputersScreen() {
         >
           <StatusDot busy={!cloudBlocked && Boolean(cloud)} blocked={cloudBlocked} />
           <View style={{ flex: 1, gap: 2 }}>
-            <Text style={{ ...type.callout, color: colors.text, fontWeight: "600" }}>
+            <Text
+              numberOfLines={1}
+              style={{ ...type.callout, color: colors.text, fontWeight: "600" }}
+            >
               Cloud computer
             </Text>
             <Text style={{ ...type.footnote, color: cloudBlocked ? colors.warning : colors.textMuted }}>
@@ -217,7 +223,9 @@ export default function ComputersScreen() {
        * relay only ever reports machines you own. Its own section, same as
        * "Your machines" above: these are reachable and selectable exactly the
        * same way, but they are not this account's machines, and saying so
-       * plainly is the whole point (see `sharedBindingLabel`).
+       * plainly is the whole point (see `sharedBindingLabel`). The row names
+       * the machine; the section names whose it is. The subtitle is liveness,
+       * not "Shared by Ada" — that attribution is already the heading.
        *
        * Not rendered at all for the (overwhelming majority) account nothing
        * has been shared with — an empty "Shared with you" heading over
@@ -235,11 +243,14 @@ export default function ComputersScreen() {
                   <Row onPress={() => void choose(c.id)}>
                     <StatusDot busy={c.online ?? true} />
                     <View style={{ flex: 1, gap: 2 }}>
-                      <Text style={{ ...type.callout, color: colors.text, fontWeight: "600" }}>
-                        {sharedBindingLabel(c.ownerLabel)}
+                      <Text
+                        numberOfLines={1}
+                        style={{ ...type.callout, color: colors.text, fontWeight: "600" }}
+                      >
+                        {sharedBindingLabel(c, sharedComputers)}
                       </Text>
                       <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted }}>
-                        {c.online === false ? "Offline" : `Shared by ${c.ownerLabel}`}
+                        {sharedComputerSubtitle(c)}
                       </Text>
                     </View>
                     {selected ? (

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -57,6 +57,7 @@ import { SessionListSkeleton } from "../src/omg/skeleton";
 import { useTheme } from "../src/omg/theme";
 import { bindingLabel, relativeTime } from "../src/omg/format";
 import { CLOUD_BINDING_ID } from "../src/omg/config";
+import { sharedBindingLabel } from "../src/omg/computer-shared-binding";
 
 /**
  * A session and everything it spawned.
@@ -370,7 +371,7 @@ export default function SessionsScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const { colors, type, space } = useTheme();
-  const { client, readiness, probe, bindingId, bindings, user } = useOmg();
+  const { client, readiness, probe, bindingId, bindings, sharedComputers, user } = useOmg();
   const computerPicker = useComputerPicker();
   // No session exists yet, so these upload to the pre-session endpoint and
   // ride along in the prompt that creates one.
@@ -698,16 +699,27 @@ export default function SessionsScreen() {
     return client.live.subscribeConnection((state) => setConnection(state.status));
   }, [client]);
 
+  const currentSharedComputer = useMemo(
+    () => sharedComputers.find((c) => c.id === bindingId) ?? null,
+    [sharedComputers, bindingId],
+  );
   const currentBinding = useMemo(
-    () => bindings.find((b) => b.id === bindingId) ?? null,
-    [bindings, bindingId],
+    () => bindings.find((b) => b.id === bindingId) ?? currentSharedComputer ?? null,
+    [bindings, currentSharedComputer, bindingId],
   );
 
-  const machineName = currentBinding
-    ? bindingLabel(currentBinding)
-    : bindingId === CLOUD_BINDING_ID
-      ? "Cloud computer"
-      : "No computer";
+  // `bindingLabel` reads a machine's OWN computerUrl/defaultFolder, neither of
+  // which a synthesized shared entry carries (a guest never gets the owner's
+  // direct box URL) — calling it there would fall through to a truncated
+  // "shared:ab12cd…" id. sharedBindingLabel is the one that actually knows
+  // how to name it.
+  const machineName = currentSharedComputer
+    ? sharedBindingLabel(currentSharedComputer.ownerLabel)
+    : currentBinding
+      ? bindingLabel(currentBinding)
+      : bindingId === CLOUD_BINDING_ID
+        ? "Cloud computer"
+        : "No computer";
 
   /** First name only, capitalised — the web greets the same way. */
   const firstName = useMemo(() => {
@@ -1219,6 +1231,25 @@ export default function SessionsScreen() {
             title="Too many agents running"
             detail={readiness.message}
             action={<PrimaryButton label="Try again" onPress={() => void probe()} />}
+          />
+        ) : readiness?.status === "unauthorized" ? (
+          /**
+           * NOT a connection problem — say so, and don't offer a retry that
+           * cannot succeed. This is the state a revoked share (or an
+           * unpaired machine still named in a stale preference) resolves to;
+           * see the readiness.ts doc comment on `"unauthorized"` for the web
+           * bug ("Computer not connected", read as offline) this exists to
+           * not repeat. "Try again" is deliberately absent — the server has
+           * already answered, and asking again gets the same answer.
+           */
+          <EmptyState
+            title="No longer available"
+            detail={readiness.message}
+            action={
+              <DropdownMenu title="Computer" options={computerPicker.options}>
+                <PrimaryButton label="Choose another" />
+              </DropdownMenu>
+            }
           />
         ) : readiness && readiness.status !== "ready" ? (
           <EmptyState

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -57,7 +57,11 @@ import { SessionListSkeleton } from "../src/omg/skeleton";
 import { useTheme } from "../src/omg/theme";
 import { bindingLabel, relativeTime } from "../src/omg/format";
 import { CLOUD_BINDING_ID } from "../src/omg/config";
-import { sharedBindingLabel } from "../src/omg/computer-shared-binding";
+import {
+  isSharedBindingId,
+  SHARED_REVOKED_DETAIL,
+  sharedBindingLabel,
+} from "../src/omg/computer-shared-binding";
 
 /**
  * A session and everything it spawned.
@@ -714,7 +718,7 @@ export default function SessionsScreen() {
   // "shared:ab12cd…" id. sharedBindingLabel is the one that actually knows
   // how to name it.
   const machineName = currentSharedComputer
-    ? sharedBindingLabel(currentSharedComputer.ownerLabel)
+    ? sharedBindingLabel(currentSharedComputer, sharedComputers)
     : currentBinding
       ? bindingLabel(currentBinding)
       : bindingId === CLOUD_BINDING_ID
@@ -1244,7 +1248,11 @@ export default function SessionsScreen() {
            */
           <EmptyState
             title="No longer available"
-            detail={readiness.message}
+            detail={
+              isSharedBindingId(bindingId ?? "")
+                ? SHARED_REVOKED_DETAIL
+                : readiness.message
+            }
             action={
               <DropdownMenu title="Computer" options={computerPicker.options}>
                 <PrimaryButton label="Choose another" />

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -105,10 +105,13 @@ export default function SettingsScreen() {
 
   const current = bindings.find((b) => b.id === bindingId);
   const currentShared = sharedComputers.find((c) => c.id === bindingId);
+  // Same record the label resolved — a selected live share must not paint
+  // idle just because `current` is owned-only and therefore undefined.
+  const selectedMachine = current ?? currentShared;
   const machineName = current
     ? bindingLabel(current)
     : currentShared
-      ? sharedBindingLabel(currentShared.ownerLabel)
+      ? sharedBindingLabel(currentShared, sharedComputers)
       : bindingId === CLOUD_BINDING_ID
         ? "Cloud computer"
         : "None selected";
@@ -277,7 +280,7 @@ export default function SettingsScreen() {
             chevron is honest here for the same reason it would have been a lie
             on a row that only opened a menu. */}
         <Row onPress={() => router.push("/computers")}>
-          <StatusDot busy={current?.online ?? false} />
+          <StatusDot busy={selectedMachine?.online ?? false} />
           <Text style={{ ...type.callout, color: colors.text, flex: 1 }}>{machineName}</Text>
           <Icon
             ios="chevron.right"

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -28,6 +28,7 @@ import { useOmg } from "../src/omg/provider";
 import { useTheme } from "../src/omg/theme";
 import { bindingLabel } from "../src/omg/format";
 import { CLOUD_BINDING_ID } from "../src/omg/config";
+import { sharedBindingLabel } from "../src/omg/computer-shared-binding";
 import {
   getStoredPushToken,
   pushPermissionStatus,
@@ -99,15 +100,18 @@ const WEB_PAGES: { label: string; path: string }[] = [
 export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
   const { colors, type, space } = useTheme();
-  const { user, client, signOut, bindings, bindingId } = useOmg();
+  const { user, client, signOut, bindings, sharedComputers, bindingId } = useOmg();
   const router = useRouter();
 
   const current = bindings.find((b) => b.id === bindingId);
+  const currentShared = sharedComputers.find((c) => c.id === bindingId);
   const machineName = current
     ? bindingLabel(current)
-    : bindingId === CLOUD_BINDING_ID
-      ? "Cloud computer"
-      : "None selected";
+    : currentShared
+      ? sharedBindingLabel(currentShared.ownerLabel)
+      : bindingId === CLOUD_BINDING_ID
+        ? "Cloud computer"
+        : "None selected";
 
   /**
    * "on" tracks whether THIS device has a live, registered token — not just

--- a/mobile/src/omg/computer-picker.ts
+++ b/mobile/src/omg/computer-picker.ts
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { Linking } from "react-native";
 
 import { CLOUD_BINDING_ID } from "./config";
+import { sharedBindingLabel } from "./computer-shared-binding";
 import { bindingLabel, cloudStatusLabel, relativeTime } from "./format";
 import { type MenuOption } from "./menu";
 import { useOmg } from "./provider";
@@ -39,7 +40,15 @@ const WEB_FIXABLE_CLOUD_STATUSES = new Set(["recycled"]);
 
 export function useComputerPicker() {
   const router = useRouter();
-  const { bindings, cloud, bindingId, selectBinding, refreshMachines, machinesError } = useOmg();
+  const {
+    bindings,
+    sharedComputers,
+    cloud,
+    bindingId,
+    selectBinding,
+    refreshMachines,
+    machinesError,
+  } = useOmg();
   const toast = useToast();
   // The pushed screen this menu replaced surfaced a listing failure with its
   // own toast. There is no longer a screen to own that effect, so the menu
@@ -93,6 +102,29 @@ export function useComputerPicker() {
     }
 
     /**
+     * Machines someone else shared with this account. Their own `section`
+     * heading keeps them visually apart from the rows above — the menu's own
+     * checkmark already tells you which of ALL of them (yours or shared) is
+     * current, but a name like "Ada's computer" sitting unlabelled among your
+     * own machines reads as one more of yours, not someone else's.
+     *
+     * Never disabled for being offline: an owner's machine can come back
+     * (theirs to wake, not something this account can do from here), and
+     * `online` on a shared entry defaults optimistic when the server could
+     * not resolve it — see computer-shared-binding.ts's SharedComputerView.
+     */
+    for (const shared of sharedComputers) {
+      rows.push({
+        label: shared.online === false
+          ? `${sharedBindingLabel(shared.ownerLabel)} — offline`
+          : sharedBindingLabel(shared.ownerLabel),
+        section: "Shared with you",
+        selected: shared.id === bindingId,
+        onPress: () => void selectBinding(shared.id),
+      });
+    }
+
+    /**
      * The menu switches; the screen manages. They are not competing answers.
      *
      * A menu is a list of short labels, and there are things it structurally
@@ -115,7 +147,7 @@ export function useComputerPicker() {
     });
 
     return rows;
-  }, [bindings, bindingId, cloud, cloudBlocked, selectBinding, router]);
+  }, [bindings, sharedComputers, bindingId, cloud, cloudBlocked, selectBinding, router]);
 
   return { options, cloudBlocked };
 }

--- a/mobile/src/omg/computer-picker.ts
+++ b/mobile/src/omg/computer-picker.ts
@@ -21,7 +21,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { Linking } from "react-native";
 
 import { CLOUD_BINDING_ID } from "./config";
-import { sharedBindingLabel } from "./computer-shared-binding";
+import { sharedComputerPickerLabel } from "./computer-shared-binding";
 import { bindingLabel, cloudStatusLabel, relativeTime } from "./format";
 import { type MenuOption } from "./menu";
 import { useOmg } from "./provider";
@@ -105,7 +105,7 @@ export function useComputerPicker() {
      * Machines someone else shared with this account. Their own `section`
      * heading keeps them visually apart from the rows above — the menu's own
      * checkmark already tells you which of ALL of them (yours or shared) is
-     * current, but a name like "Ada's computer" sitting unlabelled among your
+     * current, but a name like "Ada's MacBook" sitting unlabelled among your
      * own machines reads as one more of yours, not someone else's.
      *
      * Never disabled for being offline: an owner's machine can come back
@@ -115,9 +115,7 @@ export function useComputerPicker() {
      */
     for (const shared of sharedComputers) {
       rows.push({
-        label: shared.online === false
-          ? `${sharedBindingLabel(shared.ownerLabel)} — offline`
-          : sharedBindingLabel(shared.ownerLabel),
+        label: sharedComputerPickerLabel(shared, sharedComputers),
         section: "Shared with you",
         selected: shared.id === bindingId,
         onPress: () => void selectBinding(shared.id),

--- a/mobile/src/omg/computer-shared-binding.ts
+++ b/mobile/src/omg/computer-shared-binding.ts
@@ -1,0 +1,106 @@
+/**
+ * Addressing someone else's machine from the phone.
+ *
+ * This is a PORT, not a reinvention. The web dashboard already worked out (and
+ * broke, and fixed) this format:
+ * apps/web/src/components/computer/computer-shared-binding.ts in
+ * BennyKok/vibes, mirrored server-side by
+ * control-plane/lib/computer-access.ts's own `SHARED_BINDING_PREFIX`. A
+ * binding id already identifies a machine everywhere in this app — it keys
+ * the transport cache (transport.ts), the grant owner, the persisted
+ * preference (AsyncStorage `STORAGE_KEYS.binding`) — so a shared machine needs
+ * to be addressable by the same KIND of string, or every one of those would
+ * have to learn a second dimension.
+ *
+ * So a shared machine is spelled `shared:<ownerUserId>:<bindingId>`, exactly
+ * as the control plane expects it. Both halves are needed because sharing is
+ * PER MACHINE: the owner alone would not say which of their machines, and the
+ * binding alone would not say whose. This is a documented CONTRACT with the
+ * server, not a client convention — the first version of this on web invented
+ * its own client-only spelling and the server could not parse it. Do not
+ * change this format without changing control-plane/lib/computer-access.ts to
+ * match; that file is out of scope here (read-only, different repo).
+ */
+
+export const SHARED_BINDING_PREFIX = "shared:";
+
+export interface SharedBindingTarget {
+  ownerUserId: string;
+  bindingId: string;
+}
+
+export function sharedBindingId(ownerUserId: string, bindingId: string): string {
+  return `${SHARED_BINDING_PREFIX}${ownerUserId}:${bindingId}`;
+}
+
+export function isSharedBindingId(bindingId: string): boolean {
+  return bindingId.startsWith(SHARED_BINDING_PREFIX);
+}
+
+/**
+ * The (owner, machine) pair behind a shared binding id, or null for an
+ * ordinary machine.
+ *
+ * Splits on the FIRST colon only: the owner is a uuid and never contains one,
+ * while the trailing binding id is passed through untouched so it survives
+ * whatever spelling relay chooses for it.
+ */
+export function parseSharedBindingId(bindingId: string): SharedBindingTarget | null {
+  if (!isSharedBindingId(bindingId)) return null;
+  const rest = bindingId.slice(SHARED_BINDING_PREFIX.length);
+  const split = rest.indexOf(":");
+  if (split <= 0) return null;
+  const ownerUserId = rest.slice(0, split).trim();
+  const target = rest.slice(split + 1).trim();
+  if (!ownerUserId || !target) return null;
+  return { ownerUserId, bindingId: target };
+}
+
+/**
+ * What the session-auth mint endpoint should be asked for, for any binding id
+ * this app might have selected. The mint route (control-plane
+ * `handleSessionAuthMint`, POST /__omg/session-auth) takes the RAW binding id
+ * plus an optional `ownerUserId` — it does not understand the `shared:`
+ * spelling itself, that decoding is entirely this app's job.
+ */
+export function mintTargetForBinding(bindingId: string): {
+  bindingId: string;
+  ownerUserId?: string;
+} {
+  const shared = parseSharedBindingId(bindingId);
+  return shared ? { bindingId: shared.bindingId, ownerUserId: shared.ownerUserId } : { bindingId };
+}
+
+/** What `listSharedComputers` returns for one machine shared with the signed-in account. */
+export type SharedComputerView = {
+  ownerUserId: string;
+  bindingId: string;
+  email: string;
+  name?: string;
+  image?: string;
+  sharedAt: number;
+  /**
+   * Liveness of the OWNER's machine, resolved server-side. This app cannot
+   * ask relay itself — relay only answers "which machines are YOURS", and a
+   * shared one never is. Undefined means the server could not resolve it
+   * either; treat that as reachable rather than rendering a false "offline",
+   * same as the web dashboard does.
+   */
+  online?: boolean;
+};
+
+/** "Ada" / "ada@example.com" — whichever the share row actually carries. */
+export function sharedComputerOwnerLabel(
+  computer: Pick<SharedComputerView, "name" | "email">,
+): string {
+  return computer.name?.trim() || computer.email;
+}
+
+/** "Ada's computer" — how a shared machine is named in the picker and the
+ *  manage screen, distinct from how this app labels its OWN machines
+ *  (bindingLabel in format.ts). Never call bindingLabel on a synthesized
+ *  shared binding: it has no computerUrl/defaultFolder of its own to read,
+ *  and would fall back to a truncated id. */
+export function sharedBindingLabel(ownerLabel: string): string {
+  return `${ownerLabel}’s computer`;
+}

--- a/mobile/src/omg/computer-shared-binding.ts
+++ b/mobile/src/omg/computer-shared-binding.ts
@@ -71,8 +71,36 @@ export function mintTargetForBinding(bindingId: string): {
   return shared ? { bindingId: shared.bindingId, ownerUserId: shared.ownerUserId } : { bindingId };
 }
 
+/**
+ * Detail for a revoked share — mint 403 or a `shared:` preference that is no
+ * longer in `listSharedComputers`. The empty-state TITLE is already
+ * "No longer available"; this line says why, instead of restating that title.
+ */
+export const SHARED_REVOKED_DETAIL = "This computer is no longer shared with you.";
+
+/**
+ * Optional machine identity the share row may carry. A guest never gets the
+ * owner's live `computerUrl` for transport, but the list payload can still
+ * name the box so two shares from one person are not the same string.
+ */
+export type SharedComputerIdentity = {
+  hostname?: string;
+  computerName?: string;
+  machineName?: string;
+  machineLabel?: string;
+  defaultFolder?: string | null;
+  computerUrl?: string | null;
+  binding?: {
+    hostname?: string;
+    computerName?: string;
+    machineName?: string;
+    computerUrl?: string | null;
+    defaultFolder?: string | null;
+  };
+};
+
 /** What `listSharedComputers` returns for one machine shared with the signed-in account. */
-export type SharedComputerView = {
+export type SharedComputerView = SharedComputerIdentity & {
   ownerUserId: string;
   bindingId: string;
   email: string;
@@ -89,6 +117,19 @@ export type SharedComputerView = {
   online?: boolean;
 };
 
+/** Fields the label helpers read — a list row or the synthesized binding. */
+export type SharedComputerLabelSource = SharedComputerIdentity & {
+  ownerUserId?: string;
+  bindingId?: string;
+  id?: string;
+  email?: string;
+  name?: string;
+  ownerName?: string;
+  ownerLabel?: string;
+  ownerBindingId?: string;
+  online?: boolean;
+};
+
 /** "Ada" / "ada@example.com" — whichever the share row actually carries. */
 export function sharedComputerOwnerLabel(
   computer: Pick<SharedComputerView, "name" | "email">,
@@ -96,11 +137,148 @@ export function sharedComputerOwnerLabel(
   return computer.name?.trim() || computer.email;
 }
 
-/** "Ada's computer" — how a shared machine is named in the picker and the
- *  manage screen, distinct from how this app labels its OWN machines
- *  (bindingLabel in format.ts). Never call bindingLabel on a synthesized
- *  shared binding: it has no computerUrl/defaultFolder of its own to read,
- *  and would fall back to a truncated id. */
-export function sharedBindingLabel(ownerLabel: string): string {
-  return `${ownerLabel}’s computer`;
+export function looksLikeEmail(value: string): boolean {
+  return value.includes("@");
+}
+
+/**
+ * First name from a real display name. Never an email — possessivizing
+ * `ada@example.com` produced "ada@example.com's computer", which is the
+ * string this helper exists to stop shipping.
+ */
+export function sharedComputerFirstName(computer: SharedComputerLabelSource): string | null {
+  const named = computer.name?.trim() || computer.ownerName?.trim();
+  const fromName = firstNameToken(named);
+  if (fromName) return fromName;
+  return firstNameToken(computer.ownerLabel?.trim());
+}
+
+function firstNameToken(raw?: string): string | null {
+  if (!raw || looksLikeEmail(raw)) return null;
+  const first = raw.split(/\s+/)[0] ?? "";
+  if (!first || looksLikeEmail(first)) return null;
+  return `${first.charAt(0).toUpperCase()}${first.slice(1)}`;
+}
+
+/**
+ * Which machine this share is, when the server said. Hostname first, then
+ * an explicit name, then the same URL/folder fallbacks `bindingLabel` uses
+ * for a box you own. Missing is fine — the title falls back to "computer"
+ * and collisions get a short tail.
+ */
+export function sharedComputerMachineIdentity(
+  computer: SharedComputerLabelSource,
+): string | undefined {
+  const nested = computer.binding;
+  const candidates = [
+    computer.machineLabel,
+    computer.hostname,
+    computer.computerName,
+    computer.machineName,
+    nested?.hostname,
+    nested?.computerName,
+    nested?.machineName,
+    hostnameFromUrl(computer.computerUrl),
+    hostnameFromUrl(nested?.computerUrl),
+    folderBasename(computer.defaultFolder),
+    folderBasename(nested?.defaultFolder),
+  ];
+  for (const candidate of candidates) {
+    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+    if (trimmed && !looksLikeEmail(trimmed)) return trimmed;
+  }
+  return undefined;
+}
+
+function hostnameFromUrl(url?: string | null): string | undefined {
+  if (!url) return undefined;
+  try {
+    const host = new URL(url).hostname.split(".")[0];
+    if (host && host !== "localhost" && !/^\d+$/.test(host)) return host;
+  } catch {
+    /* fall through */
+  }
+  return undefined;
+}
+
+function folderBasename(folder?: string | null): string | undefined {
+  const name = folder?.split("/").filter(Boolean).pop()?.trim();
+  return name || undefined;
+}
+
+function ownerBindingId(computer: SharedComputerLabelSource): string {
+  if (computer.ownerBindingId?.trim()) return computer.ownerBindingId.trim();
+  if (computer.bindingId?.trim()) {
+    const parsed = parseSharedBindingId(computer.bindingId);
+    return parsed?.bindingId ?? computer.bindingId.trim();
+  }
+  if (computer.id) {
+    const parsed = parseSharedBindingId(computer.id);
+    if (parsed) return parsed.bindingId;
+  }
+  return "";
+}
+
+function uniqueTail(computer: SharedComputerLabelSource): string {
+  const compact = ownerBindingId(computer).replace(/[^a-zA-Z0-9]/g, "");
+  if (compact.length >= 6) return compact.slice(-6);
+  if (compact.length > 0) return compact;
+  return "share";
+}
+
+/**
+ * Title for a shared machine.
+ *
+ * - Owner has a name: first-name possessive + machine identity when we have
+ *   one ("Ada's MacBook" / "Ada's studio"), else "Ada's computer".
+ * - Owner is email-only: "Shared computer". Never `"ada@example.com's computer"`.
+ * - Two rows that would otherwise match get a short unique tail.
+ *
+ * Distinct from `bindingLabel` (format.ts), which reads a machine YOU own.
+ * Never call that on a synthesized shared binding: a guest has no
+ * `computerUrl` of their own, and it would fall through to a truncated id.
+ */
+export function sharedBindingLabel(
+  computer: SharedComputerLabelSource,
+  siblings: SharedComputerLabelSource[] = [],
+): string {
+  const title = sharedBindingBaseTitle(computer);
+  const collisions = siblings.filter((other) => sharedBindingBaseTitle(other) === title);
+  if (collisions.length <= 1) return title;
+  return `${title} · ${uniqueTail(computer)}`;
+}
+
+export function sharedBindingBaseTitle(computer: SharedComputerLabelSource): string {
+  const first = sharedComputerFirstName(computer);
+  if (!first) return "Shared computer";
+  const machine = sharedComputerMachineIdentity(computer);
+  return `${first}’s ${machine ?? "computer"}`;
+}
+
+/**
+ * Second line on the manage screen.
+ *
+ * Attribution is the section + title. A named owner gets liveness
+ * (Online / Offline). Email-only puts the email here — that is the only
+ * place the address belongs, and possessivizing it as a title is the
+ * thing this policy forbids.
+ */
+export function sharedComputerSubtitle(computer: SharedComputerLabelSource): string {
+  if (!sharedComputerFirstName(computer)) {
+    const email = computer.email?.trim();
+    if (email) return email;
+    const label = computer.ownerLabel?.trim();
+    if (label && looksLikeEmail(label)) return label;
+    return computer.online === false ? "Offline" : "Online";
+  }
+  return computer.online === false ? "Offline" : "Online";
+}
+
+/** Picker row: the title, plus a title-case "Offline" suffix when down. */
+export function sharedComputerPickerLabel(
+  computer: SharedComputerLabelSource,
+  siblings: SharedComputerLabelSource[] = [],
+): string {
+  const title = sharedBindingLabel(computer, siblings);
+  return computer.online === false ? `${title} — Offline` : title;
 }

--- a/mobile/src/omg/provider.tsx
+++ b/mobile/src/omg/provider.tsx
@@ -30,7 +30,9 @@ import { startCloudPresence } from "./presence";
 import { waitForReady, type ComputerReadiness } from "./readiness";
 import {
   isSharedBindingId,
+  SHARED_REVOKED_DETAIL,
   sharedBindingId,
+  sharedComputerMachineIdentity,
   sharedComputerOwnerLabel,
   type SharedComputerView,
 } from "./computer-shared-binding";
@@ -58,21 +60,33 @@ export type ComputerBinding = {
 export type SharedComputerBinding = ComputerBinding & {
   shared: true;
   ownerUserId: string;
+  /** The owner's raw binding id, for a unique tail when titles collide. */
+  ownerBindingId: string;
   /** The owner's name, or their email if they have none set. */
   ownerLabel: string;
+  /** Display name when they have one. Never an email. */
+  ownerName?: string;
+  email: string;
+  /** Hostname / machine name when the share row named the box. */
+  machineLabel?: string;
 };
 
 function toSharedBinding(computer: SharedComputerView): SharedComputerBinding {
   const ownerLabel = sharedComputerOwnerLabel(computer);
+  const ownerName = computer.name?.trim();
   return {
     id: sharedBindingId(computer.ownerUserId, computer.bindingId),
     online: computer.online ?? true,
     lastSeenAt: null,
-    defaultFolder: null,
+    defaultFolder: computer.defaultFolder ?? computer.binding?.defaultFolder ?? null,
     computerUrl: null,
     shared: true,
     ownerUserId: computer.ownerUserId,
+    ownerBindingId: computer.bindingId,
     ownerLabel,
+    ownerName: ownerName && !ownerName.includes("@") ? ownerName : undefined,
+    email: computer.email,
+    machineLabel: sharedComputerMachineIdentity(computer),
   };
 }
 
@@ -337,7 +351,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
         if (ticket === probeToken.current) {
           setReadiness({
             status: "unauthorized",
-            message: "This computer is no longer shared with you.",
+            message: SHARED_REVOKED_DETAIL,
           });
         }
         return;

--- a/mobile/src/omg/provider.tsx
+++ b/mobile/src/omg/provider.tsx
@@ -28,6 +28,12 @@ import { forgetAllTransports, getHostedTransport } from "./transport";
 import { unregisterForPushNotifications } from "./push";
 import { startCloudPresence } from "./presence";
 import { waitForReady, type ComputerReadiness } from "./readiness";
+import {
+  isSharedBindingId,
+  sharedBindingId,
+  sharedComputerOwnerLabel,
+  type SharedComputerView,
+} from "./computer-shared-binding";
 
 export type ComputerBinding = {
   id: string;
@@ -37,6 +43,38 @@ export type ComputerBinding = {
   defaultFolder?: string | null;
   computerUrl?: string | null;
 };
+
+/**
+ * A machine somebody else shared with this account, presented as an ordinary
+ * binding so it can flow through the same transport cache, grant mint and
+ * picker rows as one of the account's own. `id` is the opaque
+ * `shared:<ownerUserId>:<bindingId>` spelling from computer-shared-binding.ts
+ * — everything downstream keys on that one string.
+ *
+ * Never synthesized with a `computerUrl`: a guest never gets the owner's
+ * direct box URL, only the session proxy (which is what actually authorized
+ * them) knows how to reach it.
+ */
+export type SharedComputerBinding = ComputerBinding & {
+  shared: true;
+  ownerUserId: string;
+  /** The owner's name, or their email if they have none set. */
+  ownerLabel: string;
+};
+
+function toSharedBinding(computer: SharedComputerView): SharedComputerBinding {
+  const ownerLabel = sharedComputerOwnerLabel(computer);
+  return {
+    id: sharedBindingId(computer.ownerUserId, computer.bindingId),
+    online: computer.online ?? true,
+    lastSeenAt: null,
+    defaultFolder: null,
+    computerUrl: null,
+    shared: true,
+    ownerUserId: computer.ownerUserId,
+    ownerLabel,
+  };
+}
 
 /**
  * What the SELECTED box can run and where. Read from /api/bootstrap, which is
@@ -76,6 +114,13 @@ type OmgContextValue = {
   signOut: () => Promise<void>;
 
   bindings: ComputerBinding[];
+  /**
+   * Machines OTHER people shared with this account. Never present in
+   * `bindings` — relay only ever reports machines you own — so every
+   * consumer that used to just read `bindings` for "everything I can pick"
+   * needs to read this alongside it now.
+   */
+  sharedComputers: SharedComputerBinding[];
   cloud: CloudComputer | null;
   machinesLoading: boolean;
   /** The computer list has been answered at least once. See the state below. */
@@ -130,6 +175,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
   const [user, setUser] = useState<SignedInUser | null>(null);
 
   const [bindings, setBindings] = useState<ComputerBinding[]>([]);
+  const [sharedComputers, setSharedComputers] = useState<SharedComputerBinding[]>([]);
   const [cloud, setCloud] = useState<CloudComputer | null>(null);
   const [machinesLoading, setMachinesLoading] = useState(false);
   /**
@@ -159,16 +205,25 @@ export function OmgProvider({ children }: PropsWithChildren) {
   const refreshMachines = useCallback(async () => {
     setMachinesLoading(true);
     try {
-      const [bindingsResult, cloudResult] = await Promise.allSettled([
+      const [bindingsResult, cloudResult, sharedResult] = await Promise.allSettled([
         controlPlane<{ bindings?: ComputerBinding[] }>("listComputerBindings"),
         controlPlane<CloudComputer>("getCloudComputer"),
+        controlPlane<{ computers?: SharedComputerView[] }>("listSharedComputers"),
       ]);
       if (bindingsResult.status === "fulfilled") {
         setBindings(bindingsResult.value?.bindings ?? []);
       }
       if (cloudResult.status === "fulfilled") setCloud(cloudResult.value ?? null);
-      // Only a total failure is worth a message; one of the two answering is
-      // still a usable screen.
+      // Best-effort, same as the web dashboard: almost every account has
+      // nothing shared with it, and a failure here should cost the "Shared
+      // with you" section, never the two calls above that every account
+      // depends on.
+      if (sharedResult.status === "fulfilled") {
+        setSharedComputers((sharedResult.value?.computers ?? []).map(toSharedBinding));
+      }
+      // Only a total failure of the two calls every account depends on is
+      // worth a message; `sharedComputers` failing alone never blocks the
+      // screen (see the best-effort note above).
       if (bindingsResult.status === "rejected" && cloudResult.status === "rejected") {
         setMachinesError(
           bindingsResult.reason instanceof Error
@@ -262,6 +317,34 @@ export function OmgProvider({ children }: PropsWithChildren) {
     setReadiness((current) => (current?.status === "ready" ? current : { status: "connecting" }));
 
     /**
+     * A `shared:` selection that no longer appears in OUR OWN read of "shared
+     * with me" has had its access revoked (or never existed). Caught here,
+     * before ever asking the box: minting a grant for it would 403 anyway —
+     * readiness.ts's ComputerGrantError handling is what catches that same
+     * failure reactively, for a share that gets revoked mid-session — but
+     * finding out here means a stale preference reads as "no longer shared
+     * with you" immediately, with no failed round trip in between to frame it
+     * as a broken connection instead of a withdrawn one.
+     *
+     * Gated on `machinesLoaded` so a probe that races the FIRST
+     * `refreshMachines()` (cold start restoring a saved bindingId before the
+     * network has answered even once) falls through to the real probe below
+     * instead of misreading "not fetched yet" as "revoked".
+     */
+    if (machinesLoaded && isSharedBindingId(bindingId)) {
+      const stillShared = sharedComputers.some((c) => c.id === bindingId);
+      if (!stillShared) {
+        if (ticket === probeToken.current) {
+          setReadiness({
+            status: "unauthorized",
+            message: "This computer is no longer shared with you.",
+          });
+        }
+        return;
+      }
+    }
+
+    /**
      * Ask a sleeping cloud Computer to actually wake up.
      *
      * Nothing else this app does will. The control plane is emphatic that
@@ -295,7 +378,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
     const result = await waitForReady(getHostedTransport(bindingId));
     // A machine switch mid-probe must not overwrite the new machine's state.
     if (ticket === probeToken.current) setReadiness(result);
-  }, [bindingId]);
+  }, [bindingId, machinesLoaded, sharedComputers]);
 
   useEffect(() => {
     if (bindingId && authStatus === "signed-in") void probe();
@@ -394,6 +477,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
     setBindingId(null);
     setReadiness(null);
     setBindings([]);
+    setSharedComputers([]);
     setCloud(null);
     setUser(null);
     // The redirect to sign-in lives centrally in RootNavigator
@@ -437,6 +521,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
       refreshSession,
       signOut,
       bindings,
+      sharedComputers,
       cloud,
       machinesLoading,
       machinesLoaded,
@@ -456,6 +541,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
       refreshSession,
       signOut,
       bindings,
+      sharedComputers,
       cloud,
       machinesLoading,
       machinesLoaded,

--- a/mobile/src/omg/readiness.ts
+++ b/mobile/src/omg/readiness.ts
@@ -15,6 +15,8 @@
 
 import type { OmgTransport } from "@omg-dev/client";
 
+import { ComputerGrantError } from "./transport";
+
 /** What the box can run, and the folders it can run in. */
 export type BootstrapRoster = {
   agents: { key: string; label: string; visible?: boolean; status?: { configured?: boolean; accountConnected?: boolean } }[];
@@ -42,6 +44,18 @@ export type ComputerReadiness =
   | { status: "agent-limit"; message: string }
   /** The runtime behind the proxy is down (502/503/504). */
   | { status: "unavailable"; message: string }
+  /**
+   * The mint 403'd: the server does not consider this account authorized for
+   * the selected machine RIGHT NOW. Distinct from `unavailable` on purpose —
+   * that status reads as "the box is having trouble", which is a reason to
+   * retry, and this is not. A revoked share (or an unpaired laptop still
+   * named in the stored preference) needs a different machine, not a retry
+   * loop against a grant that will 403 forever. See computer-shared-binding.ts
+   * for the web bug this specifically exists to not repeat: a revoked share
+   * used to render as "Computer not connected", which reads as offline rather
+   * than as "pick something else".
+   */
+  | { status: "unauthorized"; message: string }
   | { status: "error"; message: string };
 
 export async function probeReadiness(
@@ -51,6 +65,9 @@ export async function probeReadiness(
   try {
     response = await transport.fetch("/api/bootstrap");
   } catch (error) {
+    if (error instanceof ComputerGrantError && error.forbidden) {
+      return { status: "unauthorized", message: error.message };
+    }
     return {
       status: "unavailable",
       message: error instanceof Error ? error.message : "Couldn't reach your Computer.",

--- a/mobile/src/omg/transport.ts
+++ b/mobile/src/omg/transport.ts
@@ -20,7 +20,11 @@ import {
 
 import { SESSION_AUTH_PATH, SESSION_ORIGIN } from "./config";
 import { getAuthToken } from "./auth";
-import { mintTargetForBinding } from "./computer-shared-binding";
+import {
+  isSharedBindingId,
+  mintTargetForBinding,
+  SHARED_REVOKED_DETAIL,
+} from "./computer-shared-binding";
 
 export class ComputerGrantError extends Error {
   /**
@@ -80,7 +84,9 @@ export async function mintSessionGrant(bindingId: string): Promise<OmgGrant> {
     // never yours or a share that was just revoked. See the `forbidden` flag's
     // doc comment above.
     throw new ComputerGrantError(
-      "This computer isn't available to your account anymore.",
+      isSharedBindingId(bindingId)
+        ? SHARED_REVOKED_DETAIL
+        : "This computer isn't available to your account anymore.",
       true,
     );
   }

--- a/mobile/src/omg/transport.ts
+++ b/mobile/src/omg/transport.ts
@@ -20,8 +20,21 @@ import {
 
 import { SESSION_AUTH_PATH, SESSION_ORIGIN } from "./config";
 import { getAuthToken } from "./auth";
+import { mintTargetForBinding } from "./computer-shared-binding";
 
-export class ComputerGrantError extends Error {}
+export class ComputerGrantError extends Error {
+  /**
+   * Set only for a 403. readiness.ts reads this to tell "the server refused
+   * this exact (owner, machine) pair" apart from "couldn't reach the session
+   * origin at all" — the two errors this class otherwise flattens into one
+   * shape. A 403 here is never transient: it means the mint's authorization
+   * check failed (an unshared/unpaired binding, or a share that has since
+   * been revoked), and retrying with the same grant will 403 again forever.
+   */
+  constructor(message: string, public readonly forbidden = false) {
+    super(message);
+  }
+}
 
 /**
  * Trade the account JWT for a signed, short-lived grant scoped to one machine.
@@ -30,10 +43,19 @@ export class ComputerGrantError extends Error {}
  * browser needs the header; we deliberately ignore it and use the field as a
  * bearer token, which the proxy's readSessionGrant() accepts precisely so
  * non-browser clients don't have to care about cookie policy.
+ *
+ * `bindingId` here is whatever this app has selected, which may be the
+ * `shared:<ownerUserId>:<bindingId>` spelling from computer-shared-binding.ts.
+ * The mint endpoint itself only understands the raw pair — decoding the
+ * opaque id into `{bindingId, ownerUserId}` is this call's job, same as the
+ * web dashboard's `mintTargetForBinding` does before it calls the identical
+ * route.
  */
 export async function mintSessionGrant(bindingId: string): Promise<OmgGrant> {
   const authToken = await getAuthToken();
   if (!authToken) throw new ComputerGrantError("Please sign in again.");
+
+  const target = mintTargetForBinding(bindingId);
 
   let response: Response;
   try {
@@ -43,7 +65,7 @@ export async function mintSessionGrant(bindingId: string): Promise<OmgGrant> {
         Authorization: `Bearer ${authToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ bindingId }),
+      body: JSON.stringify(target),
     });
   } catch {
     throw new ComputerGrantError(
@@ -53,7 +75,14 @@ export async function mintSessionGrant(bindingId: string): Promise<OmgGrant> {
 
   if (response.status === 401) throw new ComputerGrantError("Please sign in again.");
   if (response.status === 403) {
-    throw new ComputerGrantError("This computer isn't connected to your account.");
+    // The one case that is not "try again": the server does not consider this
+    // account authorized for this machine, whether that is a binding that was
+    // never yours or a share that was just revoked. See the `forbidden` flag's
+    // doc comment above.
+    throw new ComputerGrantError(
+      "This computer isn't available to your account anymore.",
+      true,
+    );
   }
   if (response.status === 402) {
     throw new ComputerGrantError("Your included computer time is used up.");

--- a/test/mobile-shared-binding-label.test.ts
+++ b/test/mobile-shared-binding-label.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Guest-side shared-computer names. The manage screen and the picker both
+ * read these helpers; the policy is "section is whose, row is which machine".
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  sharedBindingBaseTitle,
+  sharedBindingLabel,
+  sharedComputerFirstName,
+  sharedComputerPickerLabel,
+  sharedComputerSubtitle,
+  SHARED_REVOKED_DETAIL,
+} from "../mobile/src/omg/computer-shared-binding";
+
+const adaMac = {
+  ownerUserId: "ada",
+  bindingId: "bind-macbook-aa11bb",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  hostname: "MacBook",
+  online: true,
+};
+
+const adaStudio = {
+  ownerUserId: "ada",
+  bindingId: "bind-studio-cc22dd",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  hostname: "studio",
+  online: false,
+};
+
+const adaEmailOnly = {
+  ownerUserId: "ada",
+  bindingId: "bind-unknown-ee33ff",
+  email: "ada@example.com",
+  online: true,
+};
+
+describe("shared computer titles", () => {
+  test("first-name possessive plus machine identity", () => {
+    expect(sharedBindingLabel(adaMac)).toBe("Ada’s MacBook");
+    expect(sharedBindingLabel(adaStudio)).toBe("Ada’s studio");
+  });
+
+  test("falls back to 'computer' when the share row has no machine name", () => {
+    expect(sharedBindingLabel({ name: "Ada", email: "ada@example.com" })).toBe(
+      "Ada’s computer",
+    );
+  });
+
+  test("never possessivizes an email — title is Shared computer", () => {
+    expect(sharedComputerFirstName(adaEmailOnly)).toBeNull();
+    expect(sharedBindingBaseTitle(adaEmailOnly)).toBe("Shared computer");
+    expect(sharedBindingLabel(adaEmailOnly)).toBe("Shared computer");
+    expect(sharedBindingLabel({ ownerLabel: "ada@example.com", email: "ada@example.com" })).toBe(
+      "Shared computer",
+    );
+    expect(sharedBindingLabel({ name: "ada@example.com", email: "ada@example.com" })).toBe(
+      "Shared computer",
+    );
+  });
+
+  test("two shares from one owner stay distinct when the API named the boxes", () => {
+    const pair = [adaMac, adaStudio];
+    expect(sharedBindingLabel(adaMac, pair)).toBe("Ada’s MacBook");
+    expect(sharedBindingLabel(adaStudio, pair)).toBe("Ada’s studio");
+  });
+
+  test("two nameless shares from one owner get a short unique tail", () => {
+    const one = { name: "Ada", email: "ada@example.com", bindingId: "bind-aaaa1111" };
+    const two = { name: "Ada", email: "ada@example.com", bindingId: "bind-bbbb2222" };
+    const pair = [one, two];
+    const labels = [sharedBindingLabel(one, pair), sharedBindingLabel(two, pair)];
+    expect(labels[0]).not.toBe(labels[1]);
+    expect(labels[0].startsWith("Ada’s computer · ")).toBe(true);
+    expect(labels[1].startsWith("Ada’s computer · ")).toBe(true);
+  });
+});
+
+describe("shared computer subtitles", () => {
+  test("named owner gets liveness, not Shared by Ada", () => {
+    expect(sharedComputerSubtitle(adaMac)).toBe("Online");
+    expect(sharedComputerSubtitle(adaStudio)).toBe("Offline");
+  });
+
+  test("email-only puts the address on the subtitle", () => {
+    expect(sharedComputerSubtitle(adaEmailOnly)).toBe("ada@example.com");
+    expect(sharedComputerSubtitle({ ...adaEmailOnly, online: false })).toBe(
+      "ada@example.com",
+    );
+  });
+});
+
+describe("shared computer picker labels", () => {
+  test("offline suffix is title-case Offline, matching Ready / Paused / Removed", () => {
+    expect(sharedComputerPickerLabel(adaStudio, [adaMac, adaStudio])).toBe(
+      "Ada’s studio — Offline",
+    );
+    expect(sharedComputerPickerLabel(adaMac, [adaMac, adaStudio])).toBe("Ada’s MacBook");
+  });
+});
+
+describe("revoked-share copy", () => {
+  test("the share-specific line is not a restatement of No longer available", () => {
+    expect(SHARED_REVOKED_DETAIL).toBe("This computer is no longer shared with you.");
+    expect(SHARED_REVOKED_DETAIL.toLowerCase()).not.toBe("no longer available");
+  });
+});


### PR DESCRIPTION
## Summary

Ports the guest half of web's shared-Computer feature (BennyKok/vibes commits `9536d51d`..`8d0101b9`) into the native app: a machine shared with this account now appears in the picker, can be selected, the selection persists, and a revoked share degrades honestly instead of reading as a dead connection.

Owner-side "share this machine by email" is **not** in this PR — stopping before it per the task's scope, so it can be decided separately whether it belongs in phase 1 on mobile.

## What the client needed, and what it does now

- **API surface**: `listSharedComputers` (RPC, alongside the existing `listComputerBindings`/`getCloudComputer` calls), and the existing session-auth mint (`POST /__omg/session-auth`) extended to accept `{bindingId, ownerUserId}` — the server is the sole authority on access; the client only decodes an id and reflects what the server allows.
- **Picker presentation**: a shared machine renders under its own "Shared with you" grouping in both the anchored menu (`computer-picker.ts`) and the manage screen (`app/computers.tsx`), labeled `<Owner>'s computer` — distinguishable from the account's own machines, never confused with them.
- **Identity**: native currently keys the selected machine on a single opaque `bindingId` string with no roster/email/userId concept anywhere in the client. A shared machine keeps that discipline — `shared:<ownerUserId>:<bindingId>`, the documented contract ported verbatim from `apps/web/src/components/computer/computer-shared-binding.ts`, never a client-invented encoding (bug #1). The durable `ownerUserId` is what's embedded in the string, never email (bug #3) — there was no pre-existing email-keying weakness to inherit here since native has no roster/attribution feature yet at all.

## The three bugs already paid for on web

1. **Documented binding format** — `computer-shared-binding.ts` is a straight port, same prefix, same first-colon split, same reasoning in the comments.
2. **Revoked share reads honestly** — `readiness.ts` gains a new `"unauthorized"` status (distinct from `"unavailable"`) produced when the grant mint 403s. `provider.tsx`'s `probe()` also resolves a stale `shared:` preference to this status *pre-emptively*, before ever attempting a mint. The UI (`app/index.tsx`) shows "No longer available" + "Choose another", never "Try again" (retrying a 403 achieves nothing) and never anything implying the box is merely offline.
3. **Durable userId, not email** — see Identity above.

Side note: the `"unauthorized"` status also fixes the pre-existing (non-shared) case of a stale/unpaired-machine preference, since the mint 403s through the same code path today. Flagging in case a narrower fix is preferred — I didn't fork the logic since it's the same mechanism.

## Files

- `mobile/src/omg/computer-shared-binding.ts` (new) — the id codec + label helpers
- `mobile/src/omg/transport.ts` — mint decodes the opaque id, `ComputerGrantError` gained a `forbidden` flag
- `mobile/src/omg/readiness.ts` — new `"unauthorized"` status
- `mobile/src/omg/provider.tsx` — fetches + synthesizes shared machines, pre-emptive stale-share detection
- `mobile/src/omg/computer-picker.ts`, `mobile/app/computers.tsx` — picker surfaces
- `mobile/app/index.tsx`, `mobile/app/settings.tsx` — current-machine label/status resolve shared selections

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx expo export --platform ios` — clean
- [ ] Device/simulator look — **not done**. Benny's Mac was explicitly off-limits for this task (load average ~350, 13GB free disk, another session queued). Static verification only; flagging that a real device look is still worth doing before merge if someone else can run it.
- Not tested against a live share (would require sharing a real user's machine, which the task explicitly forbids) — logic was verified by reading the server contract (`control-plane/lib/computer-access.ts`, `session-proxy.ts`, `functions/computer.ts`) and matching web's own resolution flow (`computer-view-selection.ts`) line for line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)