### PR TITLE
Fix first-run so new users get the control plane, not vibes 0.4.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,11 @@ jobs:
           REG="https://registry.npmjs.org/"
           # Job-local userconfig, never the shared ~/.npmrc: the private-registry
           # step above owns that file, and this token must not end up as the
-          # default credential for every later command. Mirrors the same pattern
-          # in BennyKok/vibes, which publishes @omg-dev/cli into this scope.
+          # default credential for every later command.
+          #
+          # This repository now publishes @omg-dev/cli 0.5.0+ (the control-plane
+          # bootstrapper). BennyKok/vibes used to publish 0.4.x — the retired
+          # prompt-to-app CLI — into the same name. Do not publish 0.4.x again.
           NPMRC="$RUNNER_TEMP/.npmrc.publish"
           printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_PUBLISH_TOKEN" > "$NPMRC"
           chmod 600 "$NPMRC"
@@ -115,7 +118,7 @@ jobs:
           # first, whose pinned dependency on protocol does not exist on the
           # registry yet. npm does not validate that at publish time, so the
           # result is a window where a published package cannot be installed.
-          for pkg in protocol client react app; do
+          for pkg in protocol client react app cli; do
             # "./" is load-bearing. `npm publish dist/omg-dev-protocol-1.0.0.tgz`
             # parses as the GitHub shorthand <owner>/<repo> — npm resolves it to
             # ssh://git@github.com/dist/omg-dev-protocol-1.0.0.tgz.git and fails
@@ -180,6 +183,7 @@ jobs:
             dist/omg-dev-client-*.tgz
             dist/omg-dev-react-*.tgz
             dist/omg-dev-app-*.tgz
+            dist/omg-dev-cli-*.tgz
           fail_on_unmatched_files: true
           generate_release_notes: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - First-run installs the local control plane (v0.2.12)
+
+- **The documented install no longer goes through the retired `@omg-dev/cli`
+  0.4.x line.** That package is published from `BennyKok/vibes` and is the old
+  prompt-to-app CLI (`create` / `deploy` to `*.omgs.app`). A new user who
+  followed the previous README got that CLI, and often two `omg` binaries.
+  The README first command is now this repository's `scripts/setup.sh`. After
+  setup, open http://localhost:8766.
+- **This repository now owns `@omg-dev/cli` starting at 0.5.0.** That version
+  is required because 0.4.42 is already `latest` on npm; publishing 0.2.x would
+  not replace it. The new package only installs and forwards to the local
+  control plane. It rejects `create` / `deploy`. `lfg` stays a compatibility
+  alias. A release after this change must publish 0.5.0, and `BennyKok/vibes`
+  must stop publishing 0.4.x onto the same name.
+- **Hosted one-click points at `/sandbox/templates/omg` and `omg serve`.**
+  `lfg` remains a compatibility alias for the same product.
+
 ## August 20, 2026 - See which versions you are actually running (v0.2.11)
 
 - **Settings shows the app build and the Computer's runtime side by side.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ cd web && bun run build       # typecheck + build the UI (commit web/dist)
 
 Drop a `name.md` in `agents/` with YAML frontmatter (`name`, `title`,
 `schedule`, `enabled`, `inputs`) and a prompt body. See the existing examples and
-`lfg agents --help`.
+`omg agents --help`. `lfg` remains a compatibility alias.
 
 ## House rules
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/BennyKok/omg.dev?style=flat)](https://github.com/BennyKok/omg.dev/stargazers)
-[![npm](https://img.shields.io/npm/v/@omg-dev/cli?label=%40omg-dev%2Fcli)](https://www.npmjs.com/package/@omg-dev/cli)
+[![GitHub release](https://img.shields.io/github/v/release/BennyKok/omg.dev?label=release)](https://github.com/BennyKok/omg.dev/releases)
 [![Discord](https://img.shields.io/badge/Discord-join%20the%20community-5865F2?logo=discord&logoColor=white)](https://omg.dev/discord)
 
 [Quick start](#quick-start) · [Join the Discord](https://omg.dev/discord) · [Why omg.dev](#why-omgdev) · [Agents](#connect-a-coding-agent) · [Remote access](#reach-it-from-your-phone) · [Security](#security)
@@ -40,23 +40,25 @@ authenticate. It does not resell tokens and has no model of its own.
 
 ## Quick start
 
-The `omg` CLI is the supported way to install and manage omg.dev. Use whichever
-package manager you already have:
+The supported install is this repository's installer. It puts one `omg`
+command on your `PATH` — the local control plane — and starts it for you:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BennyKok/omg.dev/main/scripts/setup.sh | bash
+```
+
+Then open **http://localhost:8766**.
+
+Do not install the npm package `@omg-dev/cli` at 0.4.x. That line is the
+retired prompt-to-app CLI published from `BennyKok/vibes` (`create` / `deploy`
+to `*.omgs.app`). This repository publishes the control-plane bootstrapper as
+`@omg-dev/cli` 0.5.0+. After that version is on npm, this is the same install:
 
 ```bash
 bun install --global @omg-dev/cli && omg computer setup
 ```
 
-```bash
-npm install --global @omg-dev/cli && omg computer setup
-```
-
-> The published CLI is currently shebanged `#!/usr/bin/env bun`, so an `npm`
-> install still needs `bun` on your `PATH` to run. The `bun` line above always
-> works; if you install with `npm` and see
-> `env: bun: No such file or directory`, install [Bun](https://bun.sh) and retry.
-
-Then open **http://localhost:8766**.
+`lfg` remains a compatibility alias for the same command.
 
 No omg.dev account is needed for this — `omg computer setup` provisions a purely
 local install. The CLI installs Bun, `tmux`, and `git`, fetches the latest
@@ -201,13 +203,14 @@ OMG_RELAY_URL=wss://your-relay.example/connect omg connect ABC123   # outbound o
 ```
 
 No relay ships with omg.dev itself; the protocol is generic and any operator can
-implement it. [omg.dev](https://omg.dev) runs one, and the CLI configures the
-pairing for you:
+implement it. Pair with a one-time code from the relay operator:
 
 ```bash
-omg login
-omg connect        # installs omg.dev if needed, then pairs and connects
+OMG_RELAY_URL=wss://your-relay.example/connect omg connect ABC123
 ```
+
+The hosted `omg login && omg connect` convenience path is owned by
+`BennyKok/vibes`. It is not this repository's first-run command.
 
 Full comparison, the pairing flow, and opt-in session lifecycle events:
 **[docs/remote-access.md](./docs/remote-access.md)**.
@@ -226,7 +229,7 @@ privately through Tailscale.
 
 ## Don't want to run a box?
 
-[![Deploy on omg.dev](https://omg.dev/deploy-badge.svg?v=2)](https://omg.dev/sandbox/templates/lfg)
+[![Deploy on omg.dev](https://omg.dev/deploy-badge.svg?v=2)](https://omg.dev/sandbox/templates/omg)
 
 [omg.dev](https://omg.dev) is the hosted version, run by the same author — a
 cloud machine with omg.dev already running, so there's nothing to install and no
@@ -240,7 +243,9 @@ hibernate when idle and wake on the same URL.
 > repos and authenticated CLIs already on your machine — that is what omg.dev is
 > for. Use omg.dev to try it in seconds, or when you would rather not run a box
 > at all. A fresh hosted workspace has no agent CLIs signed in, and agents work
-> on repos you clone *into* it. More detail in [deploy/omg](./deploy/omg/README.md).
+> on repos you clone *into* it. The live start command is `omg serve`.
+> `lfg serve` remains a compatibility alias. More detail in
+> [deploy/omg](./deploy/omg/README.md).
 
 ## Managing an install
 
@@ -310,7 +315,8 @@ agent installed, or none signed in.
 ## MCP tools
 
 `omg mcp` talks to the local `omg serve` API and exposes omg.dev's session tools to
-any MCP client. Prefer omg.dev's own subagent tools over a client's generic "spawn
+any MCP client. These tools drive local coding-agent sessions. They do not create
+or deploy apps. Prefer omg.dev's own subagent tools over a client's generic "spawn
 agent" helper so children stay visible in the UI, inherit parent and user
 context, and can run on any configured harness.
 
@@ -414,9 +420,10 @@ locally the old way.
 
 ## Embedding omg.dev in your own product
 
-Every release publishes `@omg-dev/protocol`, `@omg-dev/client`, `@omg-dev/react`,
-and `@omg-dev/app` to npm — the last being the exact full application the
-standalone web UI runs. React hosts mount it with their own transport and asset
+Every release publishes `@omg-dev/cli`, `@omg-dev/protocol`, `@omg-dev/client`,
+`@omg-dev/react`, and `@omg-dev/app` to npm — the last being the exact full
+application the standalone web UI runs. `@omg-dev/cli` 0.5.0+ is the
+control-plane bootstrapper. Do not install 0.4.x. React hosts mount it with their own transport and asset
 origin:
 
 ```bash
@@ -430,8 +437,9 @@ See **[docs/embedding.md](./docs/embedding.md)**.
 ```text
 src/                 CLI, server, sessions, tmux, agents, MCP, integrations
 web/                 React/Vite PWA
+packages/cli         @omg-dev/cli 0.5.0+ control-plane bootstrapper
 agents/              Example markdown-defined insight agents
-scripts/setup.sh     Installer / provisioning
+scripts/setup.sh     Installer / provisioning (documented first-run)
 scripts/             Release, fleet, and smoke helpers
 scripts-internal/    Operator-only helpers (gitignored — see CONTRIBUTING.md)
 deploy/              Cloud, voice, STT, and ops deployments

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,13 @@
         "typescript": "^7.0.0",
       },
     },
+    "packages/cli": {
+      "name": "@omg-dev/cli",
+      "version": "0.5.0",
+      "bin": {
+        "omg": "./dist/omg.mjs",
+      },
+    },
     "packages/client": {
       "name": "@omg-dev/client",
       "version": "0.1.84",
@@ -520,6 +527,8 @@
     "@number-flow/react": ["@number-flow/react@0.6.2", "", { "dependencies": { "esm-env": "^1.1.4", "number-flow": "0.6.2" }, "peerDependencies": { "react": "^18 || ^19", "react-dom": "^18 || ^19" } }, "sha512-WjZuV4aA+vhRCgCF+adGLgFVVAJ8vdvq6EchRT2FiBIgElTXtDOA3YgkcMr9UHpvpS9v4H70AB5wZv0D9jc3QA=="],
 
     "@omg-dev/app": ["@omg-dev/app@workspace:web"],
+
+    "@omg-dev/cli": ["@omg-dev/cli@workspace:packages/cli"],
 
     "@omg-dev/client": ["@omg-dev/client@workspace:packages/client"],
 

--- a/deploy/omg/README.md
+++ b/deploy/omg/README.md
@@ -1,16 +1,18 @@
 # OMG
 
-omg.dev is the one-click hosted workspace path for OMG.
+omg.dev is the one-click hosted workspace path for the local agent control plane.
 
-[![Deploy on omg](https://omg.dev/deploy-badge.svg?v=2)](https://omg.dev/sandbox/templates/lfg)
+[![Deploy on omg](https://omg.dev/deploy-badge.svg?v=2)](https://omg.dev/sandbox/templates/omg)
 
 ## Flow
 
-1. Open `https://omg.dev/sandbox/templates/lfg`.
+1. Open `https://omg.dev/sandbox/templates/omg`.
 2. Sign in to OMG if prompted.
-3. OMG creates a sandbox from the prebuilt `templateId: "lfg"` template on port
-   `8766`.
-4. The control plane starts `lfg serve --host 0.0.0.0 --port 8766`.
+3. OMG creates a sandbox from the prebuilt `templateId: "omg"` template on port
+   `8766`. The older `templateId: "lfg"` route is a compatibility alias for the
+   same product.
+4. The control plane starts `omg serve --host 0.0.0.0 --port 8766`.
+   `lfg serve` remains a compatibility alias for the same command.
 5. The browser redirects to the sandbox public URL.
 
 The route is server-side. The infra service token is never sent to the browser.
@@ -20,12 +22,14 @@ are still being designed.
 ## First-run Agent Setup
 
 The workspace is intentionally fresh. In OMG, open **Settings → Coding agents**
-to check Claude, Codex, OpenCode, Hermes, and Grok setup. The screen reports the
+to check Claude, Codex, OpenCode, Jcode, and Grok setup. The screen reports the
 installed binary path, auth state, and setup action where automatic install is
 supported.
 
 For Claude or Codex, complete the normal CLI login inside the workspace, or set
 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` if you want API-key based operation.
+
+You bring your own agent accounts. omg.dev does not resell tokens.
 
 ## E2E Contract
 
@@ -33,10 +37,14 @@ The OMG side owns the launch route and template lifecycle:
 
 - Route: `https://omg.dev/sandbox/templates/<template-id>`
 - OMG repo URL: `https://github.com/BennyKok/omg.dev`
-- Template: `lfg`
+- Template: `omg` (live). `lfg` is a compatibility alias.
 - Port: `8766`
-- Start command: `lfg serve --host 0.0.0.0 --port 8766`
+- Start command: `omg serve --host 0.0.0.0 --port 8766`
 
 The underlying lifecycle test in the OMG repo creates the sandbox from
-`templateId: "lfg"`, resolves the `8766` public URL, hibernates it, wakes it with
+`templateId: "omg"`, resolves the `8766` public URL, hibernates it, wakes it with
 readiness port `8766`, and verifies the URL still reaches OMG.
+
+The hosted template definition lives in `BennyKok/vibes`
+(`templates/agent-lfg` today). A vibes follow-up should make `omg serve` the
+live start command and keep `lfg serve` only as an alias.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -50,9 +50,11 @@ mints a short-lived pairing code for the authenticated account, and invokes
 saved OMG binding. Use `omg connect --new` only when you intentionally want a
 fresh binding, or `--no-install` to require an existing OMG install.
 
-Install the command with `npm install --global @omg-dev/cli` (or
-`bun add --global @omg-dev/cli`). This convenience wrapper is operator-specific;
-the OMG command and wire protocol below remain provider-agnostic.
+The hosted `omg login && omg connect` convenience wrapper is owned by
+`BennyKok/vibes`. Do not install `@omg-dev/cli` 0.4.x for that path — that
+package is the retired prompt-to-app CLI. This repository's `@omg-dev/cli`
+0.5.0+ installs the local control plane only. The `omg connect <code>` command
+and the wire protocol below remain provider-agnostic.
 
 ### Custom relay
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,49 @@
+# `@omg-dev/cli`
+
+Install and manage the local omg.dev agent control plane.
+
+This package is the control-plane bootstrapper published from
+[BennyKok/omg.dev](https://github.com/BennyKok/omg.dev). It is not the retired
+prompt-to-app CLI that deployed apps to `*.omgs.app`.
+
+Versions `0.4.x` on this name were published from `BennyKok/vibes`. This line
+starts at `0.5.0` so `npm install --global @omg-dev/cli` resolves to the current
+product.
+
+## Install
+
+```bash
+bun install --global @omg-dev/cli && omg computer setup
+```
+
+Then open **http://localhost:8766**.
+
+The same install without npm:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BennyKok/omg.dev/main/scripts/setup.sh | bash
+```
+
+You bring your own agent accounts. omg.dev does not resell tokens.
+
+`lfg` remains a compatibility alias for the installed control plane.
+
+## Commands
+
+| Command | Does |
+| --- | --- |
+| `omg computer setup [--reinstall]` | Install the local control plane. No account needed. |
+| `omg computer update` | Update an existing install. |
+| `omg computer uninstall [--purge --yes]` | Remove the install. Keeps data unless purged. |
+| `omg computer status` | Show this machine's install. |
+| `omg serve` | After setup, run the web UI (forwarded to the install). |
+
+Any other verb the install owns (`mcp`, `doctor`, `agents`, …) is forwarded to
+it. `create`, `deploy`, and other retired prompt-to-app commands are rejected
+here on purpose.
+
+## Versioning
+
+This package is versioned independently of the control-plane runtime. The
+runtime stays on the repository tag (`v0.2.x` today). The CLI must publish
+above `0.4.42` to become `latest` on npm.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@omg-dev/cli",
+  "version": "0.5.0",
+  "description": "Install and manage the local omg.dev agent control plane.",
+  "license": "MIT",
+  "homepage": "https://github.com/BennyKok/omg.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BennyKok/omg.dev.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/BennyKok/omg.dev/issues"
+  },
+  "type": "module",
+  "bin": {
+    "omg": "./dist/omg.mjs"
+  },
+  "exports": {
+    ".": "./dist/omg.mjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bun build src/index.ts --target=bun --outfile=dist/omg-bun.mjs && cp src/bin-shim.mjs dist/omg.mjs && chmod +x dist/omg.mjs",
+    "test": "bun test",
+    "typecheck": "bun x tsc -p tsconfig.json --noEmit"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/bin-shim.mjs
+++ b/packages/cli/src/bin-shim.mjs
@@ -1,0 +1,99 @@
+#!/bin/sh
+':' //; for omg_rt in "${OMG_BUN_PATH:-}" "${BUN_PATH:-}" "$(command -v bun || true)" "$HOME/.bun/bin/bun" "${BUN_INSTALL:-/nonexistent}/bin/bun" /opt/homebrew/bin/bun /usr/local/bin/bun "$(command -v node || true)"; do
+':' //;   [ -n "$omg_rt" ] && [ -x "$omg_rt" ] && exec "$omg_rt" "$0" "$@"
+':' //; done
+':' //; echo 'omg: this CLI runs on Bun, which was not found on this machine.' >&2
+':' //; echo '  Install Bun:   curl -fsSL https://bun.sh/install | bash' >&2
+':' //; exit 1
+/**
+ * POSIX trampoline plus JS re-exec for the published `omg` bin.
+ *
+ * The documented `bun install --global @omg-dev/cli` installs onto machines
+ * that have Bun and no Node. A `#!/usr/bin/env node` shebang then dies with
+ * `env: node: No such file or directory`. A `#!/usr/bin/env bun` shebang dies
+ * the other way on an npm-only box. `sh` is present on every platform this
+ * installer supports. `':' //;` is a no-op label in sh and a string-plus
+ * comment in JS, so this file stays a valid ES module.
+ *
+ * Finding Bun in the usual install locations matters because npm's global bin
+ * PATH often omits ~/.bun/bin.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const BUN_ENTRY = "omg-bun.mjs";
+
+export function resolveBun({
+  env = process.env,
+  exists = existsSync,
+  platform = process.platform,
+  self = typeof Bun !== "undefined" ? process.execPath : null,
+} = {}) {
+  const binary = platform === "win32" ? "bun.exe" : "bun";
+  if (self && exists(self)) return self;
+  const explicit = env.OMG_BUN_PATH || env.BUN_PATH;
+  if (explicit && exists(explicit)) return explicit;
+  for (const dir of (env.PATH || "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, binary);
+    if (exists(candidate)) return candidate;
+  }
+  const home = env.HOME || env.USERPROFILE || "";
+  const fallbacks = [
+    env.BUN_INSTALL ? join(env.BUN_INSTALL, "bin", binary) : null,
+    home ? join(home, ".bun", "bin", binary) : null,
+    "/opt/homebrew/bin/bun",
+    "/usr/local/bin/bun",
+  ].filter(Boolean);
+  for (const candidate of fallbacks) {
+    if (exists(candidate)) return candidate;
+  }
+  return null;
+}
+
+export const MISSING_BUN_MESSAGE = [
+  "omg: this CLI runs on Bun, which was not found on this machine.",
+  "",
+  "  Install Bun:   curl -fsSL https://bun.sh/install | bash",
+  "  Then re-run:   omg <command>",
+  "",
+  "Already installed? Point at it with OMG_BUN_PATH=/path/to/bun.",
+].join("\n");
+
+export function run(
+  argv,
+  { env = process.env, exists = existsSync, spawn = spawnSync, stderr = process.stderr, entryDir } = {},
+) {
+  const bun = resolveBun({ env, exists });
+  if (!bun) {
+    stderr.write(`${MISSING_BUN_MESSAGE}\n`);
+    return 1;
+  }
+  const dir = entryDir ?? dirname(fileURLToPath(import.meta.url));
+  const childEnv = {
+    ...env,
+    OMG_ORIGINAL_PATH: env.PATH ?? "",
+    PATH: `${dirname(bun)}${delimiter}${env.PATH ?? ""}`,
+  };
+  const result = spawn(bun, [join(dir, BUN_ENTRY), ...argv], { stdio: "inherit", env: childEnv });
+  if (result.signal) return 128;
+  return result.status ?? 1;
+}
+
+function invokedDirectly() {
+  const arg = process.argv[1];
+  if (!arg) return false;
+  const self = fileURLToPath(import.meta.url);
+  if (self === arg) return true;
+  try {
+    return realpathSync(self) === realpathSync(arg);
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/packages/cli/src/bin-shim.test.ts
+++ b/packages/cli/src/bin-shim.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { MISSING_BUN_MESSAGE, resolveBun, run } from "./bin-shim.mjs";
+
+describe("resolveBun", () => {
+  test("prefers the Bun already running this file", () => {
+    expect(
+      resolveBun({
+        self: "/already/running/bun",
+        exists: (path) => path === "/already/running/bun",
+        env: { PATH: "/usr/bin" },
+      }),
+    ).toBe("/already/running/bun");
+  });
+
+  test("honours OMG_BUN_PATH when the current process is not Bun", () => {
+    expect(
+      resolveBun({
+        self: null,
+        exists: (path) => path === "/custom/bun",
+        env: { OMG_BUN_PATH: "/custom/bun", PATH: "" },
+      }),
+    ).toBe("/custom/bun");
+  });
+
+  test("looks in ~/.bun/bin when PATH is empty", () => {
+    expect(
+      resolveBun({
+        self: null,
+        exists: (path) => path === "/home/x/.bun/bin/bun",
+        env: { HOME: "/home/x", PATH: "" },
+      }),
+    ).toBe("/home/x/.bun/bin/bun");
+  });
+});
+
+describe("run", () => {
+  test("prints an actionable message when Bun is missing", () => {
+    let written = "";
+    const code = run(["help"], {
+      exists: () => false,
+      env: { PATH: "" },
+      stderr: { write: (chunk: string) => (written += chunk) },
+    });
+    expect(code).toBe(1);
+    expect(written).toContain(MISSING_BUN_MESSAGE);
+  });
+
+  test("puts the located Bun on PATH for the forwarded install", () => {
+    let childPath = "";
+    run(["serve"], {
+      exists: (path) => path === "/opt/bun/bin/bun",
+      env: { PATH: "/usr/bin", OMG_BUN_PATH: "/opt/bun/bin/bun" },
+      entryDir: "/tmp/cli-dist",
+      spawn: (_cmd: string, _args: string[], options: { env?: { PATH?: string } }) => {
+        childPath = options.env?.PATH ?? "";
+        return { status: 0 };
+      },
+    });
+    expect(childPath.startsWith("/opt/bun/bin:")).toBe(true);
+  });
+});

--- a/packages/cli/src/forward.test.ts
+++ b/packages/cli/src/forward.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { findInstall, forwardToInstall } from "./forward.ts";
+
+describe("findInstall", () => {
+  test("prefers lfg on PATH so it cannot recurse into this wrapper", () => {
+    expect(
+      findInstall({
+        which: (name) => (name === "lfg" ? "/opt/lfg" : "/opt/omg"),
+        exists: () => true,
+      }),
+    ).toBe("/opt/lfg");
+  });
+
+  test("falls back to ~/.local/bin/lfg when PATH has no lfg", () => {
+    expect(
+      findInstall({
+        which: () => null,
+        exists: (path) => path === "/home/x/.local/bin/lfg",
+        homedir: () => "/home/x",
+      }),
+    ).toBe("/home/x/.local/bin/lfg");
+  });
+
+  test("returns null when nothing is installed", () => {
+    expect(
+      findInstall({
+        which: () => null,
+        exists: () => false,
+        homedir: () => "/home/x",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("forwardToInstall", () => {
+  test("spawns the install with the caller's argv", async () => {
+    const spawned: string[][] = [];
+    const result = await forwardToInstall(["mcp"], {
+      which: () => "/tmp/lfg",
+      spawn: async (argv) => {
+        spawned.push(argv);
+        return 3;
+      },
+    });
+    expect(result).toEqual({ forwarded: true, exitCode: 3, binary: "/tmp/lfg" });
+    expect(spawned).toEqual([["/tmp/lfg", "mcp"]]);
+  });
+
+  test("does not spawn when there is no install", async () => {
+    const result = await forwardToInstall(["serve"], {
+      which: () => null,
+      exists: () => false,
+      homedir: () => "/tmp/empty",
+    });
+    expect(result.forwarded).toBe(false);
+    expect(result.binary).toBeNull();
+  });
+});

--- a/packages/cli/src/forward.ts
+++ b/packages/cli/src/forward.ts
@@ -1,0 +1,47 @@
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type ForwardDependencies = {
+  which?: (name: string) => string | null;
+  exists?: (path: string) => boolean;
+  spawn?: (argv: string[]) => Promise<number>;
+  homedir?: () => string;
+};
+
+export function defaultExists(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The install always exposes `lfg`. `omg` may be this npm wrapper, so looking
+ * it up would recurse. Prefer `lfg`, then the well-known launcher path.
+ */
+export function findInstall(dependencies: ForwardDependencies = {}): string | null {
+  const which = dependencies.which ?? ((name: string) => Bun.which(name));
+  const exists = dependencies.exists ?? defaultExists;
+  const found = which("lfg");
+  if (found) return found;
+  const fallback = join((dependencies.homedir ?? homedir)(), ".local", "bin", "lfg");
+  return exists(fallback) ? fallback : null;
+}
+
+export async function forwardToInstall(
+  argv: string[],
+  dependencies: ForwardDependencies = {},
+): Promise<{ forwarded: boolean; exitCode: number; binary: string | null }> {
+  const binary = findInstall(dependencies);
+  if (!binary) return { forwarded: false, exitCode: 1, binary: null };
+  const spawn =
+    dependencies.spawn ??
+    (async (command: string[]) => {
+      const child = Bun.spawn(command, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+      return await child.exited;
+    });
+  return { forwarded: true, exitCode: await spawn([binary, ...argv]), binary };
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,50 @@
+/** Shared so the setup.sh forward probe and `omg help` cannot drift. */
+export const HELP_BANNER = "omg — run and manage your AI coding agents on your own box";
+
+export const HELP = `${HELP_BANNER}
+
+Usage:
+  omg computer setup [--reinstall]     Install the local control plane
+  omg computer status                  Show this machine's install
+  omg computer update                  Update an existing install
+  omg computer uninstall [--purge --yes]
+  omg serve                            Run the web UI (after setup)
+  omg help
+
+This command installs the local omg.dev agent control plane. It does not
+create or deploy apps to *.omgs.app.
+
+You bring your own agent accounts. omg.dev does not resell tokens.
+
+After setup, unknown commands are forwarded to the install. \`lfg\` remains
+a compatibility alias for that install.
+
+Then open http://localhost:8766.
+`;
+
+/** Retired prompt-to-app verbs that must not silently fall through. */
+export const RETIRED_APP_COMMANDS = new Set([
+  "create",
+  "deploy",
+  "dev",
+  "apps",
+  "link",
+  "visibility",
+  "login",
+  "logout",
+  "whoami",
+]);
+
+export function retiredAppMessage(command: string): string {
+  return `omg: \`${command}\` is not part of the current omg.dev product.
+
+The current product is the local agent control plane. Install it with:
+
+  omg computer setup
+
+Then open http://localhost:8766.
+
+create / deploy to *.omgs.app was the retired prompt-to-app CLI, published
+as @omg-dev/cli 0.4.x from BennyKok/vibes. That line is not this package.
+`;
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { HELP_BANNER, RETIRED_APP_COMMANDS } from "./help.ts";
+import { runCli } from "./index.ts";
+import manifest from "../package.json" with { type: "json" };
+
+function capture() {
+  const lines: string[] = [];
+  return {
+    lines,
+    output: (line: string) => {
+      lines.push(line);
+    },
+    error: (line: string) => {
+      lines.push(line);
+    },
+    text: () => lines.join("\n"),
+  };
+}
+
+describe("published version can replace the retired 0.4.x line", () => {
+  test("this package is 0.5.0 or newer so npm latest is not 0.4.42", () => {
+    const [major, minor] = String(manifest.version).split(".").map(Number);
+    expect(major * 100 + minor).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("omg help is the control plane, not the retired app CLI", () => {
+  test("help prints the probe phrase setup.sh greps for", async () => {
+    const log = capture();
+    expect(await runCli(["help"], log)).toBe(0);
+    expect(log.text()).toContain(HELP_BANNER);
+    expect(log.text()).toContain("computer setup");
+    expect(log.text()).toContain("localhost:8766");
+    expect(log.text()).not.toContain("omg create");
+    expect(log.text()).not.toContain("omg deploy");
+  });
+
+  test("the forward probe is the same help, so setup.sh can surrender omg", async () => {
+    const log = capture();
+    expect(await runCli(["__omg_forward_probe"], log)).toBe(0);
+    expect(log.text()).toContain("run and manage your AI coding agents");
+  });
+
+  test("retired prompt-to-app verbs are rejected, not forwarded", async () => {
+    for (const command of RETIRED_APP_COMMANDS) {
+      const log = capture();
+      const spawned: string[][] = [];
+      const code = await runCli([command], {
+        ...log,
+        which: () => "/tmp/lfg",
+        spawn: async (argv) => {
+          spawned.push(argv);
+          return 0;
+        },
+      });
+      expect(code, command).toBe(1);
+      expect(log.text(), command).toContain("not part of the current omg.dev product");
+      expect(spawned, command).toEqual([]);
+    }
+  });
+});
+
+describe("omg computer", () => {
+  test("setup downloads setup.sh and runs it when nothing is installed", async () => {
+    const log = capture();
+    const ran: string[][] = [];
+    let installed = false;
+    const code = await runCli(["computer", "setup"], {
+      ...log,
+      which: () => (installed ? "/tmp/home/.local/bin/lfg" : null),
+      exists: () => installed,
+      homedir: () => "/tmp/home",
+      fetchText: async () => "#!/bin/sh\necho setup\n",
+      runCommand: async (argv) => {
+        ran.push(argv);
+        installed = true;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    expect(ran[0]?.[0]).toBe("bash");
+    expect(log.text()).toContain("localhost:8766");
+  });
+
+  test("setup is a no-op when lfg is already installed", async () => {
+    const log = capture();
+    let fetched = false;
+    const code = await runCli(["computer", "setup"], {
+      ...log,
+      which: () => "/tmp/lfg",
+      fetchText: async () => {
+        fetched = true;
+        return "";
+      },
+    });
+    expect(code).toBe(0);
+    expect(fetched).toBe(false);
+    expect(log.text()).toContain("already set up");
+  });
+
+  test("update and uninstall go to the install, not to setup.sh", async () => {
+    const ran: string[][] = [];
+    const log = capture();
+    await runCli(["computer", "update"], {
+      ...log,
+      which: () => "/tmp/lfg",
+      runCommand: async (argv) => {
+        ran.push(argv);
+        return 0;
+      },
+    });
+    await runCli(["computer", "uninstall", "--purge", "--yes"], {
+      ...log,
+      which: () => "/tmp/lfg",
+      runCommand: async (argv) => {
+        ran.push(argv);
+        return 0;
+      },
+    });
+    expect(ran).toEqual([
+      ["/tmp/lfg", "setup"],
+      ["/tmp/lfg", "uninstall", "--purge", "--yes"],
+    ]);
+  });
+
+  test("serve forwards to the install", async () => {
+    const spawned: string[][] = [];
+    const code = await runCli(["serve"], {
+      which: () => "/tmp/lfg",
+      spawn: async (argv) => {
+        spawned.push(argv);
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    expect(spawned).toEqual([["/tmp/lfg", "serve"]]);
+  });
+
+  test("serve without an install tells the user to run computer setup", async () => {
+    const log = capture();
+    const code = await runCli(["serve"], {
+      ...log,
+      which: () => null,
+      exists: () => false,
+      homedir: () => "/tmp/empty-home",
+    });
+    expect(code).toBe(1);
+    expect(log.text()).toContain("omg computer setup");
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,80 @@
+import { HELP, HELP_BANNER, RETIRED_APP_COMMANDS, retiredAppMessage } from "./help.ts";
+import { forwardToInstall, type ForwardDependencies } from "./forward.ts";
+import { runComputerForward, runComputerSetup, type InstallDependencies } from "./install.ts";
+
+export { HELP, HELP_BANNER };
+
+export type CliDependencies = InstallDependencies &
+  ForwardDependencies & {
+    output?: (line: string) => void;
+    error?: (line: string) => void;
+  };
+
+const COMPUTER_OWNED = new Set(["setup", "update", "uninstall", "status", "connect"]);
+
+function write(writer: ((line: string) => void) | undefined, fallback: typeof console.log, line: string) {
+  (writer ?? fallback)(line);
+}
+
+export async function runCli(argv: string[], dependencies: CliDependencies = {}): Promise<number> {
+  const out = (line: string) => write(dependencies.output, console.log, line);
+  const err = (line: string) => write(dependencies.error, console.error, line);
+  const [cmd, ...rest] = argv;
+
+  if (!cmd || cmd === "help" || cmd === "-h" || cmd === "--help" || cmd === "__omg_forward_probe") {
+    out(HELP);
+    return 0;
+  }
+
+  if (cmd === "version" || cmd === "--version" || cmd === "-v") {
+    const manifest = await Bun.file(new URL("../package.json", import.meta.url)).json();
+    out(typeof manifest.version === "string" ? manifest.version : "0.5.0");
+    return 0;
+  }
+
+  if (RETIRED_APP_COMMANDS.has(cmd)) {
+    err(retiredAppMessage(cmd));
+    return 1;
+  }
+
+  if (cmd === "computer") {
+    const verb = rest[0];
+    const args = rest.slice(1);
+    if (!verb || verb === "help" || verb === "-h" || verb === "--help") {
+      out(HELP);
+      return 0;
+    }
+    if (verb === "setup") return await runComputerSetup(args, { ...dependencies, output: out });
+    if (verb === "update") return await runComputerForward("setup", args, { ...dependencies, output: out });
+    if (verb === "uninstall") {
+      return await runComputerForward("uninstall", args, { ...dependencies, output: out });
+    }
+    if (verb === "status") {
+      return await runComputerForward("update", ["--check", ...args], { ...dependencies, output: out });
+    }
+    if (verb === "connect") {
+      return await runComputerForward("connect", args, { ...dependencies, output: out });
+    }
+    if (!COMPUTER_OWNED.has(verb)) {
+      const forwarded = await forwardToInstall([verb, ...args], dependencies);
+      if (forwarded.forwarded) return forwarded.exitCode;
+    }
+    err(`Unknown command: computer ${verb}`);
+    out(HELP);
+    return 1;
+  }
+
+  if (cmd === "setup") return await runComputerSetup(rest, { ...dependencies, output: out });
+
+  const forwarded = await forwardToInstall(argv, dependencies);
+  if (forwarded.forwarded) return forwarded.exitCode;
+  err("omg.dev is not installed on this computer. Run `omg computer setup` first.");
+  return 1;
+}
+
+if (import.meta.main) {
+  runCli(process.argv.slice(2)).then((code) => process.exit(code), (error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/packages/cli/src/install.ts
+++ b/packages/cli/src/install.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findInstall, type ForwardDependencies } from "./forward.ts";
+
+export const DEFAULT_SETUP_URL =
+  "https://raw.githubusercontent.com/BennyKok/omg.dev/main/scripts/setup.sh";
+
+export type InstallDependencies = ForwardDependencies & {
+  fetchText?: (url: string) => Promise<string>;
+  runCommand?: (argv: string[], options?: { env?: NodeJS.ProcessEnv }) => Promise<number>;
+  output?: (line: string) => void;
+  setupUrl?: string;
+};
+
+async function defaultFetchText(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`could not download setup.sh from ${url} (${response.status})`);
+  }
+  return await response.text();
+}
+
+async function defaultRunCommand(
+  argv: string[],
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<number> {
+  const child = Bun.spawn(argv, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: options.env ?? process.env,
+  });
+  return await child.exited;
+}
+
+function out(dependencies: InstallDependencies, line: string) {
+  (dependencies.output ?? console.log)(line);
+}
+
+export async function runComputerSetup(
+  args: string[],
+  dependencies: InstallDependencies = {},
+): Promise<number> {
+  const reinstall = args.includes("--reinstall");
+  if (findInstall(dependencies) && !reinstall) {
+    out(dependencies, "omg.dev is already set up on this computer.");
+    out(dependencies, "Open http://localhost:8766 — or run `omg computer update`.");
+    return 0;
+  }
+
+  out(dependencies, "Installing the local omg.dev control plane…");
+  const url = dependencies.setupUrl ?? process.env.OMG_SETUP_URL ?? DEFAULT_SETUP_URL;
+  const fetchText = dependencies.fetchText ?? defaultFetchText;
+  const script = await fetchText(url);
+  const directory = mkdtempSync(join(tmpdir(), "omg-install-"));
+  const path = join(directory, "setup.sh");
+  writeFileSync(path, script, { mode: 0o755 });
+
+  const runCommand = dependencies.runCommand ?? defaultRunCommand;
+  const code = await runCommand(["bash", path], { env: process.env });
+  if (code !== 0) return code;
+
+  if (!findInstall(dependencies)) {
+    out(dependencies, "Setup finished but `lfg` was not found on PATH.");
+    return 1;
+  }
+  out(dependencies, "Open http://localhost:8766");
+  return 0;
+}
+
+export async function runComputerForward(
+  verb: string,
+  args: string[],
+  dependencies: InstallDependencies = {},
+): Promise<number> {
+  const binary = findInstall(dependencies);
+  if (!binary) {
+    out(dependencies, "omg.dev is not installed on this computer. Run `omg computer setup` first.");
+    return 1;
+  }
+  const runCommand = dependencies.runCommand ?? defaultRunCommand;
+  return await runCommand([binary, verb, ...args], { env: process.env });
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -12,6 +12,7 @@
 # These used to be rewritten to immutable GitHub release asset URLs, because the
 # packages were not on npm. They are now published to the public registry under
 # @omg-dev, so a plain semver dependency resolves for everyone.
+# @omg-dev/cli is packed after these four and keeps its own version.
 
 set -euo pipefail
 
@@ -27,6 +28,7 @@ if [ "${SKIP_PACKAGE_BUILD:-}" != "1" ]; then
     bun run --cwd "packages/$package" build
   done
   bun run --cwd web build:lib
+  bun run --cwd packages/cli build
 fi
 
 if [ "${1:-}" = "--build-only" ]; then
@@ -93,3 +95,24 @@ fs.writeFileSync(manifest, JSON.stringify(json, null, 2) + "\n");
 '
 
 npm pack "$app_stage" --pack-destination "$OUT_DIR" --silent
+
+# @omg-dev/cli is versioned independently. The runtime packages follow the
+# repository tag (0.2.x). npm latest for this name is the retired vibes
+# prompt-to-app CLI at 0.4.42, so this bootstrapper must pack its own 0.5.0+
+# number or `bun install --global @omg-dev/cli` would keep resolving 0.4.42.
+cli_stage="$STAGE/cli"
+mkdir -p "$cli_stage"
+cp -r packages/cli/dist "$cli_stage/dist"
+cp packages/cli/package.json "$cli_stage/package.json"
+cp packages/cli/README.md "$cli_stage/README.md"
+cp LICENSE "$cli_stage/LICENSE"
+
+MANIFEST="$cli_stage/package.json" bun -e '
+const fs = require("node:fs");
+const json = JSON.parse(fs.readFileSync(process.env.MANIFEST, "utf8"));
+delete json.scripts;
+delete json.devDependencies;
+fs.writeFileSync(process.env.MANIFEST, JSON.stringify(json, null, 2) + "\n");
+'
+
+npm pack "$cli_stage" --pack-destination "$OUT_DIR" --silent

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -720,8 +720,10 @@ fi
 
 # ---- 6. expose the command on PATH ----
 # `lfg` is the unambiguous name for this CLI and is always installed: existing
-# scripts, cron entries and muscle memory keep working, and the npm CLI
-# (@omg-dev/cli) resolves `lfg` when it forwards a command here.
+# scripts, cron entries and muscle memory keep working, and the npm bootstrapper
+# (@omg-dev/cli 0.5.0+, published from this repository) resolves `lfg` when it
+# forwards a command here. @omg-dev/cli 0.4.x is the retired vibes CLI and does
+# not contain the forward-probe phrase below.
 mkdir -p "$HOME/.local/bin"
 link_command lfg "$LFG_DIR/src/cli.ts"
 

--- a/scripts/test-install-clean-vm.sh
+++ b/scripts/test-install-clean-vm.sh
@@ -8,25 +8,18 @@
 # Why this exists: the quick start is the one code path every new user runs,
 # and it is the one path no test covered. It is not testable from a developer
 # box — every machine we own already has Bun, Node, an ~/omg install, or all
-# three, and each of those hides a different failure. On 2026-08-18 the
-# documented `bun install --global @omg-dev/cli && omg computer setup` died on
-# a clean box with
+# three, and each of those hides a different failure.
 #
-#     /usr/bin/env: 'node': No such file or directory
-#
-# because the published CLI's shebang named a runtime the quick start never
-# installs. Nothing caught it: unit tests ran the CLI's JavaScript, which only
-# executes after an interpreter has been chosen, and every dev box had Node.
+# The documented first-run is this repository's setup.sh. The npm package
+# @omg-dev/cli 0.4.x is the retired vibes CLI and must not be the path under
+# test. --cli-dist DIR overlays a locally built @omg-dev/cli 0.5.0+ dist on
+# top of a global install so the npm bootstrapper can be proven before publish.
 #
 # So this rents a fresh Firecracker VM from the OMG sandbox API, runs the
-# documented commands verbatim as an ordinary sudo-capable user, and asserts
-# the finish line a user cares about: setup exits 0, `serve` listens, and the
-# web UI answers 200 with real HTML. The VM is destroyed afterwards unless
-# --keep is passed.
-#
-# --cli-dist DIR overlays a locally built @omg-dev/cli `dist/` on top of the
-# published package, so a fix can be proven against a clean machine before it
-# is released. Everything else still runs exactly as documented.
+# documented commands as an ordinary sudo-capable user, and asserts the finish
+# line a user cares about: setup exits 0, `serve` listens, and the web UI
+# answers 200 with real HTML. The VM is destroyed afterwards unless --keep is
+# passed.
 #
 # Requirements:
 #   VIBES_INFRA_SERVICE_TOKEN  - infra service token (or _CI variant via ENVF)
@@ -143,17 +136,22 @@ ok "user $VM_USER ready"
 # 2. The documented quick start, verbatim
 # ---------------------------------------------------------------------------
 
-# An unreleased fix is applied between the two documented commands, in the same
-# place the next npm publish would land it, so the rest of the run is unchanged.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+staging="$(mktemp -d)"
+# Stage this checkout's setup.sh so the VM follows the README against the
+# PR's installer, not whatever is currently on main.
+jq -nc --rawfile c <(base64 -w0 "$ROOT/scripts/setup.sh") --arg p /tmp/setup.sh \
+  '[{path:$p,content:$c}]' > "$staging/setup.json"
+api POST "/v1/sandboxes/$SANDBOX/files" "@$staging/setup.json" >/dev/null \
+  || fail "could not stage setup.sh in the VM"
+
+# An unreleased @omg-dev/cli 0.5.0+ fix is applied on top of a global install
+# in the same place the next npm publish would land it.
 overlay=""
 if [[ -n "$CLI_DIST" ]]; then
   log "overlaying local cli dist from $CLI_DIST"
-  staging="$(mktemp -d)"
-  # Pack it as `dist/` so it lands exactly where the published package keeps
-  # its own, whatever the local directory happens to be called.
   mkdir "$staging/dist" && cp "$CLI_DIST"/* "$staging/dist/"
   tar czf "$staging/cli-dist.tgz" -C "$staging" dist
-  # The files API base64-decodes `content` and writes the raw bytes.
   jq -nc --rawfile c <(base64 -w0 "$staging/cli-dist.tgz") --arg p /tmp/cli-dist.tgz \
     '[{path:$p,content:$c}]' > "$staging/body.json"
   api POST "/v1/sandboxes/$SANDBOX/files" "@$staging/body.json" >/dev/null \
@@ -163,17 +161,22 @@ if [[ -n "$CLI_DIST" ]]; then
 fi
 
 log "running README.md's quick start as $VM_USER"
+if [[ -n "$CLI_DIST" ]]; then
+  inner_install="bun install --global @omg-dev/cli
+echo \"INSTALL_EXIT=\$?\"
+$overlay
+omg computer setup"
+else
+  inner_install="bash /tmp/setup.sh"
+fi
 vm "
-cat > /home/$VM_USER/quickstart.sh <<'INNER'
+cat > /home/$VM_USER/quickstart.sh <<INNER
 #!/usr/bin/env bash
 set -x
 export PATH=\"\$HOME/.bun/bin:\$PATH\"
 export OMG_INSTALL_SYSTEM_DEPS=1
 export OMG_PORT=$PORT
-bun install --global @omg-dev/cli
-echo \"INSTALL_EXIT=\$?\"
-$overlay
-omg computer setup
+$inner_install
 echo \"SETUP_EXIT=\$?\"
 echo '=== QUICKSTART DONE ==='
 INNER

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -15,7 +15,7 @@
 # the patterns in sync with .github/workflows/release.yml. Platform bundles
 # can be legitimately absent — release.sh skips a platform whose cross-install
 # fails, and setup.sh falls back to the neutral bundle — so they are checked
-# when staged, never demanded. The neutral bundles and the four @omg-dev
+# when staged, never demanded. The neutral bundles and the five @omg-dev
 # packages are unconditional build products and are demanded outright.
 #
 # Env:
@@ -47,6 +47,7 @@ staged=(
   "$dist"/omg-dev-client-*.tgz
   "$dist"/omg-dev-react-*.tgz
   "$dist"/omg-dev-app-*.tgz
+  "$dist"/omg-dev-cli-*.tgz
 )
 
 if ((${#staged[@]} == 0)); then
@@ -61,7 +62,8 @@ for pat in \
   "$dist"/omg-bundle.tar.gz "$dist"/omg-bundle.tar.gz.sha256 \
   "$dist"/lfg-bundle.tar.gz "$dist"/lfg-bundle.tar.gz.sha256 \
   "$dist"/omg-dev-protocol-*.tgz "$dist"/omg-dev-client-*.tgz \
-  "$dist"/omg-dev-react-*.tgz "$dist"/omg-dev-app-*.tgz; do
+  "$dist"/omg-dev-react-*.tgz "$dist"/omg-dev-app-*.tgz \
+  "$dist"/omg-dev-cli-*.tgz; do
   if ! compgen -G "$pat" >/dev/null; then
     err "core asset $pat was never staged"
     core_ok=0

--- a/scripts/verify-release-assets.test.ts
+++ b/scripts/verify-release-assets.test.ts
@@ -48,7 +48,7 @@ function assetNames(version: string): string[] {
       `omg-${p}.tar.gz`,
       `omg-${p}.tar.gz.sha256`,
     ]),
-    ...["protocol", "client", "react", "app"].map((p) => `omg-dev-${p}-${version}.tgz`),
+    ...["protocol", "client", "react", "app", "cli"].map((p) => `omg-dev-${p}-${version}.tgz`),
   ];
 }
 
@@ -96,7 +96,7 @@ describe("verify-release-assets.sh", () => {
   test("passes when every staged asset is on the release with matching size", () => {
     const r = run();
     expect(r.code).toBe(0);
-    expect(r.out).toContain("all 16 staged assets present");
+    expect(r.out).toContain("all 17 staged assets present");
   });
 
   test("verify-only mode fails and names assets missing from the release", () => {
@@ -156,6 +156,6 @@ describe("verify-release-assets.sh", () => {
     }
     const r = run();
     expect(r.code).toBe(0);
-    expect(r.out).toContain("all 12 staged assets present");
+    expect(r.out).toContain("all 13 staged assets present");
   });
 });

--- a/test/setup-command-name.test.ts
+++ b/test/setup-command-name.test.ts
@@ -15,6 +15,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } 
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { HELP_BANNER } from "../packages/cli/src/help.ts";
 import { SETUP_SH } from "./setup-script-helpers.ts";
 
 const roots: string[] = [];
@@ -121,6 +122,14 @@ function exposeCommands(
 }
 
 describe("setup.sh: which command names it installs", () => {
+  test("the forward probe still matches @omg-dev/cli 0.5.0+ help", () => {
+    // setup.sh greps the npm CLI's output for this phrase. If help.ts changes
+    // the banner, setup would keep a second `omg` and the two-binary surprise
+    // comes back.
+    expect(HELP_BANNER).toContain("run and manage your AI coding agents");
+    expect(readFileSync(SETUP_SH, "utf8")).toContain("run and manage your AI coding agents");
+  });
+
   test("claims omg when nothing else holds the name", () => {
     const result = exposeCommands();
     expect(result.lfg).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A new user who followed the README installed `@omg-dev/cli` from npm. That package's `latest` is **0.4.42**, published from **BennyKok/vibes**. It is the retired prompt-to-app CLI (`create` / `deploy` to `*.omgs.app`). It also left two `omg` binaries on `PATH`.

This PR makes one first-run path that installs the current product: the local/self-hosted agent control plane. After setup, open **http://localhost:8766**. You still bring your own agent accounts. omg.dev does not resell tokens. `lfg` stays a compatibility alias.

## Investigation (hypothesis confirmed)

The labeled hypothesis was correct.

| Fact | Source (20 Aug 2026) |
| --- | --- |
| This repo is v0.2.11 and publishes `@omg-dev/{protocol,client,react,app}` only | `package.json`, `.github/workflows/release.yml` |
| npm `@omg-dev/cli` latest is 0.4.42, repo `git+https://github.com/BennyKok/vibes.git`, description "Deploy and develop omg apps from your terminal." | registry.npmjs.org |
| 0.4.42 help is create/deploy/login; `computer setup` downloads this repo's `setup.sh` and looks for `lfg` | published tarball |
| 0.4.42 help does **not** contain `run and manage your AI coding agents`, so `setup.sh` treats it as legacy and also links `omg` | `scripts/setup.sh` probe + 0.4.42 bundle |
| `docs.omg.dev` welcome still describes Firecracker / `provision.sh` / clone `BennyKok/vibes` | https://docs.omg.dev |
| `/compare` and marketing llms.txt already say the builder is not the current product | https://omg.dev/compare |
| Hosted `/sandbox/templates/omg` already answers; `/lfg` is the old id | live routes |
| Issue #82 still said the CLI is `lfg` | GitHub — now updated and closed |
| Repo description typo: `jcocde` | GitHub — this token cannot PATCH repo metadata (403). A maintainer must set `jcode` in the GitHub UI. |

**docs.omg.dev is not in this repo.** It is `BennyKok/vibes` `apps/docs/` (`apps/docs/content/docs/index.mdx`, `deploy-from-local.mdx`, `mcp.mdx`, …). This PR cannot change that site.

## npm split (what I chose, and why)

**Replace 0.4.42 on `@omg-dev/cli` with this repository's control-plane bootstrapper at 0.5.0+.**

I did not pick a new package name. The README, the npm badge, and `omg computer setup` already use `@omg-dev/cli`. A new name would leave the colliding `omg` binary on npm. I did not publish 0.2.11 onto that name: 0.2.11 < 0.4.42, so npm `latest` would stay 0.4.42.

Until 0.5.0 is published, the **canonical first-run is `scripts/setup.sh`**. That path is owned by this repo and works without waiting for npm.

After the next release publishes `@omg-dev/cli@0.5.0`:

```bash
bun install --global @omg-dev/cli && omg computer setup
```

is the same product. The new CLI:

- prints control-plane help (including the `setup.sh` forward-probe phrase)
- runs `computer setup` by downloading this repo's `setup.sh`
- forwards `serve` / `mcp` / … to the install's `lfg`
- **rejects** `create`, `deploy`, `login`, and the other retired app verbs

`BennyKok/vibes` must stop publishing 0.4.x onto `@omg-dev/cli`. If the old deploy CLI is still needed, move it (`create-omg` already exists; `@omg-dev/apps` is a reasonable new name). Do not publish 0.4.x again after 0.5.0 lands.

This PR does **not** publish to npm. A release after merge must run `scripts/tag-release.sh` so 0.5.0 becomes `latest`.

## What this repo now does

- README first command is `curl …/scripts/setup.sh | bash` → UI on `:8766`
- New workspace package `packages/cli` (`@omg-dev/cli` 0.5.0) wired into pack + release + asset verify
- Hosted one-click badge and `deploy/omg` use `/sandbox/templates/omg` and `omg serve`
- MCP docs state the tools drive local sessions and do not create or deploy apps
- `lfg` remains a compatibility alias
- Issue #82 body matches the real install and is closed

## Follow-up owned by BennyKok/vibes (not this PR)

| Owner | Path | Action |
| --- | --- | --- |
| vibes | `packages/cli/` (`@omg-dev/cli` 0.4.x) | Stop publishing. Deprecate 0.4.42 with a message that points at the control plane. Move create/deploy if still needed. |
| vibes | `packages/create-omg` / npm `create-omg` | Mark deprecated or point at the current product. Homepage is still docs.omg.dev. |
| vibes | `apps/docs/content/docs/index.mdx` | Stop teaching prompt-to-app / `provision.sh` / Firecracker as current. Point at this repo's setup and `:8766`. |
| vibes | `apps/docs/content/docs/deploy-from-local.mdx` | Same. |
| vibes | `apps/docs/content/docs/mcp.mdx` | Must not describe MCP as creating or steering app-building runs. |
| vibes | `templates/agent-lfg/` + catalog | Make `omg serve` the live start command. Keep `lfg serve` / `templateId: "lfg"` as aliases. |
| vibes | hosted `omg login && omg connect` | Stays in vibes. Not this repo's first-run. |
| GitHub repo settings | description | `jcocde` → `jcode`. This agent got HTTP 403 on `PATCH /repos`. A maintainer must edit the description in the GitHub UI. |

## Test plan

- [ ] **Fresh machine follows README, gets control plane UI on :8766.**
  1. New Linux or macOS box (no prior `omg` / `lfg` / `@omg-dev/cli`).
  2. Run the README first command: `curl -fsSL https://raw.githubusercontent.com/BennyKok/omg.dev/main/scripts/setup.sh | bash` (or this branch's `scripts/setup.sh`).
  3. Open http://localhost:8766.
  4. Confirm the omg.dev control-plane UI, not a create/deploy prompt-to-app flow.
  5. `omg help` (and `lfg help`) show "run and manage your AI coding agents".
  6. `command -v omg` is one program. No second surprise `omg` from 0.4.x.
- [ ] `omg create` / `omg deploy` are not offered as current product commands after this install.
- [ ] Hosted badge opens `https://omg.dev/sandbox/templates/omg`. Workspace starts with `omg serve` (or the `lfg serve` alias).
- [ ] Focused tests: `bun test packages/cli test/setup-command-name.test.ts test/cli-computer-namespace.test.ts scripts/verify-release-assets.test.ts`
- [ ] After the next release: `npm view @omg-dev/cli version` is `0.5.0` or newer, and `bun i -g @omg-dev/cli && omg computer setup` matches the setup.sh path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de72ee8f-3dd1-4462-8a71-0879ca21bdf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de72ee8f-3dd1-4462-8a71-0879ca21bdf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

