### PR TITLE
fix(bots): never bind a bot to its own delegated task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Recent product updates and deployment notes.
 
+## August 19, 2026 - A bot can no longer be replaced by its own task (v0.2.6)
+
+- **A bot chat always shows the bot's own conversation.** When a bot's chat
+  process ended while one of its background tasks kept running, the bot could be
+  permanently rebound to that task. Its chat then opened the task instead, new
+  messages waited behind work that was never yours, and there was no way back to
+  the real conversation. A bot now keeps its own thread, and a bot already
+  affected recovers its full history on the next message.
+- **The mobile bot chat has a Back button again.** The chat opens as a full
+  screen, so the switch above the composer was the only exit. The header now
+  returns you straight to the bot list.
+
 ## August 19, 2026 - Bot switch stays above the composer (v0.2.5)
 
 - **The mobile Chat/Bots switch no longer floats over bot messages.** It now

--- a/src/bot-session-binding.test.ts
+++ b/src/bot-session-binding.test.ts
@@ -1,0 +1,120 @@
+// A bot must never be bound to a task it delegated.
+//
+// The live failure this covers: a bot's conversation process died while two of
+// its subagents kept running. A broad `botId` match picked a surviving child
+// (children inherit `botId` for attribution), the child's id was persisted onto
+// the bot record, and from then on the bot chat opened a delegated
+// acceptance-test run. The human's messages queued behind that task's turn, and
+// nothing in the UI led back to the real conversation.
+import { describe, expect, test } from "bun:test";
+
+import {
+  botConversationRef,
+  findBotMainSession,
+  isDelegatedSession,
+} from "./bots/session.ts";
+
+const CONVERSATION = "5f1df640-20fd-4c9f-a605-e4091890b003";
+const CHILD = "58c974e7-feee-49b3-ab4d-1012b4250b1c";
+
+describe("isDelegatedSession", () => {
+  test("treats any lineage marker as delegated", () => {
+    expect(isDelegatedSession({ parentSessionId: "p" })).toBe(true);
+    expect(isDelegatedSession({ parentNativeSessionId: "p" })).toBe(true);
+    expect(isDelegatedSession({ subagentDepth: 1 })).toBe(true);
+    expect(isDelegatedSession({ spawnedBy: "subagent" })).toBe(true);
+  });
+
+  test("a bot's own conversation is not delegated", () => {
+    expect(isDelegatedSession({ sessionId: CONVERSATION, botId: "bot-1", spawnedBy: "bot" }))
+      .toBe(false);
+  });
+});
+
+describe("findBotMainSession", () => {
+  test("ignores a saved id that names one of the bot's own subagents", () => {
+    const child = {
+      sessionId: CHILD,
+      botId: "bot-1",
+      parentSessionId: CONVERSATION,
+      spawnedBy: "subagent",
+    };
+    const conversation = { sessionId: CONVERSATION, botId: "bot-1", spawnedBy: "bot" };
+
+    expect(findBotMainSession({ id: "bot-1", sessionId: CHILD }, [child, conversation]))
+      .toBe(conversation);
+  });
+
+  test("returns nothing rather than a child when the conversation is not live", () => {
+    const child = {
+      sessionId: CHILD,
+      botId: "bot-1",
+      parentSessionId: CONVERSATION,
+      spawnedBy: "subagent",
+    };
+
+    expect(findBotMainSession({ id: "bot-1", sessionId: CHILD }, [child])).toBeUndefined();
+  });
+
+  test("a child listed before the conversation never wins", () => {
+    const child = { sessionId: CHILD, botId: "bot-1", subagentDepth: 1 };
+    const conversation = { sessionId: CONVERSATION, botId: "bot-1" };
+
+    expect(findBotMainSession({ id: "bot-1" }, [child, conversation])).toBe(conversation);
+  });
+});
+
+describe("botConversationRef", () => {
+  test("keeps a healthy saved conversation untouched", () => {
+    const conversation = { sessionId: CONVERSATION, botId: "bot-1" };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: CONVERSATION }, [conversation]))
+      .toEqual({ sessionId: CONVERSATION });
+  });
+
+  test("keeps a saved conversation whose process has already exited", () => {
+    expect(botConversationRef({ id: "bot-1", sessionId: CONVERSATION }, []))
+      .toEqual({ sessionId: CONVERSATION });
+  });
+
+  test("recovers the real conversation id from a child binding", () => {
+    // The parent process is gone — which is exactly why the rebind happened —
+    // so the id has to come from the child's lineage, not from the live list.
+    const child = {
+      sessionId: CHILD,
+      botId: "bot-1",
+      parentSessionId: CONVERSATION,
+      spawnedBy: "subagent",
+    };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: CHILD }, [child]))
+      .toEqual({ sessionId: CONVERSATION });
+  });
+
+  test("walks past a nested child to the root conversation", () => {
+    const grandchild = { sessionId: "grandchild", parentSessionId: CHILD, subagentDepth: 2 };
+    const child = { sessionId: CHILD, parentSessionId: CONVERSATION, subagentDepth: 1 };
+    const conversation = { sessionId: CONVERSATION, botId: "bot-1" };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: "grandchild" }, [grandchild, child, conversation]))
+      .toEqual({ sessionId: CONVERSATION });
+  });
+
+  test("mints a fresh conversation when a child has no recoverable ancestor", () => {
+    const orphan = { sessionId: CHILD, botId: "bot-1", subagentDepth: 1 };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: CHILD }, [orphan])).toEqual({});
+  });
+
+  test("does not spin on a parent cycle", () => {
+    const a = { sessionId: "a", parentSessionId: "b", subagentDepth: 1 };
+    const b = { sessionId: "b", parentSessionId: "a", subagentDepth: 1 };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: "a" }, [a, b])).toEqual({});
+  });
+
+  test("a bot nobody has talked to yet has no conversation to repair", () => {
+    expect(botConversationRef({ id: "bot-1" }, [])).toEqual({});
+    expect(botConversationRef({ id: "bot-1", sessionId: "   " }, [])).toEqual({});
+  });
+});

--- a/src/bots/session.ts
+++ b/src/bots/session.ts
@@ -1,0 +1,127 @@
+// Which session is a bot's own conversation — the single owner of that answer.
+//
+// A bot has exactly one conversation, and it must never be a task the bot
+// delegated. Two facts make that easy to get wrong:
+//
+// 1. Child sessions INHERIT `botId` for attribution (see the lineage pass at
+//    the end of listSessions in sessions.ts). So `session.botId === bot.id`
+//    matches the bot's conversation AND every subagent it ever spawned.
+// 2. Whatever session a lookup returns gets persisted back onto the bot record
+//    (`deliverBotMessage`). A single wrong match is therefore permanent: the
+//    bot's saved conversation id becomes a child's id, the chat opens the
+//    child, and the human's next message is queued behind that child's task.
+//
+// That is not hypothetical — it happened. A bot's conversation process died
+// while two of its subagents were still running, a broad `botId` match picked a
+// surviving child, and the bot's record was rebound to it. The human then had a
+// bot chat showing a delegated acceptance-test run, with no way back to the
+// real conversation and messages stacking up behind a turn that was never
+// theirs.
+//
+// So resolution lives here, is used by the server and the web client, and
+// rejects delegated sessions on every path.
+
+/** A bot's identity plus the conversation id currently saved on its record. */
+export type BotSessionRef = {
+  id: string;
+  sessionId?: string | null;
+};
+
+/** The session fields conversation resolution reads, in either read model. */
+export type BotSessionCandidate = {
+  sessionId?: string | null;
+  nativeSessionId?: string | null;
+  botId?: string | null;
+  parentSessionId?: string | null;
+  parentNativeSessionId?: string | null;
+  subagentDepth?: number | null;
+  spawnedBy?: string | null;
+};
+
+/** Cap the ancestor walk so a corrupted parent cycle cannot spin. */
+const MAX_ANCESTOR_HOPS = 8;
+
+/**
+ * A session that belongs to someone else's turn: a delegated child, not a
+ * bot's own conversation. Any one of these markers is enough.
+ */
+export function isDelegatedSession(session: BotSessionCandidate): boolean {
+  return (
+    !!session.parentSessionId ||
+    !!session.parentNativeSessionId ||
+    !!session.subagentDepth ||
+    session.spawnedBy === "subagent"
+  );
+}
+
+function matchesId(session: BotSessionCandidate, id: string): boolean {
+  return session.sessionId === id || session.nativeSessionId === id;
+}
+
+function findById<T extends BotSessionCandidate>(
+  sessions: readonly T[],
+  id: string,
+): T | undefined {
+  return sessions.find((session) => matchesId(session, id));
+}
+
+/**
+ * Resolve only the bot's main conversation.
+ *
+ * The saved id wins when it names a real conversation. When it names a
+ * delegated child the binding is corrupt, so it is ignored rather than
+ * trusted — falling through to the bot's own top-level session if one is live.
+ */
+export function findBotMainSession<T extends BotSessionCandidate>(
+  bot: BotSessionRef,
+  sessions: readonly T[],
+): T | undefined {
+  const saved = bot.sessionId?.trim();
+  if (saved) {
+    const exact = findById(sessions, saved);
+    if (exact && !isDelegatedSession(exact)) return exact;
+  }
+  return sessions.find(
+    (session) => session.botId === bot.id && !isDelegatedSession(session),
+  );
+}
+
+/**
+ * The conversation id a bot's next process must attach to, with a corrupted
+ * binding repaired.
+ *
+ * When the saved id names one of the bot's delegated children, the bot's real
+ * conversation is that child's root ancestor — the session the child was
+ * spawned from. Walking up recovers the original id even when its process is
+ * long dead, which is the whole point: that id is the key the transcript is
+ * filed under (`lfg://session/<id>`), so recovering it brings the human's chat
+ * history back instead of adopting a subagent's thread as the bot's history.
+ *
+ * Returns null when there is nothing safe to attach to, which tells the caller
+ * to mint a fresh conversation.
+ */
+export function botConversationRef(
+  bot: BotSessionRef,
+  sessions: readonly BotSessionCandidate[],
+): { sessionId?: string } {
+  const saved = bot.sessionId?.trim();
+  if (!saved) return {};
+
+  const exact = findById(sessions, saved);
+  if (!exact || !isDelegatedSession(exact)) return { sessionId: saved };
+
+  const seen = new Set<string>([saved]);
+  let current: BotSessionCandidate = exact;
+  for (let hop = 0; hop < MAX_ANCESTOR_HOPS; hop++) {
+    const parentId = (current.parentSessionId ?? current.parentNativeSessionId)?.trim();
+    if (!parentId || seen.has(parentId)) return {};
+    seen.add(parentId);
+    const parent = findById(sessions, parentId);
+    // A parent that is no longer live is still the right conversation id: the
+    // bot is about to be relaunched onto it, and its transcript is on disk.
+    if (!parent) return { sessionId: parentId };
+    if (!isDelegatedSession(parent)) return { sessionId: parent.sessionId ?? parentId };
+    current = parent;
+  }
+  return {};
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -76,6 +76,7 @@ import {
   type BotColorway,
   type BotShape,
 } from "../bots/store.ts";
+import { botConversationRef, findBotMainSession } from "../bots/session.ts";
 import {
   BOT_SELF_CREATE_FIELDS,
   BOT_SELF_UPDATE_FIELDS,
@@ -2276,11 +2277,15 @@ async function ensureBotSession(
   firstMessage?: string,
 ): Promise<{ session: Session; delivered: boolean } | Response> {
   const sessions = await listSessions();
-  const live = sessions.find((session) =>
-    session.botId === bot.id ||
-    (bot.sessionId && (session.sessionId === bot.sessionId || session.nativeSessionId === bot.sessionId))
-  );
-  if (live) return { session: live, delivered: false };
+  const live = findBotMainSession(bot, sessions);
+  if (live) {
+    // Heal a record an older broad `botId` match rebound to a delegated child,
+    // so the corrupt id stops being handed to the next reader.
+    if (live.sessionId && live.sessionId !== bot.sessionId) {
+      await updateBot(bot.id, { sessionId: live.sessionId });
+    }
+    return { session: live, delivered: false };
+  }
 
   const config = validateBotAgent(bot.agent, bot.model, bot.thinkingLevel);
   if ("error" in config) return err(400, config.error);
@@ -2321,7 +2326,11 @@ async function ensureBotSession(
     // turns append to the history that is already there — no change to the
     // transcript API, the live socket, or the client, because none of them ever
     // cared which process produced a turn.
-    const sessionId = botConversationId(bot, () => crypto.randomUUID());
+    // botConversationRef repairs a saved id that names one of this bot's own
+    // subagents, recovering the conversation the human has actually been
+    // talking to instead of resuming a delegated task's thread.
+    const conversation = botConversationRef(bot, sessions);
+    const sessionId = botConversationId(conversation, () => crypto.randomUUID());
     // aisdk decides resume-vs-fresh by asking the index itself
     // (sessionHasIndexedMessages, aisdk-session.ts), so reusing the id restores
     // the model's own thread too and a summary would only repeat what it can
@@ -2336,8 +2345,11 @@ async function ensureBotSession(
         ensureConversationVisibleFrom(repo.cwd, sessionId);
       } catch {}
     }
-    const continuity = !resumesOwnThread && bot.sessionId
-      ? await botContinuitySummary(bot.sessionId)
+    // Summarize the repaired conversation, never the corrupt id: a bot rebound
+    // to its own subagent would otherwise be reintroduced to that task's
+    // transcript as if it were its own history.
+    const continuity = !resumesOwnThread && conversation.sessionId
+      ? await botContinuitySummary(conversation.sessionId)
       : null;
     const prompt = [
       botRuntimeContract(bot.name, bot.persona, {
@@ -3839,12 +3851,10 @@ a{color:#60a5fa}
             try {
               let target = reservedTarget;
               if (target.runtimeRefreshPending) {
-                const live = sessions.find((session) =>
-                  session.botId === target.id ||
-                  (target.sessionId && (
-                    session.sessionId === target.sessionId || session.nativeSessionId === target.sessionId
-                  ))
-                );
+                // Only the bot's own conversation may be closed for a profile
+                // refresh. A delegated child matches on inherited `botId` and
+                // would be killed mid-task.
+                const live = findBotMainSession(target, sessions);
                 if (botRuntimeRefreshDecision(target, live) === "wait") {
                   throw new BotPeerMessageError(
                     409,
@@ -4120,10 +4130,9 @@ a{color:#60a5fa}
           if (bot.runtimeRefreshPending) {
             const pendingBot = bot;
             const sessions = await listSessions();
-            const live = sessions.find((session) =>
-              session.botId === pendingBot.id ||
-              (pendingBot.sessionId && (session.sessionId === pendingBot.sessionId || session.nativeSessionId === pendingBot.sessionId))
-            );
+            // The bot's own conversation only — a delegated child inherits
+            // `botId` and must not be closed to apply a profile change.
+            const live = findBotMainSession(pendingBot, sessions);
             // Never kill or rewrite the prompt of the turn that requested the
             // update. A client that races the next message retries once that
             // turn settles, and the message is never run under stale rules.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24674,6 +24674,19 @@ function BotsView({
               className="flex items-center gap-2 border-b border-border px-4 pb-3"
               style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.75rem)" }}
             >
+              {/* This chat is a full-screen portal above the app shell, so its
+                  own header is the only way out. The surface toggle above the
+                  composer switches products; it is not a way back to the
+                  roster, which left the bot chat with no exit at all. */}
+              <button
+                type="button"
+                onClick={onBack}
+                aria-label="Back to bots"
+                className="-ml-2 flex h-9 shrink-0 items-center gap-0.5 rounded-full pl-1 pr-2 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
+              >
+                <ChevronLeft className="size-[18px]" />
+                <span>Bots</span>
+              </button>
               <BotAvatar bot={bot} working={busy} size={28} />
               <span className="min-w-0 flex-1">
                 <span className="block truncate text-[15px] font-semibold leading-tight">{bot.name}</span>

--- a/web/src/lib/bot-session.ts
+++ b/web/src/lib/bot-session.ts
@@ -1,29 +1,11 @@
-type BotSessionRef = {
-  id: string;
-  sessionId?: string | null;
-};
-
-type SessionRef = {
-  sessionId?: string | null;
-  nativeSessionId?: string | null;
-  botId?: string | null;
-  parentSessionId?: string | null;
-  parentNativeSessionId?: string | null;
-  subagentDepth?: number | null;
-};
-
-/**
- * Resolve only the persistent bot's main conversation.
- *
- * Child sessions inherit botId for attribution. A broad botId match can
- * therefore open a delegated task instead of the bot's saved conversation.
- */
-export function findBotMainSession<T extends SessionRef>(bot: BotSessionRef, sessions: T[]): T | undefined {
-  const savedSessionId = bot.sessionId?.trim();
-  if (savedSessionId) {
-    const exact = sessions.find((session) => session.sessionId === savedSessionId || session.nativeSessionId === savedSessionId);
-    if (exact) return exact;
-  }
-
-  return sessions.find((session) => session.botId === bot.id && !session.parentSessionId && !session.parentNativeSessionId && !session.subagentDepth);
-}
+// The client resolves a bot's conversation with the same rules the server
+// binds it by. Two copies drifted once already: the client learned to skip
+// delegated children while the server was still rebinding bot records to them,
+// so the chat and the record disagreed about which session a bot owned.
+export {
+  botConversationRef,
+  findBotMainSession,
+  isDelegatedSession,
+  type BotSessionCandidate,
+  type BotSessionRef,
+} from "../../../src/bots/session.ts";

--- a/web/src/mobile-bot-chat-navigation.test.ts
+++ b/web/src/mobile-bot-chat-navigation.test.ts
@@ -23,4 +23,16 @@ describe("mobile bot chat navigation", () => {
   test("keeps Chat active and returns to the Bots roster", () => {
     expect(BOTS_VIEW).toMatch(/const mobileNavigation[\s\S]*?active="sessions"[\s\S]*?onOpenBots=\{onBack\}/);
   });
+
+  // The mobile chat is a full-screen portal over the app shell, so the shell's
+  // own back affordance is not reachable. Without this control the bot chat had
+  // no exit at all.
+  test("gives the full-screen mobile chat its own way back to the roster", () => {
+    const portal = BOTS_VIEW.slice(
+      BOTS_VIEW.indexOf("if (isMobile) {"),
+      BOTS_VIEW.indexOf("document.body,"),
+    );
+    expect(portal).toContain('aria-label="Back to bots"');
+    expect(portal).toMatch(/onClick=\{onBack\}[\s\S]*?aria-label="Back to bots"/);
+  });
 });


### PR DESCRIPTION
## What was wrong

The Engineer bot's chat had been taken over by one of its own background tasks. Three separate symptoms, one cause.

A bot's conversation process can end while the subagents it spawned keep running. Child sessions **inherit `botId`** for attribution (the lineage pass at the end of `listSessions`), so the broad `botId` match in `ensureBotSession` returned a surviving child. `deliverBotMessage` then persisted that child's id onto the bot record, which made the damage permanent:

- the bot chat opened a delegated acceptance-test run instead of the conversation
- the human's messages were queued behind a turn that was never theirs
- the mobile chat had no way back to the roster

Confirmed on the live box: bot `Engineer` was bound to `58c974e7`, a session whose managed record reads `spawnedBy: "subagent"`, `parentSessionId: 5f1df640`. `5f1df640` is the real conversation and its process was gone. Three of the user's messages sat in that child's queue behind a 26-minute turn.

`v0.2.1` fixed the client half (`findBotMainSession` skips children), but the server kept rebinding, and by then the saved id was already corrupt — so the client's exact-match branch trusted it and opened the child anyway.

## Change

- **One owner for "which session is this bot's conversation"** in `src/bots/session.ts`, imported by both the server and the web client. The two copies had already drifted apart once.
- **Delegated sessions are rejected on every path**, including a saved id that names one of the bot's own children.
- **A corrupt binding is repaired, not just ignored.** The real conversation is the child's root ancestor, so walking up recovers the id the transcript is filed under (`lfg://session/<id>`) — which is what brings the history back rather than adopting a subagent's thread. Unrecoverable cases mint a fresh conversation instead of resuming a task. The record is rewritten on the next message, so an affected bot self-heals with no manual repair.
- **Both runtime-refresh paths** now resolve the main conversation too; the same broad match could close a child mid-task to apply a profile change.
- **Mobile Back button restored.** `v0.2.2` removed it on the assumption the chat sits at the mobile root, but it renders as a full-screen portal above the app shell, so the switch above the composer was the only exit.

## Test plan

- [x] `bun test src/bot-session-binding.test.ts` — 12 new cases: lineage markers, a child listed before the conversation, a dead conversation, ancestor recovery, nested children, parent cycles, unrecoverable orphans
- [x] `bun test web/src/mobile-bot-chat-navigation.test.ts` — asserts the full-screen portal has its own back control
- [x] `bun test` — 1851 pass, same 4 pre-existing baseline failures as `origin/main` (verified by running the suite on the clean checkout at the same commit)
- [x] `bun run typecheck`

Made with [Cursor](https://cursor.com)