### PR TITLE
feat(settings): show the frontend and Computer versions side by side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - See which versions you are actually running (v0.2.11)
+
+- **Settings shows the app build and the Computer's runtime side by side.**
+  Settings > Computer now has two rows, `Frontend` and `Computer`. The first is
+  the version of the app you are looking at right now; the second is the
+  version the selected Computer is really executing. Tap either to copy it.
+  When they disagree, a short line under them says which side is behind. This
+  is what you read to tell whether an update actually reached the box.
+- **The two numbers cannot agree by accident.** They are read from two separate
+  places: the app build stamps its own version at build time, and the Computer
+  value only ever comes from that Computer's own reply. Neither one falls back
+  to the other, so a matching pair is real evidence and not an assumption.
+- **Honest when it does not know.** A Computer that cannot be reached reads
+  `Disconnected`, and one running a version too old to report itself reads
+  `Unavailable`. Neither shows a guessed number. Self-hosted installs are
+  unchanged.
+- **The Computer row keeps up with restarts and machine switches.** Updating and
+  restarting a Computer used to leave the old version on screen until you
+  reloaded the page, which is the one moment the number has to be right. It now
+  corrects itself. Switching to a different Computer no longer shows the
+  previous machine's version under the new machine's name.
+- **Fixed: everyone with access to a shared Computer can see and open that
+  Computer's bots again.**
+
 ## August 19, 2026 - One row per bot, and faster bot chats (v0.2.10)
 
 - **The Bots list shows each bot once.** A bot that had handed work to a

--- a/test/settings-version-diagnostics.test.ts
+++ b/test/settings-version-diagnostics.test.ts
@@ -1,0 +1,172 @@
+// Contract coverage for the Settings > Computer version rows.
+//
+// The feature exists to answer one question during a bad deploy: "is the UI I
+// am looking at the same build as the runtime I am talking to?" That answer is
+// only worth anything if the two numbers come from two INDEPENDENT sources. The
+// tempting simplifications — stamp web/package.json instead of the root, or let
+// a missing server marker fall back to the frontend's number — each turn this
+// screen into a mirror that always agrees, which is strictly worse than not
+// having it, because it looks like evidence.
+//
+// App.tsx and the vite configs are side-effect-bearing modules (App.tsx mounts
+// the app on import), so these assert against source text, following the
+// pattern already used by app-version-pin.test.ts and bootstrap-payload.test.ts.
+// The behavioural half lives in web/src/lib/version-diagnostics.test.ts.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO = join(import.meta.dir, "..");
+const APP = readFileSync(join(REPO, "web/src/App.tsx"), "utf8");
+const SERVE = readFileSync(join(REPO, "src/commands/serve.ts"), "utf8");
+const VITE_APP = readFileSync(join(REPO, "web/vite.config.ts"), "utf8");
+const VITE_LIB = readFileSync(join(REPO, "web/vite.lib.config.ts"), "utf8");
+const DIAGNOSTICS = readFileSync(join(REPO, "web/src/lib/version-diagnostics.ts"), "utf8");
+const OMG_CLIENT = readFileSync(join(REPO, "web/src/lib/omg-client.ts"), "utf8");
+
+const ROOT_VERSION = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")).version as string;
+const WEB_VERSION = JSON.parse(readFileSync(join(REPO, "web/package.json"), "utf8")).version as string;
+
+/** The Settings > Computer section, where both rows live. */
+function computerSection(): string {
+  const start = APP.indexOf("function SettingsView(");
+  expect(start, "SettingsView not found").toBeGreaterThan(-1);
+  const section = APP.slice(start);
+  const end = section.indexOf("function MoreView(");
+  return end > -1 ? section.slice(0, end) : section;
+}
+
+describe("the frontend version is stamped from the ROOT package.json", () => {
+  // Both shipped bundles must stamp, and both must stamp the same number the
+  // release actually publishes.
+  for (const [name, source] of [
+    ["web/vite.config.ts (standalone bundle)", VITE_APP],
+    ["web/vite.lib.config.ts (@omg-dev/app, the hosted app.omg.dev pin)", VITE_LIB],
+  ] as const) {
+    test(`${name} defines __OMG_FRONTEND_VERSION__`, () => {
+      expect(source).toContain("__OMG_FRONTEND_VERSION__");
+      expect(source).toMatch(/define:\s*\{/);
+    });
+
+    test(`${name} reads the root manifest, not web/package.json`, () => {
+      // scripts/pack-packages.sh rewrites every published manifest to the ROOT
+      // version at pack time, so the root number is what a released tarball
+      // ships as. web/package.json is never published and has already drifted.
+      expect(source).toMatch(/readFileSync\(\s*path\.resolve\([^)]*"\.\.\/package\.json"\)/);
+      expect(source).not.toMatch(/readFileSync\(\s*path\.resolve\([^)]*"\.\/package\.json"\)/);
+    });
+  }
+
+  test("the drift that makes web/package.json the wrong source is real, not hypothetical", () => {
+    // If these ever converge the rule still holds, but this test is the record
+    // of WHY the rule exists. Root is 0.2.x; web/package.json is 0.1.x.
+    expect(WEB_VERSION).not.toBe(ROOT_VERSION);
+  });
+
+  test("an unstamped bundle degrades to null instead of throwing or guessing", () => {
+    // A downstream host bundler that skips the define must not crash Settings.
+    expect(DIAGNOSTICS).toMatch(/typeof __OMG_FRONTEND_VERSION__ === "string"/);
+  });
+});
+
+describe("the Computer version comes only from the Computer", () => {
+  test("/api/bootstrap still carries the version marker Settings reads", () => {
+    const start = SERVE.indexOf('if (path === "/api/bootstrap"');
+    expect(start, "bootstrap handler not found").toBeGreaterThan(-1);
+    const block = SERVE.slice(start, SERVE.indexOf('Cache-Control": "no-cache"', start));
+    expect(block).toContain("version: appVersion()");
+  });
+
+  test("the app stores the raw marker instead of collapsing it to a string", () => {
+    // The old `payload.version || "unknown"` made "an older runtime that sends
+    // no version" indistinguishable from "we have not asked yet", and rendered
+    // the word "unknown" as if it were a version.
+    expect(APP).not.toContain('payload.version || "unknown"');
+    expect(APP).toMatch(/version: typeof payload\.version === "string" \? payload\.version : null/);
+  });
+
+  test("a version is tagged with the transport it was reported over", () => {
+    // A host switches Computers by swapping the transport in place, without
+    // remounting the tree, so an untagged value keeps describing the machine
+    // you just left. Only a genuine swap bumps the counter.
+    expect(OMG_CLIENT).toContain("export function omgTransportGeneration()");
+    expect(OMG_CLIENT).toMatch(/if \(transport !== omgTransport\) omgTransportGenerationCounter \+= 1;/);
+    expect(APP).toMatch(/generation: omgTransportGeneration\(\)/);
+    expect(computerSection()).toMatch(/stale:\s*\n?\s*computerVersionReport != null &&/);
+  });
+
+  test("a restart under an open tab does not leave a stale version on screen", () => {
+    // Observed live during verification: the box was restarted onto a new
+    // version and Settings went on showing the pre-restart number until a
+    // manual reload. bootId is the only marker that distinguishes processes
+    // (two builds can share a version), so the reconnect edge checks it and
+    // re-bootstraps only when it actually moved.
+    expect(APP).toMatch(/bootId: typeof payload\.bootId === "string" \? payload\.bootId : null/);
+    expect(APP).toContain('"/api/install?ready=1"');
+    // Fires on the connection EDGE (not-live -> live), not on every render,
+    // and re-fetches nothing when the process is the same one as before.
+    expect(APP).toMatch(/if \(liveStatus !== "live" \|\| wasLive\) return;/);
+    expect(APP).toMatch(/if \(!seen \|\| !now \|\| seen === now\) return;/);
+  });
+
+  test("neither value is ever derived from the other", () => {
+    const section = computerSection();
+    const frontendRow = section.slice(section.indexOf('label="Frontend"'));
+    const computerRow = section.slice(section.indexOf('label="Computer"'));
+
+    // The Frontend row reads the build stamp and nothing else.
+    expect(frontendRow.slice(0, frontendRow.indexOf("/>"))).toContain("FRONTEND_VERSION");
+    // The Computer row reads the resolved server state and MUST NOT mention
+    // the build stamp — that would be the mirror bug.
+    const computerRowProps = computerRow.slice(0, computerRow.indexOf("/>"));
+    expect(computerRowProps).toContain("computerVersion");
+    expect(computerRowProps).not.toContain("FRONTEND_VERSION");
+
+    // And the resolver itself has no frontend fallback anywhere in it.
+    expect(DIAGNOSTICS.slice(
+      DIAGNOSTICS.indexOf("export function resolveComputerVersion"),
+      DIAGNOSTICS.indexOf("export function compareVersions"),
+    )).not.toContain("FRONTEND_VERSION");
+  });
+});
+
+describe("the rendered rows", () => {
+  test("both rows are present in Settings > Computer", () => {
+    const section = computerSection();
+    expect(section).toContain('label="Frontend"');
+    expect(section).toContain('label="Computer"');
+    // Rendered inside the Computer card, after the existing navigation rows.
+    expect(section.indexOf("Storage &amp; performance")).toBeLessThan(section.indexOf('label="Frontend"'));
+  });
+
+  test("a mismatch note is quiet and conditional, never always-on", () => {
+    const section = computerSection();
+    expect(section).toMatch(/\{versionNote \?/);
+    expect(section).toContain("isVersionMismatch(versionSkew)");
+  });
+
+  test("rows cannot overflow a narrow screen", () => {
+    // Desktop and mobile share this row. The label column must be allowed to
+    // shrink and truncate while the version itself never does.
+    const row = APP.slice(APP.indexOf("function VersionRow("), APP.indexOf("function SettingsView("));
+    expect(row).toContain("min-w-0");
+    expect(row).toContain("truncate");
+    expect(row).toContain("shrink-0");
+  });
+
+  test("copy is offered for real versions and withheld for states", () => {
+    const row = APP.slice(APP.indexOf("function VersionRow("), APP.indexOf("function SettingsView("));
+    // No copyValue => a plain div, no button, no clipboard write.
+    expect(row).toMatch(/if \(!copyValue\) \{/);
+    expect(row).toContain("copyMessageText(copyValue)");
+    expect(row).toMatch(/aria-label=\{`Copy \$\{label\} version/);
+  });
+
+  test("no row can leak a path, command line, or host identifier", () => {
+    const section = computerSection();
+    const rows = section.slice(section.indexOf('label="Frontend"'), section.indexOf("</section>", section.indexOf('label="Computer"')));
+    for (const banned of ["installInfo", "updateCommand", "cwd", "hostname", "bootId", "process.env"]) {
+      expect(rows, `the version rows must not surface ${banned}`).not.toContain(banned);
+    }
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,8 +30,21 @@ import {
   isPlanLimitError,
   omgAssetUrl,
   omgFetch,
+  omgTransportGeneration,
   omgUpload,
 } from "./lib/omg-client";
+import {
+  FRONTEND_VERSION,
+  formatComputerVersion,
+  formatVersion,
+  copyableVersion,
+  isVersionMismatch,
+  normalizeVersion,
+  resolveComputerVersion,
+  versionMismatchNote,
+  versionRelation,
+  type ComputerVersionState,
+} from "./lib/version-diagnostics";
 import { cacheProjectFilter, readCachedProjectFilter } from "./lib/project-filter";
 import {
   MOBILE_BOT_ROSTER_ROW_CLASS,
@@ -951,6 +964,13 @@ type SessionUsage = {
 
 type BootstrapPayload = {
   version?: string | null;
+  /**
+   * Identifies the server PROCESS, so it changes on every restart. `version`
+   * alone cannot detect a restart (two builds can share a version), and a
+   * restart is exactly when the running version changes underneath a tab that
+   * is already open — see the reconnect check that re-bootstraps on a change.
+   */
+  bootId?: string | null;
   agents?: Agent[] | null;
   codingAgents?: CodingAgentInfo[] | null;
   models?: ModelCatalogItem[] | null;
@@ -5510,7 +5530,19 @@ export function App() {
   // full-screen onboarding flow is showing. See loadCore for the gate.
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
-  const [omgVersion, setOmgVersion] = useState("unknown");
+  // What the SELECTED Computer said it is running, tagged with the transport it
+  // said it over. The tag is what makes the claim falsifiable: a host switches
+  // Computers by swapping the transport in place, without remounting this tree,
+  // so an untagged version string would silently keep describing the previous
+  // machine. null = no bootstrap has returned yet.
+  const [computerVersionReport, setComputerVersionReport] = useState<
+    { version: string | null; generation: number; bootId: string | null } | null
+  >(null);
+  // Read by the reconnect check below. A ref, not a dep: depending on the state
+  // would re-arm that effect every time a bootstrap lands, and the effect's job
+  // is to fire on a connection EDGE, not on new data.
+  const computerVersionReportRef = useRef(computerVersionReport);
+  computerVersionReportRef.current = computerVersionReport;
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loading, setLoading] = useState(true);
   // STARTUP failures only — "the app could not load its own state". Every other
@@ -5980,7 +6012,14 @@ export function App() {
         { cache: "no-store" },
       ),
     ]);
-    setOmgVersion(payload.version || "unknown");
+    // Stored raw, including absent/blank. Settings needs to tell "an older
+    // runtime that sends no version marker" apart from "we have not asked yet",
+    // and `|| "unknown"` collapsed both into one unreadable string.
+    setComputerVersionReport({
+      version: typeof payload.version === "string" ? payload.version : null,
+      generation: omgTransportGeneration(),
+      bootId: typeof payload.bootId === "string" ? payload.bootId : null,
+    });
     setOnboarding(payload.onboarding ?? null);
     // First-run gate: a brand-new install has no roster (env or stored
     // profiles), no sessions, and no completed onboarding. The flag is sticky
@@ -6769,6 +6808,38 @@ export function App() {
     onStatusRows: applyLiveStatusRows,
   });
   const liveStream = useWsLive ? wsLiveStream : sseLiveStream;
+
+  // A box that restarts under an open tab keeps serving, so nothing else here
+  // notices — but the version it runs has just changed, and Settings would go
+  // on showing the pre-restart number indefinitely. That is the worst possible
+  // direction for this row to fail: it is the exact signal people use to
+  // confirm a deploy landed (see the RUNNING_VERSION note in src/config.ts).
+  //
+  // bootId is the existing owner of "this is a different process", so a
+  // reconnect asks the cheap /api/install?ready=1 for it and re-bootstraps only
+  // when it actually changed. An ordinary network blip costs one tiny request
+  // and re-fetches nothing.
+  const liveStatus = wsLiveStream.connection?.status ?? null;
+  const wasLiveRef = useRef(false);
+  useEffect(() => {
+    if (!useWsLive) return;
+    const wasLive = wasLiveRef.current;
+    wasLiveRef.current = liveStatus === "live";
+    if (liveStatus !== "live" || wasLive) return;
+    let cancelled = false;
+    void api<{ bootId?: string | null }>("/api/install?ready=1", { cache: "no-store" })
+      .then((payload) => {
+        if (cancelled) return;
+        const seen = computerVersionReportRef.current?.bootId ?? null;
+        const now = typeof payload.bootId === "string" ? payload.bootId : null;
+        if (!seen || !now || seen === now) return;
+        void loadCore().catch(() => {});
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [useWsLive, liveStatus, loadCore]);
 
   const selectedConversationSid = selectedBotConversationId ??
     (selectedBotId ? bots.find((bot) => bot.id === selectedBotId)?.sessionId ?? null : null);
@@ -7798,7 +7869,7 @@ export function App() {
     return (
       <OnboardingFlow
         onboarding={onboarding}
-        version={omgVersion}
+        version={normalizeVersion(computerVersionReport?.version)}
         codingAgents={codingAgents}
         repos={repos}
         identity={identity}
@@ -8457,6 +8528,7 @@ export function App() {
             settings={settings}
             onSettingsChange={updateSettings}
             connection={useWsLive ? wsLiveStream.connection : null}
+            computerVersionReport={computerVersionReport}
           />
         ) : null}
         </>}
@@ -9556,7 +9628,8 @@ function OnboardingFlow({
   onDone,
 }: {
   onboarding: OnboardingState | null;
-  version: string;
+  /** Null when the box reported no usable version — the chip is dropped, not faked. */
+  version: string | null;
   codingAgents: CodingAgentInfo[];
   repos: Repo[];
   identity: string | null;
@@ -9835,9 +9908,11 @@ function OnboardingFlow({
               alt="omg"
               className="size-7 shrink-0"
             />
-            <span className="text-xs font-medium text-muted-foreground">
-              v{version}
-            </span>
+            {version ? (
+              <span className="text-xs font-medium text-muted-foreground">
+                v{version}
+              </span>
+            ) : null}
           </div>
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             {labels.map(([key, label], i) => (
@@ -23831,6 +23906,94 @@ function UserIconSettingsSection({ identityEmail }: { identityEmail: string | nu
   );
 }
 
+/**
+ * One version row in Settings > Computer.
+ *
+ * Copy is offered only when there is a real version behind it. "Unavailable"
+ * and "Disconnected" are states, not values, and putting either on someone's
+ * clipboard to paste into a bug report would be worse than offering nothing.
+ */
+function VersionRow({
+  icon,
+  iconClassName,
+  label,
+  detail,
+  value,
+  copyValue,
+}: {
+  icon: ReactNode;
+  iconClassName: string;
+  label: string;
+  detail: string;
+  value: string;
+  copyValue: string | null;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 1200);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  // min-w-0 + truncate on the label column and shrink-0 on the value keeps a
+  // long label from pushing the number off a 320px screen.
+  const body = (
+    <>
+      <div className="flex min-w-0 items-center gap-3">
+        <span
+          className={cn(
+            "flex size-7 shrink-0 items-center justify-center rounded-[7px]",
+            iconClassName,
+          )}
+        >
+          {icon}
+        </span>
+        <span className="min-w-0">
+          <span className="block text-sm font-medium">{label}</span>
+          <span className="block truncate text-xs text-muted-foreground">{detail}</span>
+        </span>
+      </div>
+      <span className="flex shrink-0 items-center gap-2">
+        <span
+          className={cn(
+            "text-sm font-semibold tabular-nums",
+            copyValue ? "font-mono" : "text-muted-foreground",
+          )}
+        >
+          {value}
+        </span>
+        {copyValue ? (
+          copied ? (
+            <Check className="size-3.5 text-success" />
+          ) : (
+            <Copy className="size-3.5 text-muted-foreground/60" />
+          )
+        ) : null}
+      </span>
+    </>
+  );
+
+  if (!copyValue) {
+    return <div className="flex items-center justify-between gap-3 px-4 py-2.5">{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={`Copy ${label} version ${copyValue}`}
+      onClick={() => {
+        void copyMessageText(copyValue)
+          .then(() => setCopied(true))
+          .catch(() => toast.error("Could not copy the version"));
+      }}
+      className="flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left transition-colors duration-150 ease-ios hover:bg-foreground/[0.03] active:bg-foreground/[0.06]"
+    >
+      {body}
+    </button>
+  );
+}
+
 function SettingsView({
   user,
   settings,
@@ -23840,6 +24003,7 @@ function SettingsView({
   onOpenStorage,
   onOpenMore,
   connection,
+  computerVersionReport,
 }: {
   user: string | null;
   settings: GlobalSettings;
@@ -23849,12 +24013,30 @@ function SettingsView({
   onOpenStorage: () => void;
   onOpenMore: () => void;
   connection: ConnectionState | null;
+  computerVersionReport: { version: string | null; generation: number } | null;
 }) {
   const initial = (user ?? "").trim().slice(0, 1).toUpperCase() || "?";
   // A host mounting this page renders the signed-in account itself — and its
   // account is the real one, where ours is only a per-device session tag. Two
   // identity blocks on one page is worse than none.
   const bare = useBareSurface();
+
+  // The two halves of "what am I actually looking at", resolved from two
+  // independent sources: FRONTEND_VERSION is stamped into this bundle at build
+  // time, and the Computer value comes only from that box's own bootstrap
+  // response. Neither falls back to the other — see version-diagnostics.ts.
+  const computerVersion = resolveComputerVersion({
+    reported: computerVersionReport?.version,
+    loaded: computerVersionReport != null,
+    connection: connection?.status ?? null,
+    // A number captured over a previous transport describes the machine we
+    // just switched away from, so it is dropped rather than relabelled.
+    stale:
+      computerVersionReport != null &&
+      computerVersionReport.generation !== omgTransportGeneration(),
+  });
+  const versionSkew = versionRelation(FRONTEND_VERSION, computerVersion);
+  const versionNote = versionMismatchNote(versionSkew);
 
   return (
     <div className="mx-auto max-w-xl space-y-8 pb-10" data-lfg-page-column>
@@ -23979,7 +24161,36 @@ function SettingsView({
             </div>
             <ChevronRight className="size-4 text-muted-foreground/60" />
           </button>
+          {/* Two independent facts, side by side, so a skew is visible without
+              reading logs: which UI build is rendering, and what the selected
+              Computer is really executing. */}
+          <VersionRow
+            icon={<Layers className="size-4" />}
+            iconClassName="bg-muted text-foreground/70"
+            label="Frontend"
+            detail="This app build"
+            value={formatVersion(FRONTEND_VERSION)}
+            copyValue={FRONTEND_VERSION ? `v${FRONTEND_VERSION}` : null}
+          />
+          <VersionRow
+            icon={<Cpu className="size-4" />}
+            iconClassName="bg-foreground text-background"
+            label="Computer"
+            detail="Runtime on this machine"
+            value={formatComputerVersion(computerVersion)}
+            copyValue={copyableVersion(computerVersion)}
+          />
         </div>
+        {versionNote ? (
+          <p
+            className={cn(
+              "px-4 text-xs text-pretty",
+              isVersionMismatch(versionSkew) ? "text-warning" : "text-muted-foreground",
+            )}
+          >
+            {versionNote}
+          </p>
+        ) : null}
       </section>
 
       <AgentConcurrencySettingsSection

--- a/web/src/lib/omg-client.ts
+++ b/web/src/lib/omg-client.ts
@@ -73,6 +73,7 @@ export type OmgErrorSink = {
 };
 
 let omgErrorSinkConfig: OmgErrorSink | null = null;
+let omgTransportGenerationCounter = 0;
 
 /**
  * Installs the host-owned runtime boundary before the shared LFG application
@@ -82,9 +83,27 @@ export function configureOmgTransport(
   transport: OmgTransport,
   options: { assetBaseUrl?: string; errorSink?: OmgErrorSink } = {},
 ): void {
+  // Bump only on a genuine swap. A host re-renders this surface freely and
+  // calls us with the same transport object each time; treating that as a
+  // change would blank the version rows on every render.
+  if (transport !== omgTransport) omgTransportGenerationCounter += 1;
   omgTransport = transport;
   omgAssetBaseUrl = options.assetBaseUrl?.replace(/\/+$/, "") ?? "";
   omgErrorSinkConfig = options.errorSink ?? null;
+}
+
+/**
+ * Which transport a value was fetched over.
+ *
+ * A host switches Computers by handing us a new transport, in place — the app
+ * tree is not remounted, so state captured from the previous machine survives
+ * the switch. Anything claiming to describe "the selected Computer" has to
+ * record this counter alongside the value and discard it when the counter
+ * moves, or it will keep displaying the old box's answer under the new box's
+ * name. Settings' Computer version row is the first such reader.
+ */
+export function omgTransportGeneration(): number {
+  return omgTransportGenerationCounter;
 }
 
 export function omgErrorSink(): OmgErrorSink | null {

--- a/web/src/lib/version-diagnostics.test.ts
+++ b/web/src/lib/version-diagnostics.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareVersions,
+  copyableVersion,
+  formatComputerVersion,
+  formatVersion,
+  isVersionMismatch,
+  normalizeVersion,
+  readStampedFrontendVersion,
+  resolveComputerVersion,
+  versionMismatchNote,
+  versionRelation,
+  VERSION_DISCONNECTED_LABEL,
+  VERSION_UNAVAILABLE_LABEL,
+  type ComputerVersionState,
+} from "./version-diagnostics.ts";
+
+const reported = (version: string): ComputerVersionState => ({ state: "reported", version });
+
+describe("normalizeVersion", () => {
+  test("accepts a plain release version and tolerates a v prefix", () => {
+    expect(normalizeVersion("0.2.10")).toBe("0.2.10");
+    expect(normalizeVersion("v0.2.10")).toBe("0.2.10");
+    expect(normalizeVersion("  0.2.10  ")).toBe("0.2.10");
+  });
+
+  test("rejects the literal 'unknown' appVersion() emits when package.json is unreadable", () => {
+    // src/config.ts returns this string on a failed read. Passing it through
+    // would render "vunknown", which reads like a version instead of a failure.
+    expect(normalizeVersion("unknown")).toBeNull();
+    expect(normalizeVersion("UNKNOWN")).toBeNull();
+  });
+
+  test("rejects empty and non-string markers", () => {
+    expect(normalizeVersion("")).toBeNull();
+    expect(normalizeVersion("   ")).toBeNull();
+    expect(normalizeVersion(undefined)).toBeNull();
+    expect(normalizeVersion(null)).toBeNull();
+    expect(normalizeVersion(42)).toBeNull();
+    expect(normalizeVersion({ version: "0.2.10" })).toBeNull();
+  });
+});
+
+describe("frontend bundle version", () => {
+  test("standalone/hosted bundle reports the version its bundler stamped in", () => {
+    // bun test does not apply Vite's `define`, so the identifier is undefined
+    // here — which is exactly the unstamped case, and it must degrade to null
+    // rather than throwing a ReferenceError or inventing a number.
+    expect(readStampedFrontendVersion()).toBeNull();
+  });
+
+  test("an unstamped frontend renders Unavailable, never the Computer's number", () => {
+    expect(formatVersion(null)).toBe(VERSION_UNAVAILABLE_LABEL);
+    // The critical property: no borrowing across the two sources.
+    expect(formatVersion(null)).not.toContain("0.2.10");
+    expect(versionRelation(null, reported("0.2.10"))).toBe("unknown");
+  });
+
+  test("a stamped frontend renders its own value", () => {
+    // Simulates both shipped paths: the standalone bundle built by
+    // web/vite.config.ts and the @omg-dev/app library bundle that hosted
+    // app.omg.dev pins as a release tarball. Both stamp the ROOT version.
+    expect(formatVersion(normalizeVersion("0.2.11"))).toBe("v0.2.11");
+  });
+});
+
+describe("resolveComputerVersion", () => {
+  const base = { loaded: true, connection: "live" as const };
+
+  test("a live box that reports its version is taken at its word", () => {
+    expect(resolveComputerVersion({ ...base, reported: "0.2.10" })).toEqual(reported("0.2.10"));
+  });
+
+  test("missing server marker (older runtime) is 'unreported', not a guess", () => {
+    // An LFG old enough to predate the bootstrap `version` field. The row must
+    // say Unavailable rather than borrowing the frontend's number.
+    expect(resolveComputerVersion({ ...base, reported: undefined })).toEqual({ state: "unreported" });
+    expect(resolveComputerVersion({ ...base, reported: "" })).toEqual({ state: "unreported" });
+    expect(resolveComputerVersion({ ...base, reported: "unknown" })).toEqual({ state: "unreported" });
+    expect(formatComputerVersion({ state: "unreported" })).toBe(VERSION_UNAVAILABLE_LABEL);
+  });
+
+  test("an offline Computer reports Disconnected even though we still hold its last number", () => {
+    // "What is it running right now" is not answerable while it is unreachable.
+    const state = resolveComputerVersion({ ...base, reported: "0.2.10", connection: "offline" });
+    expect(state).toEqual({ state: "disconnected" });
+    expect(formatComputerVersion(state)).toBe(VERSION_DISCONNECTED_LABEL);
+  });
+
+  test("offline outranks staleness and missing markers alike", () => {
+    expect(resolveComputerVersion({ reported: undefined, loaded: false, connection: "offline" }))
+      .toEqual({ state: "disconnected" });
+    expect(resolveComputerVersion({ reported: "0.2.9", loaded: true, connection: "offline", stale: true }))
+      .toEqual({ state: "disconnected" });
+  });
+
+  test("a stale cached response from the previously selected Computer is discarded", () => {
+    // The host swaps the transport in place to switch machines, so this value
+    // belongs to the box we just left. Showing it under the new box's name
+    // would be a straight lie, so it drops back to loading.
+    const state = resolveComputerVersion({ ...base, reported: "0.1.99", stale: true });
+    expect(state).toEqual({ state: "loading" });
+    expect(formatComputerVersion(state)).toBe(VERSION_UNAVAILABLE_LABEL);
+    expect(copyableVersion(state)).toBeNull();
+  });
+
+  test("before the first bootstrap returns there is no claim to make", () => {
+    expect(resolveComputerVersion({ reported: undefined, loaded: false, connection: null }))
+      .toEqual({ state: "loading" });
+  });
+
+  test("a reconnecting socket keeps the version that box actually reported", () => {
+    // The socket dropping does not change what the runtime is executing, and
+    // we do hold a genuine response from this same machine.
+    expect(resolveComputerVersion({ ...base, reported: "0.2.10", connection: "reconnecting" }))
+      .toEqual(reported("0.2.10"));
+  });
+});
+
+describe("compareVersions", () => {
+  test("orders release versions numerically, not lexically", () => {
+    // The lexical trap: "0.2.9" > "0.2.10" as strings.
+    expect(compareVersions("0.2.9", "0.2.10")).toBe(-1);
+    expect(compareVersions("0.2.10", "0.2.9")).toBe(1);
+    expect(compareVersions("0.2.10", "0.2.10")).toBe(0);
+    expect(compareVersions("1.0.0", "0.99.99")).toBe(1);
+  });
+
+  test("unparsable versions compare to null rather than to an accidental order", () => {
+    expect(compareVersions("main", "0.2.10")).toBeNull();
+    expect(compareVersions("0.2", "0.2.10")).toBeNull();
+  });
+
+  test("equal cores with different prerelease suffixes are not the same build", () => {
+    expect(compareVersions("0.2.10-rc.1", "0.2.10")).toBeNull();
+  });
+});
+
+describe("versionRelation", () => {
+  test("matching versions", () => {
+    const relation = versionRelation("0.2.10", reported("0.2.10"));
+    expect(relation).toBe("match");
+    expect(isVersionMismatch(relation)).toBe(false);
+    expect(versionMismatchNote(relation)).toBeNull();
+  });
+
+  test("mismatch: the Computer is behind the app", () => {
+    const relation = versionRelation("0.2.11", reported("0.2.10"));
+    expect(relation).toBe("computer-older");
+    expect(isVersionMismatch(relation)).toBe(true);
+    expect(versionMismatchNote(relation)).toContain("older");
+  });
+
+  test("mismatch: the Computer is ahead of the app", () => {
+    const relation = versionRelation("0.2.10", reported("0.2.11"));
+    expect(relation).toBe("computer-newer");
+    expect(isVersionMismatch(relation)).toBe(true);
+    expect(versionMismatchNote(relation)).toContain("newer");
+  });
+
+  test("a 9-to-10 skew is reported by number, not by string order", () => {
+    expect(versionRelation("0.2.10", reported("0.2.9"))).toBe("computer-older");
+  });
+
+  test("unorderable disagreement still reads as a difference", () => {
+    const relation = versionRelation("0.2.10", reported("0.2.10-rc.1"));
+    expect(relation).toBe("differs");
+    expect(isVersionMismatch(relation)).toBe(true);
+  });
+
+  test("missing data is never presented as agreement", () => {
+    // Each of these once had a tempting "just show the version we know" fix.
+    // All of them must stay 'unknown', and none may count as a mismatch.
+    for (const state of [
+      { state: "loading" },
+      { state: "disconnected" },
+      { state: "unreported" },
+    ] satisfies ComputerVersionState[]) {
+      expect(versionRelation("0.2.10", state)).toBe("unknown");
+      expect(isVersionMismatch(versionRelation("0.2.10", state))).toBe(false);
+      expect(versionMismatchNote(versionRelation("0.2.10", state))).toBeNull();
+    }
+    expect(versionRelation(null, reported("0.2.10"))).toBe("unknown");
+    expect(versionRelation(null, { state: "unreported" })).toBe("unknown");
+  });
+});
+
+describe("copy affordance", () => {
+  test("only a real reported version is copyable", () => {
+    expect(copyableVersion(reported("0.2.10"))).toBe("v0.2.10");
+  });
+
+  test("states are never put on the clipboard", () => {
+    // Pasting "Unavailable" into a bug report is worse than pasting nothing.
+    expect(copyableVersion({ state: "loading" })).toBeNull();
+    expect(copyableVersion({ state: "disconnected" })).toBeNull();
+    expect(copyableVersion({ state: "unreported" })).toBeNull();
+  });
+});
+
+describe("rendered labels", () => {
+  test("the happy path reads as the task specified", () => {
+    expect(formatVersion("0.2.10")).toBe("v0.2.10");
+    expect(formatComputerVersion(reported("0.2.10"))).toBe("v0.2.10");
+  });
+
+  test("no label leaks a path, host identifier, or command line", () => {
+    const labels = [
+      formatVersion(null),
+      formatVersion("0.2.10"),
+      formatComputerVersion({ state: "loading" }),
+      formatComputerVersion({ state: "disconnected" }),
+      formatComputerVersion({ state: "unreported" }),
+      formatComputerVersion(reported("0.2.10")),
+      ...(["computer-older", "computer-newer", "differs", "match", "unknown"] as const)
+        .map((relation) => versionMismatchNote(relation) ?? ""),
+    ];
+    for (const label of labels) {
+      expect(label).not.toMatch(/\//);
+      expect(label).not.toMatch(/git |bun |npm |curl /);
+      expect(label).not.toMatch(/localhost|127\.0\.0\.1|\.tail[0-9a-z]+\.ts\.net/);
+    }
+  });
+});

--- a/web/src/lib/version-diagnostics.ts
+++ b/web/src/lib/version-diagnostics.ts
@@ -1,0 +1,186 @@
+/**
+ * Version diagnostics for Settings > Computer: what UI bundle is rendering,
+ * and what runtime the selected Computer is actually executing.
+ *
+ * Kept as pure functions so every honest-but-awkward state (older runtime that
+ * reports no version, offline box, a cached number that belongs to the machine
+ * you just switched away from) is testable without mounting Settings.
+ *
+ * THE ONE RULE: the two numbers come from two independent sources and must
+ * never be derived from each other. The frontend value is stamped into this
+ * bundle at build time; the Computer value only ever comes from a real response
+ * from that Computer. Defaulting either to the other would turn this screen —
+ * whose entire job is to reveal a skew — into a mirror that always agrees.
+ */
+
+/**
+ * Build-time stamp, injected by `define` in web/vite.config.ts (standalone
+ * bundle) and web/vite.lib.config.ts (the @omg-dev/app library bundle the
+ * hosted app.omg.dev pins as a release tarball).
+ *
+ * Both configs read the ROOT package.json, not web/package.json. That is
+ * deliberate: scripts/pack-packages.sh rewrites every published manifest's
+ * version to the root version at pack time ("versioned in lockstep off the root
+ * package.json"), so the root number is what a released @omg-dev/app tarball
+ * actually ships as. web/package.json's own version is never published and
+ * drifts freely — stamping it would print a number that matches nothing.
+ */
+declare const __OMG_FRONTEND_VERSION__: string | undefined;
+
+/**
+ * A version we are willing to show, or null.
+ *
+ * `"unknown"` is rejected on purpose rather than passed through: that is the
+ * literal string src/config.ts's appVersion() returns when it cannot read
+ * package.json, and rendering "vunknown" would look like a version rather than
+ * like the failure it is.
+ */
+export function normalizeVersion(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/^v/i, "");
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase() === "unknown") return null;
+  return trimmed;
+}
+
+/**
+ * The version of the bundle currently executing, or null when this bundle was
+ * built by something that did not stamp it (a bare `tsc`, a test run, or a
+ * downstream bundler that re-built our source without the define).
+ *
+ * Returning null rather than guessing is the point: an unstamped bundle must
+ * read "Unavailable", not borrow the Computer's number.
+ */
+export function readStampedFrontendVersion(): string | null {
+  // `typeof` on a never-declared identifier is safe (no ReferenceError), which
+  // is what makes this survive a host bundler that skips the define entirely.
+  return typeof __OMG_FRONTEND_VERSION__ === "string"
+    ? normalizeVersion(__OMG_FRONTEND_VERSION__)
+    : null;
+}
+
+export const FRONTEND_VERSION: string | null = readStampedFrontendVersion();
+
+/** What we can honestly say about the selected Computer's runtime version. */
+export type ComputerVersionState =
+  /** No usable response from this Computer yet. */
+  | { state: "loading" }
+  /** The box is not reachable, so no claim about what it runs is defensible. */
+  | { state: "disconnected" }
+  /** It answered, but sent no version marker (an older runtime). */
+  | { state: "unreported" }
+  /** It told us, in its own response, what it is running. */
+  | { state: "reported"; version: string };
+
+export type ComputerVersionInput = {
+  /** `version` from the most recent /api/bootstrap of the selected Computer. */
+  reported: unknown;
+  /** False until a bootstrap for the selected Computer has actually returned. */
+  loaded: boolean;
+  /** Live socket state, or null when it has not been established yet. */
+  connection: "live" | "connecting" | "reconnecting" | "offline" | null;
+  /**
+   * True when `reported` was captured against a DIFFERENT transport than the
+   * one now selected — i.e. the host switched Computers and this number
+   * describes the previous machine. Showing it would be a straight lie, so it
+   * is discarded rather than aged out.
+   */
+  stale?: boolean;
+};
+
+export function resolveComputerVersion(input: ComputerVersionInput): ComputerVersionState {
+  // Offline outranks a cached value. We may well still hold the last number
+  // that box reported, but "what is it running right now" is not answerable
+  // while it is unreachable, and this row exists to be trusted.
+  if (input.connection === "offline") return { state: "disconnected" };
+  // A number belonging to the machine we just switched away from is worse than
+  // no number, so it never survives into a render.
+  if (input.stale) return { state: "loading" };
+  if (!input.loaded) return { state: "loading" };
+  const version = normalizeVersion(input.reported);
+  return version ? { state: "reported", version } : { state: "unreported" };
+}
+
+/** Numeric release ordering, or null when either side is not `x.y.z`. */
+export function compareVersions(a: string, b: string): number | null {
+  const parse = (value: string): number[] | null => {
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value.trim());
+    return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+  };
+  const left = parse(a);
+  const right = parse(b);
+  if (!left || !right) return null;
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i]! !== right[i]!) return left[i]! < right[i]! ? -1 : 1;
+  }
+  // Equal cores with different suffixes (0.2.10 vs 0.2.10-rc.1) are NOT the
+  // same build, so they must not report as a match.
+  return a.trim() === b.trim() ? 0 : null;
+}
+
+export type VersionRelation =
+  /** Not enough information to compare — never rendered as agreement. */
+  | "unknown"
+  | "match"
+  | "computer-older"
+  | "computer-newer"
+  /** They differ, but not in an orderable way. */
+  | "differs";
+
+export function versionRelation(
+  frontend: string | null,
+  computer: ComputerVersionState,
+): VersionRelation {
+  if (!frontend) return "unknown";
+  if (computer.state !== "reported") return "unknown";
+  if (frontend === computer.version) return "match";
+  const order = compareVersions(computer.version, frontend);
+  if (order === null) return "differs";
+  if (order === 0) return "match";
+  return order < 0 ? "computer-older" : "computer-newer";
+}
+
+export const VERSION_UNAVAILABLE_LABEL = "Unavailable";
+export const VERSION_DISCONNECTED_LABEL = "Disconnected";
+
+/** `v0.2.10`, or an honest word when there is no version to show. */
+export function formatVersion(version: string | null): string {
+  return version ? `v${version}` : VERSION_UNAVAILABLE_LABEL;
+}
+
+export function formatComputerVersion(state: ComputerVersionState): string {
+  switch (state.state) {
+    case "reported":
+      return `v${state.version}`;
+    case "disconnected":
+      return VERSION_DISCONNECTED_LABEL;
+    case "loading":
+    case "unreported":
+      return VERSION_UNAVAILABLE_LABEL;
+  }
+}
+
+/** Only a real, orderable skew is worth a sentence. Silence otherwise. */
+export function versionMismatchNote(relation: VersionRelation): string | null {
+  switch (relation) {
+    case "computer-older":
+      return "This Computer runs an older omg.dev than this app. Update the Computer to match.";
+    case "computer-newer":
+      return "This Computer runs a newer omg.dev than this app. Reload to pick up the latest app.";
+    case "differs":
+      return "This app and this Computer are on different omg.dev builds.";
+    case "match":
+    case "unknown":
+      return null;
+  }
+}
+
+/** True only for a genuine, known disagreement — never for missing data. */
+export function isVersionMismatch(relation: VersionRelation): boolean {
+  return relation === "computer-older" || relation === "computer-newer" || relation === "differs";
+}
+
+/** The value the copy affordance should put on the clipboard, or null. */
+export function copyableVersion(state: ComputerVersionState): string | null {
+  return state.state === "reported" ? `v${state.version}` : null;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -91,8 +91,24 @@ function precompressAssets(): Plugin {
 const API_TARGET = process.env.LFG_API_TARGET ?? "http://localhost:8766";
 const BUILD_SOURCEMAP = process.env.LFG_WEB_SOURCEMAP === "0" ? false : "hidden";
 
+// The version Settings shows as "Frontend". Read from the ROOT package.json,
+// never from web/package.json: scripts/pack-packages.sh rewrites every
+// published manifest to the root version at pack time, so the root number is
+// what a released bundle actually ships as. web/package.json's own version is
+// never published and has drifted (0.1.366 against a 0.2.x root).
+//
+// Read here, at config load, so the stamp is the version of the tree being
+// built. The release workflow builds from the tag checkout, which is exactly
+// when root package.json already holds the release version.
+const ROOT_VERSION: string = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf8"),
+).version;
+
 export default defineConfig({
   plugins: [react(), tailwindcss(), stampServiceWorkerVersion(), precompressAssets()],
+  define: {
+    __OMG_FRONTEND_VERSION__: JSON.stringify(ROOT_VERSION),
+  },
   // Emit source maps so the auto-fix agent can map a minified production stack
   // frame back to the original source in web/src. "hidden" keeps the .map files
   // out of the served bundle's sourceMappingURL (no end-user devtools exposure),

--- a/web/vite.lib.config.ts
+++ b/web/vite.lib.config.ts
@@ -9,6 +9,16 @@ import prefixSelector from "postcss-prefix-selector";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// The version Settings shows as "Frontend" on a HOSTED surface. app.omg.dev
+// pins this package as a release tarball, and pack-packages.sh stamps that
+// tarball's manifest with the root version — so reading the root package.json
+// here makes the number the bundle reports identical to the number the pin
+// resolves to. Without this define the hosted surface would have no honest way
+// to name its own build. See web/src/lib/version-diagnostics.ts.
+const ROOT_VERSION: string = JSON.parse(
+  fs.readFileSync(path.resolve(dirname, "../package.json"), "utf8"),
+).version;
+
 const HOST_SHARED_EXTERNALS = [
   "react",
   "react-dom",
@@ -108,6 +118,9 @@ export default defineConfig({
     tailwindcss(),
     ...(process.env.ANALYZE === "1" ? [moduleReportPlugin()] : []),
   ],
+  define: {
+    __OMG_FRONTEND_VERSION__: JSON.stringify(ROOT_VERSION),
+  },
   css: {
     postcss: {
       plugins: [


### PR DESCRIPTION
Settings > Computer now answers "is the UI I am looking at the same build as the runtime I am talking to" without reading logs.

Two rows, each copyable:

```
Frontend   This app build              v0.2.11
Computer   Runtime on this machine     v0.2.11
```

with a quiet line underneath when they disagree.

## The rule

The two numbers come from two independent sources and neither falls back to the other. Letting one default to the other would turn this screen into a mirror that always agrees, which is worse than not having it, because it looks like evidence.

**Frontend** is stamped at build time by a new `__OMG_FRONTEND_VERSION__` define in **both** `web/vite.config.ts` (standalone) and `web/vite.lib.config.ts` (the `@omg-dev/app` library bundle hosted app.omg.dev pins as a release tarball). Both read the **root** `package.json`, because `scripts/pack-packages.sh` rewrites every published manifest to the root version at pack time. `web/package.json`'s own version is never published and has already drifted to `0.1.366` against a `0.2.x` root, so stamping it would print a number that matches nothing. Verified in the built artifact: the lib bundle compiles to `function Jh(){return Nl("0.2.10")}`.

**Computer** comes only from that box's own `/api/bootstrap`. It is modelled as `loading | disconnected | unreported | reported`, so an older runtime that sends no marker, an unreachable box, and "not asked yet" stay distinguishable. The previous `payload.version || "unknown"` collapsed all of them and rendered the word "unknown" as if it were a version.

## Two staleness holes found and closed

Both would have made the row lie in the exact situation it exists for.

- **Switching Computers.** A host swaps the transport in place without remounting the tree, so a captured version silently kept describing the machine you just left. Values are now tagged with `omgTransportGeneration()` and dropped when it moves.
- **Restart under an open tab.** The pre-restart version stayed on screen indefinitely — the one moment the number must be right. `bootId` already identifies the process, so a reconnect edge asks the cheap `/api/install?ready=1` and re-bootstraps only when it actually changed.

## Verification

Focused tests: 45 passing across the new `version-diagnostics` suite plus the existing `bootstrap-payload` / `app-version-pin` contracts. Root + web typecheck clean. `build:packages`, standalone web build, and `bun run audit` all clean. Full suite: 1941 pass, 1 pre-existing failure (`bot-unread-wiring`, fails identically on untouched `origin/main`).

Browser acceptance with ego-browser against a real `serve` on loopback:

- Both rows render at desktop and at **390px** with no overflow — page `scrollWidth` 390 of 390, rows inset 9..381.
- Killing the box drove Computer to **`Disconnected`** while Frontend held its stamped `v0.2.10`. That is the proof the two sources are independent.
- A real `0.2.10` / `0.2.11` skew produced **"This Computer runs a newer omg.dev than this app."** in `text-warning`.
- Restarting the box onto a different version **self-corrected the row with no page reload**, and the note cleared.

Self-hosted is unaffected (bootstrap `computer` stays null there). No row can surface a path, command line, or host identifier; a test asserts that.

This branch also carries the `v0.2.11` CHANGELOG entry, which covers the shared-Computer bot visibility fix from #179 as well, so one release note describes the whole tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)