### PR TITLE
feat(mobile): bot chat, reusing the session transcript and composer

### DIFF
--- a/mobile/app/bots/[id]/index.tsx
+++ b/mobile/app/bots/[id]/index.tsx
@@ -1,0 +1,82 @@
+/**
+ * A bot's chat — the missing half of Bot Mode on this app.
+ *
+ * The roster, the mascot avatars and the full-page create/edit flow already
+ * shipped (feat/mobile-omg-foundation); tapping a roster row opened edit,
+ * which app/bots/index.tsx's own doc comment called a truthful stand-in for
+ * a screen that did not exist yet ("you can at least see and change what you
+ * made"). This is that screen. The roster row now opens HERE instead — see
+ * the change to app/bots/index.tsx's `openBot` — and edit moves to a header
+ * action reached from inside the chat (the "Edit bot" overflow item added to
+ * SessionScreenBody's bot-mode menu).
+ *
+ * NOT A NEW TRANSCRIPT COMPONENT. A bot's `sessionId` is a normal managed
+ * session (see src/commands/serve.ts's `POST /api/bots/:id/messages`), so
+ * this mounts the exact same session screen every other session uses
+ * (app/session/[id].tsx's `SessionScreenBody`), passing it `bot` (swaps the
+ * header identity, hides fork/close, adds "Edit bot", bubbles the bot's
+ * turns) and `onDeliver` (routes the composer's send through the bot
+ * endpoint instead of the plain session send/resume path). Everything else —
+ * streaming, the composer, load-more, dictation, attachments — is the same
+ * code a normal session runs, unmodified.
+ *
+ * OWNS THE RESOLVED SESSION ID AS ITS OWN STATE, seeded from the bot record
+ * and updated once the first message mints (or reattaches) a backing
+ * session. `SessionScreenBody` reacts to that the same way it already reacts
+ * to a route's `id` changing — no new mechanism, see its own doc comment.
+ * The URL stays `/bots/<botId>` the whole time: a bot chat's address names
+ * the bot, not whichever session happens to be its current backing process.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { ActivityIndicator, View } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+
+import { SessionScreenBody } from "../../session/[id]";
+import { useBots, sendBotMessage } from "../../../src/omg/bots";
+import { useOmg } from "../../../src/omg/provider";
+import { useTheme } from "../../../src/omg/theme";
+
+export default function BotChatScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { colors } = useTheme();
+  const { client } = useOmg();
+  const { bots, loading } = useBots();
+  const bot = bots.find((b) => b.id === id) ?? null;
+
+  // The chat's own source of truth for which session it is showing — seeded
+  // from the bot record, then advanced in place by `deliver` below. Not read
+  // from `bot.sessionId` on every render: a background roster refetch must
+  // not yank the open chat to a stale id, the same reasoning EditBotScreen's
+  // `initial` ref gives for not re-seeding from a live-refetched `bot`.
+  const [chatSessionId, setChatSessionId] = useState<string | null>(null);
+  const [seededFor, setSeededFor] = useState<string | null>(null);
+  useEffect(() => {
+    if (!bot || seededFor === bot.id) return;
+    setChatSessionId(bot.sessionId ?? null);
+    setSeededFor(bot.id);
+  }, [bot, seededFor]);
+
+  const deliver = useCallback(
+    async (text: string, mode: "steer" | "queue") => {
+      if (!client || !bot) return undefined;
+      const result = await sendBotMessage(client, bot.id, text, mode);
+      if (result?.sessionId) setChatSessionId(result.sessionId);
+      return result;
+    },
+    [client, bot],
+  );
+
+  // Same reasoning as app/bots/[id]/edit.tsx: a spinner for the brief window
+  // before the roster's own fetch resolves, never a chat screen for a bot
+  // that does not exist.
+  if (!bot) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.bg }}>
+        {loading ? <ActivityIndicator color={colors.textMuted} /> : null}
+      </View>
+    );
+  }
+
+  return <SessionScreenBody sessionId={chatSessionId} bot={bot} onDeliver={deliver} />;
+}

--- a/mobile/app/bots/index.tsx
+++ b/mobile/app/bots/index.tsx
@@ -23,19 +23,19 @@
  *
  * Master-detail lives under the same route family the web uses (`/bots`
  * roster, `/bots/[id]` chat) rather than two unrelated tabs — mirrors how
- * `session/[id]` nests under the sessions surface. `/bots/[id]` itself
- * (bot chat) is a later phase; `/bots/[id]/edit` exists now — see
- * bot-edit-screen.tsx — and is nested a level under the reserved chat route
- * rather than sitting flat at `/bots/[id]` for exactly that reason.
+ * `session/[id]` nests under the sessions surface. `/bots/[id]` is the chat
+ * (app/bots/[id]/index.tsx) — it reuses session/[id].tsx's `SessionScreenBody`
+ * rather than a new transcript implementation, because a bot's conversation
+ * is a normal managed session underneath (see serve.ts's `POST
+ * /api/bots/:id/messages`). `/bots/[id]/edit` (bot-edit-screen.tsx) is still
+ * a route, nested a level under chat exactly because chat is now the level
+ * above it — edit is reached from the chat's own overflow menu instead of
+ * from this roster.
  *
  * "+ New bot" is visually present (both the header action and, empty-roster
  * only, EmptyState's action slot — same pattern as home's "Choose a
  * computer") and pushes the full-page create flow (`/bots/new`,
- * bot-create-flow.tsx). Bot chat is still a later phase — tapping a roster
- * row pushes the full-page edit screen (`/bots/[id]/edit`,
- * bot-edit-screen.tsx) instead of routing to bot chat, because that screen
- * does not exist yet and editing is a truthful stand-in for "tap a bot"
- * while a dead toast was not.
+ * bot-create-flow.tsx).
  */
 
 import { useFocusEffect, useNavigation, useRouter } from "expo-router";
@@ -100,10 +100,11 @@ export default function BotsScreen() {
   const animateEntry = Date.now() - mountedAtRef.current >= COLD_LOAD_WINDOW_MS;
 
   const openBot = (bot: Bot) => {
-    // TODO(bot chat): route to /bots/[id] once that screen exists. Until
-    // then, the full-page edit screen is a truthful stand-in — you can at
-    // least see and change what you made — rather than a dead toast.
-    router.push(`/bots/${encodeURIComponent(bot.id)}/edit`);
+    // Bot chat (app/bots/[id]/index.tsx): the point of a bot is talking to
+    // it, so tapping a roster row opens the conversation now, not the edit
+    // form that used to stand in for it. Edit is still one tap away — the
+    // "Edit bot" item in the chat's own overflow menu.
+    router.push(`/bots/${encodeURIComponent(bot.id)}`);
   };
 
   const createBot = () => {

--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -82,6 +82,9 @@ import {
   VoiceMeter,
 } from "../../src/components";
 import { useAttachments } from "../../src/omg/attachments";
+import { BotAvatar } from "../../src/omg/bot-avatar";
+import { filterBotChatEntries, stripBotLaunchEnvelope } from "../../src/omg/bot-transcript";
+import type { Bot } from "../../src/omg/bots";
 import { useDictation } from "../../src/omg/dictation";
 import { GlassSurface, LIQUID_GLASS } from "../../src/omg/glass";
 import { DropdownMenu, type MenuOption } from "../../src/omg/menu";
@@ -141,6 +144,47 @@ const BAR_ITEM = 44;
 
 export default function SessionScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  return <SessionScreenBody sessionId={id ?? null} />;
+}
+
+/**
+ * The actual session screen — transcript, header bar, composer, streaming.
+ * Pulled out from the default export so a bot's chat (app/bots/[id]/index.tsx)
+ * can mount the SAME screen instead of a second implementation of it: bot
+ * chat is a normal session under the hood (see serve.ts's `POST
+ * /api/bots/:id/messages`), and the design brief for it is explicit that it
+ * is not a new transcript component. `sessionId` replaces every use of route
+ * param `id` below (the two really are the underlying session id, one just
+ * comes from the URL and one from a bot's own record); `bot` and `onDeliver`
+ * are the only two bot-specific seams, and everything below that is not
+ * behind one of them behaves exactly as it did for a normal session.
+ */
+export function SessionScreenBody({
+  sessionId,
+  bot = null,
+  onDeliver,
+}: {
+  sessionId: string | null;
+  /**
+   * Present only for a bot's own conversation. Swaps the header identity for
+   * the bot's face and name, hides fork/close/continue (a bot session never
+   * ends), adds "Edit bot" to the overflow, and wraps the bot's own turns in
+   * a bubble instead of bare markdown — see docs/design/bot-mode/spec.md §4,
+   * and bot-transcript.ts's header for where the shipped web behavior moved
+   * past what that spec still describes.
+   */
+  bot?: Bot | null;
+  /**
+   * How a bot chat's composer actually delivers a message: the new
+   * `POST /api/bots/:id/messages`, via app/bots/[id]/index.tsx, instead of
+   * the plain-session send/resume path below. Bot chat also has to cover one
+   * case a normal session never hits — sending the very first message before
+   * any backing session exists (`sessionId` is null) — so this is what makes
+   * that legal; see the guard at the top of `submit`.
+   */
+  onDeliver?: (text: string, mode: "steer" | "queue") => Promise<{ sessionId?: string } | undefined>;
+}) {
+  const id = sessionId;
   const navigation = useNavigation();
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -200,7 +244,11 @@ export default function SessionScreen() {
   useEffect(() => {
     if (dictation.error) toast.show(dictation.error, { intent: "error" });
   }, [dictation.error, toast]);
-  const [loading, setLoading] = useState(true);
+  // Starts false when there is no id yet — a bot's first-ever chat, before
+  // any message has minted a backing session (see the `onDeliver` doc
+  // above). Every existing call site always has an id from the route, so
+  // this is `true` exactly as it always was for a normal session.
+  const [loading, setLoading] = useState(!!id);
   /**
    * THE TRANSCRIPT STAYS INVISIBLE UNTIL IT HAS SOMETHING SETTLED TO SHOW.
    *
@@ -398,14 +446,23 @@ export default function SessionScreen() {
              * a local fact about how it was sent, so it is carried onto the
              * echo rather than expected back from the server.
              */
-            const confirmed = prev.find(
-              (m) => isOptimisticId(m.id) && m.text === event.message.text,
-            );
+            /**
+             * `stripBotLaunchEnvelope` here (not just at render time) is what
+             * keeps a bot's very first message from showing up twice. Its
+             * echo comes back as the whole launch prompt — the plumbing
+             * envelope plus the human's own line, folded together so the
+             * agent's boot and the first message can't race (see serve.ts's
+             * `POST /api/bots/:id/messages`) — which would otherwise never
+             * text-match the plain line the composer sent optimistically. A
+             * pure, namespace-marked no-op for every non-bot message.
+             */
+            const echoText = stripBotLaunchEnvelope(event.message.text ?? "");
+            const confirmed = prev.find((m) => isOptimisticId(m.id) && m.text === echoText);
             const incoming: Entry = confirmed?.queued
               ? { ...event.message, queued: true }
               : event.message;
             const withoutOptimistic = prev.filter(
-              (m) => !(isOptimisticId(m.id) && m.text === event.message.text),
+              (m) => !(isOptimisticId(m.id) && m.text === echoText),
             );
             if (incoming.id) liveKeysRef.current.add(incoming.id);
             if (incoming.id && withoutOptimistic.some((m) => m.id === incoming.id)) {
@@ -462,8 +519,13 @@ export default function SessionScreen() {
           { id: "__streaming__", role: "assistant", text: streamText, streaming: true },
         ]
       : messages;
-    return buildTranscriptItems(entries);
-  }, [messages, streamText]);
+    // Bot chat reads as a conversation, not a session log — tool calls,
+    // results and thinking blocks are hidden, and the launch envelope
+    // folded into the first turn is stripped back to what the human
+    // actually typed. See bot-transcript.ts. A normal session (bot === null)
+    // never runs this filter.
+    return buildTranscriptItems(bot ? filterBotChatEntries(entries) : entries);
+  }, [messages, streamText, bot]);
 
   const onScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -593,7 +655,15 @@ export default function SessionScreen() {
    */
   const pinnedForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!data.length || !id) return;
+    // A bot's first-ever chat opens with no id and nothing to pin to (see the
+    // `onDeliver` doc above) — reveal the empty transcript immediately rather
+    // than holding the opening spinner for a page that has no reason to
+    // arrive until the first message mints one.
+    if (!id) {
+      setContentReady(true);
+      return;
+    }
+    if (!data.length) return;
     if (pinnedForRef.current === id) return;
     pinnedForRef.current = id;
     setContentReady(false);
@@ -631,7 +701,11 @@ export default function SessionScreen() {
   const submit = useCallback(
     async (text: string, mode: "steer" | "queue" = "steer") => {
       const trimmed = text.trim();
-      if (!trimmed || !client || !id) return;
+      // A bot's first-ever message has no id yet — nothing has minted its
+      // backing session — so `onDeliver` is what's allowed to send with one
+      // missing. Every other caller (every normal session, and a bot after
+      // its first turn) always has both, unchanged from before.
+      if (!trimmed || !client || (!id && !onDeliver)) return;
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       const optimisticId = `local-${++localSeq}`;
       const optimistic: Entry = {
@@ -650,6 +724,32 @@ export default function SessionScreen() {
       setMessages((prev) => [...prev, optimistic]);
       setSending(true);
       try {
+        if (onDeliver) {
+          /**
+           * BOT CHAT'S ONE DELIVERY SEAM. Everything below this branch is the
+           * plain-session send/resume path, untouched.
+           *
+           * A cold start here (`!id`) is a bot that has never been talked to:
+           * same "waking the agent" beat a resumed session gets, because the
+           * server mints and launches a whole new session underneath this
+           * send (see serve.ts's `POST /api/bots/:id/messages`).
+           */
+          const coldStart = !id;
+          if (coldStart) setResuming(true);
+          const delivered = await onDeliver(trimmed, mode);
+          if (!delivered?.sessionId) throw new Error("the bot did not return a conversation");
+          setLive(true);
+          setError(null);
+          // No `router.replace` — a bot chat's URL names the BOT
+          // (`/bots/[id]`), not its backing session, and the parent screen
+          // owns that session id as its own state, re-rendering this one
+          // with it. See app/bots/[id]/index.tsx.
+          setMessages((prev) =>
+            prev.map((m) => (m.id === optimistic.id ? { ...m, pending: false } : m)),
+          );
+          return;
+        }
+        if (!id) return; // unreachable — the guard above requires id when onDeliver is absent
         if (live === false) {
           /**
            * SENDING IS WHAT RESUMES IT — one gesture, not a Resume button
@@ -723,7 +823,7 @@ export default function SessionScreen() {
         setResuming(false);
       }
     },
-    [client, id, live, router],
+    [client, id, live, router, onDeliver],
   );
 
   /** Shown for a beat after a long-press send, so the gesture confirms itself. */
@@ -941,6 +1041,33 @@ export default function SessionScreen() {
    * by how often they are wanted, with the destructive one last and alone.
    */
   const menuOptions = useMemo<MenuOption[]>(() => {
+    /**
+     * A BOT SESSION NEVER CLOSES. Fork, Continue-with (which archives the
+     * source — effectively a close) and Archive session all end in the
+     * normal session's transcript being retired; a bot's session is the
+     * bot's one persistent conversation, and none of those verbs make sense
+     * pointed at it — see docs/design/bot-mode/spec.md §4.1: "no fork
+     * button... no close/archive control." Its only entry point is editing
+     * the bot itself, which was previously the roster's whole reason to push
+     * a full-page screen (app/bots/index.tsx) — now that tapping a bot opens
+     * this chat instead, edit moves in here as the one overflow item, same
+     * idiom the rest of this menu already uses for a screen's secondary
+     * actions. Copy reference and stopping a run in progress are unrelated
+     * to closing/forking, so both stay.
+     */
+    if (bot) {
+      const options: MenuOption[] = [];
+      if (busy) {
+        options.push({ label: "Stop the agent", icon: "stop.fill", onPress: () => void stop() });
+      }
+      options.push({
+        label: "Edit bot",
+        icon: "pencil",
+        onPress: () => router.push(`/bots/${encodeURIComponent(bot.id)}/edit`),
+      });
+      options.push({ label: "Copy reference", icon: "link", onPress: copyReference });
+      return options;
+    }
     const options: MenuOption[] = [];
     if (busy) {
       options.push({ label: "Stop the agent", icon: "stop.fill", onPress: () => void stop() });
@@ -1007,7 +1134,19 @@ export default function SessionScreen() {
      * used verb on the sheet: a phone is not where anyone copies a thousand
      * lines of transcript.
      */
-  }, [agents, busy, stop, archive, rename, continueWithAgent, fork, copyReference, sessionInfo]);
+  }, [
+    agents,
+    bot,
+    busy,
+    stop,
+    archive,
+    rename,
+    continueWithAgent,
+    fork,
+    copyReference,
+    sessionInfo,
+    router,
+  ]);
 
   /**
    * The native bar: system back on the left (this is a pushed screen, so the
@@ -1132,7 +1271,20 @@ export default function SessionScreen() {
             with its spinner. Two lines of chrome in a navigation bar for one
             piece of information, and the title got 190pt to fit in because of
             it. One line now, and the title has the room. */}
-        <AgentAvatar agent={agentLabel} size={26} busy={busy} plain />
+        {/**
+         * A BOT CHAT'S HEADER IS A FACE AND A NAME, not the agent running it
+         * or a prompt-derived title — spec §4.1: "Avatar: same rounded-full
+         * emoji avatar as the roster row... Title line: bot name." The
+         * mascot mark (bot-avatar.tsx) is this app's native equivalent of
+         * that avatar, and its own pulsing dot already carries "working" the
+         * same way AgentAvatar's spinner does, so nothing else about this
+         * capsule has to change to say it.
+         */}
+        {bot ? (
+          <BotAvatar shape={bot.shape} colorway={bot.colorway} size={26} working={busy} />
+        ) : (
+          <AgentAvatar agent={agentLabel} size={26} busy={busy} plain />
+        )}
         <Text
           numberOfLines={1}
           ellipsizeMode="tail"
@@ -1143,11 +1295,11 @@ export default function SessionScreen() {
             maxWidth: 210,
           }}
         >
-          {title}
+          {bot ? bot.name : title}
         </Text>
       </GlassSurface>
     ),
-    [agentLabel, busy, colors, radius.pill, space, title, type],
+    [agentLabel, bot, busy, colors, radius.pill, space, title, type],
   );
 
   /**
@@ -1388,9 +1540,15 @@ export default function SessionScreen() {
         scrollEventThrottle={16}
         onContentSizeChange={handleContentSizeChange}
         renderItem={({ item }) => (
-          <TranscriptRow item={item} fresh={contentReady && liveKeysRef.current.has(item.key)} />
+          <TranscriptRow
+            item={item}
+            fresh={contentReady && liveKeysRef.current.has(item.key)}
+            bot={bot}
+          />
         )}
-        ListFooterComponent={thinking ? <ThinkingPill /> : null}
+        ListFooterComponent={
+          thinking ? bot ? <BotWorkingIndicator bot={bot} /> : <ThinkingPill /> : null
+        }
         ListEmptyComponent={
           // The spinner lives INSIDE the list so it inherits the content
           // inset; a plain View above the list would start under the
@@ -1917,6 +2075,27 @@ export default function SessionScreen() {
             the session's other verbs already are. */}
       </Reanimated.View>
     </Reanimated.View>
+  );
+}
+
+/**
+ * The wait state, for a bot instead of a task session.
+ *
+ * A named creature already has a face and a working pose (`BotAvatar`'s
+ * pulsing corner dot), so standing an anonymous three-dot pill in for it is a
+ * worse answer to "what is happening" than just showing the bot at work —
+ * this mirrors the web's `TypingIndicator` for a bot chat (App.tsx), which is
+ * the ONE place its avatar appears in the stream: not on every settled bubble
+ * (a face beside every reply read as several speakers, not one bot saying
+ * several things — see bot-transcript.ts's header for that same shipped-code-
+ * over-spec call), only here, where the header's identity is not enough
+ * because the header cannot say "happening right now".
+ */
+function BotWorkingIndicator({ bot }: { bot: Bot }) {
+  return (
+    <View style={{ alignSelf: "flex-start", marginTop: 16, marginLeft: 4 }}>
+      <BotAvatar shape={bot.shape} colorway={bot.colorway} size={40} working />
+    </View>
   );
 }
 

--- a/mobile/src/omg/bot-transcript.ts
+++ b/mobile/src/omg/bot-transcript.ts
@@ -1,0 +1,85 @@
+/**
+ * What of a bot's backing session the human is meant to read as a chat.
+ *
+ * A bot's session is a normal managed session (see the server's
+ * `POST /api/bots/:id/messages`, src/commands/serve.ts), so its transcript
+ * carries the same plumbing any session does — tool calls, tool results,
+ * thinking blocks — plus one thing unique to a bot's FIRST turn: the launch
+ * envelope the server folds in with the human's own opening line (bundling
+ * them avoids a race between the agent's boot and a message sent right after
+ * it — see the server route's own comment). A bot chat should read as talking
+ * to somebody, not as a session log, so both get stripped here at the
+ * rendering boundary — never in the message store itself, so the underlying
+ * session is still a complete, honest transcript when opened as a session.
+ *
+ * Mirrors the web's web/src/lib/bot-transcript.ts in spirit (same envelope
+ * strip, same hidden-kind set), narrower in scope: this branch's server does
+ * not carry the prior-conversation-summary block, background-task reports, or
+ * bot-to-bot peer messages the web strips, because this branch's minimal
+ * `POST /api/bots/:id/messages` (see serve.ts's own note on it) does not
+ * generate any of those. Extend this file, not that endpoint, once the
+ * pending reconciliation lands the fuller bot stack.
+ */
+
+const ENVELOPE_HEADER = "=== omg.dev BOT CHAT LAUNCH ===";
+const ENVELOPE_BLOCK =
+  /===\s*omg\.dev BOT CHAT LAUNCH\s*===[\s\S]*?===\s*END omg\.dev BOT CHAT LAUNCH\s*===/i;
+
+/**
+ * Remove the launch envelope, leaving whatever real message rode in with it.
+ *
+ * A pure, namespace-marked string transform — safe to run over EVERY
+ * incoming message, bot chat or not, because the marker never occurs in
+ * ordinary text. That is what lets it double as the optimistic-send dedupe
+ * fix in app/session/[id].tsx: the echoed first turn of a new bot
+ * conversation comes back as `envelope + "\n\n" + text`, which would
+ * otherwise never text-match the plain `text` the composer sent
+ * optimistically, leaving two copies of the human's own first line on
+ * screen.
+ */
+export function stripBotLaunchEnvelope(text: string): string {
+  return text.replace(ENVELOPE_BLOCK, "").trim();
+}
+
+/** True only for a launch turn that is *pure* plumbing — should never happen
+ * given the server always folds real text in, but a transcript reloaded
+ * mid-launch could still catch it half-written. */
+export function isBotLaunchOnlyText(text: string): boolean {
+  return text.trimStart().startsWith(ENVELOPE_HEADER) && stripBotLaunchEnvelope(text) === "";
+}
+
+/** Transcript kinds a bot chat does not show — the machinery behind a reply,
+ * not the reply. See transcript.tsx's own header for why `kind` is how a
+ * message's shape is read. */
+const HIDDEN_IN_BOT_CHAT = new Set(["tool_use", "tool_result", "thinking"]);
+
+export function isBotHiddenKind(kind: string | undefined): boolean {
+  return !!kind && HIDDEN_IN_BOT_CHAT.has(kind);
+}
+
+/**
+ * The messages array as a bot chat should read it: plumbing kinds dropped,
+ * the launch envelope stripped off whichever turn carried it, and a
+ * now-fully-stripped launch-only turn dropped rather than left as an empty
+ * bubble.
+ *
+ * Applied at render time (see app/session/[id].tsx's `data` memo), not to the
+ * `messages` state itself — the same session opened from the sessions rail
+ * still shows its whole, honest log.
+ */
+export function filterBotChatEntries<T extends { role?: string; kind?: string; text?: string }>(
+  entries: readonly T[],
+): T[] {
+  const out: T[] = [];
+  for (const entry of entries) {
+    if (isBotHiddenKind(entry.kind)) continue;
+    if (entry.role !== "user" || typeof entry.text !== "string") {
+      out.push(entry);
+      continue;
+    }
+    if (isBotLaunchOnlyText(entry.text)) continue;
+    const stripped = stripBotLaunchEnvelope(entry.text);
+    out.push(stripped === entry.text ? entry : { ...entry, text: stripped });
+  }
+  return out;
+}

--- a/mobile/src/omg/bots.ts
+++ b/mobile/src/omg/bots.ts
@@ -25,6 +25,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useFocusEffect } from "expo-router";
+import type { OmgClient } from "@omg-dev/client";
 
 import { useOmg } from "./provider";
 
@@ -74,6 +75,30 @@ export function botPreviewText(bot: Pick<Bot, "lastMessagePreview">): string {
   const raw = bot.lastMessagePreview?.trim();
   if (!raw) return "Say hi to get started.";
   return raw.replace(/\s+/g, " ").slice(0, 140);
+}
+
+/**
+ * Send one chat message to a bot, over the minimal `POST /api/bots/:id/messages`
+ * this PR adds (see src/commands/serve.ts's own note on that route — it is a
+ * placeholder composed from the existing session endpoints, flagged there for
+ * the pending server-side bot-messaging reconciliation). Returns the bot's
+ * conversation session id — unchanged for an existing conversation, freshly
+ * minted for a bot's first-ever message.
+ */
+export async function sendBotMessage(
+  client: OmgClient,
+  botId: string,
+  text: string,
+  mode: "steer" | "queue" = "queue",
+): Promise<{ sessionId: string }> {
+  return client.transport.request<{ sessionId: string }>(
+    `/api/bots/${encodeURIComponent(botId)}/messages`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text, mode }),
+    },
+  );
 }
 
 export function useBots(): {

--- a/mobile/src/omg/transcript.tsx
+++ b/mobile/src/omg/transcript.tsx
@@ -214,20 +214,35 @@ function entryKey(message: Entry, index: number): string {
  * above it grows — a streaming reply gaining a paragraph, a thinking block
  * resolving into text.
  */
-export function TranscriptRow({ item, fresh }: { item: TranscriptItem; fresh?: boolean }) {
+export function TranscriptRow({
+  item,
+  fresh,
+  bot,
+}: {
+  item: TranscriptItem;
+  fresh?: boolean;
+  /** Present only inside a bot chat — see app/session/[id].tsx's `SessionScreenBody`. */
+  bot?: BotBubbleIdentity | null;
+}) {
   return (
     <Reanimated.View
       entering={fresh ? FadeInDown.springify().damping(18).mass(0.6) : undefined}
       layout={LinearTransition.springify().damping(20).mass(0.7)}
     >
       {item.type === "message" ? (
-        <TranscriptEntry message={item.message} nextTs={item.nextTs} />
+        <TranscriptEntry message={item.message} nextTs={item.nextTs} bot={bot} />
       ) : (
         <ToolRun pairs={item.pairs} />
       )}
     </Reanimated.View>
   );
 }
+
+/** The little a bot bubble needs to know — not the whole `Bot` record, so
+ * this module does not have to import bots.ts for a shape/colorway it
+ * already has no use for on a settled bubble (that's carried on the working
+ * indicator instead — see app/session/[id].tsx's `BotWorkingIndicator`). */
+export type BotBubbleIdentity = { id: string };
 
 /**
  * A RUN COLLAPSES TO ONE BADGE — "4 tool calls" — and opens into the four.
@@ -467,11 +482,13 @@ function isInterruptedTurn(message: Entry): boolean {
 export function TranscriptEntry({
   message,
   nextTs,
+  bot,
 }: {
   message: Entry;
   nextTs?: number | null;
+  bot?: BotBubbleIdentity | null;
 }) {
-  const { colors, type, space } = useTheme();
+  const { colors, type, space, radius } = useTheme();
   const isUser = message.role === "user";
 
   if (isInterruptedTurn(message)) {
@@ -533,6 +550,36 @@ export function TranscriptEntry({
         <Text style={{ ...type.caption, color: colors.textMuted, textAlign: "center" }}>
           {message.text}
         </Text>
+      </View>
+    );
+  }
+
+  // A bot's reply gets a bubble — spec §4.2, and the point of bot chat at
+  // all: it should read as talking to somebody, not as a session log. Card
+  // shell + taller corner (matches the web's shipped `rounded-[18px]
+  // border-border bg-card px-3.5 py-2.5`, radius.xl already being that same
+  // 18 — see palette.ts), capped at 84% of the stream. No avatar on the
+  // bubble itself: the web's shipped behavior (App.tsx's `TypingIndicator`)
+  // moved the bot's face to the ONE place it earns its space — the working
+  // indicator, app/session/[id].tsx's `BotWorkingIndicator` — after finding
+  // on-device that a face beside every settled reply reads as several
+  // speakers, not one bot saying several things. See bot-transcript.ts's own
+  // header for that same "shipped code over spec.md" note.
+  if (bot) {
+    return (
+      <View
+        style={{
+          alignSelf: "flex-start",
+          maxWidth: "84%",
+          borderRadius: radius.xl,
+          borderWidth: StyleSheet.hairlineWidth,
+          borderColor: colors.border,
+          backgroundColor: colors.card,
+          paddingHorizontal: 14,
+          paddingVertical: 10,
+        }}
+      >
+        <Markdown text={message.text ?? ""} streaming={message.streaming} />
       </View>
     );
   }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -3253,6 +3253,142 @@ a{color:#60a5fa}
           return json({ bot });
         }
       }
+      // ---- bot chat: the minimum wiring to hold a conversation ----
+      //
+      // NOT the real implementation. `main` has a full bot messaging stack
+      // (src/bots/messaging.ts, src/bots/session.ts, deliverBotMessage's
+      // launch-envelope + continuity-summary + peer-message machinery) that
+      // this branch diverged from before it existed, and a reconciliation
+      // between the two is already pending (see AGENTS.md / this repo's own
+      // note on /api/bots). Re-deriving that whole stack here — accounts,
+      // delegated-session repair, self-management tools, peer messaging —
+      // would be exactly the "restructure" the task asked this endpoint NOT
+      // to be.
+      //
+      // So this is the smallest thing that lets the mobile app hold a real
+      // conversation with a bot, built by COMPOSING the session primitives
+      // that already exist and are already tested — the same self-loopback
+      // idiom this file already uses elsewhere (see /api/sessions/continue,
+      // or the ask-answer delivery above) rather than reaching into their
+      // internals:
+      //   - no backing session yet  -> POST /api/sessions/new (mints one,
+      //     folds a small identity envelope + the human's text into the one
+      //     launch prompt, same reasoning as main's `ensureBotSession`: a
+      //     message sent separately from the launch prompt races the boot).
+      //   - a live backing session  -> POST /api/sessions/:id/send (mode
+      //     "queue", so a message arriving mid-turn waits rather than steers).
+      //   - a dead backing session  -> POST /api/sessions/resume, which
+      //     already knows how to cold-start a session back onto its OWN id —
+      //     the same id keeps the transcript one continuous conversation.
+      // The bot record's `sessionId` is the only piece of continuity state
+      // this endpoint owns, and it is the same field the roster and the
+      // (currently CRUD-only) edit screen already read.
+      //
+      // FLAG FOR THE RECONCILIATION: this endpoint should be replaced by (or
+      // reconciled with) whatever `POST /api/bots/:id/messages` main's
+      // src/bots stack ends up owning — same path, same request shape
+      // (`{ text }`), so the mobile client this PR ships needs no change
+      // when that lands.
+      {
+        const match = path.match(/^\/api\/bots\/([^/]+)\/messages$/);
+        if (match && req.method === "POST") {
+          const id = decodeURIComponent(match[1]);
+          const bot = await getBot(id);
+          if (!bot) return err(404, "bot not found");
+          if (!bot.enabled) return err(409, "bot is disabled");
+          const b = (await req.json().catch(() => null)) as { text?: unknown; mode?: unknown } | null;
+          const text = typeof b?.text === "string" ? b.text.trim() : "";
+          if (!text) return err(400, "text is required");
+          // "steer" interrupts the bot's turn in flight, "queue" waits behind
+          // it. Default to queue — the same default `/api/sessions/resume`
+          // uses for a follow-up into an already-live session, and the
+          // gentler choice for a chat surface where cutting the bot off
+          // mid-reply is rarely what sending your next line meant.
+          const mode = b?.mode === "steer" ? "steer" : "queue";
+
+          const forward = async (
+            url: string,
+            body: Record<string, unknown>,
+          ): Promise<{ ok: boolean; status: number; data: Record<string, unknown> | null }> => {
+            const r = await fetch(`http://127.0.0.1:${PORT}${url}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            });
+            const data = (await r.json().catch(() => null)) as Record<string, unknown> | null;
+            return { ok: r.ok, status: r.status, data };
+          };
+
+          if (!bot.sessionId) {
+            // Never talked to before: mint the bot's one conversation. The
+            // envelope rides IN the launch prompt with the human's own first
+            // line, not a separate send after — see the header note above.
+            const repos = await listRepos();
+            const repo = bot.cwd
+              ? repos.find((item) => item.cwd === bot.cwd)
+              : (repos.find((item) => item.cwd === SELF_REPO) ?? repos[0]);
+            if (!repo) return err(400, bot.cwd ? "unknown repo" : "no repo is available");
+            const prompt = [
+              "=== omg.dev BOT CHAT LAUNCH ===",
+              `You are "${bot.name}", a persistent bot a human is chatting with directly — this is`,
+              "an ongoing conversation, not a one-off task. Reply the way you would text a person",
+              "back: plain sentences, no tool-call narration needed unless the human's message asks",
+              "you to do something that requires one.",
+              `Persona: ${bot.persona}`,
+              "=== END omg.dev BOT CHAT LAUNCH ===",
+              "",
+              text,
+            ].join("\n");
+            const created = await forward("/api/sessions/new", {
+              cwd: repo.cwd,
+              prompt,
+              title: bot.name,
+              agent: bot.agent,
+              model: bot.model,
+              thinkingLevel: bot.thinkingLevel,
+              user: bot.owner,
+            });
+            if (!created.ok) {
+              return err(created.status, (created.data?.error as string | undefined) ?? "failed to start bot session");
+            }
+            const sessionId = created.data?.sessionId as string | undefined;
+            if (!sessionId) return err(502, "bot session did not come back with an id");
+            await updateBot(bot.id, { sessionId, lastMessageAt: Date.now() });
+            return json({ sessionId });
+          }
+
+          const live = (await listSessions()).find(
+            (s) => s.sessionId === bot.sessionId || s.nativeSessionId === bot.sessionId,
+          );
+          if (live) {
+            const sent = await forward(`/api/sessions/${encodeURIComponent(bot.sessionId)}/send`, {
+              text,
+              mode,
+            });
+            if (!sent.ok) {
+              return err(sent.status, (sent.data?.error as string | undefined) ?? "failed to send bot message");
+            }
+            await updateBot(bot.id, { lastMessageAt: Date.now() });
+            return json({ sessionId: bot.sessionId });
+          }
+
+          // The backing session ended (box restarted, harness died between
+          // turns). Resuming BY THE SAME ID is what keeps this one continuous
+          // conversation rather than starting a new one every time the process
+          // does not survive between messages.
+          const resumed = await forward("/api/sessions/resume", {
+            sessionId: bot.sessionId,
+            prompt: text,
+            user: bot.owner,
+          });
+          if (!resumed.ok) {
+            return err(resumed.status, (resumed.data?.error as string | undefined) ?? "failed to resume bot session");
+          }
+          const resumedSessionId = (resumed.data?.sessionId as string | undefined) ?? bot.sessionId;
+          await updateBot(bot.id, { sessionId: resumedSessionId, lastMessageAt: Date.now() });
+          return json({ sessionId: resumedSessionId });
+        }
+      }
       // Resolve a client-supplied cwd to a KNOWN repo before we ever chdir into
       // it for a compose/enhance pass. Unknown/blank → undefined (repo-blind,
       // tool-less generation) rather than a hard error or an arbitrary chdir.


### PR DESCRIPTION
## Status: implementation complete, statically verified, **NOT verified on a device**

Read this before merging — the one thing this PR has not done is prove the risky part actually works on a phone.

## What this does

Bot chat was the missing half of Bot Mode on this app: the roster, mascot avatars, and full-page create/edit flow shipped in `feat/mobile-omg-foundation`, but tapping a bot opened edit — backwards, since the point of a bot is talking to it. This adds chat.

- **`mobile/app/session/[id].tsx`**: pure extraction, not a rewrite. The default export is now a 2-line wrapper around a newly-exported `SessionScreenBody({ sessionId, bot?, onDeliver? })` that contains the *entire* previous implementation, unchanged, with `id` swapped for a `sessionId` prop. Bot-specific behavior lives in exactly three seams:
  - `onDeliver` — when present, the composer's `submit()` routes through it instead of the plain session send/resume path (also the one thing that lets a bot's *first-ever* message send with no `sessionId` yet — every other call site always has one).
  - `menuOptions` — a bot-mode branch at the top hides Fork / Continue-with / Archive (a bot session never closes) and adds "Edit bot".
  - `TitleCapsule` — swaps `AgentAvatar` + session title for `BotAvatar` + bot name when `bot` is passed.
  - Two small null-safety additions (`loading`'s initial state, the `contentReady` pin effect) so a bot's pre-first-message state (`sessionId: null`) doesn't hang on a permanent spinner. Both are no-ops for every existing call site, which always has an id.
- **`mobile/app/bots/[id]/index.tsx`** (new): the chat route. Resolves the bot record, owns the resolved session id as local state (seeded from `bot.sessionId`, advanced in place once the first message mints one), and mounts `SessionScreenBody`.
- **`mobile/app/bots/index.tsx`**: roster tap now opens chat (`/bots/[id]`) instead of edit. Edit is still a route (`/bots/[id]/edit`), reached from the chat's own overflow menu now instead of from the roster.
- **`mobile/src/omg/transcript.tsx`**: a bot's text turns render in a card bubble (`radius.xl` = 18, matching the web's shipped `rounded-[18px]`). No avatar on the bubble — mirrors the web's *current* shipped shape (`b16bea0`, "the creature shows up when there is something happening"), not the per-run-avatar commit cited in the original brief, which was superseded before I started. The bot's face now shows only on the working/typing indicator (`BotWorkingIndicator` in `session/[id].tsx`).
- **`mobile/src/omg/bot-transcript.ts`** (new): strips the server's launch envelope and hides `tool_use`/`tool_result`/`thinking` kinds — display-time only, applied in the `data` memo before `buildTranscriptItems`. The underlying session is untouched and still shows its full log if opened from the sessions rail.

### Server: one new endpoint, flagged for the pending reconciliation

This branch's `/api/bots` routes (`src/commands/serve.ts`) are phase-1 record CRUD only — no chat/messaging existed here. A fuller bot-messaging stack (`src/bots/messaging.ts`, `session.ts`, `deliverBotMessage`) already exists on a diverged `main`, and a reconciliation between the two branches is already pending per `AGENTS.md`. Rebuilding that whole stack here would be exactly the "restructure" the task asked this endpoint not to be.

Added the minimum: **`POST /api/bots/:id/messages`**, composed entirely by looping back through the *existing, already-tested* `/api/sessions/new`, `/api/sessions/:id/send`, and `/api/sessions/resume` — the same self-loopback `fetch(http://127.0.0.1:${PORT}/...)` idiom this file already uses elsewhere (e.g. `/api/sessions/continue`). No restructuring of the existing `/api/bots` routes. Heavily commented in place, flagged explicitly for whoever does the reconciliation — same path and request shape (`{ text }`) as main's eventual route, so the mobile client needs no change when that lands.

## Verification

- `npx tsc --noEmit` (mobile): clean
- `npx expo export --platform ios` (mobile): clean
- `bun run typecheck` (root, after `bun run build:packages`): clean

**Not done: driving it on a simulator and getting screenshots with a real conversation in them.** See "On-device verification" below for exactly why, and the resume procedure for whoever picks this back up.

## On-device verification: blocked, not skipped

I set up the full pass on Benny's Mac — isolated server, isolated Metro, a fresh simulator, an uncommitted `createDirectTransport` dev shim — and got the app to its dev-client launcher. I could not get past that screen: the SSH session I had access to could not synthesize clicks or keystrokes into the simulator.

This was diagnosed, not assumed. Window geometry and window identity were confirmed exactly correct (`CGWindowListCopyWindowInfo`'s ground-truth bounds matched AppleScript's report exactly, and `AXRaise` via System Events visibly worked and hit the right window). But actual input synthesis never landed, tested three independent ways (raw `CGEventPost`, `CGEventPost` with a real HID event source + cursor warp, and System Events `click at`/`keystroke`) — including against a target with *no modal in front of it*, to rule out the specific dialog being the issue. `AXRaise` succeeding while synthesis doesn't points at a missing Accessibility (TCC) permission grant for that specific execution path, not a locked screen or a wrong window — the console session was confirmed logged in and active throughout.

**Open question, not a closed one:** three other sessions drove this same simulator with real taps and typing earlier the same day. Whatever permission grant they had, this session didn't. If that grant was revoked or expired between then and now, it will block the next attempt too — worth checking before assuming a retry will just work.

### Resume procedure

1. `git clone --branch feat/mobile-bot-chat --single-branch --depth 1 https://github.com/BennyKok/omg.dev.git <throwaway-dir>` — never work in place on `~/omg`.
2. Root: `bun install && bun run build:packages`.
3. Server: `cd <throwaway-dir> && LFG_HOST=127.0.0.1 LFG_PORT=<free-port> bun run src/cli.ts serve` (data dir is automatically isolated — repo-relative `data/`, not shared with the real instance).
4. Mobile: `cd mobile && bun install`.
5. Dev shim (uncommitted, in the throwaway clone only): patch `mobile/src/omg/provider.tsx` so its `client` `useMemo` and the bindingId auto-select effect fall back to `createDirectTransport(process.env.EXPO_PUBLIC_OMG_DIRECT_URL)` when that env var is set, bypassing the hosted Computers picker (`createDirectTransport` already exists in `transport.ts`, just was never wired to anything — see its own doc comment). Write `mobile/.env.local` with `EXPO_PUBLIC_OMG_DIRECT_URL=http://127.0.0.1:<port-from-step-3>`.
6. `npx expo start --port <free-port> --dev-client` for Metro.
7. `xcrun simctl create`/`boot` a **fresh** simulator (do not touch Benny's 4 existing ones — check `xcrun simctl list devices booted` first and never target those UDIDs), `xcrun simctl install <udid> /tmp/omg-shot.app`, `xcrun simctl launch <udid> dev.omg.computer`, then `xcrun simctl openurl <udid> "omg://expo-development-client/?url=http%3A%2F%2F127.0.0.1%3A<metro-port>"`.
8. Dismiss the one-time "Open in omg?" system dialog (needs a real tap — this is the step that was blocked), sign in as `appreview@omg.dev` / OTP `823014`, then it should land on the direct-connected home screen.
9. Verify **both**: a normal session (send, streaming reply, Fork and Archive still present and working — those are exactly what's suppressed for bots, so they're the most likely casualty of the `session/[id].tsx` extraction) and bot chat (create a bot, tap it from the roster, send a message, get a real reply, header shows the bot's face/name, no Fork/Close/Continue in the overflow, "Edit bot" does, bot bubble renders). Light and dark.
10. Tear down when done: kill the server/Metro processes, `xcrun simctl delete` the throwaway simulator, `rm -rf` the throwaway clone. Leave `/tmp/omg-shot.app` in place.

## Not done

- No screenshots — see above.
- No verification that fork/close/archive still work on a **normal** session after the `session/[id].tsx` extraction — this is the regression risk to check first on resume, not bot chat itself.
- Disabled-bot banner (spec §4.4) not implemented — a disabled bot's send attempt currently surfaces the server's 409 as a toast via the existing error-toast plumbing, which is a real but minimal fallback, not the dashed-border banner the spec describes.
- The new `POST /api/bots/:id/messages` endpoint needs folding into the pending main-branch bot-messaging reconciliation (flagged inline in `serve.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)