### PR TITLE
fix(web): keep the desktop Chat/Bots switch bar visible after selecting a bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - The desktop Chat/Bots switch could disappear after selecting a bot
+
+- **On desktop, opening a bot's conversation hid the Chat/Bots switch bar in
+  the rail, with no way back to the session list short of a reload.** A fix
+  that correctly took the switch out of the mobile full-screen bot chat (once
+  that view got its own "Back to bots" button, making the switch redundant
+  there) copied the same `selectedBotId` guard onto the desktop rail's own
+  switch. Desktop never gets that full-screen takeover — the rail keeps
+  showing the roster regardless of which bot or session is open in the stage
+  — so the guard just stranded desktop users on the Bots surface. The desktop
+  rail now always renders its switch; mobile's behavior is unchanged.
+
 ## August 20, 2026 - A selected bot could render as a plain session
 
 - **A persistent bot's chat could show the plain session header instead of

--- a/test/bot-unread-wiring.test.ts
+++ b/test/bot-unread-wiring.test.ts
@@ -10,9 +10,18 @@ describe("bot unread surface wiring", () => {
     expect(APP).toContain("hasUnreadBotConversation(botConversations)");
   });
 
-  test("the switch stays on the conversation list and out of an open bot chat", () => {
+  test("the mobile switch stays on the conversation list and out of an open bot chat", () => {
     expect(APP).toContain("shouldShowMobileSurfaceToggle(isMobile, tab, selectedBotId)");
-    expect(APP).toContain("{!selectedBotId ? (");
+  });
+
+  // Desktop regressed here once: an earlier revision copied the mobile
+  // `selectedBotId` guard onto the desktop rail's own SurfaceToggle mount.
+  // Unlike the mobile full-screen chat, the desktop rail is never replaced by
+  // an open bot conversation — it keeps showing the roster — so that guard
+  // hid the switch with no way back to Chat. See
+  // test/desktop-rail-switch-bar.test.ts for the focused regression coverage.
+  test("the desktop rail's switch is never gated on selectedBotId", () => {
+    expect(APP).not.toMatch(/\{!selectedBotId\s*\?\s*\(\s*<SurfaceToggle/);
   });
 
   test("the mobile roster and desktop rail render conversation rows and accessible dots", () => {

--- a/test/desktop-rail-switch-bar.test.ts
+++ b/test/desktop-rail-switch-bar.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+
+/**
+ * Regression coverage for a desktop-only bug: commit 1b3ca7d added a
+ * `{!selectedBotId ? <SurfaceToggle/> : null}` guard to `RailStage`'s rail
+ * header to keep the Chat/Bots switch out of the *mobile* full-screen bot
+ * conversation (which has its own Back button, per v0.2.6). That guard was
+ * folded into the desktop rail too, as a side effect of the merge, even
+ * though the desktop rail is never replaced by a full-screen conversation —
+ * it always keeps showing the roster, with the stage panes doing the
+ * switching. The result: selecting any bot on desktop hid the switch bar
+ * with no way back to the Chat surface.
+ *
+ * `shouldShowMobileSurfaceToggle` (web/src/lib/mobile-bots-nav.ts) already
+ * pins the *mobile* half of this rule. This file pins the desktop half: the
+ * rail's `SurfaceToggle` mount must never be gated on `selectedBotId`.
+ */
+function railStageBody(): string {
+  const start = APP.indexOf("function RailStage({");
+  expect(start).toBeGreaterThan(-1);
+  const end = APP.indexOf("\nfunction SurfaceToggle(", start);
+  expect(end).toBeGreaterThan(start);
+  return APP.slice(start, end);
+}
+
+describe("the desktop rail keeps its Chat/Bots switch bar", () => {
+  test("RailStage's SurfaceToggle mount is not guarded by selectedBotId", () => {
+    const body = railStageBody();
+    // The exact regression: a bot-selection guard wrapped around the rail's
+    // own SurfaceToggle mount.
+    expect(body).not.toMatch(/\{!selectedBotId\s*\?\s*\(\s*<SurfaceToggle/);
+    expect(body).not.toContain("selectedBotId ? null :");
+  });
+
+  test("RailStage always mounts a SurfaceToggle wired to railSurface", () => {
+    const body = railStageBody();
+    expect(body).toContain(
+      "<SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />",
+    );
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12454,10 +12454,14 @@ function RailStage({
             </div>
             {/* Sits below the actions, directly above the list it switches.
                 Above the brand row it read as app-level navigation; what it
-                actually does is change which list the rail is showing. */}
-            {!selectedBotId ? (
-              <SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />
-            ) : null}
+                actually does is change which list the rail is showing.
+                Unlike the mobile dock, this never sits inside a full-screen
+                bot conversation — the desktop rail always keeps showing the
+                roster, with the stage panes doing the switching. Hiding it
+                once a bot is selected (`selectedBotId`, mirroring the mobile
+                guard added in 1b3ca7d) stranded desktop users on the Bots
+                surface with no way back to Chat. Always render it here. */}
+            <SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />
           </div>
         )}
         <div className="session-list-scroll min-h-0 flex-1 overflow-y-auto px-1.5 py-2">


### PR DESCRIPTION
## Summary
- On desktop, opening a bot's conversation hid the rail's Chat/Bots switch bar (`SurfaceToggle`), with no way back to the session list short of a reload.
- Root cause: commit 1b3ca7d correctly took the switch out of the *mobile* full-screen bot conversation (that view now has its own "Back to bots" button, making the switch redundant there), but applied the same `selectedBotId` guard to the *desktop* rail's own switch mount (`RailStage`, `web/src/App.tsx` ~line 12455) as a side effect. Desktop's rail is never replaced by a full-screen conversation — it always keeps showing the roster, with the stage panes doing the actual switching — so the guard just stranded desktop users on the Bots surface.
- Fix: drop the guard on `RailStage`'s own `SurfaceToggle` mount only. The mobile dock (`shouldShowMobileSurfaceToggle`) and the tablet inline copy (`shouldShowInlineBotsSurfaceToggle`) are untouched — desktop and mobile behavior is otherwise identical to before.

## Verification
- Confirmed live in the real production browser (`https://dev-us.tail8c417.ts.net`, tailnet-only, this box's actual local control plane) before the fix:
  - Desktop width (1180px), navigated to `/bots/bot_d05dfbd5`: `document.querySelector('[aria-label="Switch surface"]')` is `null` while the bot's own header/settings render — reproduces the bug exactly.
  - Same route, CDP-emulated mobile width (390px, iPhone UA): switch also absent, but `[aria-label="Back to bots"]` is present — confirms mobile's existing behavior is correct and out of scope for this fix.
- `bun test test/desktop-rail-switch-bar.test.ts test/bot-conversation-surface-toggle.test.ts web/src/mobile-bot-chat-navigation.test.ts test/bot-unread-wiring.test.ts` — all pass.
- `bun run typecheck` — clean.
- `bun run test` (full suite) — 2011 pass, 1 fail; the 1 failure (`test/bot-unread-wiring.test.ts > selection marks one server conversation...`) is pre-existing and unrelated — reproduces identically on `main` before this change (also flagged independently by PR #188).
- Rebased on `v0.2.12` (#188); confirmed no overlap — that PR only touched `RailStage`'s `botStageColumns` useMemo, above this edit.

## Test plan
- [x] Focused regression tests (`test/desktop-rail-switch-bar.test.ts`, updated `test/bot-unread-wiring.test.ts`) pin the desktop mount as never gated on `selectedBotId`.
- [x] Full suite green apart from the documented pre-existing failure.
- [x] Live production DOM check at desktop and emulated-mobile widths (see above).
- [ ] Not yet re-verified against production *after* this fix deploys — the shared local control plane serves many concurrent live agent sessions right now, so I did not restart it to force an update. Safe to re-verify once it auto-updates to this release.