### PR TITLE
fix(bots): one roster row per bot, and take the roster off the open path

### DIFF
--- a/src/bot-roster-canonical.test.ts
+++ b/src/bot-roster-canonical.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { botCanonicalSessionId, isDelegatedSession } from "./bots/session.ts";
+
+// One roster row per bot, backed by that bot's canonical conversation.
+// The cases below are the shapes that produced duplicate rows in v0.2.9.
+
+const main = { sessionId: "main", botId: "bot-1" };
+
+describe("botCanonicalSessionId", () => {
+  test("keeps the configured primary when a bot has a delegated child", () => {
+    const child = { sessionId: "child", botId: "bot-1", parentSessionId: "main", spawnedBy: "subagent" };
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, [child, main])).toBe("main");
+  });
+
+  test("ignores a nested grandchild at any depth", () => {
+    const child = { sessionId: "child", botId: "bot-1", parentSessionId: "main", subagentDepth: 1 };
+    const grandchild = { sessionId: "grandchild", botId: "bot-1", parentSessionId: "child", subagentDepth: 2 };
+    const greatgrandchild = { sessionId: "ggchild", botId: "bot-1", parentSessionId: "grandchild", subagentDepth: 3 };
+    const sessions = [greatgrandchild, grandchild, child, main];
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, sessions)).toBe("main");
+    // Every descendant is recognised as delegated, so none can back a row.
+    for (const session of [child, grandchild, greatgrandchild]) {
+      expect(isDelegatedSession(session)).toBe(true);
+    }
+  });
+
+  test("repairs a primary that was rebound onto a child, up to the root", () => {
+    const child = { sessionId: "child", botId: "bot-1", parentSessionId: "main", subagentDepth: 1 };
+    const grandchild = { sessionId: "grandchild", botId: "bot-1", parentSessionId: "child", subagentDepth: 2 };
+    // The bot record points at the grandchild — the corrupt-binding case.
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "grandchild" }, [grandchild, child, main])).toBe("main");
+  });
+
+  test("collapses several stale top-level sessions to one stable choice", () => {
+    const a = { sessionId: "aaa", botId: "bot-1" };
+    const b = { sessionId: "bbb", botId: "bot-1" };
+    const c = { sessionId: "ccc", botId: "bot-1" };
+    const bot = { id: "bot-1" };
+    const first = botCanonicalSessionId(bot, [a, b, c]);
+    // Same answer whatever order the fleet listed them in.
+    expect(botCanonicalSessionId(bot, [c, a, b])).toBe(first);
+    expect(botCanonicalSessionId(bot, [b, c, a])).toBe(first);
+    expect(first).toBe("aaa");
+  });
+
+  test("falls back to a true top-level session when the configured primary is missing", () => {
+    const child = { sessionId: "child", botId: "bot-1", parentSessionId: "gone", spawnedBy: "subagent" };
+    const live = { sessionId: "live", botId: "bot-1" };
+    // The bot has no saved binding at all.
+    expect(botCanonicalSessionId({ id: "bot-1" }, [child, live])).toBe("live");
+  });
+
+  test("never chooses a child when only children are live", () => {
+    const child = { sessionId: "child", botId: "bot-1", parentSessionId: "dead", subagentDepth: 1 };
+    expect(botCanonicalSessionId({ id: "bot-1" }, [child])).toBeNull();
+  });
+
+  test("keeps a stale configured primary whose transcript is still on disk", () => {
+    // Nothing live matches, but the saved id is where the history is filed.
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "archived" }, [])).toBe("archived");
+  });
+
+  test("returns null for a bot that has never held a conversation", () => {
+    expect(botCanonicalSessionId({ id: "fresh" }, [])).toBeNull();
+  });
+
+  test("keeps bots isolated from each other's sessions and children", () => {
+    const sessions = [
+      { sessionId: "a-main", botId: "bot-a" },
+      { sessionId: "a-child", botId: "bot-a", parentSessionId: "a-main", spawnedBy: "subagent" },
+      { sessionId: "b-main", botId: "bot-b" },
+      { sessionId: "b-child", botId: "bot-b", parentSessionId: "b-main", spawnedBy: "subagent" },
+    ];
+    expect(botCanonicalSessionId({ id: "bot-a", sessionId: "a-main" }, sessions)).toBe("a-main");
+    expect(botCanonicalSessionId({ id: "bot-b", sessionId: "b-main" }, sessions)).toBe("b-main");
+  });
+
+  test("treats a delegate/auto child as delegated, not as a bot conversation", () => {
+    const delegated = { sessionId: "d", botId: "bot-1", parentNativeSessionId: "main" };
+    expect(isDelegatedSession(delegated)).toBe(true);
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, [delegated, main])).toBe("main");
+  });
+});

--- a/src/bots/session.ts
+++ b/src/bots/session.ts
@@ -141,3 +141,56 @@ export function botConversationRef(
   }
   return {};
 }
+
+/**
+ * The single conversation a bot's roster row is backed by.
+ *
+ * The roster invariant is one row per persistent bot. Getting there needs more
+ * than "pick a session with this botId", because child sessions inherit
+ * `botId` (see the note at the top of this file). A bot that delegated three
+ * subagents matched four sessions, and both the API and the list view turned
+ * each one into its own row — the roster showed "Bot Improver" twice, "iOS
+ * Manager" twice, and so on, each duplicate carrying a subagent's last line as
+ * if the bot had said it.
+ *
+ * Resolution order, and why:
+ *
+ * 1. The configured primary, when it names a real conversation that is not
+ *    delegated. This is the binding the bot's own record owns.
+ * 2. A configured primary that names a delegated child is a corrupt binding,
+ *    so it is repaired to that child's root ancestor rather than trusted.
+ *    `botConversationRef` owns that walk.
+ * 3. Otherwise the bot's own top-level sessions, lowest id first. Sorting
+ *    matters: `find` returns whatever the session list happened to order
+ *    first, so two stale top-level sessions could alternate between refreshes
+ *    and read as a moving duplicate. A stable key makes the choice the same on
+ *    every request and on every client.
+ * 4. Otherwise the saved id even though nothing live matches it. The
+ *    transcript is filed on disk under that id, so it still names the right
+ *    history.
+ *
+ * Returns null only for a bot that has never held a conversation, which the
+ * roster renders as a single "say hi" row.
+ */
+export function botCanonicalSessionId(
+  bot: BotSessionRef,
+  sessions: readonly BotSessionCandidate[],
+): string | null {
+  const saved = bot.sessionId?.trim();
+  if (saved) {
+    const exact = findById(sessions, saved);
+    if (exact && !isDelegatedSession(exact)) return exact.sessionId ?? saved;
+    // Present but delegated: repair rather than adopt the child.
+    if (exact) {
+      const repaired = botConversationRef(bot, sessions).sessionId;
+      if (repaired) return repaired;
+    }
+  }
+  const own = sessions
+    .filter((session) => session.botId === bot.id && !isDelegatedSession(session))
+    .map((session) => session.sessionId)
+    .filter((id): id is string => !!id)
+    .sort();
+  if (own.length) return own[0];
+  return saved || null;
+}

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -76,7 +76,7 @@ import {
   type BotColorway,
   type BotShape,
 } from "../bots/store.ts";
-import { botConversationRef, findBotMainSession } from "../bots/session.ts";
+import { botCanonicalSessionId, botConversationRef, findBotMainSession } from "../bots/session.ts";
 import {
   BOT_SELF_CREATE_FIELDS,
   BOT_SELF_UPDATE_FIELDS,
@@ -98,7 +98,6 @@ import {
 import {
   assertConversationAccess,
   botReadUser,
-  conversationOwner,
   conversationUnread,
   ensureBotConversationReadBaseline,
   markBotConversationRead,
@@ -4076,29 +4075,42 @@ a{color:#60a5fa}
               ? { ...bot, lastMessagePreview: last.text.slice(0, 400), lastMessageTs: last.ts ?? null }
               : bot;
           });
-          // New clients consume one row per conversation. Keep `bots` unchanged
-          // for v0.1.411 clients, which know only the bot-level roster.
+          // Exactly one conversation per bot — the roster invariant, decided
+          // here rather than left to the client.
+          //
+          // This used to key off every session carrying the bot's `botId`.
+          // Delegated children inherit `botId`, so a bot that had spawned
+          // background work contributed one conversation per subagent and the
+          // roster showed it two or three times, each duplicate captioned with
+          // a child's last line. `botCanonicalSessionId` owns the choice and
+          // never returns a delegated session.
+          //
+          // Collapsing here is also what makes the roster cheap. The per
+          // conversation body below reads the read-watermark file and runs two
+          // index queries, so the old fan-out paid that for every subagent a
+          // bot had ever spawned; on this machine that was 39 conversations
+          // for 9 bots.
           const sessions = await listSessionsCached();
-          const ids = new Map<string, { bot: Bot; assignedUser?: string | null }>();
-          for (const bot of visibleBots) {
-            if (bot.sessionId) ids.set(bot.sessionId, { bot, assignedUser: bot.owner });
-          }
-          for (const session of sessions) {
-            if (!session.sessionId || !session.botId) continue;
-            const bot = visibleBots.find((candidate) => candidate.id === session.botId);
-            if (bot) ids.set(session.sessionId, { bot, assignedUser: session.assignedUser });
-          }
           const user = botReadUser(requestedUser);
-          const conversations = [...ids].flatMap(([sessionId, value]) => {
-            const owner = conversationOwner(sessionId, sessions, visibleBots);
-            if (!owner || (requestedUser != null && owner.user !== user)) return [];
+          const conversations = visibleBots.flatMap((bot) => {
+            const sessionId = botCanonicalSessionId(bot, sessions);
+            if (!sessionId) return [];
+            // Ownership is anchored to the bot we already resolved from, so a
+            // repaired binding that names a session the fleet no longer lists
+            // still reports under its own bot instead of dropping out.
+            const session = sessions.find((row) => row.sessionId === sessionId);
+            const assigned = session?.assignedUser?.trim();
+            const botOwner = bot.owner?.trim();
+            if (assigned && botOwner && botReadUser(assigned) !== botReadUser(botOwner)) return [];
+            const conversationUser = botReadUser(assigned || botOwner);
+            if (requestedUser != null && conversationUser !== user) return [];
             const cursor = latestIndexedAssistantCursor(sessionId);
             ensureBotConversationReadBaseline(user, sessionId, cursor?.rowid ?? null);
             const last = lastIndexedAssistantMessage(sessionId);
             return [{
               sessionId,
-              botId: value.bot.id,
-              assignedUser: value.assignedUser ?? value.bot.owner ?? null,
+              botId: bot.id,
+              assignedUser: assigned ?? bot.owner ?? null,
               unread: conversationUnread(user, sessionId, cursor?.rowid ?? null),
               lastMessagePreview: last?.text?.slice(0, 400),
               lastMessageTs: last?.ts ?? null,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,8 @@ import {
   BOT_UNREAD_DOT_CLASS,
   botConversationRows,
   botUnreadActionForTranscript,
+  botConversationSubscriptionIds,
+  clearBotConversationUnread,
   hasUnreadBotConversation,
   type BotConversationUnread,
 } from "./lib/bot-unread";
@@ -6770,14 +6772,20 @@ export function App() {
 
   const selectedConversationSid = selectedBotConversationId ??
     (selectedBotId ? bots.find((bot) => bot.id === selectedBotId)?.sessionId ?? null : null);
+  // Clearing a dot must not sit in front of the conversation the human just
+  // opened. This used to await the POST and then await a full `/api/bots`
+  // refetch, so every bot open queued a roster rebuild behind a write on the
+  // same server before the transcript request could be served. The row state
+  // is the only thing the POST changes, so it is applied locally first and the
+  // write goes out behind the paint.
   const markBotConversationVisible = useCallback(async (sessionId: string) => {
+    setBotConversations((prev) => clearBotConversationUnread(prev, sessionId));
     await api(`/api/bot-conversations/${encodeURIComponent(sessionId)}/read`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ user: botUnreadIdentity }),
     });
-    await refreshBots();
-  }, [botUnreadIdentity, refreshBots]);
+  }, [botUnreadIdentity]);
 
   // Selection is committed before this effect runs, so a route preload or a
   // tap that never revealed the conversation cannot clear its watermark.
@@ -6789,24 +6797,39 @@ export function App() {
   // Reuse the transcript websocket. Every committed assistant row refreshes
   // the server-owned watermark view. The open conversation advances its own
   // watermark; background conversations only gain an unread dot.
+  // Which conversations to watch, as a value that only changes when the set
+  // does. `botConversations` is a fresh array on every roster refresh, and a
+  // refresh happens on every assistant message, so keying the effect on the
+  // payload tore down and re-established every bot transcript channel each
+  // time — on the same socket the open chat streams its own transcript over.
+  const botConversationSidKey = botConversationSubscriptionIds(botConversations).join(",");
+  const botConversationSids = useMemo(
+    () => (botConversationSidKey ? botConversationSidKey.split(",") : []),
+    [botConversationSidKey],
+  );
+  // Read through a ref so changing the open conversation re-targets the
+  // existing subscriptions instead of replacing all of them.
+  const botUnreadViewRef = useRef({ selectedConversationSid, tab });
+  botUnreadViewRef.current = { selectedConversationSid, tab };
   useEffect(() => {
     if (!useWsLive) return;
-    const unsubs = botConversations.map((conversation) =>
-      wsLiveStream.subscribeTranscript(conversation.sessionId, (event) => {
+    const unsubs = botConversationSids.map((sessionId) =>
+      wsLiveStream.subscribeTranscript(sessionId, (event) => {
         if (event.type !== "message") return;
+        const view = botUnreadViewRef.current;
         const action = botUnreadActionForTranscript({
           role: event.message.role,
           text: event.message.text,
-          conversationId: conversation.sessionId,
-          selectedConversationId: selectedConversationSid,
-          botsVisible: tab === "bots" && document.visibilityState === "visible",
+          conversationId: sessionId,
+          selectedConversationId: view.selectedConversationSid,
+          botsVisible: view.tab === "bots" && document.visibilityState === "visible",
         });
-        if (action === "mark-read") void markBotConversationVisible(conversation.sessionId).catch(() => {});
+        if (action === "mark-read") void markBotConversationVisible(sessionId).catch(() => {});
         if (action === "refresh") void refreshBots().catch(() => {});
       })
     );
     return () => unsubs.forEach((unsubscribe) => unsubscribe());
-  }, [botConversations, markBotConversationVisible, refreshBots, selectedConversationSid, tab, useWsLive, wsLiveStream.subscribeTranscript]);
+  }, [botConversationSids, markBotConversationVisible, refreshBots, useWsLive, wsLiveStream.subscribeTranscript]);
 
   function toggleTheme() {
     setThemePreference(!document.documentElement.classList.contains("dark"));

--- a/web/src/lib/bot-open-performance.test.ts
+++ b/web/src/lib/bot-open-performance.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  botConversationRows,
+  botConversationSubscriptionIds,
+  clearBotConversationUnread,
+  type BotConversationUnread,
+} from "./bot-unread";
+
+// Opening a bot has to be as cheap as opening a regular chat. These lock the
+// properties that made it expensive in v0.2.9.
+
+describe("opening a bot conversation", () => {
+  test("clears the opened dot locally, so the row never waits on the read POST", () => {
+    const before: BotConversationUnread[] = [
+      { sessionId: "a1", botId: "a", unread: true },
+      { sessionId: "b1", botId: "b", unread: true },
+    ];
+    const after = clearBotConversationUnread(before, "a1");
+    // Cleared without any server round trip having happened.
+    expect(after.map((row) => [row.sessionId, row.unread])).toEqual([["a1", false], ["b1", true]]);
+  });
+
+  test("opening an already-read conversation does not churn roster identity", () => {
+    const conversations: BotConversationUnread[] = [{ sessionId: "a1", botId: "a", unread: false }];
+    // Same reference: effects that key on the roster must not re-run.
+    expect(clearBotConversationUnread(conversations, "a1")).toBe(conversations);
+    expect(clearBotConversationUnread(conversations, "missing")).toBe(conversations);
+  });
+
+  test("watches one transcript channel per bot, not one per delegated child", () => {
+    // What the server now sends: one canonical conversation per bot.
+    const conversations: BotConversationUnread[] = [
+      { sessionId: "a1", botId: "a", unread: false },
+      { sessionId: "b1", botId: "b", unread: false },
+      { sessionId: "c1", botId: "c", unread: false },
+    ];
+    expect(botConversationSubscriptionIds(conversations)).toEqual(["a1", "b1", "c1"]);
+  });
+
+  test("keeps the subscription set stable when a refresh reorders the payload", () => {
+    const one: BotConversationUnread[] = [
+      { sessionId: "b1", botId: "b", unread: false },
+      { sessionId: "a1", botId: "a", unread: true },
+    ];
+    // Same conversations, different order and different unread flags — the
+    // subscribing effect must not see a changed set and re-open every channel.
+    const two: BotConversationUnread[] = [
+      { sessionId: "a1", botId: "a", unread: false },
+      { sessionId: "b1", botId: "b", unread: false },
+    ];
+    expect(botConversationSubscriptionIds(one).join(",")).toBe(
+      botConversationSubscriptionIds(two).join(","),
+    );
+  });
+
+  test("a bot with a large delegated fleet still costs one row and one channel", () => {
+    // Realistic heavy case: one long-lived bot that has spawned 200 children.
+    const bot = { id: "busy", sessionId: "busy-main" };
+    const sessions = [
+      { sessionId: "busy-main", botId: "busy" },
+      ...Array.from({ length: 200 }, (_, i) => ({
+        sessionId: `child-${i}`,
+        botId: "busy",
+        parentSessionId: "busy-main",
+        subagentDepth: 1 + (i % 3),
+        spawnedBy: "subagent",
+      })),
+    ];
+    const conversations: BotConversationUnread[] = [
+      { sessionId: "busy-main", botId: "busy", unread: true },
+    ];
+    const rows = botConversationRows([bot], sessions, conversations);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sessionId).toBe("busy-main");
+    expect(botConversationSubscriptionIds(conversations)).toEqual(["busy-main"]);
+  });
+
+  test("resolving the row does not depend on the child sessions being present", () => {
+    // The roster must not need a full session-list scan to know which
+    // conversation to open: the configured primary alone is enough.
+    const bot = { id: "a", sessionId: "a1" };
+    const conversations: BotConversationUnread[] = [{ sessionId: "a1", botId: "a", unread: false }];
+    const withNoSessions = botConversationRows([bot], [], conversations);
+    const withManySessions = botConversationRows(
+      [bot],
+      [
+        { sessionId: "a1", botId: "a" },
+        { sessionId: "x", botId: "a", parentSessionId: "a1", subagentDepth: 1 },
+      ],
+      conversations,
+    );
+    expect(withNoSessions[0].sessionId).toBe("a1");
+    expect(withMany(withManySessions)).toBe("a1");
+    function withMany(rows: typeof withManySessions) {
+      return rows[0].sessionId;
+    }
+  });
+});

--- a/web/src/lib/bot-roster-duplicates.test.ts
+++ b/web/src/lib/bot-roster-duplicates.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { botConversationRows } from "./bot-unread";
+
+// Negative control for the v0.2.9 roster bug, built from the reported screenshot.
+//
+// Three bots on that roster each rendered twice — "Bot Improver", "iOS
+// Manager", "Landing + Funnel Optimization" — because each had delegated a
+// background session, and a delegated child inherits its parent's `botId`.
+// The fixture below is that exact shape: one primary conversation and one
+// child per bot. Before the fix this produced six rows with three repeated
+// names; the roster invariant is three.
+const BOTS = [
+  { id: "bot-improver", sessionId: "improver-main" },
+  { id: "ios-manager", sessionId: "ios-main" },
+  { id: "landing-funnel", sessionId: "landing-main" },
+];
+
+const SESSIONS = [
+  { sessionId: "improver-main", botId: "bot-improver" },
+  { sessionId: "improver-child", botId: "bot-improver", parentSessionId: "improver-main", spawnedBy: "subagent" },
+  { sessionId: "ios-main", botId: "ios-manager" },
+  { sessionId: "ios-child", botId: "ios-manager", parentSessionId: "ios-main", spawnedBy: "subagent" },
+  { sessionId: "landing-main", botId: "landing-funnel" },
+  { sessionId: "landing-child", botId: "landing-funnel", parentSessionId: "landing-main", spawnedBy: "subagent" },
+];
+
+const CONVERSATIONS = SESSIONS.map((session) => ({
+  sessionId: session.sessionId,
+  botId: session.botId,
+  unread: false,
+}));
+
+describe("bots roster duplicate rows (screenshot regression)", () => {
+  test("renders exactly one row per bot when each bot has a delegated child", () => {
+    const rows = botConversationRows(BOTS, SESSIONS, CONVERSATIONS);
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.bot.id)).toEqual(["bot-improver", "ios-manager", "landing-funnel"]);
+  });
+
+  test("never backs a roster row with a delegated child session", () => {
+    const rows = botConversationRows(BOTS, SESSIONS, CONVERSATIONS);
+    expect(rows.map((row) => row.sessionId)).toEqual(["improver-main", "ios-main", "landing-main"]);
+  });
+
+  test("shows no bot name twice", () => {
+    const ids = botConversationRows(BOTS, SESSIONS, CONVERSATIONS).map((row) => row.bot.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/web/src/lib/bot-session.ts
+++ b/web/src/lib/bot-session.ts
@@ -3,6 +3,7 @@
 // delegated children while the server was still rebinding bot records to them,
 // so the chat and the record disagreed about which session a bot owned.
 export {
+  botCanonicalSessionId,
   botChatSessionId,
   botConversationRef,
   findBotMainSession,

--- a/web/src/lib/bot-unread.test.ts
+++ b/web/src/lib/bot-unread.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { BOT_UNREAD_DOT_CLASS, botConversationRows, botUnreadActionForTranscript, hasUnreadBotConversation } from "./bot-unread";
 
 describe("bot conversation unread presentation", () => {
-  test("keeps two conversations for one bot isolated", () => {
+  test("gives one bot one row, backed by its configured primary", () => {
+    // "two" is a second top-level session the bot once used. It must not
+    // become a second row, and its unread flag must not leak onto the row the
+    // human actually opens.
     const rows = botConversationRows(
       [{ id: "bot", sessionId: "one" }],
       [{ sessionId: "one", botId: "bot" }, { sessionId: "two", botId: "bot" }],
@@ -11,8 +14,49 @@ describe("bot conversation unread presentation", () => {
         { sessionId: "two", botId: "bot", unread: true },
       ],
     );
-    expect(rows.map((row) => [row.sessionId, row.unread])).toEqual([["one", false], ["two", true]]);
-    expect(hasUnreadBotConversation(rows.flatMap((row) => row.sessionId ? [{ sessionId: row.sessionId, botId: row.bot.id, unread: row.unread }] : []))).toBe(true);
+    expect(rows.map((row) => [row.sessionId, row.unread])).toEqual([["one", false]]);
+  });
+
+  test("marks the row unread from the canonical conversation only", () => {
+    const rows = botConversationRows(
+      [{ id: "bot", sessionId: "one" }],
+      [
+        { sessionId: "one", botId: "bot" },
+        { sessionId: "child", botId: "bot", parentSessionId: "one", spawnedBy: "subagent" },
+      ],
+      [
+        { sessionId: "one", botId: "bot", unread: true },
+        { sessionId: "child", botId: "bot", unread: false },
+      ],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].unread).toBe(true);
+    expect(rows[0].sessionId).toBe("one");
+  });
+
+  test("clearing one bot leaves the other bot's unread row alone", () => {
+    const bots = [{ id: "a", sessionId: "a1" }, { id: "b", sessionId: "b1" }];
+    const sessions = [{ sessionId: "a1", botId: "a" }, { sessionId: "b1", botId: "b" }];
+    // "a" was just opened and cleared; "b" is still unread.
+    const rows = botConversationRows(bots, sessions, [
+      { sessionId: "a1", botId: "a", unread: false },
+      { sessionId: "b1", botId: "b", unread: true },
+    ]);
+    expect(rows.map((row) => [row.bot.id, row.unread])).toEqual([["a", false], ["b", true]]);
+  });
+
+  test("keeps roster order stable and one row per bot as sessions churn", () => {
+    const bots = [{ id: "a", sessionId: "a1" }, { id: "b", sessionId: "b1" }];
+    const base = [{ sessionId: "a1", botId: "a" }, { sessionId: "b1", botId: "b" }];
+    const withChildren = [
+      { sessionId: "b-child", botId: "b", parentSessionId: "b1", subagentDepth: 1 },
+      ...base,
+      { sessionId: "a-child", botId: "a", parentSessionId: "a1", subagentDepth: 1 },
+    ];
+    const keys = (sessions: typeof withChildren) =>
+      botConversationRows(bots, sessions, []).map((row) => row.key);
+    expect(keys(base)).toEqual(["bot:a", "bot:b"]);
+    expect(keys(withChildren)).toEqual(["bot:a", "bot:b"]);
   });
 
   test("keeps an unstarted bot as one readable row", () => {

--- a/web/src/lib/bot-unread.ts
+++ b/web/src/lib/bot-unread.ts
@@ -1,3 +1,5 @@
+import { botCanonicalSessionId, type BotSessionCandidate } from "./bot-session";
+
 export type BotConversationUnread = {
   sessionId: string;
   botId: string;
@@ -21,38 +23,43 @@ export function hasUnreadBotConversation(conversations: BotConversationUnread[])
   return conversations.some((conversation) => conversation.unread);
 }
 
+/**
+ * One roster row per persistent bot.
+ *
+ * The row is backed by that bot's canonical conversation, resolved with the
+ * same rules the server binds by (`botCanonicalSessionId`). This used to fan
+ * out instead: every session carrying the bot's `botId` became its own row.
+ * Delegated children inherit `botId`, so a bot that had spawned background
+ * work appeared two or three times, each copy captioned with a subagent's
+ * last line. The server now sends one conversation per bot, and this stays
+ * canonical-aware so a roster rendered against an older payload still
+ * collapses to one row instead of showing the duplicates again.
+ */
 export function botConversationRows<
   B extends { id: string; sessionId?: string },
-  S extends { sessionId: string | null; botId?: string | null },
+  S extends BotSessionCandidate & { sessionId: string | null },
 >(bots: B[], sessions: S[], conversations: BotConversationUnread[]): BotConversationRow<B, S>[] {
-  const rows: BotConversationRow<B, S>[] = [];
-  for (const bot of bots) {
-    const ids = new Set<string>();
-    for (const conversation of conversations) {
-      if (conversation.botId === bot.id) ids.add(conversation.sessionId);
-    }
-    for (const session of sessions) {
-      if (session.sessionId && session.botId === bot.id) ids.add(session.sessionId);
-    }
-    if (bot.sessionId) ids.add(bot.sessionId);
-    if (!ids.size) {
-      rows.push({ key: `bot:${bot.id}`, bot, session: undefined, sessionId: null, unread: false });
-      continue;
-    }
-    for (const sessionId of ids) {
-      const conversation = conversations.find((item) => item.sessionId === sessionId);
-      rows.push({
-        key: `conversation:${sessionId}`,
-        bot,
-        session: sessions.find((item) => item.sessionId === sessionId),
-        sessionId,
-        unread: !!conversation?.unread,
-        lastMessagePreview: conversation?.lastMessagePreview,
-        lastMessageTs: conversation?.lastMessageTs,
-      });
-    }
-  }
-  return rows;
+  return bots.map((bot) => {
+    const own = conversations.filter((conversation) => conversation.botId === bot.id);
+    // Prefer the shared resolver, then the server's row for this bot when it
+    // named a conversation the client's session list does not carry.
+    const canonical = botCanonicalSessionId(bot, sessions) ??
+      (own.length === 1 ? own[0].sessionId : null);
+    const conversation = canonical
+      ? own.find((item) => item.sessionId === canonical)
+      : undefined;
+    // Keyed by bot, not by session: the row survives a rebind of the bot's
+    // conversation without React tearing it down and losing scroll position.
+    return {
+      key: `bot:${bot.id}`,
+      bot,
+      session: sessions.find((item) => item.sessionId === canonical),
+      sessionId: canonical,
+      unread: !!conversation?.unread,
+      lastMessagePreview: conversation?.lastMessagePreview,
+      lastMessageTs: conversation?.lastMessageTs,
+    };
+  });
 }
 
 export const BOT_UNREAD_DOT_CLASS = "size-2 shrink-0 rounded-full bg-primary";
@@ -69,4 +76,38 @@ export function botUnreadActionForTranscript(input: {
   return input.botsVisible && input.selectedConversationId === input.conversationId
     ? "mark-read"
     : "refresh";
+}
+
+/**
+ * The transcript channels the roster watches, one per canonical conversation,
+ * in a stable order.
+ *
+ * The order matters as much as the contents. The subscribing effect keys on
+ * this list, so returning it in payload order would make an unrelated roster
+ * refresh look like a changed subscription set and churn every channel.
+ */
+export function botConversationSubscriptionIds(
+  conversations: BotConversationUnread[],
+): string[] {
+  return [...new Set(conversations.map((conversation) => conversation.sessionId))].sort();
+}
+
+/**
+ * Clear one conversation's unread flag without waiting for the server.
+ *
+ * Returns the same array when there was nothing to clear, so an open of an
+ * already-read conversation does not produce a new roster identity and re-run
+ * the effects that key on it.
+ */
+export function clearBotConversationUnread(
+  conversations: BotConversationUnread[],
+  sessionId: string,
+): BotConversationUnread[] {
+  return conversations.some(
+    (conversation) => conversation.sessionId === sessionId && conversation.unread,
+  )
+    ? conversations.map((conversation) =>
+        conversation.sessionId === sessionId ? { ...conversation, unread: false } : conversation,
+      )
+    : conversations;
 }


### PR DESCRIPTION
## What was wrong

The mobile Bots list showed several bots twice — **Bot Improver**, **iOS Manager**, **Landing + Funnel Optimization** — each duplicate captioned with a subagent's last line.

Delegated children inherit their parent's `botId`. Both `GET /api/bots` and the list view turned every `botId` match into its own conversation row, so a bot that had spawned background work contributed one row per child. On the reporting machine that was **39 conversations for 9 bots**.

## The fix

`botCanonicalSessionId` now owns "which one conversation backs a bot's row":

1. the configured primary, when it names a real non-delegated conversation
2. a primary that was rebound onto a child is repaired by walking to the root ancestor
3. otherwise the bot's own top-level sessions in a stable order, so several stale candidates cannot alternate between refreshes

It never returns a delegated session. The **API** returns one conversation per bot, so this is a contract fix rather than presentation dedupe; the client stays canonical-aware so an older payload still collapses to one row.

## Slow bot history, same root

The roster subscribed one transcript channel per conversation and keyed that effect on the payload array, which is rebuilt on every refresh — and a refresh ran on every assistant message from any bot. Every message tore down and re-established every bot transcript channel, on the same socket the open chat streams its own transcript over. Opening a bot also awaited the read-watermark POST and then a full roster refetch before the transcript request could be served.

The subscribe effect now keys on a sorted id list, the open conversation is read through a ref so changing selection re-targets instead of resubscribing, and marking read clears the dot locally and posts behind the paint.

Measured against the real 2.3 GB transcript index **first**: per-conversation index queries cost 0.54 ms and bot transcripts are small (mean 129 rows vs 4,732 for the largest ordinary session), so history size and SQLite were ruled out before anything changed.

## Tests

- **Negative control** built from the reported screenshot (three bots, one delegated child each). Produced six rows with three repeated names before the fix.
- Canonical resolution: parent+child, nested grandchildren, corrupt-binding repair, duplicate stale top-level, missing primary, cross-bot isolation, stable ordering.
- Unread aggregation, clear-one, ordering.
- Open-path regressions, including a bot with 200 children that must still cost one row and one channel.

## Verification

Root typecheck, web typecheck, web build, and `bun run audit` all clean. 62/62 bot tests pass. The full suite's remaining failures were diffed against a stashed baseline and differ in both directions — a load-flaky pool on that machine, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)