### PR TITLE
fix(cursor): stop ACP turns gluing into one wall of text

### DIFF
--- a/src/agents/backends/acp-session.test.ts
+++ b/src/agents/backends/acp-session.test.ts
@@ -11,12 +11,16 @@ import type { ManagedSdkEventSink } from "./managed-sdk-session.ts";
 
 function sinkRecorder() {
   const drafts: string[] = [];
+  const committed: string[] = [];
   const tools: string[] = [];
   const sink: ManagedSdkEventSink = {
     draft(text) {
       drafts.push(text);
     },
     thinking() {},
+    commitText(text) {
+      committed.push(text);
+    },
     toolStart(id, name) {
       tools.push(`start:${id}:${name}`);
     },
@@ -27,7 +31,7 @@ function sinkRecorder() {
       return null;
     },
   };
-  return { sink, drafts, tools };
+  return { sink, drafts, committed, tools };
 }
 
 describe("ACP initialize capabilities", () => {
@@ -92,6 +96,71 @@ describe("ACP load replay suppression", () => {
     }, sink, state);
     expect(drafts).toEqual(["fresh"]);
     expect(state.draft).toBe("fresh");
+  });
+});
+
+describe("ACP mid-turn draft flush", () => {
+  test("commits narrated text before each tool so segments do not glue together", () => {
+    const { sink, drafts, committed, tools } = sinkRecorder();
+    const state: AcpUpdateState = { draft: "", thought: "", replaying: false };
+
+    applyAcpSessionUpdate({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "I'll start by understanding the current state." },
+    }, sink, state);
+    applyAcpSessionUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "call-1",
+      title: "Shell",
+      status: "pending",
+    }, sink, state);
+
+    expect(committed).toEqual(["I'll start by understanding the current state."]);
+    expect(state.draft).toBe("");
+    expect(drafts.at(-1)).toBe("");
+    expect(tools).toEqual(["start:call-1:Shell"]);
+
+    applyAcpSessionUpdate({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "This is the vibes repo." },
+    }, sink, state);
+    applyAcpSessionUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "call-2",
+      title: "Read",
+      status: "completed",
+    }, sink, state);
+
+    expect(committed).toEqual([
+      "I'll start by understanding the current state.",
+      "This is the vibes repo.",
+    ]);
+    expect(state.draft).toBe("");
+    expect(tools).toEqual([
+      "start:call-1:Shell",
+      "start:call-2:Read",
+      "end:call-2:Read",
+    ]);
+
+    applyAcpSessionUpdate({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "Final answer." },
+    }, sink, state);
+    expect(state.draft).toBe("Final answer.");
+    expect(committed).toHaveLength(2);
+  });
+
+  test("does not commit an empty draft when a tool arrives with no prior text", () => {
+    const { sink, committed, tools } = sinkRecorder();
+    const state: AcpUpdateState = { draft: "", thought: "", replaying: false };
+    applyAcpSessionUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "call-1",
+      title: "Shell",
+      status: "pending",
+    }, sink, state);
+    expect(committed).toEqual([]);
+    expect(tools).toEqual(["start:call-1:Shell"]);
   });
 });
 

--- a/src/agents/backends/acp-session.ts
+++ b/src/agents/backends/acp-session.ts
@@ -44,6 +44,16 @@ export function acpResumeStrategy(
   return "new";
 }
 
+function flushAcpDraft(sink: ManagedSdkEventSink, state: AcpUpdateState): void {
+  const body = state.draft;
+  if (!body.trim()) return;
+  // Clear ACP state first so a later session.prompt return cannot re-emit the
+  // same narration as one concatenated turn-end blob.
+  state.draft = "";
+  sink.commitText(body);
+  sink.draft("");
+}
+
 export function applyAcpSessionUpdate(
   update: acp.SessionUpdate,
   sink: ManagedSdkEventSink,
@@ -62,6 +72,10 @@ export function applyAcpSessionUpdate(
       sink.thinking(state.thought);
       break;
     case "tool_call":
+      // Cursor (and other ACP agents) stream short narrations between tools.
+      // Commit each segment before the tool so the transcript keeps message
+      // boundaries instead of one glued wall of text at turn end.
+      flushAcpDraft(sink, state);
       sink.toolStart(update.toolCallId, update.name ?? update.title, update.rawInput);
       if (update.status === "completed" || update.status === "failed") {
         sink.toolEnd(update.toolCallId, update.name ?? update.title, update.rawOutput, update.status === "failed");

--- a/src/agents/backends/cursor-acp-extensions.test.ts
+++ b/src/agents/backends/cursor-acp-extensions.test.ts
@@ -11,6 +11,7 @@ function sinkWithAnswers(...answers: Array<number | null>): ManagedSdkEventSink 
   return {
     draft() {},
     thinking() {},
+    commitText() {},
     toolStart() {},
     toolEnd() {},
     async ask() {

--- a/src/agents/backends/managed-sdk-session.ts
+++ b/src/agents/backends/managed-sdk-session.ts
@@ -28,6 +28,13 @@ export type ManagedSdkPromptOption = {
 export type ManagedSdkEventSink = {
   draft(text: string): void;
   thinking(text: string): void;
+  /**
+   * Commit streamed assistant text into the transcript before a tool call (or
+   * any other mid-turn boundary). ACP agents narrate between tools; without a
+   * commit those segments stay in one draft and glue into a single wall of text
+   * at turn end (e.g. "codebase.This is the vibes repo").
+   */
+  commitText(text: string): void;
   toolStart(id: string, name: string, input?: unknown): void;
   toolEnd(id: string, name: string, output?: unknown, error?: boolean): void;
   ask(question: string, options: ManagedSdkPromptOption[], header?: string): Promise<number | null>;
@@ -133,6 +140,13 @@ export async function runManagedSdkSession(options: ManagedSdkSessionOptions): P
     thinking(next) {
       thought = next;
       if (!draft) publishDraft(next);
+    },
+    commitText(next) {
+      const body = next.trim();
+      draft = "";
+      publishDraft("", true);
+      if (!body) return;
+      indexSessionMessagesDirect(key, [row("assistant", "text", body)]);
     },
     toolStart(id, name, input) {
       const toolId = `${id}:start`;


### PR DESCRIPTION
## Summary
- Cursor (and other ACP agents) stream short narrations between tool calls. The harness kept them in one draft and flushed once at turn end, so the transcript became a single glued blob (`codebase.This is the vibes repo`).
- Commit each narrated segment into the transcript before the next `tool_call`, and clear the ACP draft so turn-end cannot re-emit the pile.
- Evidence from session `5c0028e4`: one 10,964-char assistant text row with 56 glued joins across 179 tool calls.

## Test plan
- [x] `bun test src/agents/backends/acp-session.test.ts src/agents/backends/cursor-acp-extensions.test.ts` (13 pass)
- [ ] Restart live serve and start a fresh Cursor session that narrates between tools; confirm separate assistant bubbles instead of one wall of text