### PR TITLE
Add IndexNow ping for omg.dev and docs.omg.dev

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -1,0 +1,46 @@
+name: indexnow
+
+# Public-host sitemap notify. Default is dry-run so pull requests and
+# pushes never POST a urlList to https://api.indexnow.org/indexnow.
+# A real ping is workflow_dispatch with submit=true and the repo
+# variable INDEXNOW_SUBMIT=1.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      submit:
+        description: "POST to IndexNow (requires vars.INDEXNOW_SUBMIT=1)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Test IndexNow helpers
+        run: bun test scripts/indexnow.test.ts
+
+      - name: Dry-run sitemap notify
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.submit) }}
+        run: bun run scripts/gsc-submit-sitemaps.ts --dry-run
+
+      - name: Submit IndexNow
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.submit }}
+        env:
+          INDEXNOW_SUBMIT: ${{ vars.INDEXNOW_SUBMIT }}
+          GSC_ACCESS_TOKEN: ${{ secrets.GSC_ACCESS_TOKEN }}
+          GSC_SITE: ${{ vars.GSC_SITE }}
+        run: bun run scripts/gsc-submit-sitemaps.ts --submit

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "build:packages": "bash scripts/pack-packages.sh --build-only",
     "pack:packages": "bash scripts/pack-packages.sh",
     "typecheck": "bun x tsc -p tsconfig.json --noEmit",
-    "chat:smoke": "bun run scripts/chat-ingest-smoke.ts"
+    "chat:smoke": "bun run scripts/chat-ingest-smoke.ts",
+    "sitemap:submit": "bun run scripts/gsc-submit-sitemaps.ts"
   },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.83.0",

--- a/scripts/gsc-submit-sitemaps.ts
+++ b/scripts/gsc-submit-sitemaps.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * Search-engine sitemap notify for the public omg.dev hosts.
+ *
+ * Live https://omg.dev/robots.txt already names this path as the Search
+ * Console feed. This runtime repo had no such script and does not deploy
+ * the apex or docs hosts. The script is the single local owner for:
+ *
+ *   1. Optional Google Search Console sitemap PUT, when GSC_ACCESS_TOKEN
+ *      is set. Google does not speak IndexNow; this path stays.
+ *   2. IndexNow POST to https://api.indexnow.org/indexnow for omg.dev
+ *      and docs.omg.dev public URLs collected from those sitemaps.
+ *
+ * Default is dry-run (print payloads, no IndexNow POST). A real ping
+ * needs both `--submit` and INDEXNOW_SUBMIT=1. GitHub Actions never sets
+ * that variable on pull_request or push. Use workflow_dispatch.
+ *
+ * Usage:
+ *   bun run scripts/gsc-submit-sitemaps.ts
+ *   bun run scripts/gsc-submit-sitemaps.ts --dry-run
+ *   INDEXNOW_SUBMIT=1 bun run scripts/gsc-submit-sitemaps.ts --submit
+ */
+
+import {
+  INDEXNOW_KEY,
+  PUBLIC_SITEMAPS,
+  buildIndexNowPayloads,
+  checkKeyLocationServed,
+  collectSitemapUrls,
+  parseSubmitArgs,
+  pingIndexNow,
+  readCommittedIndexNowKey,
+  shouldPostIndexNow,
+  type FetchLike,
+  type IndexNowPayload,
+} from "./indexnow.ts";
+
+const LOG = "[gsc-submit-sitemaps]";
+const GSC_SITE_DEFAULT = "sc-domain:omg.dev";
+
+export type GscSubmitResult = {
+  sitemapUrl: string;
+  ok: boolean;
+  status: number;
+  skipped?: boolean;
+  error?: string;
+};
+
+type GscDeps = {
+  token?: string;
+  site?: string;
+  fetchFn?: FetchLike;
+};
+
+export async function submitSitemapsToGsc(
+  sitemapUrls: readonly string[] = PUBLIC_SITEMAPS,
+  deps: GscDeps = {},
+): Promise<GscSubmitResult[]> {
+  const token = deps.token ?? process.env.GSC_ACCESS_TOKEN;
+  const site = deps.site ?? process.env.GSC_SITE ?? GSC_SITE_DEFAULT;
+  const fetchFn = deps.fetchFn ?? fetch;
+  if (!token) {
+    return sitemapUrls.map((sitemapUrl) => ({
+      sitemapUrl,
+      ok: true,
+      status: 0,
+      skipped: true,
+      error: "GSC_ACCESS_TOKEN is unset; Search Console submit skipped",
+    }));
+  }
+
+  const results: GscSubmitResult[] = [];
+  for (const sitemapUrl of sitemapUrls) {
+    const url = `https://www.googleapis.com/webmasters/v3/sites/${encodeURIComponent(site)}/sitemaps/${encodeURIComponent(sitemapUrl)}`;
+    try {
+      const res = await fetchFn(url, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        results.push({ sitemapUrl, ok: true, status: res.status });
+        continue;
+      }
+      results.push({
+        sitemapUrl,
+        ok: false,
+        status: res.status,
+        error: (await res.text()).slice(0, 200),
+      });
+    } catch (error) {
+      results.push({
+        sitemapUrl,
+        ok: false,
+        status: 0,
+        error: (error as Error).message,
+      });
+    }
+  }
+  return results;
+}
+
+export async function submitIndexNow(opts: {
+  payloads: IndexNowPayload[];
+  post: boolean;
+  fetchFn?: FetchLike;
+}): Promise<{ ok: boolean; posted: boolean }> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  if (!opts.post) {
+    for (const payload of opts.payloads) {
+      console.log(`${LOG} dry-run ${payload.host} (${payload.urlList.length} URLs)`);
+      console.log(JSON.stringify(payload, null, 2));
+    }
+    return { ok: true, posted: false };
+  }
+
+  let ok = true;
+  for (const payload of opts.payloads) {
+    const keyCheck = await checkKeyLocationServed(payload.keyLocation, payload.key, fetchFn);
+    if (!keyCheck.ok) {
+      console.error(`${LOG} key file not served at ${payload.keyLocation}: ${keyCheck.error}`);
+      ok = false;
+      continue;
+    }
+    console.log(`${LOG} POST ${payload.host} (${payload.urlList.length} URLs)`);
+    const result = await pingIndexNow(payload, fetchFn);
+    if (!result.ok) {
+      console.error(`${LOG} IndexNow ${payload.host} failed status=${result.status} error=${result.error}`);
+      ok = false;
+      continue;
+    }
+    console.log(`${LOG} IndexNow ${payload.host} ok status=${result.status}`);
+  }
+  return { ok, posted: true };
+}
+
+export async function main(
+  argv: string[] = process.argv.slice(2),
+  deps: { fetchFn?: FetchLike; env?: NodeJS.ProcessEnv } = {},
+): Promise<number> {
+  const { submit } = parseSubmitArgs(argv);
+  const env = deps.env ?? process.env;
+  const fetchFn = deps.fetchFn ?? fetch;
+  const post = shouldPostIndexNow({ submit, env });
+
+  if (submit && !post) {
+    console.error(`${LOG} --submit requires INDEXNOW_SUBMIT=1. Refusing to POST.`);
+    return 2;
+  }
+
+  const committedKey = readCommittedIndexNowKey();
+  if (committedKey !== INDEXNOW_KEY) {
+    console.error(`${LOG} committed key file does not match INDEXNOW_KEY`);
+    return 1;
+  }
+
+  const urls = await collectSitemapUrls(PUBLIC_SITEMAPS, fetchFn);
+  const payloads = buildIndexNowPayloads(urls, INDEXNOW_KEY);
+  if (payloads.length === 0) {
+    console.error(`${LOG} no public omg.dev / docs.omg.dev URLs to notify`);
+    return 1;
+  }
+
+  const gsc = await submitSitemapsToGsc(PUBLIC_SITEMAPS, {
+    fetchFn,
+    token: env.GSC_ACCESS_TOKEN ?? "",
+    site: env.GSC_SITE ?? GSC_SITE_DEFAULT,
+  });
+  for (const result of gsc) {
+    if (result.skipped) {
+      console.log(`${LOG} GSC skip ${result.sitemapUrl}: ${result.error}`);
+    } else if (result.ok) {
+      console.log(`${LOG} GSC ok ${result.sitemapUrl} status=${result.status}`);
+    } else {
+      console.error(`${LOG} GSC fail ${result.sitemapUrl} status=${result.status}: ${result.error}`);
+    }
+  }
+
+  const indexNow = await submitIndexNow({ payloads, post, fetchFn });
+  const gscFailed = gsc.some((result) => !result.ok);
+  return indexNow.ok && !gscFailed ? 0 : 1;
+}
+
+if (import.meta.main) {
+  main().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error(error instanceof Error ? error.stack : error);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/indexnow.test.ts
+++ b/scripts/indexnow.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  INDEXNOW_ENDPOINT,
+  INDEXNOW_HOSTS,
+  INDEXNOW_KEY,
+  INDEXNOW_KEY_FILE,
+  PUBLIC_SITEMAPS,
+  buildIndexNowPayloads,
+  checkKeyLocationServed,
+  collectSitemapUrls,
+  dedupeUrls,
+  filterPublicIndexNowUrls,
+  isPublicIndexNowUrl,
+  isValidIndexNowKey,
+  keyLocationFor,
+  locTags,
+  parseSubmitArgs,
+  pingIndexNow,
+  readCommittedIndexNowKey,
+  shouldPostIndexNow,
+} from "./indexnow.ts";
+import { main, submitIndexNow, submitSitemapsToGsc } from "./gsc-submit-sitemaps.ts";
+
+const APEX = "https://omg.dev/pricing";
+const DOCS = "https://docs.omg.dev/docs/mcp";
+const APP = "https://app.omg.dev/sandbox";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), { status });
+}
+
+describe("IndexNow key file", () => {
+  test("committed key is valid and matches the hosted filename", () => {
+    expect(isValidIndexNowKey(INDEXNOW_KEY)).toBe(true);
+    expect(readCommittedIndexNowKey()).toBe(INDEXNOW_KEY);
+    expect(readFileSync(INDEXNOW_KEY_FILE, "utf8").trim()).toBe(INDEXNOW_KEY);
+    expect(INDEXNOW_KEY_FILE.endsWith(`${INDEXNOW_KEY}.txt`)).toBe(true);
+    expect(keyLocationFor("omg.dev")).toBe(`https://omg.dev/${INDEXNOW_KEY}.txt`);
+    expect(keyLocationFor("docs.omg.dev")).toBe(`https://docs.omg.dev/${INDEXNOW_KEY}.txt`);
+  });
+});
+
+describe("public URL filter", () => {
+  test("keeps apex and docs https URLs", () => {
+    expect(isPublicIndexNowUrl(APEX)).toBe(true);
+    expect(isPublicIndexNowUrl(DOCS)).toBe(true);
+    expect(isPublicIndexNowUrl("https://omg.dev/")).toBe(true);
+  });
+
+  test("drops app, preview, localhost, and non-https URLs", () => {
+    expect(isPublicIndexNowUrl(APP)).toBe(false);
+    expect(isPublicIndexNowUrl("https://app.omg.dev/")).toBe(false);
+    expect(isPublicIndexNowUrl("http://omg.dev/pricing")).toBe(false);
+    expect(isPublicIndexNowUrl("https://localhost:8766/")).toBe(false);
+    expect(isPublicIndexNowUrl("https://127.0.0.1/")).toBe(false);
+    expect(isPublicIndexNowUrl("https://preview.omg.dev/blog")).toBe(false);
+    expect(isPublicIndexNowUrl("https://evil-omg.dev/")).toBe(false);
+    expect(isPublicIndexNowUrl("https://omg.dev.evil.example/")).toBe(false);
+    expect(isPublicIndexNowUrl("not a url")).toBe(false);
+  });
+
+  test("dedups and filters a mixed list", () => {
+    expect(filterPublicIndexNowUrls([APEX, APEX, APP, DOCS, "https://localhost/x"])).toEqual([APEX, DOCS]);
+    expect(dedupeUrls([APEX, APEX])).toEqual([APEX]);
+  });
+});
+
+describe("sitemap loc parsing", () => {
+  test("reads loc tags from a urlset", () => {
+    const xml = `<?xml version="1.0"?>
+      <urlset>
+        <url><loc>https://omg.dev/</loc></url>
+        <url><loc> ${APP} </loc></url>
+        <url><loc>${DOCS}</loc></url>
+      </urlset>`;
+    expect(locTags(xml)).toEqual(["https://omg.dev/", APP, DOCS]);
+  });
+
+  test("collects sitemap URLs plus public page locs, and follows one index", async () => {
+    const fetchFn = async (input: string) => {
+      if (input === "https://omg.dev/sitemap.xml") {
+        return new Response(`<sitemapindex><sitemap><loc>https://omg.dev/blog/sitemap.xml</loc></sitemap></sitemapindex>`);
+      }
+      if (input === "https://omg.dev/blog/sitemap.xml") {
+        return new Response(`<urlset><url><loc>${APEX}</loc></url><url><loc>${APP}</loc></url></urlset>`);
+      }
+      if (input === "https://docs.omg.dev/sitemap.xml") {
+        return new Response(`<urlset><url><loc>${DOCS}</loc></url></urlset>`);
+      }
+      return new Response("missing", { status: 404 });
+    };
+
+    const urls = await collectSitemapUrls([...PUBLIC_SITEMAPS], fetchFn);
+    expect(urls).toContain("https://omg.dev/sitemap.xml");
+    expect(urls).toContain("https://omg.dev/blog/sitemap.xml");
+    expect(urls).toContain(APEX);
+    expect(urls).toContain(DOCS);
+    expect(urls).not.toContain(APP);
+  });
+});
+
+describe("IndexNow payloads", () => {
+  test("groups by host and attaches keyLocation", () => {
+    const payloads = buildIndexNowPayloads([APEX, DOCS, APP, APEX]);
+    expect(payloads.map((p) => p.host).sort()).toEqual(["docs.omg.dev", "omg.dev"]);
+    const apex = payloads.find((p) => p.host === "omg.dev")!;
+    expect(apex.urlList).toEqual([APEX]);
+    expect(apex.key).toBe(INDEXNOW_KEY);
+    expect(apex.keyLocation).toBe(`https://omg.dev/${INDEXNOW_KEY}.txt`);
+    expect(INDEXNOW_HOSTS).toEqual(["omg.dev", "docs.omg.dev"]);
+  });
+
+  test("rejects an invalid key", () => {
+    expect(() => buildIndexNowPayloads([APEX], "short")).toThrow(/8–128/);
+  });
+});
+
+describe("submit gates", () => {
+  test("defaults to dry-run and requires the env gate for POST", () => {
+    expect(parseSubmitArgs([])).toEqual({ submit: false });
+    expect(parseSubmitArgs(["--dry-run"])).toEqual({ submit: false });
+    expect(parseSubmitArgs(["--submit"])).toEqual({ submit: true });
+    expect(() => parseSubmitArgs(["--submit", "--dry-run"])).toThrow(/only one/);
+    expect(shouldPostIndexNow({ submit: true, env: {} })).toBe(false);
+    expect(shouldPostIndexNow({ submit: true, env: { INDEXNOW_SUBMIT: "1" } })).toBe(true);
+    expect(shouldPostIndexNow({ submit: false, env: { INDEXNOW_SUBMIT: "1" } })).toBe(false);
+    expect(shouldPostIndexNow({ submit: true, env: { INDEXNOW_SUBMIT: "true" } })).toBe(false);
+  });
+});
+
+describe("IndexNow HTTP", () => {
+  test("200 is success and 202 is a pending-key failure", async () => {
+    const payload = buildIndexNowPayloads([APEX])[0]!;
+    const ok = await pingIndexNow(payload, async () => jsonResponse(200, ""));
+    expect(ok).toEqual({ ok: true, status: 200, error: null });
+
+    const pending = await pingIndexNow(payload, async () => jsonResponse(202, "accepted"));
+    expect(pending.ok).toBe(false);
+    expect(pending.status).toBe(202);
+    expect(pending.error).toContain("key validation is pending");
+  });
+
+  test("key location must serve the exact key", async () => {
+    const url = keyLocationFor("omg.dev");
+    const good = await checkKeyLocationServed(url, INDEXNOW_KEY, async () => new Response(`${INDEXNOW_KEY}\n`));
+    expect(good.ok).toBe(true);
+    const missing = await checkKeyLocationServed(url, INDEXNOW_KEY, async () => new Response("nope", { status: 404 }));
+    expect(missing.ok).toBe(false);
+    expect(missing.status).toBe(404);
+  });
+
+  test("dry-run never POSTs to IndexNow", async () => {
+    const payload = buildIndexNowPayloads([APEX])[0]!;
+    const calls: string[] = [];
+    const result = await submitIndexNow({
+      payloads: [payload],
+      post: false,
+      fetchFn: async (input) => {
+        calls.push(input);
+        return jsonResponse(200, "");
+      },
+    });
+    expect(result).toEqual({ ok: true, posted: false });
+    expect(calls).toEqual([]);
+  });
+
+  test("submit checks the key file before POSTing", async () => {
+    const payload = buildIndexNowPayloads([APEX])[0]!;
+    const calls: string[] = [];
+    const result = await submitIndexNow({
+      payloads: [payload],
+      post: true,
+      fetchFn: async (input) => {
+        calls.push(input);
+        if (input === payload.keyLocation) return new Response(INDEXNOW_KEY);
+        if (input === INDEXNOW_ENDPOINT) return jsonResponse(200, "");
+        return new Response("no", { status: 404 });
+      },
+    });
+    expect(result).toEqual({ ok: true, posted: true });
+    expect(calls).toEqual([payload.keyLocation, INDEXNOW_ENDPOINT]);
+  });
+});
+
+describe("GSC sitemap submit", () => {
+  test("skips when no access token is configured", async () => {
+    const results = await submitSitemapsToGsc(PUBLIC_SITEMAPS, { token: "" });
+    expect(results.every((r) => r.skipped && r.ok)).toBe(true);
+  });
+
+  test("PUTs each sitemap when a token is present", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const results = await submitSitemapsToGsc(["https://omg.dev/sitemap.xml"], {
+      token: "tok",
+      site: "sc-domain:omg.dev",
+      fetchFn: async (input, init) => {
+        calls.push({ url: input, method: init?.method });
+        return jsonResponse(200, "");
+      },
+    });
+    expect(results).toEqual([{ sitemapUrl: "https://omg.dev/sitemap.xml", ok: true, status: 200 }]);
+    expect(calls[0]?.method).toBe("PUT");
+    expect(calls[0]?.url).toContain("webmasters/v3/sites/");
+  });
+});
+
+describe("CLI", () => {
+  test("--submit without INDEXNOW_SUBMIT=1 exits 2 and does not fetch sitemaps", async () => {
+    const calls: string[] = [];
+    const code = await main(["--submit"], {
+      env: {},
+      fetchFn: async (input) => {
+        calls.push(input);
+        return jsonResponse(200, "");
+      },
+    });
+    expect(code).toBe(2);
+    expect(calls).toEqual([]);
+  });
+
+  test("dry-run fetches sitemaps and never hits api.indexnow.org", async () => {
+    const calls: string[] = [];
+    const code = await main(["--dry-run"], {
+      env: {},
+      fetchFn: async (input) => {
+        calls.push(input);
+        if (input === "https://omg.dev/sitemap.xml") {
+          return new Response(`<urlset><url><loc>${APEX}</loc></url></urlset>`);
+        }
+        if (input === "https://docs.omg.dev/sitemap.xml") {
+          return new Response(`<urlset><url><loc>${DOCS}</loc></url></urlset>`);
+        }
+        return jsonResponse(500, "should not be called");
+      },
+    });
+    expect(code).toBe(0);
+    expect(calls).toEqual([...PUBLIC_SITEMAPS]);
+  });
+});

--- a/scripts/indexnow.ts
+++ b/scripts/indexnow.ts
@@ -1,0 +1,243 @@
+/**
+ * IndexNow helpers for the public omg.dev hosts.
+ *
+ * This runtime repo does not deploy https://omg.dev or https://docs.omg.dev.
+ * Those hosts are the hosted product (Caddy apex + Cloudflare/Fumadocs).
+ * The key file in scripts/indexnow/ is the source of truth: copy it to each
+ * host's static root so GET https://<host>/<key>.txt returns the key as
+ * text/plain. Search engines fetch that file to prove ownership.
+ *
+ * Google does not speak IndexNow. Do not treat a successful ping as a
+ * replacement for Search Console sitemap submission.
+ *
+ * The retired Bing sitemap ping (https://www.bing.com/ping?sitemap=) returns
+ * HTTP 410. The only supported notify path is POST https://api.indexnow.org/indexnow.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+
+/** 32 hex chars (IndexNow allows 8–128 hex / [A-Za-z0-9-]). */
+export const INDEXNOW_KEY = "3ec7fbeb8241def221cf92823220d4dc";
+
+export const INDEXNOW_HOSTS = ["omg.dev", "docs.omg.dev"] as const;
+export type IndexNowHost = (typeof INDEXNOW_HOSTS)[number];
+
+export const PUBLIC_SITEMAPS = [
+  "https://omg.dev/sitemap.xml",
+  "https://docs.omg.dev/sitemap.xml",
+] as const;
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+export const INDEXNOW_KEY_FILE = join(SCRIPT_DIR, "indexnow", `${INDEXNOW_KEY}.txt`);
+
+const KEY_RE = /^[A-Za-z0-9-]{8,128}$/;
+
+export type IndexNowPayload = {
+  host: IndexNowHost;
+  key: string;
+  keyLocation: string;
+  urlList: string[];
+};
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export function isValidIndexNowKey(key: string): boolean {
+  return KEY_RE.test(key);
+}
+
+export function keyLocationFor(host: IndexNowHost, key: string = INDEXNOW_KEY): string {
+  return `https://${host}/${key}.txt`;
+}
+
+export function readCommittedIndexNowKey(path: string = INDEXNOW_KEY_FILE): string {
+  return readFileSync(path, "utf8").trim();
+}
+
+/**
+ * Public marketing/docs URLs only. Drops localhost, previews, and the
+ * authenticated app host (app.omg.dev), even when a sitemap lists them.
+ */
+export function isPublicIndexNowUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  if (url.username || url.password) return false;
+  return (INDEXNOW_HOSTS as readonly string[]).includes(url.hostname);
+}
+
+export function locTags(xml: string): string[] {
+  const out: string[] = [];
+  const re = /<loc>\s*([^<]+)\s*<\/loc>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(xml))) {
+    const loc = match[1]?.trim();
+    if (loc) out.push(loc);
+  }
+  return out;
+}
+
+export function dedupeUrls(urls: readonly string[]): string[] {
+  return [...new Set(urls)];
+}
+
+export function filterPublicIndexNowUrls(urls: readonly string[]): string[] {
+  return dedupeUrls(urls.filter(isPublicIndexNowUrl));
+}
+
+export function groupUrlsByHost(urls: readonly string[]): Map<IndexNowHost, string[]> {
+  const grouped = new Map<IndexNowHost, string[]>();
+  for (const host of INDEXNOW_HOSTS) grouped.set(host, []);
+  for (const raw of urls) {
+    let url: URL;
+    try {
+      url = new URL(raw);
+    } catch {
+      continue;
+    }
+    if (!(INDEXNOW_HOSTS as readonly string[]).includes(url.hostname)) continue;
+    grouped.get(url.hostname as IndexNowHost)!.push(raw);
+  }
+  return grouped;
+}
+
+export function buildIndexNowPayloads(urls: readonly string[], key: string = INDEXNOW_KEY): IndexNowPayload[] {
+  if (!isValidIndexNowKey(key)) {
+    throw new Error(`IndexNow key must be 8–128 characters of [A-Za-z0-9-], got ${JSON.stringify(key)}`);
+  }
+  const payloads: IndexNowPayload[] = [];
+  for (const [host, urlList] of groupUrlsByHost(filterPublicIndexNowUrls(urls))) {
+    if (urlList.length === 0) continue;
+    payloads.push({
+      host,
+      key,
+      keyLocation: keyLocationFor(host, key),
+      urlList,
+    });
+  }
+  return payloads;
+}
+
+export async function collectSitemapUrls(
+  sitemapUrls: readonly string[] = PUBLIC_SITEMAPS,
+  fetchFn: FetchLike = fetch,
+  remainingIndexDepth = 2,
+): Promise<string[]> {
+  const collected: string[] = [...sitemapUrls];
+  for (const sitemapUrl of sitemapUrls) {
+    const res = await fetchFn(sitemapUrl);
+    if (!res.ok) {
+      throw new Error(`GET ${sitemapUrl} → ${res.status}`);
+    }
+    const xml = await res.text();
+    const locs = locTags(xml);
+    const childSitemaps = remainingIndexDepth > 0
+      ? locs.filter((loc) => loc.endsWith(".xml") && loc !== sitemapUrl)
+      : [];
+    const pages = locs.filter((loc) => !childSitemaps.includes(loc));
+    collected.push(...pages);
+    if (childSitemaps.length > 0) {
+      collected.push(
+        ...await collectSitemapUrls(childSitemaps, fetchFn, remainingIndexDepth - 1),
+      );
+    }
+  }
+  return filterPublicIndexNowUrls(collected);
+}
+
+export type KeyLocationCheck = {
+  ok: boolean;
+  status: number | null;
+  error: string | null;
+};
+
+export async function checkKeyLocationServed(
+  keyLocation: string,
+  expectedKey: string,
+  fetchFn: FetchLike = fetch,
+): Promise<KeyLocationCheck> {
+  try {
+    const res = await fetchFn(keyLocation);
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error: `GET ${keyLocation} → ${res.status} (expected 200)`,
+      };
+    }
+    const body = (await res.text()).trim();
+    if (body !== expectedKey) {
+      return {
+        ok: false,
+        status: res.status,
+        error: `GET ${keyLocation} returned 200 but the body does not match the key`,
+      };
+    }
+    return { ok: true, status: res.status, error: null };
+  } catch (error) {
+    return { ok: false, status: null, error: (error as Error).message };
+  }
+}
+
+export type IndexNowPingResult = {
+  ok: boolean;
+  status: number | null;
+  error: string | null;
+};
+
+/**
+ * 202 means IndexNow accepted the URL list but has not verified the key
+ * file yet. Treat that as a failure here so a missing key file cannot
+ * look like a successful production ping.
+ */
+export async function pingIndexNow(
+  payload: IndexNowPayload,
+  fetchFn: FetchLike = fetch,
+): Promise<IndexNowPingResult> {
+  try {
+    const res = await fetchFn(INDEXNOW_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(payload),
+    });
+    if (res.status === 202) {
+      return {
+        ok: false,
+        status: 202,
+        error: `202 — IndexNow has the URL list but key validation is pending. Confirm GET ${payload.keyLocation} returns 200 with the key.`,
+      };
+    }
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 300);
+      return { ok: false, status: res.status, error: body };
+    }
+    return { ok: true, status: res.status, error: null };
+  } catch (error) {
+    return { ok: false, status: null, error: (error as Error).message };
+  }
+}
+
+export function parseSubmitArgs(argv: readonly string[]): { submit: boolean } {
+  const submit = argv.includes("--submit");
+  const dryRun = argv.includes("--dry-run");
+  if (submit && dryRun) {
+    throw new Error("Pass only one of --submit or --dry-run");
+  }
+  return { submit };
+}
+
+/**
+ * Production POST requires both --submit and INDEXNOW_SUBMIT=1.
+ * CI and local runs stay dry-run unless that gate is set on purpose.
+ */
+export function shouldPostIndexNow(opts: { submit: boolean; env?: NodeJS.ProcessEnv }): boolean {
+  const env = opts.env ?? process.env;
+  return opts.submit && env.INDEXNOW_SUBMIT === "1";
+}

--- a/scripts/indexnow/3ec7fbeb8241def221cf92823220d4dc.txt
+++ b/scripts/indexnow/3ec7fbeb8241def221cf92823220d4dc.txt
@@ -1,0 +1,1 @@
+3ec7fbeb8241def221cf92823220d4dc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

This repo is the local omg.dev runtime. It does not deploy the public marketing site or the docs site.

Live `https://omg.dev/robots.txt` already names `scripts/gsc-submit-sitemaps.ts` as the Search Console feed. That file was not in this checkout. There is no other search-engine submit pipeline here. This PR adds that script and puts IndexNow next to an optional Search Console sitemap PUT.

The script collects public URLs from `https://omg.dev/sitemap.xml` and `https://docs.omg.dev/sitemap.xml`. It drops `app.omg.dev`, localhost, preview, and non-https URLs. It then POSTs per host to `https://api.indexnow.org/indexnow`. It does not use the retired Bing `https://www.bing.com/ping?sitemap=` endpoint (HTTP 410).

Google does not support IndexNow. Search Console submission is unchanged: the script PUTs the two sitemaps only when `GSC_ACCESS_TOKEN` is set. Otherwise it skips that step.

## Key file

Key: `3ec7fbeb8241def221cf92823220d4dc` (32 hex characters).

Source file in this repo:

`scripts/indexnow/3ec7fbeb8241def221cf92823220d4dc.txt`

Copy that file to the static root of both public hosts so these URLs return `text/plain` with the key:

```
https://omg.dev/3ec7fbeb8241def221cf92823220d4dc.txt
https://docs.omg.dev/3ec7fbeb8241def221cf92823220d4dc.txt
```

This runtime repo cannot serve those files after merge. The apex host is Caddy. The docs host is a separate Fumadocs deploy behind Cloudflare.

## Cloudflare Crawler Hints

`omg.dev` is Caddy. It is not on Cloudflare. Crawler Hints does not apply to the apex.

`docs.omg.dev` is on Cloudflare. This PR cannot see whether Crawler Hints is already on. The PR still adds an explicit IndexNow POST with a hosted key. That is what Bing Webmaster Tools → IndexNow records. The script does not also ping a second IndexNow endpoint.

## How to verify

After the key file is on both hosts:

```
curl -sS https://omg.dev/3ec7fbeb8241def221cf92823220d4dc.txt
curl -sS https://docs.omg.dev/3ec7fbeb8241def221cf92823220d4dc.txt
```

Each response must be the key. Then run a production ping:

1. Set repository variable `INDEXNOW_SUBMIT` to `1`.
2. Run the `indexnow` workflow with `submit=true`.

Or locally:

```
INDEXNOW_SUBMIT=1 bun run scripts/gsc-submit-sitemaps.ts --submit
```

Then open Bing Webmaster Tools → IndexNow after that run.

Dry-run (no POST):

```
bun run scripts/gsc-submit-sitemaps.ts --dry-run
bun test scripts/indexnow.test.ts
```

## Gate

`--submit` without `INDEXNOW_SUBMIT=1` exits 2 and does not fetch or POST.

Pull requests and pushes run tests plus `--dry-run` only. They do not POST to IndexNow.

## Verification in this PR

`bun test scripts/indexnow.test.ts` — 17 pass.

A live `--dry-run` collected 24 `omg.dev` URLs and 25 `docs.omg.dev` URLs. It dropped `https://app.omg.dev/sandbox` from the apex sitemap. It did not POST to IndexNow.

This change does not claim traffic or ranking effects.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c96d3b3-31e7-4da1-bf2b-fbfa1bbaab3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c96d3b3-31e7-4da1-bf2b-fbfa1bbaab3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

