### PR TITLE
test: fix 3 stale/rotting test assertions on main

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -377,12 +377,20 @@ describe("mobile overlay scroll contract", () => {
     expect(app).toContain(
       'tab === "live" || tab === "bots" || tab === "notifications" || tab === "artifacts"',
     );
-    expect(app).toContain(
-      "pb-[var(--lfg-inline-composer-height,var(--lfg-composer-clear))]",
-    );
-    expect(app).not.toContain(
-      "pb-[calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+var(--lfg-mobile-composer-fade-height))]",
-    );
+    // <main>'s bottom padding must clear the inline composer, but the exact
+    // expression has grown legitimate additive terms since this test was
+    // written (e.g. the bot-nav dock height). What must stay true is the
+    // regression this test exists for: that reserved space never also adds
+    // the fade's height, which would double-count space the fade only
+    // overlays instead of reserving. Match every pb-[...] that clears the
+    // composer and assert none of them fold in the fade height.
+    const composerClearances = [
+      ...app.matchAll(/pb-\[[^\]]*--lfg-inline-composer-height[^\]]*\]/g),
+    ].map((m) => m[0]);
+    expect(composerClearances.length, "no pb-[...] clears the inline composer height").toBeGreaterThan(0);
+    for (const clearance of composerClearances) {
+      expect(clearance).not.toContain("--lfg-mobile-composer-fade-height");
+    }
     expect(app).toContain(
       "mobile-scroll-composer-fade pointer-events-auto relative z-[55] mt-auto",
     );

--- a/test/session-list-payload.test.ts
+++ b/test/session-list-payload.test.ts
@@ -74,7 +74,13 @@ describe("which responses drop cmd", () => {
   test("/api/sessions keeps a full=1 opt-in", () => {
     const route = SERVE.indexOf('path === "/api/sessions"');
     expect(route, "/api/sessions route not found").toBeGreaterThanOrEqual(0);
-    const block = SERVE.slice(route, route + 600);
+    // Slice to the start of the *next* top-level route handler rather than a
+    // fixed char count — a fixed window silently stops covering this route
+    // the moment someone adds a comment inside it (see the pendingLogins
+    // hibernation note above), which is exactly what happened here.
+    const nextRoute = SERVE.indexOf("\n      if (path ===", route + 1);
+    expect(nextRoute, "next route boundary not found").toBeGreaterThan(route);
+    const block = SERVE.slice(route, nextRoute);
     expect(block).toContain('url.searchParams.get("full") === "1"');
     expect(block).toContain("full ? sessions : sessions.map(sessionListRow)");
   });

--- a/test/settings-rendering.test.ts
+++ b/test/settings-rendering.test.ts
@@ -29,11 +29,29 @@ describe("settings rendering", () => {
   });
 
   test("mobile secondary chrome leaves clearance above page content", () => {
-    expect(app).toContain(
-      'className="z-40 flex shrink-0 items-center pb-3 pl-3 pr-[calc(0.75rem+var(--lfg-host-top-inset))]',
-    );
-    expect(app).toContain(
-      'className="relative z-40 flex shrink-0 items-center justify-between gap-2 px-2 pb-3 pt-[calc(0.5rem+env(safe-area-inset-top))] md:px-3 md:pb-1"',
-    );
+    // Anchor on the header's own explanatory comment rather than its full
+    // className string: the comment identifies *which* header this is, and
+    // the class-token checks below survive unrelated layout classes
+    // (justify-between, gap-2, ordering) getting added around the padding
+    // that actually creates the clearance.
+    function headerTagAfter(comment: string): string {
+      const commentIdx = app.indexOf(comment);
+      expect(commentIdx, `comment "${comment}" not found`).toBeGreaterThanOrEqual(0);
+      const tagStart = app.indexOf("<header", commentIdx);
+      const tagEnd = app.indexOf(">", tagStart);
+      expect(tagStart, `<header> after "${comment}" not found`).toBeGreaterThanOrEqual(0);
+      return app.slice(tagStart, tagEnd);
+    }
+
+    const secondaryHeader = headerTagAfter("Secondary pages sit below Live in the mobile hierarchy");
+    expect(secondaryHeader).toContain("pb-3");
+    expect(secondaryHeader).toContain("pl-3");
+    expect(secondaryHeader).toContain("pr-[calc(0.75rem+var(--lfg-host-top-inset))]");
+    expect(secondaryHeader).toContain("pt-[calc(0.5rem+env(safe-area-inset-top))]");
+
+    const pageHeader = headerTagAfter("Embedded used to be suppressed here too");
+    expect(pageHeader).toContain("pb-3");
+    expect(pageHeader).toContain("pt-[calc(0.5rem+env(safe-area-inset-top))]");
+    expect(pageHeader).toContain("md:pb-1");
   });
 });


### PR DESCRIPTION
## Summary

Three tests fail on a clean `origin/main` checkout, unrelated to any in-flight work — the suite was lying on every run. All three turned out to be stale assertions (markup/expression drift), not product regressions.

- **`test/session-list-payload.test.ts`** — `/api/sessions keeps a full=1 opt-in` sliced a fixed 600-char window from the route body to check it. A hibernation-fix comment was added inside the route, pushing the `full ? sessions : sessions.map(sessionListRow)` line past that window. Route code is correct. Now slices to the start of the next route handler instead of a fixed length, so it survives future comments/code growth in this route.
- **`test/settings-rendering.test.ts`** — `mobile secondary chrome leaves clearance above page content` matched a header's `className` as one exact literal string. `justify-between gap-2` were legitimately added to that header. Replaced with token-level checks for the actual clearance classes (`pb-3`, `pl-3`, `pr-[calc(...)]`, `pt-[calc(...)]`), anchored on the header's adjacent explanatory comment instead of the full string.
- **`test/embed.test.ts`** — `composer pages reserve chrome while the fade overlays content` matched an exact `pb-[calc(...)]` expression on `<main>`. The mobile-bot-nav feature (#169) legitimately added a `--lfg-mobile-surface-dock-height` term to that calc. Verified the actual regression this test guards against — the composer-fade's height getting folded into the *reserved* padding (double-counting space the fade only overlays) — still cannot happen. Rewrote the assertion to check that invariant directly (regex over every `pb-[...]` that clears composer height, assert none also reference `--lfg-mobile-composer-fade-height`) instead of one exact string.

No product bugs found. All three were assertion drift.

### On the shared pattern

Two of these (and other tests nearby) assert exact `className` literals against `web/src/App.tsx`, a large monolith component file. That pattern is brittle to any incidental class reordering/insertion and will keep rotting. A cheap fix worth considering separately: a small test helper that extracts a JSX element's className by a stable anchor (a nearby unique comment, or a `data-testid`) and asserts on individual class tokens instead of the full string — the pattern used in both fixes here. Not done as part of this change per scope (test-only cleanup, no sweeping refactor).

## Test plan

- [x] Reproduced all 3 failures against a clean checkout before touching anything (also found `bun install` was needed — `marked` was missing from `node_modules`, unrelated env issue).
- [x] `bun x tsc --noEmit` — clean (after `bun run build:packages`, required for the `@omg-dev/client` workspace package types).
- [x] `bun run build:packages` — succeeds.
- [x] `bun run test` — 1859 pass, 0 fail, 1 skip (pre-existing skip, unrelated).
- [x] No release cut — test-only/internal change per repo release rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)