### PR TITLE
fix(bots): stop the chat falling back to a corrupt bot binding

### DIFF
--- a/src/bot-session-binding.test.ts
+++ b/src/bot-session-binding.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  botChatSessionId,
   botConversationRef,
   findBotMainSession,
   isDelegatedSession,
@@ -116,5 +117,36 @@ describe("botConversationRef", () => {
   test("a bot nobody has talked to yet has no conversation to repair", () => {
     expect(botConversationRef({ id: "bot-1" }, [])).toEqual({});
     expect(botConversationRef({ id: "bot-1", sessionId: "   " }, [])).toEqual({});
+  });
+});
+
+describe("botChatSessionId", () => {
+  test("reads the live conversation when one is running", () => {
+    const conversation = { sessionId: CONVERSATION, botId: "bot-1" };
+
+    expect(botChatSessionId({ id: "bot-1", sessionId: CONVERSATION }, [conversation]))
+      .toBe(CONVERSATION);
+  });
+
+  // The chat used to fall back to the raw saved id, which put the delegated
+  // child back on screen even though findBotMainSession had refused to return
+  // it.
+  test("never renders the delegated child a corrupt record points at", () => {
+    const child = {
+      sessionId: CHILD,
+      botId: "bot-1",
+      parentSessionId: CONVERSATION,
+      spawnedBy: "subagent",
+    };
+
+    expect(botChatSessionId({ id: "bot-1", sessionId: CHILD }, [child])).toBe(CONVERSATION);
+  });
+
+  test("reads the saved conversation while its process is down", () => {
+    expect(botChatSessionId({ id: "bot-1", sessionId: CONVERSATION }, [])).toBe(CONVERSATION);
+  });
+
+  test("has nothing to read for a bot nobody has talked to", () => {
+    expect(botChatSessionId({ id: "bot-1" }, [])).toBeNull();
   });
 });

--- a/src/bots/session.ts
+++ b/src/bots/session.ts
@@ -87,6 +87,22 @@ export function findBotMainSession<T extends BotSessionCandidate>(
 }
 
 /**
+ * The session id a bot's chat should read.
+ *
+ * The bot's live conversation when there is one, otherwise the conversation it
+ * will reattach to. Falling back to the raw saved id instead would put a
+ * corrupt binding back on screen: `findBotMainSession` refuses to return the
+ * delegated child, and the chat would then render that child anyway.
+ */
+export function botChatSessionId(
+  bot: BotSessionRef,
+  sessions: readonly BotSessionCandidate[],
+): string | null {
+  const live = findBotMainSession(bot, sessions);
+  return live?.sessionId ?? botConversationRef(bot, sessions).sessionId ?? null;
+}
+
+/**
  * The conversation id a bot's next process must attach to, with a corrupted
  * binding repaired.
  *

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,7 +41,7 @@ import {
   shouldShowInlineBotsSurfaceToggle,
   shouldShowMobileSurfaceToggle,
 } from "./lib/mobile-bots-nav";
-import { findBotMainSession } from "./lib/bot-session";
+import { botChatSessionId, findBotMainSession } from "./lib/bot-session";
 import { resolveRosterUser } from "./lib/roster-user";
 import {
   botVisibleUserText as botVisibleUserTextFor,
@@ -11455,8 +11455,7 @@ function RailStage({
   const botsBySid = useMemo(() => {
     const map = new Map<string, PersistentBot>();
     for (const bot of bots) {
-      const backing = findBotMainSession(bot, sessions);
-      const sid = backing?.sessionId ?? bot.sessionId ?? null;
+      const sid = botChatSessionId(bot, sessions);
       if (sid) map.set(sid, bot);
     }
     return map;
@@ -24594,7 +24593,7 @@ function BotsView({
 
   if (bot) {
     const backingSession = findBotMainSession(bot, sessions);
-    const sid = backingSession?.sessionId ?? bot.sessionId ?? null;
+    const sid = botChatSessionId(bot, sessions);
     const session: Session | null = sid
       ? backingSession ?? {
           sessionId: sid,

--- a/web/src/lib/bot-session.ts
+++ b/web/src/lib/bot-session.ts
@@ -3,6 +3,7 @@
 // delegated children while the server was still rebinding bot records to them,
 // so the chat and the record disagreed about which session a bot owned.
 export {
+  botChatSessionId,
   botConversationRef,
   findBotMainSession,
   isDelegatedSession,


### PR DESCRIPTION
## Why

Follow-up to [#172](https://github.com/BennyKok/omg.dev/pull/172), which is incomplete without this.

`findBotMainSession` correctly refuses to return a bot's delegated child. But both chat call sites then did:

```ts
const sid = findBotMainSession(bot, sessions)?.sessionId ?? bot.sessionId ?? null;
```

When the bot record is corrupt, `bot.sessionId` **is** the child. So the resolver declined to return it and the fallback put it straight back — the child rendered as the bot's chat regardless. The guarantee never reached the screen.

## Change

One owner for that fallback, `botChatSessionId`: the bot's live conversation when there is one, otherwise the conversation it will reattach to (the repaired ancestor). An affected bot now shows its real history immediately, before the record is rewritten on the next message.

## Test plan

- [x] `bun test src/bot-session-binding.test.ts` — 4 new cases, including "never renders the delegated child a corrupt record points at"
- [x] `bun run typecheck`

Made with [Cursor](https://cursor.com)