### PR TITLE
fix: keep agent temp files off ram-backed /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Recent product updates and deployment notes.
 
+## August 19, 2026 - Agents stop filling RAM-backed /tmp
+
+- **Agent temp files go to disk when `/tmp` is tmpfs.** Leftover bun installs
+  and checkouts in RAM-backed `/tmp` filled 7.8G on one box, which then stalled
+  in memory reclaim and looked like a CPU melt. Serve and every agent launch
+  now use `~/.cache/lfg/tmp` (or `LFG_TMPDIR`) so those files cost disk, not
+  RAM.
+- **Unused leftovers in tmpfs `/tmp` are swept.** Entries older than two hours
+  with no open process are removed. Live names such as `lfg-uploads`, Claude
+  caches, tmux, and ssh sockets stay. The disk cache is swept after a day.
+
 ## August 19, 2026 - An affected bot shows its own history right away (v0.2.7)
 
 - **A bot whose chat had been taken over by one of its tasks now recovers its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Recent product updates and deployment notes.
 
-## August 19, 2026 - Agents stop filling RAM-backed /tmp
+## August 19, 2026 - Agents stop filling RAM-backed /tmp (v0.2.8)
 
 - **Agent temp files go to disk when `/tmp` is tmpfs.** Leftover bun installs
   and checkouts in RAM-backed `/tmp` filled 7.8G on one box, which then stalled

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -43,6 +43,7 @@ import {
   isJcodeBusy,
   parsePrompt,
 } from "./tmux.ts";
+import { agentTmpEnv } from "./tmp-reclaim.ts";
 
 function sorted(values: Iterable<string>): string[] {
   return [...values].sort((a, b) => a.localeCompare(b));
@@ -300,6 +301,9 @@ describe("coding agent adapter contract", () => {
     expect(argv).toContain("--setenv=AGENT_BROWSER_SESSION=lfg-test");
     expect(argv).toContain(`--setenv=AGENT_BROWSER_IDLE_TIMEOUT_MS=${AGENT_BROWSER_IDLE_TIMEOUT_MS}`);
     expect(argv.some((part) => part.startsWith("--setenv=DBUS_SESSION_BUS_ADDRESS="))).toBe(true);
+    for (const [key, value] of Object.entries(agentTmpEnv())) {
+      expect(argv).toContain(`--setenv=${key}=${value}`);
+    }
     expect(argv.slice(-3)).toEqual(["/usr/bin/example-agent", "--task", "hello"]);
   });
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -287,6 +287,7 @@ import {
   resolveInputCwd,
 } from "../repo-resolve.ts";
 import { WORKTREE_ROOT, resolveSessionCwd, startWorktreeSweep } from "../worktree.ts";
+import { ensureDiskBackedTmpdir, startTmpSweep } from "../tmp-reclaim.ts";
 import {
   FolderDeleteError,
   deleteFolder,
@@ -2701,6 +2702,10 @@ function prepareLoginTerminal(kind: string, command: string): string {
 }
 
 export async function cmdServe() {
+  const diskTmp = ensureDiskBackedTmpdir();
+  if (diskTmp) {
+    console.log(`lfg tmp → ${diskTmp} (disk-backed; /tmp is RAM)`);
+  }
   const liveWs = createLiveWsSupport({
     evlog,
     getAgentRun: agentRunSnapshot,
@@ -8059,6 +8064,7 @@ a{color:#60a5fa}
   }
   startModelDiscoveryScheduler((l) => console.log(l));
   startWorktreeSweep((l) => console.log(l));
+  startTmpSweep((l) => console.log(l));
   startIdleAgentArchiveSweep();
   // Watch the fleet for busy -> idle transitions and fan "completed" events out
   // to fleet subscribers (Web Push). Idempotent + best-effort.

--- a/src/tmp-reclaim.test.ts
+++ b/src/tmp-reclaim.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  agentTmpEnv,
+  defaultDiskTmpDir,
+  diskTmpDirIfNeeded,
+  ensureDiskBackedTmpdir,
+  isProtectedTmpName,
+  isRamBackedFs,
+  pathIsOpen,
+  RAMFS_MAGIC,
+  shouldSweepTmpEntry,
+  stopTmpSweepForTests,
+  sweepTmpRoot,
+  TMPFS_MAGIC,
+} from "./tmp-reclaim.ts";
+
+describe("tmp reclaim", () => {
+  afterEach(() => {
+    stopTmpSweepForTests();
+    delete process.env.LFG_TMPDIR;
+  });
+
+  test("tmpfs and ramfs magic numbers are ram-backed", () => {
+    expect(isRamBackedFs(TMPFS_MAGIC)).toBe(true);
+    expect(isRamBackedFs(RAMFS_MAGIC)).toBe(true);
+    expect(isRamBackedFs(0xef53)).toBe(false);
+  });
+
+  test("LFG_TMPDIR wins over the default cache path", () => {
+    const env = { LFG_TMPDIR: "/var/tmp/lfg-agents" };
+    expect(diskTmpDirIfNeeded(env, "/home/dev")).toBe("/var/tmp/lfg-agents");
+    expect(agentTmpEnv(env, "/home/dev")).toEqual({
+      TMPDIR: "/var/tmp/lfg-agents",
+      TMP: "/var/tmp/lfg-agents",
+      TEMP: "/var/tmp/lfg-agents",
+    });
+  });
+
+  test("without LFG_TMPDIR the default is $HOME/.cache/lfg/tmp", () => {
+    expect(defaultDiskTmpDir("/home/dev")).toBe("/home/dev/.cache/lfg/tmp");
+  });
+
+  test("ensureDiskBackedTmpdir applies LFG_TMPDIR onto the given env", () => {
+    const root = mkdtempSync(join(tmpdir(), "lfg-tmpdir-"));
+    try {
+      const dest = join(root, "cache");
+      const env: NodeJS.ProcessEnv = { LFG_TMPDIR: dest };
+      expect(ensureDiskBackedTmpdir(env, root)).toBe(dest);
+      expect(env.TMPDIR).toBe(dest);
+      expect(env.TMP).toBe(dest);
+      expect(env.TEMP).toBe(dest);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("protects live runtime names and unix sockets", () => {
+    expect(isProtectedTmpName("lfg-uploads")).toBe(true);
+    expect(isProtectedTmpName("claude-1001")).toBe(true);
+    expect(isProtectedTmpName("cursor-agent-logs-1001")).toBe(true);
+    expect(isProtectedTmpName("tmux-1001")).toBe(true);
+    expect(isProtectedTmpName("ssh-XXXX")).toBe(true);
+    expect(isProtectedTmpName("systemd-private-abc")).toBe(true);
+    expect(isProtectedTmpName(".X11-unix")).toBe(true);
+    expect(isProtectedTmpName("main-check")).toBe(false);
+    expect(isProtectedTmpName("prune-abc")).toBe(false);
+    expect(isProtectedTmpName("bunx-1001-wrangler@1")).toBe(false);
+  });
+
+  test("sweep keeps open, young, protected, and other-uid entries", () => {
+    const minAgeMs = 60_000;
+    expect(
+      shouldSweepTmpEntry({
+        name: "prune-old",
+        ageMs: 120_000,
+        minAgeMs,
+        open: false,
+        uidOwned: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSweepTmpEntry({
+        name: "prune-old",
+        ageMs: 120_000,
+        minAgeMs,
+        open: true,
+        uidOwned: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSweepTmpEntry({
+        name: "prune-old",
+        ageMs: 10,
+        minAgeMs,
+        open: false,
+        uidOwned: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSweepTmpEntry({
+        name: "lfg-uploads",
+        ageMs: 120_000,
+        minAgeMs,
+        open: false,
+        uidOwned: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSweepTmpEntry({
+        name: "prune-old",
+        ageMs: 120_000,
+        minAgeMs,
+        open: false,
+        uidOwned: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("pathIsOpen matches the directory and its children", () => {
+    expect(pathIsOpen("/tmp/main-check", ["/tmp/main-check/node_modules"])).toBe(true);
+    expect(pathIsOpen("/tmp/main-check", ["/tmp/other"])).toBe(false);
+  });
+
+  test("sweepTmpRoot deletes old unused leftovers and keeps the rest", () => {
+    const root = mkdtempSync(join(tmpdir(), "lfg-tmpsweep-"));
+    try {
+      const oldJunk = join(root, "main-check");
+      const young = join(root, "fresh-install");
+      const protectedDir = join(root, "lfg-uploads");
+      const openDir = join(root, "omg-doctor-live");
+      mkdirSync(oldJunk);
+      mkdirSync(young);
+      mkdirSync(protectedDir);
+      mkdirSync(openDir);
+      writeFileSync(join(oldJunk, "x"), "stale");
+      const now = Date.now();
+      const twoHoursAgo = now / 1000 - 3 * 60 * 60;
+      utimesSync(oldJunk, twoHoursAgo, twoHoursAgo);
+      utimesSync(join(oldJunk, "x"), twoHoursAgo, twoHoursAgo);
+      utimesSync(protectedDir, twoHoursAgo, twoHoursAgo);
+      utimesSync(openDir, twoHoursAgo, twoHoursAgo);
+
+      const result = sweepTmpRoot(root, {
+        now,
+        minAgeMs: 2 * 60 * 60_000,
+        openPaths: [join(openDir, "fd")],
+        uid: typeof process.getuid === "function" ? process.getuid() : -1,
+      });
+
+      expect(result.removed).toEqual(["main-check"]);
+      expect(result.failed).toEqual([]);
+      expect(existsSync(oldJunk)).toBe(false);
+      expect(existsSync(young)).toBe(true);
+      expect(existsSync(protectedDir)).toBe(true);
+      expect(existsSync(openDir)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/tmp-reclaim.ts
+++ b/src/tmp-reclaim.ts
@@ -1,0 +1,300 @@
+// Agents and bunx default to os.tmpdir(). On this fleet /tmp is tmpfs, so a
+// leftover checkout or bun install is a RAM allocation. One incident filled
+// 7.8G, put the box in memory reclaim (load ~30, PSI ~97%), and made every
+// process look like it was "eating CPU".
+//
+// One owner: this module. It picks a disk-backed temp dir, applies it to the
+// serve process and every agent launch, and sweeps unused leftovers in tmpfs
+// /tmp plus our own cache dir. It never deletes a path a live process still
+// holds, and it never touches systemd/tmux/ssh/X11 names.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  statfsSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const TMPFS_MAGIC = 0x01021994;
+export const RAMFS_MAGIC = 0x858458f6;
+
+const DEFAULT_TMP_SWEEP_MS = 30 * 60_000;
+const DEFAULT_TMPFS_MIN_AGE_MS = 2 * 60 * 60_000;
+const DEFAULT_CACHE_MIN_AGE_MS = 24 * 60 * 60_000;
+
+const PROTECTED_PREFIXES = [
+  ".",
+  "ssh-",
+  "systemd-private",
+  "snap-private",
+  "tmux-",
+  "vscode-",
+  "pulse-",
+  "claude-",
+  "cursor-agent-logs-",
+] as const;
+
+const PROTECTED_NAMES = new Set(["lfg-uploads"]);
+
+export function isRamBackedFs(type: number | bigint): boolean {
+  const n = Number(type);
+  return n === TMPFS_MAGIC || n === RAMFS_MAGIC;
+}
+
+export function isPathRamBacked(path: string): boolean {
+  try {
+    return isRamBackedFs(statfsSync(path).type);
+  } catch {
+    return false;
+  }
+}
+
+export function defaultDiskTmpDir(home = homedir()): string {
+  return join(home, ".cache", "lfg", "tmp");
+}
+
+export function resolveAgentTmpDir(
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): string {
+  const override = env.LFG_TMPDIR?.trim();
+  if (override) return override;
+  return defaultDiskTmpDir(home);
+}
+
+/** Disk temp dir when /tmp (or the current TMPDIR) is RAM-backed, else null. */
+export function diskTmpDirIfNeeded(
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): string | null {
+  if (env.LFG_TMPDIR?.trim()) return env.LFG_TMPDIR.trim();
+  const current = env.TMPDIR?.trim() || tmpdir();
+  if (isPathRamBacked(current) || isPathRamBacked("/tmp")) {
+    return defaultDiskTmpDir(home);
+  }
+  return null;
+}
+
+export function agentTmpEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): Record<string, string> {
+  const dir = diskTmpDirIfNeeded(env, home);
+  if (!dir) return {};
+  return { TMPDIR: dir, TMP: dir, TEMP: dir };
+}
+
+export function ensureDiskBackedTmpdir(
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): string | null {
+  const dir = diskTmpDirIfNeeded(env, home);
+  if (!dir) return null;
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  env.TMPDIR = dir;
+  env.TMP = dir;
+  env.TEMP = dir;
+  return dir;
+}
+
+export function isProtectedTmpName(name: string): boolean {
+  if (PROTECTED_NAMES.has(name)) return true;
+  return PROTECTED_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+export function shouldSweepTmpEntry(input: {
+  name: string;
+  ageMs: number;
+  minAgeMs: number;
+  open: boolean;
+  uidOwned: boolean;
+}): boolean {
+  if (!input.uidOwned) return false;
+  if (input.open) return false;
+  if (input.ageMs < input.minAgeMs) return false;
+  if (isProtectedTmpName(input.name)) return false;
+  return true;
+}
+
+export function pathIsOpen(path: string, openPaths: Iterable<string>): boolean {
+  const target = resolve(path);
+  for (const raw of openPaths) {
+    const open = resolve(raw);
+    if (open === target || open.startsWith(`${target}/`)) return true;
+  }
+  return false;
+}
+
+/** Live cwd / fd / exe paths under `root`. Linux only; empty elsewhere. */
+export function collectOpenPathsUnder(root: string): Set<string> {
+  const hits = new Set<string>();
+  if (process.platform !== "linux") return hits;
+  const prefix = resolve(root);
+  const want = (dest: string) => {
+    if (!dest.startsWith("/") || dest.includes("(deleted)")) return;
+    const abs = resolve(dest);
+    if (abs === prefix || abs.startsWith(`${prefix}/`)) hits.add(abs);
+  };
+  let pids: string[];
+  try {
+    pids = readdirSync("/proc");
+  } catch {
+    return hits;
+  }
+  for (const pid of pids) {
+    if (!/^\d+$/.test(pid)) continue;
+    for (const rel of ["cwd", "exe"] as const) {
+      try {
+        want(readlinkSync(`/proc/${pid}/${rel}`));
+      } catch {}
+    }
+    try {
+      for (const fd of readdirSync(`/proc/${pid}/fd`)) {
+        try {
+          want(readlinkSync(`/proc/${pid}/fd/${fd}`));
+        } catch {}
+      }
+    } catch {}
+  }
+  return hits;
+}
+
+export type TmpSweepResult = {
+  scanned: number;
+  removed: string[];
+  failed: string[];
+};
+
+export function sweepTmpRoot(
+  root: string,
+  opts: {
+    now?: number;
+    minAgeMs?: number;
+    uid?: number;
+    openPaths?: Iterable<string>;
+    protectNames?: boolean;
+  } = {},
+): TmpSweepResult {
+  const result: TmpSweepResult = { scanned: 0, removed: [], failed: [] };
+  let names: string[];
+  try {
+    names = readdirSync(root);
+  } catch {
+    return result;
+  }
+  const now = opts.now ?? Date.now();
+  const minAgeMs = opts.minAgeMs ?? DEFAULT_TMPFS_MIN_AGE_MS;
+  const uid = opts.uid ?? (typeof process.getuid === "function" ? process.getuid() : -1);
+  const openPaths = opts.openPaths ?? collectOpenPathsUnder(root);
+  const protectNames = opts.protectNames ?? true;
+
+  for (const name of names) {
+    const path = join(root, name);
+    result.scanned += 1;
+    let st: ReturnType<typeof lstatSync>;
+    try {
+      st = lstatSync(path);
+    } catch {
+      continue;
+    }
+    const ageMs = Math.max(0, now - st.mtimeMs);
+    const uidOwned = uid < 0 || st.uid === uid;
+    const open = pathIsOpen(path, openPaths);
+    const protectedName = protectNames && isProtectedTmpName(name);
+    if (!uidOwned || open || ageMs < minAgeMs || protectedName) continue;
+    try {
+      rmSync(path, { recursive: true, force: true });
+      if (!existsSync(path)) result.removed.push(name);
+    } catch {
+      result.failed.push(name);
+    }
+  }
+  return result;
+}
+
+export function sweepStaleTmp(
+  env: NodeJS.ProcessEnv = process.env,
+  home = homedir(),
+): { tmpfs: TmpSweepResult | null; cache: TmpSweepResult | null } {
+  const tmpfs = isPathRamBacked("/tmp")
+    ? sweepTmpRoot("/tmp", { minAgeMs: tmpfsMinAgeMs(env) })
+    : null;
+  const cache = resolveAgentTmpDir(env, home);
+  const cacheSweep =
+    cache !== "/tmp" && existsSync(cache)
+      ? sweepTmpRoot(cache, {
+          minAgeMs: cacheMinAgeMs(env),
+          protectNames: false,
+        })
+      : null;
+  return { tmpfs, cache: cacheSweep };
+}
+
+function tmpfsMinAgeMs(env: NodeJS.ProcessEnv): number {
+  return readMs(env.LFG_TMP_SWEEP_MIN_AGE_MS, DEFAULT_TMPFS_MIN_AGE_MS);
+}
+
+function cacheMinAgeMs(env: NodeJS.ProcessEnv): number {
+  return readMs(env.LFG_TMP_CACHE_MIN_AGE_MS, DEFAULT_CACHE_MIN_AGE_MS);
+}
+
+function sweepIntervalMs(env: NodeJS.ProcessEnv): number {
+  if (env.LFG_TMP_SWEEP_MS === "0") return 0;
+  return readMs(env.LFG_TMP_SWEEP_MS, DEFAULT_TMP_SWEEP_MS);
+}
+
+function readMs(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+let sweeping = false;
+
+export function startTmpSweep(onLog: (s: string) => void = () => {}): void {
+  if (process.platform !== "linux") return;
+  const intervalMs = sweepIntervalMs(process.env);
+  if (intervalMs === 0) return;
+  if (sweepTimer) return;
+
+  const run = () => {
+    if (sweeping) return;
+    sweeping = true;
+    try {
+      const { tmpfs, cache } = sweepStaleTmp();
+      const removed = (tmpfs?.removed.length ?? 0) + (cache?.removed.length ?? 0);
+      const failed = (tmpfs?.failed.length ?? 0) + (cache?.failed.length ?? 0);
+      if (removed || failed) {
+        onLog(
+          `[tmp-sweep] tmpfs_removed=${tmpfs?.removed.length ?? 0}` +
+            ` cache_removed=${cache?.removed.length ?? 0}` +
+            (failed ? ` failed=${failed}` : ""),
+        );
+      }
+    } catch (e) {
+      onLog(`[tmp-sweep] error: ${e}`);
+    } finally {
+      sweeping = false;
+    }
+  };
+
+  sweepTimer = setInterval(run, intervalMs);
+  const startupDelayMs = Math.min(intervalMs, 5 * 60_000);
+  setTimeout(run, startupDelayMs);
+  onLog(
+    `[tmp-sweep] started (every ${Math.round(intervalMs / 60_000)}m, ` +
+      `tmpfs min-age ${Math.round(tmpfsMinAgeMs(process.env) / 3600_000)}h)`,
+  );
+}
+
+export function stopTmpSweepForTests(): void {
+  if (sweepTimer) clearInterval(sweepTimer);
+  sweepTimer = null;
+  sweeping = false;
+}

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -14,6 +14,7 @@ import {
   claudeAccountConfigDir,
   resolveClaudeAccount,
 } from "./claude-accounts.ts";
+import { agentTmpEnv } from "./tmp-reclaim.ts";
 
 // Known-good Claude model alias to launch with when a caller doesn't specify
 // one. Never launch a managed `claude` bare — see spawnManagedSession. Opus is
@@ -130,6 +131,9 @@ function addSessionEnv(
   } else {
     env.push("-e", `AGENT_BROWSER_IDLE_TIMEOUT_MS=${AGENT_BROWSER_IDLE_TIMEOUT_MS}`);
   }
+  for (const [key, value] of Object.entries(agentTmpEnv())) {
+    env.push("-e", `${key}=${value}`);
+  }
   if (env.length) argv.splice(i + 1, 0, ...env);
 }
 
@@ -175,6 +179,9 @@ export function containedAgentCommand(
   if (opts.omgSessionId) argv.push(`--setenv=LFG_SESSION_ID=${opts.omgSessionId}`);
   argv.push(`--setenv=OMG_CAPABILITY_VERSION=${OMG_CAPABILITY_VERSION}`);
   if (opts.omgUser) argv.push(`--setenv=LFG_USER=${opts.omgUser}`);
+  for (const [key, value] of Object.entries(agentTmpEnv())) {
+    argv.push(`--setenv=${key}=${value}`);
+  }
   return [...argv, "--", ...command];
 }
 
@@ -210,6 +217,7 @@ function spawnManagedHarness(
   // Always name + idle-timeout the browser, including parent (non-slice) harness
   // spawns. containInAgentSlice still only wraps subagents in systemd-run.
   Object.assign(env, agentBrowserEnv(opts.name));
+  Object.assign(env, agentTmpEnv());
   const cmd = opts.containInAgentSlice
     ? containedAgentCommand(command, opts, { pty: false })
     : command;


### PR DESCRIPTION
## Summary
- RAM-backed `/tmp` filled with leftover agent installs (7.8G) and stalled this box in memory reclaim. Load sat near 30 and looked like a CPU melt.
- Serve and every agent launch now set `TMPDIR`/`TMP`/`TEMP` to `~/.cache/lfg/tmp` when `/tmp` is tmpfs (`LFG_TMPDIR` overrides).
- A sweeper removes unused tmpfs leftovers older than two hours that no process still holds. Live names (`lfg-uploads`, Claude caches, tmux, ssh) stay.

## Test plan
- [x] `bun test src/tmp-reclaim.test.ts src/coding-agent-adapters.test.ts` (31 pass)
- [ ] After merge and serve restart, a new agent has `TMPDIR=/home/dev/.cache/lfg/tmp`