### PR TITLE
fix(bots): stop a sessionId match alone from erasing a bot's chat surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - A selected bot could render as a plain session
+
+- **A persistent bot's chat could show the plain session header instead of
+  the bot's own avatar, settings button, and composer.** The bot resolution
+  shared by the server and the web client trusted a bot's saved session id as
+  soon as a live, non-delegated session existed at that id — without checking
+  that session actually belonged to the bot. A stale saved id, or an ordinary
+  session that later reused the same id, was enough to make the roster point
+  at someone else's session, and the bot's identity dropped silently because
+  the render path read `botId` straight off that unrelated session record.
+  `findBotMainSession`, `botConversationRef`, and `botCanonicalSessionId`
+  (`src/bots/session.ts`) now require the found session to carry the bot's
+  own id before they trust it. The desktop stage column also stamps the
+  selected bot's identity onto its rendered session directly, instead of
+  trusting whatever `botId` (if any) the raw session record carries.
+
 ## August 20, 2026 - First-run installs the local control plane (v0.2.12)
 
 - **The documented install no longer goes through the retired `@omg-dev/cli`

--- a/src/bot-roster-canonical.test.ts
+++ b/src/bot-roster-canonical.test.ts
@@ -80,4 +80,20 @@ describe("botCanonicalSessionId", () => {
     expect(isDelegatedSession(delegated)).toBe(true);
     expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, [delegated, main])).toBe("main");
   });
+
+  // The reported routing bug: an ordinary chat already open under a sessionId
+  // that now happens to equal the bot's saved (stale) id must never be
+  // adopted as the bot's roster row just because the id matches and the
+  // session is live and not delegated.
+  test("never adopts an already-open regular chat that reuses the saved id", () => {
+    const regularChat = { sessionId: "main" };
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, [regularChat])).toBeNull();
+  });
+
+  test("falls through to the bot's own live session when the saved id was reused elsewhere", () => {
+    const regularChat = { sessionId: "main" };
+    const own = { sessionId: "own-live", botId: "bot-1" };
+    expect(botCanonicalSessionId({ id: "bot-1", sessionId: "main" }, [regularChat, own]))
+      .toBe("own-live");
+  });
 });

--- a/src/bot-session-binding.test.ts
+++ b/src/bot-session-binding.test.ts
@@ -63,6 +63,26 @@ describe("findBotMainSession", () => {
 
     expect(findBotMainSession({ id: "bot-1" }, [child, conversation])).toBe(conversation);
   });
+
+  // The reported bug: a bot's saved id can outlive the conversation it once
+  // named. If an ordinary, unrelated chat is later opened under that exact
+  // same id, matching on the id alone would hand that stranger's session back
+  // as "the bot's own conversation" — the bot's face and composer disappear
+  // in favour of a regular session header, even though the session found is
+  // live and not delegated.
+  test("never adopts a live, non-delegated session that isn't this bot's own", () => {
+    const strangersChat = { sessionId: CONVERSATION, botId: undefined };
+
+    expect(findBotMainSession({ id: "bot-1", sessionId: CONVERSATION }, [strangersChat]))
+      .toBeUndefined();
+  });
+
+  test("never adopts a live session owned by a different bot", () => {
+    const otherBotsChat = { sessionId: CONVERSATION, botId: "bot-2" };
+
+    expect(findBotMainSession({ id: "bot-1", sessionId: CONVERSATION }, [otherBotsChat]))
+      .toBeUndefined();
+  });
 });
 
 describe("botConversationRef", () => {
@@ -117,6 +137,16 @@ describe("botConversationRef", () => {
   test("a bot nobody has talked to yet has no conversation to repair", () => {
     expect(botConversationRef({ id: "bot-1" }, [])).toEqual({});
     expect(botConversationRef({ id: "bot-1", sessionId: "   " }, [])).toEqual({});
+  });
+
+  // Same failure as findBotMainSession, at the relaunch/reattach layer: a
+  // saved id that now names a live, unrelated, non-delegated session must
+  // never be handed back as safe to attach the bot's next process to.
+  test("refuses to attach to a live session that isn't this bot's own", () => {
+    const strangersChat = { sessionId: CONVERSATION };
+
+    expect(botConversationRef({ id: "bot-1", sessionId: CONVERSATION }, [strangersChat]))
+      .toEqual({});
   });
 });
 

--- a/src/bots/session.ts
+++ b/src/bots/session.ts
@@ -79,7 +79,12 @@ export function findBotMainSession<T extends BotSessionCandidate>(
   const saved = bot.sessionId?.trim();
   if (saved) {
     const exact = findById(sessions, saved);
-    if (exact && !isDelegatedSession(exact)) return exact;
+    // A live, non-delegated session sharing the saved id is the bot's own
+    // conversation only when it actually carries this bot's `botId`. Ids are
+    // handed out to ordinary chats too — trusting the id alone once let a
+    // stray collision (or a stale saved id that now names someone else's
+    // session) hand back an ordinary session as "the bot's own."
+    if (exact && exact.botId === bot.id && !isDelegatedSession(exact)) return exact;
   }
   return sessions.find(
     (session) => session.botId === bot.id && !isDelegatedSession(session),
@@ -124,7 +129,18 @@ export function botConversationRef(
   if (!saved) return {};
 
   const exact = findById(sessions, saved);
-  if (!exact || !isDelegatedSession(exact)) return { sessionId: saved };
+  // Not live at all: nothing else could have taken the id, so the saved id
+  // still names the bot's own transcript on disk.
+  if (!exact) return { sessionId: saved };
+  if (!isDelegatedSession(exact)) {
+    // Live and not delegated — but only this bot's own conversation if it
+    // actually carries this bot's `botId`. A live session that merely shares
+    // the saved id (a stray collision, or a saved id a corrupt write pointed
+    // at someone else's conversation) must never be handed back as safe to
+    // attach to: that is exactly what let a bot's process, and its chat
+    // header, land on an ordinary session that was never its own.
+    return exact.botId === bot.id ? { sessionId: saved } : {};
+  }
 
   const seen = new Set<string>([saved]);
   let current: BotSessionCandidate = exact;
@@ -177,20 +193,30 @@ export function botCanonicalSessionId(
   sessions: readonly BotSessionCandidate[],
 ): string | null {
   const saved = bot.sessionId?.trim();
-  if (saved) {
-    const exact = findById(sessions, saved);
-    if (exact && !isDelegatedSession(exact)) return exact.sessionId ?? saved;
-    // Present but delegated: repair rather than adopt the child.
-    if (exact) {
-      const repaired = botConversationRef(bot, sessions).sessionId;
-      if (repaired) return repaired;
-    }
-  }
   const own = sessions
     .filter((session) => session.botId === bot.id && !isDelegatedSession(session))
     .map((session) => session.sessionId)
     .filter((id): id is string => !!id)
     .sort();
+
+  if (saved) {
+    const exact = findById(sessions, saved);
+    if (exact && exact.botId === bot.id) {
+      if (!isDelegatedSession(exact)) return exact.sessionId ?? saved;
+      // Present but delegated: repair rather than adopt the child.
+      const repaired = botConversationRef(bot, sessions).sessionId;
+      if (repaired) return repaired;
+    } else if (exact) {
+      // Live at the saved id, but owned by someone else (or no one): a
+      // reused/stray id collision, never this bot's row just because it
+      // matches. Falling through to `saved` below — the "transcript is
+      // still filed under that id" case — would be wrong here, because the
+      // id is not idle: something else's live conversation is sitting on
+      // it. Prefer this bot's own live session if it has one, else this bot
+      // has nothing to show rather than borrowing someone else's chat.
+      return own.length ? own[0] : null;
+    }
+  }
   if (own.length) return own[0];
   return saved || null;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,7 +54,7 @@ import {
   shouldShowInlineBotsSurfaceToggle,
   shouldShowMobileSurfaceToggle,
 } from "./lib/mobile-bots-nav";
-import { botChatSessionId, findBotMainSession } from "./lib/bot-session";
+import { botChatSessionId, botStageSession, findBotMainSession } from "./lib/bot-session";
 import {
   BOT_UNREAD_DOT_CLASS,
   botConversationRows,
@@ -12242,12 +12242,15 @@ function RailStage({
   // Stage pins belong to the session surface; carrying them over would answer
   // "open this bot" with someone else's session sitting next to it.
   const botStageColumns = useMemo(() => {
-    if (railSurface !== "chat" || !selectedBotSid) return [];
+    if (railSurface !== "chat" || !selectedBotSid || !selectedBot) return [];
     const node = railTree.nodeForSessionId(selectedBotSid);
-    const session =
+    const rawSession =
       node?.session ?? sessions.find((item) => item.sessionId === selectedBotSid) ?? null;
-    return session ? [{ sid: selectedBotSid, session }] : [];
-  }, [railSurface, selectedBotSid, railTree, sessions]);
+    if (!rawSession) return [];
+    // Found by sessionId alone — stamp this bot's identity on rather than
+    // trust whatever `botId` the raw record carries. See botStageSession.
+    return [{ sid: selectedBotSid, session: botStageSession(selectedBot, rawSession) }];
+  }, [railSurface, selectedBotSid, selectedBot, railTree, sessions]);
   const activeStageColumns = railSurface === "chat" ? botStageColumns : stageColumns;
 
   // The bot list is the session list's sibling, not a page: same rail, same

--- a/web/src/lib/bot-session.ts
+++ b/web/src/lib/bot-session.ts
@@ -11,3 +11,31 @@ export {
   type BotSessionCandidate,
   type BotSessionRef,
 } from "../../../src/bots/session.ts";
+
+/**
+ * The session object a bot's own stage column renders.
+ *
+ * The stage column is picked by sessionId (`botCanonicalSessionId`, then a
+ * plain lookup by that id in the live session list). The resolver already
+ * refuses to name a session owned by someone else, but it cannot invent
+ * ownership a session hasn't been tagged with yet: a freshly launched session
+ * the list hasn't caught up on, or the documented fallback to a saved id
+ * whose session isn't live at all. Whatever the picker hands back, its
+ * `botId` field was still read straight off the raw record — so a session
+ * found by id alone, but not carrying this bot's `botId`, rendered with the
+ * harness's generic session header instead of the bot's own, silently
+ * dropping the bot surface the roster had just picked.
+ *
+ * The picker already knows which bot this column belongs to, so stamp that
+ * identity on directly rather than trust whatever `botId` (if any) the raw
+ * session record carries. A session already tagged with a DIFFERENT bot's id
+ * is left untouched — that is a real conflict to surface, not a label to
+ * silently overwrite.
+ */
+export function botStageSession<S extends { botId?: string | null; botName?: string | null }>(
+  bot: { id: string; name: string },
+  session: S,
+): S {
+  if (session.botId) return session;
+  return { ...session, botId: bot.id, botName: bot.name };
+}

--- a/web/src/lib/bot-stage-session.test.ts
+++ b/web/src/lib/bot-stage-session.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { botStageSession } from "./bot-session";
+
+// The reported bug: the Engineer bot's roster row resolved a real canonical
+// sessionId, but the desktop stage column read that session's own `botId`
+// field to decide whether to render the bot's avatar/composer or the plain
+// harness header — and a session found by id alone does not always carry it
+// yet (or ever, for the documented "saved id, nothing live matches" case).
+// botStageSession is the guard: the picker already knows which bot the
+// column belongs to, so it must not let the raw record's missing `botId`
+// erase that.
+describe("botStageSession", () => {
+  const engineer = { id: "bot-engineer", name: "Engineer" };
+
+  test("stamps identity onto a canonical session the record never tagged", () => {
+    const session = { sessionId: "s1" };
+
+    expect(botStageSession(engineer, session)).toEqual({
+      sessionId: "s1",
+      botId: "bot-engineer",
+      botName: "Engineer",
+    });
+  });
+
+  test("leaves an already-correctly-tagged session untouched (no-op)", () => {
+    const session = { sessionId: "s1", botId: "bot-engineer", botName: "Engineer" };
+
+    expect(botStageSession(engineer, session)).toBe(session);
+  });
+
+  // Reload / deep link and switching between bots both resolve straight to
+  // whatever the roster or the URL names; both must render correctly with no
+  // extra state carried over from a prior selection.
+  test("stamps identity the same way on a fresh reload/deep-link lookup", () => {
+    const session = { sessionId: "s1", title: "Engineer" };
+
+    expect(botStageSession(engineer, session).botId).toBe("bot-engineer");
+  });
+
+  test("switching to a second bot stamps the second bot's identity, not the first's", () => {
+    const improver = { id: "bot-improver", name: "Bot Improver" };
+    const engineerSession = botStageSession(engineer, { sessionId: "s1" });
+    const improverSession = botStageSession(improver, { sessionId: "s2" });
+
+    expect(engineerSession.botId).toBe("bot-engineer");
+    expect(improverSession.botId).toBe("bot-improver");
+  });
+
+  // An already-open regular chat that happens to share a sessionId with what
+  // a bot's canonical resolution named is a real conflict (or, after the
+  // src/bots/session.ts hardening, should no longer be handed back at all) —
+  // it must be surfaced honestly, never silently relabelled as this bot's.
+  test("never overwrites a session already tagged with a different bot's id", () => {
+    const session = { sessionId: "s1", botId: "bot-other", botName: "Other Bot" };
+
+    expect(botStageSession(engineer, session)).toBe(session);
+  });
+});


### PR DESCRIPTION
## Summary
- `findBotMainSession`, `botConversationRef`, `botCanonicalSessionId` (`src/bots/session.ts`, shared server + web client) trusted a bot's saved `sessionId` once a live, non-delegated session existed at that id — without checking that session actually carried the bot's own `botId`. A stale saved id, or an ordinary session that later reused the same id, was enough for the roster and the server's delivery routing to adopt a session that was never the bot's own.
- The desktop stage column (`RailStage` → `renderStageCard` → `SessionCard`) reads `botId` straight off that session record with no fallback, so the bot's avatar/settings button/composer silently dropped in favour of the plain harness session header — reported for the Engineer bot, working for Bot Improver, because only Engineer's binding had drifted.
- All three resolvers now require `session.botId === bot.id` before trusting a live, non-delegated match by id alone.
- New `botStageSession` helper (`web/src/lib/bot-session.ts`) stamps the selected bot's identity onto its stage-column session directly — mirroring `BotsView`'s existing synthetic-session fallback — rather than trusting whatever `botId` (if any) a session found by id alone happens to carry. This covers the resolver's documented "saved id, nothing live matches" fallback case too.

## Test plan
- [x] `bun test src/bot-session-binding.test.ts src/bot-roster-canonical.test.ts web/src/lib/bot-stage-session.test.ts web/src/lib/bot-unread.test.ts web/src/lib/bot-roster-duplicates.test.ts web/src/lib/bot-open-performance.test.ts web/src/lib/bot-session.test.ts` — 55 pass
- [x] `bun run typecheck` — clean
- [x] `bun run test` (full suite) — 2007 pass, 1 pre-existing unrelated failure (`test/bot-unread-wiring.test.ts`, fails identically on `main` before this change — a stale string-match assertion)
- [ ] Live-browser verification not performed against production: the running local instance is several versions behind `main` and embedded in a different host shell, and the session the bug touches (`5f1df640-...`) was live/busy at verification time (an active persistent-bot conversation) — safe re-verification happens after this releases and the local install auto-updates.