### PR TITLE
feat(users): configurable user icon uploads and machine facepile

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -238,17 +238,33 @@ import {
 } from "../live-ws.ts";
 import { appendCmd as appendAisdkCmd, removeEntry as removeAisdkEntry, readEntry as readAisdkEntry, findEntryByAnyId as findAisdkEntryByAnyId, isEntryBusy as isAisdkEntryBusy, isPidAlive as isAisdkPidAlive, patchEntry as patchAisdkEntry, terminateHarnessProcess, waitForHarnessExit, wakeHarnessCommandReader } from "../aisdk-registry.ts";
 import { markClosed } from "../closing.ts";
-import { assignUser, resolveSessionUserTag, rosterBoxAccount, rosterEmails, userAssignments, userRoster } from "../users.ts";
+import {
+  assignUser,
+  gravatar,
+  iconIdentityKey,
+  machineMembers,
+  resolveSessionUserTag,
+  rosterBoxAccount,
+  rosterEmails,
+  userAssignments,
+  userRoster,
+} from "../users.ts";
 import {
   addOnboardingProfile,
   getOnboarding,
   patchOnboarding,
   setProfileAvatar,
-  AVATARS_DIR,
-  AVATAR_MIME_BY_EXT,
   type HostedFirstRun,
   type OnboardingSteps,
 } from "../onboarding.ts";
+import {
+  AVATARS_DIR,
+  AVATAR_MIME_BY_EXT,
+  iconUrl,
+  removeUserIcon,
+  setUserIcon,
+  userIconsSync,
+} from "../user-icons.ts";
 import {
   listCustomRepos,
   listHiddenRepos,
@@ -3206,6 +3222,47 @@ a{color:#60a5fa}
           return err(400, e instanceof Error ? e.message : "invalid image");
         }
       }
+      // ---- user icon (settings-configurable, not just onboarding-once) ----
+      // `email` in the query names which roster member the caller is acting
+      // as; a roster-less hosted box ignores it and keys by its paired omg
+      // account instead (see iconIdentityKey in users.ts — this is the
+      // hosted-side identity decision for the whole feature).
+      if (path === "/api/settings/icon" && req.method === "GET") {
+        const identity = iconIdentityKey(url.searchParams.get("email"));
+        if (!identity.ok) return err(400, identity.reason);
+        const custom = iconUrl(userIconsSync(), identity.key);
+        return json({
+          key: identity.key,
+          avatar: custom ?? gravatar(identity.key),
+          hasCustomIcon: !!custom,
+        });
+      }
+      if (path === "/api/settings/icon" && req.method === "POST") {
+        const identity = iconIdentityKey(url.searchParams.get("email"));
+        if (!identity.ok) return err(400, identity.reason);
+        const mime = (req.headers.get("content-type") ?? "").split(";")[0]!.trim();
+        try {
+          const bytes = new Uint8Array(await req.arrayBuffer());
+          const { url: avatar } = await setUserIcon(identity.key, bytes, mime);
+          return json({ key: identity.key, avatar, users: userRoster() });
+        } catch (e) {
+          return err(400, e instanceof Error ? e.message : "invalid image");
+        }
+      }
+      if (path === "/api/settings/icon" && req.method === "DELETE") {
+        const identity = iconIdentityKey(url.searchParams.get("email"));
+        if (!identity.ok) return err(400, identity.reason);
+        await removeUserIcon(identity.key);
+        return json({
+          key: identity.key,
+          avatar: gravatar(identity.key),
+          users: userRoster(),
+        });
+      }
+      // ---- machine membership (facepile source of truth) ----
+      if (path === "/api/machine/members" && req.method === "GET") {
+        return json({ members: machineMembers() });
+      }
       // Clone a git repository into LFG_REPOS_ROOT — the onboarding "set up
       // your repo" step for installs that have no repos yet.
       if (path === "/api/onboarding/repo" && req.method === "POST") {
@@ -3232,10 +3289,20 @@ a{color:#60a5fa}
         if (m && req.method === "GET") {
           const file = Bun.file(join(AVATARS_DIR(), `${m[1]}.${m[2]}`));
           if (!(await file.exists())) return err(404, "avatar not found");
+          // A request carrying `?v=` (user-icons.ts's version cache-buster)
+          // names a URL that can only ever resolve to this exact image — a
+          // replace bumps the version and therefore the URL, it never
+          // overwrites one a client already cached. That makes it safe to
+          // cache indefinitely, unlike the unversioned legacy onboarding URLs
+          // (no `?v=`), which stay on the conservative short TTL because the
+          // same URL really can change under a client's feet.
+          const versioned = url.searchParams.has("v");
           return new Response(file, {
             headers: {
               "Content-Type": AVATAR_MIME_BY_EXT[m[2]!] ?? "application/octet-stream",
-              "Cache-Control": "private, max-age=3600",
+              "Cache-Control": versioned
+                ? "private, max-age=31536000, immutable"
+                : "private, max-age=3600",
               "X-Content-Type-Options": "nosniff",
             },
           });

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -11,10 +11,10 @@
 //   gates its full-screen onboarding on this plus "no existing state"
 //   (empty roster + empty session list) from the bootstrap payload.
 import { readFileSync } from "node:fs";
-import { createHash } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { PATHS } from "./config.ts";
+import { setUserIcon } from "./user-icons.ts";
 
 export type OnboardingProfile = {
   email: string;
@@ -223,48 +223,29 @@ export async function addOnboardingProfile(input: {
 }
 
 // ------------------------------------------------------------ avatars
-
-export const AVATARS_DIR = () => join(PATHS.data, "avatars");
-
-const AVATAR_EXT: Record<string, string> = {
-  "image/png": "png",
-  "image/jpeg": "jpg",
-  "image/webp": "webp",
-  "image/gif": "gif",
-};
-
-export const AVATAR_MIME_BY_EXT: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  webp: "image/webp",
-  gif: "image/gif",
-};
-
-const AVATAR_MAX_BYTES = 5 * 1024 * 1024;
-
-// Store an uploaded profile photo for an onboarding profile. File name is
-// derived from the email hash (stable, no user input in the path) + extension
-// from the validated mime type. Throws with a user-facing message on bad
-// input so the route can 400.
+//
+// Storage (validation, normalization, the file itself) lives in
+// user-icons.ts now — that module is the single owner for every uploaded
+// icon, keyed by an identity key that can be a roster email OR a hosted box's
+// paired account email (see iconIdentityKey in users.ts). This function is
+// kept as the onboarding-flow entry point: it still requires an existing
+// profile (photo-during-onboarding only makes sense once the profile exists)
+// and still returns OnboardingState so the route's response shape is
+// unchanged, but no longer writes the file itself or the profile's `avatar`
+// field — userRoster() (users.ts) reads the new store directly. `avatar` on
+// OnboardingProfile is kept only so already-stored on-disk state (uploaded
+// before this change) keeps resolving as a fallback; nothing writes it
+// anymore.
 export async function setProfileAvatar(
   email: string,
   bytes: Uint8Array,
   mimeType: string,
 ): Promise<OnboardingState> {
-  const ext = AVATAR_EXT[mimeType];
-  if (!ext) throw new Error("expected a png, jpeg, webp, or gif image");
-  if (!bytes.length) throw new Error("empty image");
-  if (bytes.length > AVATAR_MAX_BYTES) throw new Error("image too large (max 5MB)");
   const normalized = email.trim().toLowerCase();
   const cur = await getOnboarding();
   if (!cur.profiles.some((p) => p.email === normalized)) {
     throw new Error("no profile for that email — create the profile first");
   }
-  const file = `${createHash("md5").update(normalized).digest("hex")}.${ext}`;
-  await mkdir(AVATARS_DIR(), { recursive: true });
-  await Bun.write(join(AVATARS_DIR(), file), bytes);
-  const profiles = cur.profiles.map((p) =>
-    p.email === normalized ? { ...p, avatar: file } : p,
-  );
-  return write({ ...cur, profiles });
+  await setUserIcon(normalized, bytes, mimeType);
+  return cur;
 }

--- a/src/user-icons.test.ts
+++ b/src/user-icons.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { PATHS } from "./config.ts";
+import { removeUserIcon, setUserIcon, userIconsSync, iconUrl } from "./user-icons.ts";
+
+async function pngBytes(width: number, height: number): Promise<Uint8Array> {
+  const buf = await sharp({
+    create: { width, height, channels: 3, background: "#336699" },
+  })
+    .png()
+    .toBuffer();
+  return new Uint8Array(buf);
+}
+
+describe("user-icons", () => {
+  const originalData = PATHS.data;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "omg-user-icons-"));
+    PATHS.data = root;
+  });
+
+  afterEach(() => {
+    PATHS.data = originalData;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("stores a valid upload and serves it back at a versioned URL", async () => {
+    const bytes = await pngBytes(400, 400);
+    const { url } = await setUserIcon("benny@example.com", bytes, "image/png");
+    expect(url).toMatch(/^\/api\/avatars\/[a-f0-9]{32}\.webp\?v=1$/);
+
+    const icons = userIconsSync();
+    expect(iconUrl(icons, "benny@example.com")).toBe(url);
+    // Key resolution is case/whitespace insensitive, like every other email
+    // key in this codebase.
+    expect(iconUrl(icons, "  Benny@Example.com ")).toBe(url);
+  });
+
+  test("a replace bumps the version, changing the URL", async () => {
+    const first = await setUserIcon("benny@example.com", await pngBytes(400, 400), "image/png");
+    const second = await setUserIcon("benny@example.com", await pngBytes(400, 400), "image/png");
+    expect(first.url).not.toBe(second.url);
+    expect(second.url).toMatch(/\?v=2$/);
+    // Same identity key -> same file path (webp, from the md5 of the key) —
+    // no orphaned files from the old per-mimetype extension scheme.
+    expect(first.url.split("?")[0]).toBe(second.url.split("?")[0]);
+  });
+
+  test("rejects an oversized upload", async () => {
+    const huge = new Uint8Array(6 * 1024 * 1024);
+    await expect(setUserIcon("benny@example.com", huge, "image/png")).rejects.toThrow(/too large/);
+  });
+
+  test("rejects an unsupported mime type", async () => {
+    await expect(
+      setUserIcon("benny@example.com", await pngBytes(400, 400), "image/svg+xml"),
+    ).rejects.toThrow(/png, jpeg, webp, or gif/);
+  });
+
+  test("rejects an image that is too small to be a meaningful icon", async () => {
+    await expect(setUserIcon("benny@example.com", await pngBytes(8, 8), "image/png")).rejects.toThrow(
+      /too small/,
+    );
+  });
+
+  test("rejects an image with an absurd pixel canvas (decompression-bomb guard)", async () => {
+    const bytes = await pngBytes(9000, 9000);
+    await expect(setUserIcon("benny@example.com", bytes, "image/png")).rejects.toThrow(/too large/);
+  });
+
+  test("rejects empty bytes", async () => {
+    await expect(setUserIcon("benny@example.com", new Uint8Array(), "image/png")).rejects.toThrow(
+      /empty/,
+    );
+  });
+
+  test("removing an icon deletes the file and the index entry", async () => {
+    const { url } = await setUserIcon("benny@example.com", await pngBytes(400, 400), "image/png");
+    const file = url.split("/").pop()!.split("?")[0];
+    expect(existsSync(join(root, "avatars", file))).toBe(true);
+
+    const removed = await removeUserIcon("benny@example.com");
+    expect(removed).toBe(true);
+    expect(existsSync(join(root, "avatars", file))).toBe(false);
+    expect(iconUrl(userIconsSync(), "benny@example.com")).toBeUndefined();
+  });
+
+  test("removing an icon that doesn't exist is a no-op, not an error", async () => {
+    expect(await removeUserIcon("nobody@example.com")).toBe(false);
+  });
+
+  test("an unrelated key has no icon", () => {
+    expect(iconUrl(userIconsSync(), "nobody@example.com")).toBeUndefined();
+  });
+});

--- a/src/user-icons.ts
+++ b/src/user-icons.ts
@@ -1,0 +1,173 @@
+// Single owner for uploaded user icons — the settings-configurable avatar
+// (Part 1 of the avatar/icon feature) and the legacy onboarding profile photo
+// both funnel through here now, keyed by an arbitrary "identity key" string
+// rather than by "an onboarding profile must already exist". That decoupling
+// is what makes a hosted, roster-less Computer able to have an icon at all:
+// see `iconIdentityKey` in users.ts for which key a given request resolves to
+// (a roster email when a roster is configured, else the box's paired omg
+// account email).
+//
+// Storage: one directory of normalized webp files (data/avatars/, unchanged
+// from the original onboarding-only layout so already-served URLs keep
+// working) plus one small JSON index (data/user-icons.json) mapping identity
+// key -> { file, version, updatedAt }. `file` is always `md5(key).webp`, so
+// re-uploading for the same key overwrites the same path — no orphaned
+// extensions to clean up the way the old png/jpg/webp/gif mix could leave
+// behind.
+//
+// Cache-busting: gravatar() (users.ts) rotates a 10-minute time bucket
+// because it has no control over when the third-party image actually
+// changes. We control this origin directly, so we don't need to guess — each
+// upload bumps `version`, the served URL embeds it (`?v=<version>`), and a
+// version therefore never refers to two different images. That makes the
+// image cacheable *forever* at that exact URL instead of merely "for up to
+// ten minutes", and a replace is visible on the very next request rather than
+// eventually.
+import { readFileSync, mkdirSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import { PATHS } from "./config.ts";
+import { loadSharp } from "./native-deps.ts";
+
+export const AVATARS_DIR = () => join(PATHS.data, "avatars");
+
+export const AVATAR_MIME_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+};
+
+const ACCEPTED_UPLOAD_MIME = new Set(Object.values(AVATAR_MIME_BY_EXT));
+
+// Bytes cap applies to the ORIGINAL upload, before normalization — this is
+// what stands between a request body and disk/memory, so it has to hold
+// regardless of what the image turns out to decode to.
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+// Dimension guards apply to the DECODED image. The lower bound rejects a
+// 1x1-style upload that would just be a solid color once resized; the upper
+// bound is a decompression-bomb guard — a small file that claims an enormous
+// canvas is expensive to resize even though it passed the byte cap.
+const MIN_INPUT_DIMENSION = 32;
+const MAX_INPUT_DIMENSION = 8000;
+
+// Every stored icon is normalized to one square size — icons only ever render
+// small (facepiles, filter dropdowns, session rows), so there is nothing to
+// gain from keeping the original resolution, and a fixed size keeps layout
+// math (the facepile ring math in particular) simple everywhere.
+const OUTPUT_SIZE = 256;
+const OUTPUT_WEBP_QUALITY = 82;
+
+export type UserIconRecord = { file: string; version: number; updatedAt: string };
+type UserIconsState = Record<string, UserIconRecord>;
+
+const iconsFilePath = () => join(PATHS.data, "user-icons.json");
+
+const normalizeKey = (key: string) => key.trim().toLowerCase();
+
+function sanitize(raw: unknown): UserIconsState {
+  if (!raw || typeof raw !== "object") return {};
+  const out: UserIconsState = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const v = value as Partial<UserIconRecord>;
+    if (
+      typeof v.file === "string" &&
+      /^[a-f0-9]{32}\.[a-z0-9]+$/.test(v.file) &&
+      typeof v.version === "number" &&
+      Number.isFinite(v.version) &&
+      typeof v.updatedAt === "string"
+    ) {
+      out[normalizeKey(key)] = { file: v.file, version: v.version, updatedAt: v.updatedAt };
+    }
+  }
+  return out;
+}
+
+/** Sync read for users.ts, whose roster/display helpers can't await. */
+export function userIconsSync(): UserIconsState {
+  try {
+    return sanitize(JSON.parse(readFileSync(iconsFilePath(), "utf8")));
+  } catch {
+    return {};
+  }
+}
+
+function writeIcons(state: UserIconsState): void {
+  mkdirSync(dirname(iconsFilePath()), { recursive: true });
+  Bun.write(iconsFilePath(), JSON.stringify(state, null, 2));
+}
+
+/** The served, cache-busted URL for a key's icon, or undefined if it has none. */
+export function iconUrl(icons: UserIconsState, key: string): string | undefined {
+  const rec = icons[normalizeKey(key)];
+  return rec ? `/api/avatars/${rec.file}?v=${rec.version}` : undefined;
+}
+
+export function fileForKey(key: string): string {
+  return `${createHash("md5").update(normalizeKey(key)).digest("hex")}.webp`;
+}
+
+/**
+ * Validate, normalize, and store an uploaded icon for an identity key.
+ * Throws a user-facing message on invalid input so the route can 400 it.
+ */
+export async function setUserIcon(
+  key: string,
+  bytes: Uint8Array,
+  mimeType: string,
+): Promise<{ url: string }> {
+  const normalizedKey = normalizeKey(key);
+  if (!normalizedKey) throw new Error("expected an identity to attach the icon to");
+  if (!bytes.length) throw new Error("empty image");
+  if (bytes.length > MAX_UPLOAD_BYTES) {
+    throw new Error(`image too large (max ${MAX_UPLOAD_BYTES / (1024 * 1024)}MB)`);
+  }
+  if (!ACCEPTED_UPLOAD_MIME.has(mimeType)) {
+    throw new Error("expected a png, jpeg, webp, or gif image");
+  }
+
+  const sharp = await loadSharp();
+  const meta = await sharp(Buffer.from(bytes))
+    .metadata()
+    .catch(() => null);
+  const { width, height } = meta ?? {};
+  if (!width || !height) throw new Error("couldn't read that image");
+  if (width < MIN_INPUT_DIMENSION || height < MIN_INPUT_DIMENSION) {
+    throw new Error(`image too small (min ${MIN_INPUT_DIMENSION}x${MIN_INPUT_DIMENSION}px)`);
+  }
+  if (width > MAX_INPUT_DIMENSION || height > MAX_INPUT_DIMENSION) {
+    throw new Error(`image too large (max ${MAX_INPUT_DIMENSION}x${MAX_INPUT_DIMENSION}px)`);
+  }
+
+  const normalized = await sharp(Buffer.from(bytes))
+    .rotate() // respect EXIF orientation before the square crop
+    .resize({ width: OUTPUT_SIZE, height: OUTPUT_SIZE, fit: "cover" })
+    .webp({ quality: OUTPUT_WEBP_QUALITY })
+    .toBuffer();
+
+  const file = fileForKey(normalizedKey);
+  await mkdir(AVATARS_DIR(), { recursive: true });
+  await Bun.write(join(AVATARS_DIR(), file), normalized);
+
+  const state = userIconsSync();
+  const version = (state[normalizedKey]?.version ?? 0) + 1;
+  state[normalizedKey] = { file, version, updatedAt: new Date().toISOString() };
+  writeIcons(state);
+
+  return { url: iconUrl(state, normalizedKey)! };
+}
+
+/** Delete a stored icon. Returns false (not an error) when there was none. */
+export async function removeUserIcon(key: string): Promise<boolean> {
+  const normalizedKey = normalizeKey(key);
+  const state = userIconsSync();
+  const rec = state[normalizedKey];
+  if (!rec) return false;
+  delete state[normalizedKey];
+  writeIcons(state);
+  await rm(join(AVATARS_DIR(), rec.file), { force: true }).catch(() => undefined);
+  return true;
+}

--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { PATHS } from "./config.ts";
+import { addOnboardingProfile } from "./onboarding.ts";
+import { setUserIcon } from "./user-icons.ts";
+import { iconIdentityKey, machineMembers, userRoster } from "./users.ts";
+
+describe("iconIdentityKey", () => {
+  test("a roster box keys the icon by a roster email", () => {
+    const roster = ["benny@example.com", "angel@example.com"];
+    expect(iconIdentityKey("benny@example.com", roster, null)).toEqual({
+      ok: true,
+      key: "benny@example.com",
+    });
+  });
+
+  test("a roster box normalizes case/whitespace before matching", () => {
+    const roster = ["benny@example.com"];
+    expect(iconIdentityKey("  Benny@Example.COM ", roster, null)).toEqual({
+      ok: true,
+      key: "benny@example.com",
+    });
+  });
+
+  test("a roster box rejects an email that isn't on the roster", () => {
+    const roster = ["benny@example.com"];
+    expect(iconIdentityKey("stranger@example.com", roster, null)).toEqual({
+      ok: false,
+      reason: "unknown user",
+    });
+  });
+
+  test("a roster box rejects an empty/missing email — it never falls back to the box account", () => {
+    const roster = ["benny@example.com"];
+    expect(iconIdentityKey(null, roster, "benny@example.com").ok).toBe(false);
+  });
+
+  test("a roster-less hosted box ignores the requested email and keys by its paired account", () => {
+    expect(iconIdentityKey("whatever@example.com", [], "account@omg.dev")).toEqual({
+      ok: true,
+      key: "account@omg.dev",
+    });
+    expect(iconIdentityKey(null, [], "account@omg.dev")).toEqual({
+      ok: true,
+      key: "account@omg.dev",
+    });
+  });
+
+  test("a roster-less, unpaired box has no identity to key by", () => {
+    expect(iconIdentityKey(null, [], null)).toEqual({
+      ok: false,
+      reason: "no identity available on this box",
+    });
+  });
+});
+
+describe("machineMembers", () => {
+  test("a shared box lists its whole roster, unchanged", () => {
+    const roster = [
+      { email: "benny@example.com", name: "Benny", avatar: "https://gravatar/benny" },
+      { email: "angel@example.com", name: "Angel", avatar: "https://gravatar/angel" },
+    ];
+    expect(machineMembers(roster, "unused@example.com")).toEqual(roster);
+  });
+
+  test("a roster-less hosted box is never empty — its one member is the paired account", () => {
+    const members = machineMembers([], "account@omg.dev");
+    expect(members).toHaveLength(1);
+    expect(members[0]!.email).toBe("account@omg.dev");
+    // Falls back to Gravatar/identicon exactly like every other member without
+    // an uploaded icon.
+    expect(members[0]!.avatar).toContain("gravatar.com");
+  });
+
+  test("a roster-less, unpaired box genuinely has nobody on it", () => {
+    expect(machineMembers([], null)).toEqual([]);
+  });
+});
+
+describe("userRoster / machineMembers icon precedence (integration)", () => {
+  const originalData = PATHS.data;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "omg-users-"));
+    PATHS.data = root;
+  });
+
+  afterEach(() => {
+    PATHS.data = originalData;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("a settings-uploaded icon beats Gravatar in userRoster()", async () => {
+    await addOnboardingProfile({ email: "benny@example.com", name: "Benny" });
+    expect(userRoster().find((u) => u.email === "benny@example.com")?.avatar).toContain(
+      "gravatar.com",
+    );
+
+    const bytes = await sharp({
+      create: { width: 300, height: 300, channels: 3, background: "#336699" },
+    })
+      .png()
+      .toBuffer();
+    await setUserIcon("benny@example.com", new Uint8Array(bytes), "image/png");
+
+    const roster = userRoster();
+    expect(roster.find((u) => u.email === "benny@example.com")?.avatar).toMatch(
+      /^\/api\/avatars\/[a-f0-9]{32}\.webp\?v=1$/,
+    );
+  });
+
+  test("machineMembers() reflects the same uploaded icon for a real roster", async () => {
+    await addOnboardingProfile({ email: "benny@example.com", name: "Benny" });
+    const members = machineMembers();
+    expect(members).toHaveLength(1);
+    expect(members[0]!.email).toBe("benny@example.com");
+  });
+});

--- a/src/users.ts
+++ b/src/users.ts
@@ -13,6 +13,7 @@ import { dirname } from "node:path";
 import { PATHS } from "./config.ts";
 import { onboardingProfilesSync } from "./onboarding.ts";
 import { boxAccountEmail } from "./box-account.ts";
+import { userIconsSync, iconUrl } from "./user-icons.ts";
 
 // Roster config. Each LFG_USERS entry is `email` or `email:displayname` — the
 // optional name is what the UI shows (raw emails are hard to scan). Parse once
@@ -106,19 +107,92 @@ export function gravatar(email: string): string {
   return `https://www.gravatar.com/avatar/${h}?d=identicon&s=80&_=${bucket}`;
 }
 
+// Legacy fallback: avatars uploaded during onboarding before user-icons.ts
+// existed are still recorded on the profile itself (data/onboarding.json).
+// Nothing writes this field anymore (see onboarding.ts's setProfileAvatar) —
+// it is read-only, kept so an already-uploaded photo doesn't disappear out
+// from under an existing install just because the storage was refactored.
+function legacyOnboardingAvatarUrl(email: string): string | undefined {
+  const file = onboardingProfilesSync().find((p) => p.email === email)?.avatar;
+  return file ? `/api/avatars/${file}` : undefined;
+}
+
 export function userRoster(): { email: string; name: string; avatar: string }[] {
-  // Photo uploaded during onboarding beats Gravatar; served by
+  // A settings-uploaded icon (user-icons.ts) beats a legacy onboarding photo,
+  // which beats Gravatar. Both upload paths are served by
   // GET /api/avatars/<file> out of data/avatars/.
-  const uploaded = new Map(
-    onboardingProfilesSync()
-      .filter((p) => p.avatar)
-      .map((p) => [p.email, `/api/avatars/${p.avatar}`]),
-  );
+  const icons = userIconsSync();
   return rosterEmails().map((email) => ({
     email,
     name: displayName(email),
-    avatar: uploaded.get(email) ?? gravatar(email),
+    avatar: iconUrl(icons, email) ?? legacyOnboardingAvatarUrl(email) ?? gravatar(email),
   }));
+}
+
+/**
+ * Which identity key an icon upload/replace/remove for `requested` should
+ * act on, or why it can't be resolved. THE hosted-side identity decision:
+ *
+ * A box with a configured roster (LFG_USERS / onboarding profiles) keys the
+ * icon by a roster email, exactly like every other roster-scoped action
+ * (assignUser, resolveSessionUserTag) — several people can share one box, so
+ * "whose icon" has to name one of them, and an unrecognized email is a hard
+ * error for the same reason a typo'd session tag is.
+ *
+ * A hosted Computer is provisioned with its roster intentionally empty (see
+ * onboarding.ts's HostedFirstRun doc) — there is no roster to validate an
+ * email against, but unlike session tagging (where an empty roster correctly
+ * means "the feature is off"), an icon is never actually ownerless on a
+ * hosted box: it is paired to exactly one omg account (box-account.ts), and
+ * that account IS the identity. So a roster-less box ignores whatever email
+ * the caller sent (there is no roster identity to have sent) and keys the
+ * icon by the paired account instead. The only real failure is a roster-less,
+ * unpaired box — a bare local dev checkout with nobody signed in at all.
+ */
+export function iconIdentityKey(
+  requested: string | null | undefined,
+  roster: string[] = rosterEmails(),
+  accountEmail: string | null = boxAccountEmail(),
+): { ok: true; key: string } | { ok: false; reason: string } {
+  if (roster.length > 0) {
+    const wanted = requested?.trim().toLowerCase() || undefined;
+    if (!wanted) return { ok: false, reason: "expected an email" };
+    if (!roster.includes(wanted)) return { ok: false, reason: "unknown user" };
+    return { ok: true, key: wanted };
+  }
+  if (accountEmail) return { ok: true, key: accountEmail };
+  return { ok: false, reason: "no identity available on this box" };
+}
+
+/**
+ * Who is "on this machine" for display purposes — the facepile, a "who's on
+ * this machine" settings row, anywhere that wants people rather than session
+ * tags. Deliberately NOT userRoster()/rosterEmails(): those feed the
+ * onboarding "fresh install" gate and session-tag validation, both of which
+ * read an empty roster as a specific, meaningful signal that a synthesized
+ * entry here must never disturb (see the giant caller-facing comment on
+ * resolveSessionUserTag).
+ *
+ * So this composes rather than replaces: the roster when one is configured
+ * (a real box may be shared by several people), else the single omg account
+ * the box is paired to — a roster-less hosted Computer is never actually
+ * empty of people, it just has exactly one and no roster to name them with —
+ * else nobody (a bare, unpaired local checkout).
+ */
+export function machineMembers(
+  roster: { email: string; name: string; avatar: string }[] = userRoster(),
+  accountEmail: string | null = boxAccountEmail(),
+): { email: string; name: string; avatar: string }[] {
+  if (roster.length) return roster;
+  if (!accountEmail) return [];
+  const icons = userIconsSync();
+  return [
+    {
+      email: accountEmail,
+      name: displayName(accountEmail),
+      avatar: iconUrl(icons, accountEmail) ?? gravatar(accountEmail),
+    },
+  ];
 }
 
 const FILE = `${PATHS.data}/session-users.json`;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,8 @@ import {
   type BotShape,
 } from "./components/BotAvatar";
 import { EmbeddedConnectGate } from "./components/embedded-connect-gate";
+import { UserFacepile } from "./components/UserFacepile";
+import { facepileLabel, type FacepileMember } from "./lib/facepile";
 import {
   AuthenticatedArtifactImage,
   AuthenticatedArtifactVideo,
@@ -256,6 +258,8 @@ import {
   Trash2,
   TriangleAlert,
   UserRound,
+  Users,
+  Camera,
   X,
   Ellipsis,
 } from "lucide-react";
@@ -23585,6 +23589,168 @@ export type ShipPost = {
   code?: ShipProvenance;
 };
 
+// Backend shape from GET /api/machine/members (src/users.ts's machineMembers()).
+// Roster emails on a shared box, or the box's one paired omg account on a
+// roster-less hosted Computer — never empty unless the box is both
+// roster-less and unpaired.
+function MachineMembersRow() {
+  const [members, setMembers] = useState<FacepileMember[] | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void omgFetch("/api/machine/members")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { members?: FacepileMember[] } | null) => {
+        if (alive) setMembers(d?.members ?? []);
+      })
+      .catch(() => {
+        if (alive) setMembers([]);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <div className="flex w-full items-center justify-between gap-4 px-4 py-2.5">
+      <div className="flex items-center gap-3">
+        <span className="flex size-7 items-center justify-center rounded-[7px] bg-foreground text-background">
+          <Users className="size-4" />
+        </span>
+        <span className="text-sm font-medium">Who&apos;s on this machine</span>
+      </div>
+      {members === null ? (
+        <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground/60" />
+      ) : (
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-xs text-muted-foreground">{facepileLabel(members)}</span>
+          <UserFacepile members={members} size={22} maxVisible={4} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Settings-configurable icon: upload, replace, remove. Works identically on a
+ * roster box (icon keyed by the selected profile, `identityEmail`) and a
+ * roster-less hosted Computer (identityEmail is null there — the server
+ * resolves identity from the paired omg account instead; see
+ * iconIdentityKey in src/users.ts). Falls back to Gravatar/identicon, exactly
+ * like every other avatar in the app, until something is uploaded.
+ */
+function UserIconSettingsSection({ identityEmail }: { identityEmail: string | null }) {
+  const [state, setState] = useState<{ avatar: string; hasCustomIcon: boolean } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const query = identityEmail ? `?email=${encodeURIComponent(identityEmail)}` : "";
+
+  const load = useCallback(() => {
+    void omgFetch(`/api/settings/icon${query}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { avatar?: string; hasCustomIcon?: boolean } | null) => {
+        if (d?.avatar) setState({ avatar: d.avatar, hasCustomIcon: !!d.hasCustomIcon });
+      })
+      .catch(() => {});
+  }, [query]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function upload(file: File) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await api<{ avatar: string }>(`/api/settings/icon${query}`, {
+        method: "POST",
+        headers: { "Content-Type": file.type || "application/octet-stream" },
+        body: file,
+      });
+      setState({ avatar: res.avatar, hasCustomIcon: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't upload that image");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await api<{ avatar: string }>(`/api/settings/icon${query}`, {
+        method: "DELETE",
+      });
+      setState({ avatar: res.avatar, hasCustomIcon: false });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't remove that image");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="space-y-2">
+      <h2 className="px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Icon
+      </h2>
+      <div className="flex items-center gap-4 rounded-2xl border border-border bg-card/40 px-4 py-3.5">
+        <span className="relative flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted">
+          {state?.avatar ? (
+            <img src={state.avatar} alt="" className="size-full object-cover" />
+          ) : (
+            <UserRound className="size-6 text-muted-foreground" />
+          )}
+          {busy ? (
+            <span className="absolute inset-0 flex items-center justify-center bg-background/60">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            </span>
+          ) : null}
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <p className="text-xs text-muted-foreground">
+            Shown next to your sessions and in the facepile of anyone sharing this machine.
+            PNG, JPEG, WebP, or GIF, up to 5MB.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Camera className="size-3.5" />
+              {state?.hasCustomIcon ? "Replace" : "Upload"}
+            </Button>
+            {state?.hasCustomIcon ? (
+              <Button type="button" variant="outline" size="sm" disabled={busy} onClick={remove}>
+                <Trash2 className="size-3.5" />
+                Remove
+              </Button>
+            ) : null}
+          </div>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/gif"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            e.target.value = "";
+            if (file) void upload(file);
+          }}
+        />
+      </div>
+    </section>
+  );
+}
+
 function SettingsView({
   user,
   settings,
@@ -23627,6 +23793,8 @@ function SettingsView({
         </div>
       </div>
       )}
+
+      <UserIconSettingsSection identityEmail={user} />
 
       {/* Live browser-to-server RTT, measured over the same socket that carries
           session updates. This is intentionally dynamic rather than a cached
@@ -23731,6 +23899,7 @@ function SettingsView({
             </div>
             <ChevronRight className="size-4 text-muted-foreground/60" />
           </button>
+          <MachineMembersRow />
         </div>
       </section>
 

--- a/web/src/components/UserFacepile.tsx
+++ b/web/src/components/UserFacepile.tsx
@@ -1,0 +1,103 @@
+import { UserRound } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { buildFacepile, type FacepileMember } from "@/lib/facepile";
+
+/**
+ * An overlapping stack of user icons ("facepile") — who is on a machine, at a
+ * glance. Sibling of BotAvatar.tsx (the mascot avatar) but for real people:
+ * same instinct of "the circle carries the identity, no extra plate behind
+ * it", adapted for photos instead of a procedural silhouette.
+ *
+ * Two things make small overlapping circles read as separate people instead
+ * of a smear: the ring between them (a `ring-background` border, which tracks
+ * the light/dark theme token automatically — see the same trick on the
+ * unread-count dot elsewhere in this app) and z-index running in visual
+ * (left-to-right) order so the ring always sits on top of the circle behind
+ * it, in both directions.
+ *
+ * Accessibility: the stack is one group with one label ("Benny and Angel", or
+ * "No one on this machine") — every avatar image is `aria-hidden`/`alt=""` so
+ * a screen reader announces the stack once, not once per circle.
+ */
+export function UserFacepile({
+  members,
+  size = 24,
+  maxVisible = 4,
+  className,
+}: {
+  members: FacepileMember[];
+  /** Diameter of each circle, in px. */
+  size?: number;
+  /** How many circles to draw before folding the rest into a "+N" badge. */
+  maxVisible?: number;
+  className?: string;
+}) {
+  const { visible, overflowCount, label } = buildFacepile(members, maxVisible);
+  const overlap = Math.round(size * 0.32);
+  const ring = size <= 20 ? 1.5 : 2;
+
+  if (visible.length === 0) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center justify-center rounded-full bg-muted text-muted-foreground",
+          className,
+        )}
+        style={{ width: size, height: size, boxShadow: `0 0 0 ${ring}px var(--background)` }}
+        role="img"
+        aria-label={label}
+        title={label}
+      >
+        <UserRound className="size-1/2" aria-hidden />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn("inline-flex items-center", className)}
+      role="img"
+      aria-label={label}
+      title={label}
+    >
+      {visible.map((member, i) => (
+        <span
+          key={member.email}
+          className="relative shrink-0 overflow-hidden rounded-full bg-muted"
+          style={{
+            width: size,
+            height: size,
+            marginLeft: i === 0 ? 0 : -overlap,
+            zIndex: visible.length - i,
+            boxShadow: `0 0 0 ${ring}px var(--background)`,
+          }}
+        >
+          {member.avatar ? (
+            <img src={member.avatar} alt="" aria-hidden className="size-full object-cover" />
+          ) : (
+            <span className="flex size-full items-center justify-center text-muted-foreground">
+              <UserRound aria-hidden style={{ width: size * 0.55, height: size * 0.55 }} />
+            </span>
+          )}
+        </span>
+      ))}
+      {overflowCount > 0 ? (
+        <span
+          className="relative flex shrink-0 items-center justify-center rounded-full bg-foreground text-background"
+          style={{
+            width: size,
+            height: size,
+            marginLeft: -overlap,
+            zIndex: 0,
+            boxShadow: `0 0 0 ${ring}px var(--background)`,
+            fontSize: Math.max(9, size * 0.36),
+            fontWeight: 600,
+          }}
+          aria-hidden
+        >
+          +{overflowCount}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/web/src/lib/facepile.test.ts
+++ b/web/src/lib/facepile.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { buildFacepile, facepileLabel } from "./facepile";
+
+const benny = { email: "benny@example.com", name: "Benny", avatar: "https://x/benny.webp" };
+const angel = { email: "angel@example.com", name: "Angel", avatar: "https://x/angel.webp" };
+const cass = { email: "cass@example.com", name: "", avatar: undefined }; // no photo, no name
+
+describe("facepileLabel", () => {
+  test("the single-user case", () => {
+    expect(facepileLabel([benny])).toBe("Benny");
+  });
+
+  test("two members read as a conjunction", () => {
+    expect(facepileLabel([benny, angel])).toBe("Benny and Angel");
+  });
+
+  test("three+ members get an oxford-comma list", () => {
+    expect(facepileLabel([benny, angel, cass])).toBe("Benny, Angel, and cass");
+  });
+
+  test("a member with no name falls back to the email's local part", () => {
+    expect(facepileLabel([cass])).toBe("cass");
+  });
+
+  test("nobody on the machine still gets one coherent label", () => {
+    expect(facepileLabel([])).toBe("No one on this machine");
+  });
+});
+
+describe("buildFacepile", () => {
+  test("the single-user case: one visible circle, no overflow", () => {
+    const layout = buildFacepile([benny], 4);
+    expect(layout.visible).toEqual([benny]);
+    expect(layout.overflowCount).toBe(0);
+    expect(layout.label).toBe("Benny");
+  });
+
+  test("the shared-machine case within the visible cap: no overflow badge", () => {
+    const layout = buildFacepile([benny, angel], 4);
+    expect(layout.visible.map((m) => m.email)).toEqual(["angel@example.com", "benny@example.com"]);
+    expect(layout.overflowCount).toBe(0);
+  });
+
+  test("beyond the visible cap: +N overflow, N counts everyone past the cap", () => {
+    const dana = { email: "dana@example.com", name: "Dana" };
+    const eli = { email: "eli@example.com", name: "Eli" };
+    const layout = buildFacepile([benny, angel, cass, dana, eli], 3);
+    expect(layout.visible).toHaveLength(3);
+    expect(layout.overflowCount).toBe(2);
+    // Label still names everyone, independent of how many circles render.
+    expect(layout.label).toContain("Eli");
+  });
+
+  test("a member with no photo is still included — the caller renders a fallback glyph", () => {
+    const layout = buildFacepile([cass], 4);
+    expect(layout.visible[0]!.avatar).toBeUndefined();
+  });
+
+  test("ordering is deterministic regardless of input order", () => {
+    const a = buildFacepile([angel, benny, cass], 4);
+    const b = buildFacepile([cass, benny, angel], 4);
+    expect(a.visible.map((m) => m.email)).toEqual(b.visible.map((m) => m.email));
+  });
+
+  test("empty input never crashes and reports no overflow", () => {
+    const layout = buildFacepile([], 4);
+    expect(layout.visible).toEqual([]);
+    expect(layout.overflowCount).toBe(0);
+  });
+});

--- a/web/src/lib/facepile.ts
+++ b/web/src/lib/facepile.ts
@@ -1,0 +1,52 @@
+/**
+ * Layout + label logic for an overlapping user-icon stack ("facepile") —
+ * kept apart from the rendering component (UserFacepile.tsx) so the ordering,
+ * overflow, and accessible-label rules are unit-testable without a DOM, the
+ * same split this repo already uses for sessionMatchesUserFilter /
+ * resolveRosterUser.
+ */
+export type FacepileMember = {
+  email: string;
+  name: string;
+  /** Absent/empty means "no uploaded or Gravatar photo" — render a fallback glyph. */
+  avatar?: string;
+};
+
+export type FacepileLayout = {
+  /** Members to render as circles, already in final display order. */
+  visible: FacepileMember[];
+  /** How many members beyond `visible` exist — 0 means no "+N" badge. */
+  overflowCount: number;
+  /** The single accessible label for the whole stack (not one per avatar). */
+  label: string;
+};
+
+const fallbackDisplayName = (member: FacepileMember): string =>
+  member.name.trim() || member.email.split("@")[0] || member.email;
+
+/**
+ * One label for the whole stack, not N redundant per-avatar ones — screen
+ * readers get "Benny and Angel", not "Benny. Angel." from two child nodes.
+ */
+export function facepileLabel(members: FacepileMember[]): string {
+  if (members.length === 0) return "No one on this machine";
+  const names = members.map(fallbackDisplayName);
+  if (names.length === 1) return names[0]!;
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+/**
+ * Build the stack's layout. Members are re-sorted by email rather than
+ * trusting caller order — the caller's list order can legitimately vary
+ * between requests/callers (roster insertion order vs. a future API's own
+ * order), and a facepile that silently reshuffles on every poll reads as
+ * broken. Sorting here makes "deterministic" a property of this function,
+ * not an obligation on every caller.
+ */
+export function buildFacepile(members: FacepileMember[], maxVisible = 4): FacepileLayout {
+  const ordered = [...members].sort((a, b) => a.email.localeCompare(b.email));
+  const visible = ordered.slice(0, Math.max(0, maxVisible));
+  const overflowCount = Math.max(0, ordered.length - visible.length);
+  return { visible, overflowCount, label: facepileLabel(ordered) };
+}


### PR DESCRIPTION
## Summary
- Adds a Settings > Icon section so a user can upload/replace/remove their own avatar instead of relying on Gravatar (`src/user-icons.ts`, new single-owner store: sharp-normalized 256x256 webp, versioned/cache-busted URLs, GET/POST/DELETE `/api/settings/icon`).
- Adds a "Who's on this machine" facepile row (`web/src/lib/facepile.ts`, `web/src/components/UserFacepile.tsx`, `GET /api/machine/members`) showing everyone active on a shared box, or the single paired omg account on a roster-less hosted Computer.
- `src/onboarding.ts`'s `setProfileAvatar` now delegates storage to `user-icons.ts` instead of owning its own avatar file logic; legacy on-disk avatar field is kept as a read-only fallback.
- Avatar GET route now sets an immutable long-lived cache header for versioned icon URLs.

## Test plan
- [x] `bun x tsc --noEmit` — clean
- [x] `bun run build:packages` (includes web build) — succeeds
- [x] `bun run test` — 1835 pass / 3 fail / 1 skip (1839 total). The 3 failures are pre-existing and unrelated to this change (stale source-string assertions in `settings-rendering.test.ts`, `session-list-payload.test.ts`, and `mobile-overlay-scroll-contract` tests that search for literal `className` snippets in `web/src/App.tsx`); confirmed identical failures reproduce on bare `origin/main` before this branch's commit.
- [x] New tests added: `src/user-icons.test.ts`, `src/users.test.ts`, `web/src/lib/facepile.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)