### PR TITLE
feat(bots): enforce owner quotas with trusted identity

### DIFF
--- a/docs/bot-self-management.md
+++ b/docs/bot-self-management.md
@@ -59,9 +59,45 @@ poll hydrates the same server state after reload, reconnect, or a change from
 another tab or device. The v0.1.411 `bots` response field remains unchanged;
 new clients also read the additive `conversations` field.
 
-One assigned user can own at most 10 persistent bots. Disabled bots count. The
-store performs the quota check and write in one synchronous commit section, so
-concurrent create calls cannot take the same final slot.
+## Persistent-bot quota
+
+One verified owner can store 20 persistent bots by default. Disabled and idle
+bots count because the quota measures stored bot identities, not processes.
+The store performs the count, quota check, and write in one synchronous commit
+section. Concurrent create calls therefore cannot take the same final slot.
+
+The server derives a managed caller from the host-stamped
+`X-Omg-Viewer-Email` header. A request body cannot choose another Computer
+member as the bot owner or consume that member's allowance. A local install has
+no HTTP authentication layer. Its existing server roster validation remains
+the local administrator boundary.
+
+`GET /api/bots` and successful creates return an additive `quota` object with
+`used`, `limit`, `remaining`, `scope`, and `source`. A refused create returns
+HTTP 409 with `code: "bot_quota_limit"` and the same quota object.
+
+The root-written `/etc/omg/computer-entitlement.json` contract can supply an
+optional numeric `persistentBotLimit`. This is the only plan integration. The
+runtime does not map plan names to guessed free, pro, or team values. Without
+that field, a local administrator can set `LFG_PERSISTENT_BOT_LIMIT`; otherwise
+the explicit default is 20.
+
+Legacy bots that have no `owner` stay ownerless. The migration never guesses
+ownership from a bot name, display name, session, or roster order. These bots
+are reported in the grandfathered `legacy_pool` with a null limit. They remain
+shared as before and do not consume any verified owner's allowance. Every new
+managed create is stamped with the trusted caller, so the legacy pool does not
+grow through the hosted API.
+
+Four resource counts remain separate:
+
+- The machine's total persistent bot records are the full `bots.json` list.
+- A verified owner's allowance counts only records with that normalized owner.
+- Sharing a Computer or a conversation changes access. It does not combine or
+  transfer personal stored-bot allowances.
+- Concurrent resident bot and agent runtimes use `maxLiveAgents`, the Computer
+  admission entitlement, and the memory gate. They do not use this stored-bot
+  quota.
 
 A bot-created bot inherits the caller's approved execution workspace. The tool
 does not accept a workspace path, so bot creation cannot expand filesystem

--- a/src/agent-admission.test.ts
+++ b/src/agent-admission.test.ts
@@ -208,6 +208,18 @@ describe("Computer agent admission", () => {
     ).toEqual({ plan: "x", limit: 64, scheduleLimit: 64 });
   });
 
+  test("accepts an additive persistent-bot entitlement without deriving it from plan", () => {
+    expect(computerAgentAdmissionContext(
+      '{"plan":"custom","limit":4,"scheduleLimit":2,"persistentBotLimit":37}',
+    )).toEqual({ plan: "custom", limit: 4, scheduleLimit: 2, persistentBotLimit: 37 });
+    expect(computerAgentAdmissionContext(
+      '{"plan":"custom","limit":4,"scheduleLimit":2}',
+    )).toEqual({ plan: "custom", limit: 4, scheduleLimit: 2 });
+    expect(computerAgentAdmissionContext(
+      '{"plan":"custom","limit":4,"scheduleLimit":2,"persistentBotLimit":"team"}',
+    )).toEqual({ plan: "custom", limit: 4, scheduleLimit: 2 });
+  });
+
   test("NO_AGENT_LIMIT waives the count, and ONLY the count", () => {
     // The self-hosted override. Discarding the cap must not also discard the
     // memory budget — that budget is the whole reason overriding is safe to

--- a/src/agent-admission.ts
+++ b/src/agent-admission.ts
@@ -23,6 +23,14 @@ export type AgentAdmissionContext = {
   limit: number;
   /** Concurrent scheduled runs. Separate from `limit` — a cron must not fill the interactive cap. */
   scheduleLimit: number;
+  /**
+   * Optional persistent-bot allowance per verified owner.
+   *
+   * Older control planes do not send this field. Its absence is therefore not
+   * an invalid entitlement and leaves the bot store on its explicit default or
+   * local administrator override. The host owns only the value it supplies.
+   */
+  persistentBotLimit?: number;
 };
 
 export type AgentActivity = {
@@ -83,6 +91,9 @@ const COMPUTER_ENTITLEMENT_FILE = "/etc/omg/computer-entitlement.json";
  * memory budget is still the real gate underneath it.
  */
 const MAX_SUPPLIED_LIMIT = 64;
+
+/** Sanity ceiling for a host-supplied stored-bot allowance. */
+const MAX_SUPPLIED_PERSISTENT_BOT_LIMIT = 10_000;
 
 /**
  * A Computer whose entitlement we cannot read admits one agent.
@@ -149,8 +160,22 @@ export function computerAgentAdmissionContext(
   const scheduleLimit = positiveInteger(entitlement.scheduleLimit, MAX_SUPPLIED_LIMIT);
   if (limit === null || scheduleLimit === null) return failUnreadable(source);
 
+  const persistentBotLimit = entitlement.persistentBotLimit === undefined
+    ? undefined
+    : positiveInteger(entitlement.persistentBotLimit, MAX_SUPPLIED_PERSISTENT_BOT_LIMIT);
+  // This field is additive. A malformed new value must not invalidate the
+  // already-authoritative runtime limits in an otherwise readable entitlement.
+  // Ignore it and use the documented bot fallback instead.
+
   const plan = typeof entitlement.plan === "string" ? entitlement.plan.trim() : "";
-  return { plan: plan || "managed", limit, scheduleLimit };
+  return {
+    plan: plan || "managed",
+    limit,
+    scheduleLimit,
+    ...(persistentBotLimit === null || persistentBotLimit === undefined
+      ? {}
+      : { persistentBotLimit }),
+  };
 }
 
 function failUnreadable(source: string): AgentAdmissionContext {

--- a/src/bot-quota.test.ts
+++ b/src/bot-quota.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import { createBot, listBots } from "./bots/store.ts";
+import {
+  BotOwnerQuotaError,
+  DEFAULT_PERSISTENT_BOT_LIMIT,
+  botQuotaLimitPayload,
+  persistentBotQuota,
+  persistentBotQuotaPolicy,
+} from "./bots/quota.ts";
+
+const originalData = PATHS.data;
+let root = "";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "omg-bot-quota-"));
+  PATHS.data = root;
+});
+
+afterEach(() => {
+  PATHS.data = originalData;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("persistent bot quota policy", () => {
+  test("defaults to 20 and never derives a value from a plan name", () => {
+    expect(persistentBotQuotaPolicy({ entitlement: null, configuredLimit: null })).toEqual({
+      limit: DEFAULT_PERSISTENT_BOT_LIMIT,
+      source: "default",
+    });
+    expect(persistentBotQuotaPolicy({
+      entitlement: { plan: "free-or-team-is-not-policy", limit: 1, scheduleLimit: 1 },
+      configuredLimit: null,
+    })).toEqual({ limit: DEFAULT_PERSISTENT_BOT_LIMIT, source: "default" });
+  });
+
+  test("uses the admin override when no host bot entitlement exists", () => {
+    expect(persistentBotQuotaPolicy({ entitlement: null, configuredLimit: "32" }))
+      .toEqual({ limit: 32, source: "config" });
+    expect(persistentBotQuotaPolicy({ entitlement: null, configuredLimit: "not-a-limit" }))
+      .toEqual({ limit: DEFAULT_PERSISTENT_BOT_LIMIT, source: "default" });
+  });
+
+  test("an authoritative host value wins over local configuration", () => {
+    expect(persistentBotQuotaPolicy({
+      entitlement: { plan: "managed", limit: 4, scheduleLimit: 2, persistentBotLimit: 48 },
+      configuredLimit: "99",
+    })).toEqual({ limit: 48, source: "host_entitlement" });
+  });
+});
+
+describe("persistent bot quota accounting", () => {
+  test("disabled and idle records count, while another owner and legacy records do not", async () => {
+    const mine = await createBot({ name: "Mine", persona: "p", owner: "Me@Example.com" });
+    await createBot({ name: "Disabled", persona: "p", owner: "me@example.com" });
+    await createBot({ name: "Other", persona: "p", owner: "other@example.com" });
+    await createBot({ name: "Legacy", persona: "p" });
+    // No session was started for any record. Stored state, not runtime state,
+    // is the resource this quota measures.
+    expect(mine.sessionId).toBeUndefined();
+    const bots = await listBots();
+    bots[1]!.enabled = false;
+    expect(persistentBotQuota(bots, "me@example.com", { limit: 20, source: "default" }))
+      .toEqual({ used: 2, limit: 20, remaining: 18, scope: "owner", source: "default" });
+  });
+
+  test("grandfathers ownerless legacy bots in a separate pool", async () => {
+    await createBot({ name: "Legacy 1", persona: "p" });
+    await createBot({ name: "Legacy 2", persona: "p" });
+    const bots = await listBots();
+    expect(persistentBotQuota(bots, undefined)).toEqual({
+      used: 2,
+      limit: null,
+      remaining: null,
+      scope: "legacy_pool",
+      source: "legacy",
+    });
+    expect(persistentBotQuota(bots, "new-owner@example.com")).toMatchObject({
+      used: 0,
+      remaining: DEFAULT_PERSISTENT_BOT_LIMIT,
+      scope: "owner",
+    });
+  });
+
+  test("serializes a concurrent create storm at exactly the final slot", async () => {
+    const policy = { limit: 20, source: "default" } as const;
+    const results = await Promise.all(Array.from({ length: 30 }, async (_, index) => {
+      try {
+        await createBot({
+          name: `Bot ${index}`,
+          persona: "p",
+          owner: "owner@example.com",
+          ownerQuota: policy,
+        });
+        return "created" as const;
+      } catch (error) {
+        expect(error).toBeInstanceOf(BotOwnerQuotaError);
+        return "limited" as const;
+      }
+    }));
+    expect(results.filter((result) => result === "created")).toHaveLength(20);
+    expect(results.filter((result) => result === "limited")).toHaveLength(10);
+    expect(await listBots()).toHaveLength(20);
+  });
+
+  test("returns a structured error with the same typed quota snapshot", () => {
+    const quota = { used: 20, limit: 20, remaining: 0, scope: "owner", source: "default" } as const;
+    const error = new BotOwnerQuotaError("owner@example.com", quota);
+    expect(botQuotaLimitPayload(error)).toEqual({
+      code: "bot_quota_limit",
+      error: "Persistent bot limit reached: 20 of 20 stored bots are in use. Delete a bot before creating another.",
+      quota,
+    });
+  });
+});

--- a/src/bot-self-management.test.ts
+++ b/src/bot-self-management.test.ts
@@ -5,12 +5,12 @@ import { join } from "node:path";
 
 import { PATHS } from "./config.ts";
 import {
-  BOT_OWNER_QUOTA,
   BotOwnerQuotaError,
   createBot,
   listBots,
   updateBot,
 } from "./bots/store.ts";
+import { DEFAULT_PERSISTENT_BOT_LIMIT, persistentBotQuotaPolicy } from "./bots/quota.ts";
 import {
   BOT_SELF_CREATE_FIELDS,
   BOT_SELF_UPDATE_FIELDS,
@@ -40,13 +40,14 @@ async function bot(name: string, owner = "owner@example.com") {
 }
 
 describe("persistent bot self-management", () => {
-  test("atomically enforces the hard quota of 10 bots per assigned user", async () => {
-    for (let i = 0; i < BOT_OWNER_QUOTA; i++) {
+  test("atomically enforces the default quota per assigned user", async () => {
+    const policy = persistentBotQuotaPolicy({ entitlement: null, configuredLimit: null });
+    for (let i = 0; i < DEFAULT_PERSISTENT_BOT_LIMIT; i++) {
       await createBot({
         name: `Bot ${i}`,
         persona: "Be useful",
         owner: "Owner@Example.com",
-        ownerQuota: BOT_OWNER_QUOTA,
+        ownerQuota: policy,
       });
     }
 
@@ -54,16 +55,16 @@ describe("persistent bot self-management", () => {
       name: "Recursive bot",
       persona: "Create more bots",
       owner: "owner@example.com",
-      ownerQuota: BOT_OWNER_QUOTA,
+      ownerQuota: policy,
     })).rejects.toBeInstanceOf(BotOwnerQuotaError);
 
     await expect(createBot({
       name: "Another user's bot",
       persona: "Be useful",
       owner: "other@example.com",
-      ownerQuota: BOT_OWNER_QUOTA,
+      ownerQuota: policy,
     })).resolves.toMatchObject({ owner: "other@example.com" });
-    expect(await listBots()).toHaveLength(11);
+    expect(await listBots()).toHaveLength(DEFAULT_PERSISTENT_BOT_LIMIT + 1);
   });
 
   test("derives bot and user identity only from matching server session state", async () => {

--- a/src/bot-shared-computer-access.test.ts
+++ b/src/bot-shared-computer-access.test.ts
@@ -15,6 +15,7 @@ import { PATHS } from "./config.ts";
 import { createBot, updateBot, type Bot } from "./bots/store.ts";
 import {
   assertBotConversationAccess,
+  botCreationOwner,
   botViewer,
   botViewerFromRequest,
   visibleBots,
@@ -101,6 +102,22 @@ describe("shared Computer bot visibility", () => {
 });
 
 describe("the ?user= parameter is an identity, never an authorization input", () => {
+  test("a managed create is charged to the trusted member, not the body user", () => {
+    const viewer = botViewerFromRequest(clientReq({ [VIEWER_EMAIL_HEADER]: ANGEL }), BENNY);
+    expect(botCreationOwner(viewer, BENNY, [BENNY, ANGEL])).toEqual({
+      ok: true,
+      owner: ANGEL,
+    });
+  });
+
+  test("a local create still rejects a user outside the configured roster", () => {
+    const viewer = botViewerFromRequest(clientReq(), STRANGER);
+    expect(botCreationOwner(viewer, STRANGER, [BENNY, ANGEL])).toEqual({
+      ok: false,
+      unknown: STRANGER,
+    });
+  });
+
   test("a forged ?user= cannot change what a managed viewer sees", async () => {
     const bots = await hostedBots();
     // Angel edits the URL to claim she is Benny. The trusted header still

--- a/src/bots/access.ts
+++ b/src/bots/access.ts
@@ -38,6 +38,7 @@
 
 import type { Bot } from "./store.ts";
 import { botReadUser, conversationOwner, type BotConversationOwnerRow } from "./unread.ts";
+import { resolveSessionUserTag } from "../users.ts";
 
 /**
  * Viewer email stamped by control-plane's session proxy, taken from the
@@ -88,6 +89,24 @@ export function botViewerFromRequest(
   requestedUser: string | null | undefined,
 ): BotViewer {
   return botViewer(req.headers.get(VIEWER_EMAIL_HEADER), requestedUser);
+}
+
+/**
+ * Resolve attribution for a new bot.
+ *
+ * A managed request always uses the identity stamped by the authenticated host
+ * proxy. Its body cannot move the create into another member's allowance. A
+ * local administrator has no HTTP identity layer, so the existing roster
+ * validation remains its explicit attribution boundary.
+ */
+export function botCreationOwner(
+  viewer: BotViewer,
+  requestedUser: string | null | undefined,
+  roster: string[],
+): { ok: true; owner: string | undefined } | { ok: false; unknown: string } {
+  if (viewer.managed) return { ok: true, owner: viewer.identity };
+  const tag = resolveSessionUserTag(requestedUser, roster);
+  return tag.ok ? { ok: true, owner: tag.user } : tag;
 }
 
 /**

--- a/src/bots/quota.ts
+++ b/src/bots/quota.ts
@@ -1,0 +1,113 @@
+import { computerAgentAdmissionContext, type AgentAdmissionContext } from "../agent-admission.ts";
+import type { Bot } from "./store.ts";
+
+/** Default stored-bot allowance for one verified owner. */
+export const DEFAULT_PERSISTENT_BOT_LIMIT = 20;
+export const PERSISTENT_BOT_LIMIT_ENV = "LFG_PERSISTENT_BOT_LIMIT";
+const MAX_CONFIGURED_PERSISTENT_BOT_LIMIT = 10_000;
+
+export type PersistentBotQuotaSource = "default" | "config" | "host_entitlement" | "legacy";
+export type PersistentBotQuotaScope = "owner" | "legacy_pool";
+
+/** Additive API payload. Nullable limits mean the ownerless legacy pool is grandfathered. */
+export type PersistentBotQuota = {
+  used: number;
+  limit: number | null;
+  remaining: number | null;
+  scope: PersistentBotQuotaScope;
+  source: PersistentBotQuotaSource;
+};
+
+export type PersistentBotQuotaPolicy = {
+  limit: number;
+  source: Exclude<PersistentBotQuotaSource, "legacy">;
+};
+
+function configuredLimit(raw: string | null | undefined): number | null {
+  if (!raw?.trim()) return null;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) return null;
+  return Math.min(value, MAX_CONFIGURED_PERSISTENT_BOT_LIMIT);
+}
+
+/**
+ * Resolve policy only from server-owned inputs.
+ *
+ * The root-written Computer entitlement wins when it carries the additive
+ * persistentBotLimit field. Older entitlements carry only live-agent and
+ * schedule limits, so they fall through to the administrator environment
+ * override and then the explicit product default. Plan names never imply a
+ * number here.
+ */
+export function persistentBotQuotaPolicy(options: {
+  entitlement?: AgentAdmissionContext | null;
+  configuredLimit?: string | null;
+} = {}): PersistentBotQuotaPolicy {
+  const entitlement = Object.hasOwn(options, "entitlement")
+    ? options.entitlement ?? null
+    : computerAgentAdmissionContext();
+  if (entitlement?.persistentBotLimit) {
+    return { limit: entitlement.persistentBotLimit, source: "host_entitlement" };
+  }
+  const local = configuredLimit(
+    Object.hasOwn(options, "configuredLimit")
+      ? options.configuredLimit
+      : process.env[PERSISTENT_BOT_LIMIT_ENV],
+  );
+  if (local !== null) return { limit: local, source: "config" };
+  return { limit: DEFAULT_PERSISTENT_BOT_LIMIT, source: "default" };
+}
+
+function normalizedOwner(owner: string | null | undefined): string | null {
+  return owner?.trim().toLowerCase() || null;
+}
+
+/**
+ * Count stored records, not running processes. Disabled and idle bots count.
+ * Ownerless legacy records stay in a separate grandfathered pool. They never
+ * consume a verified person's allowance and are never guessed onto an owner.
+ */
+export function persistentBotQuota(
+  bots: readonly Bot[],
+  owner: string | null | undefined,
+  policy: PersistentBotQuotaPolicy = persistentBotQuotaPolicy(),
+): PersistentBotQuota {
+  const key = normalizedOwner(owner);
+  if (!key) {
+    return {
+      used: bots.filter((bot) => !normalizedOwner(bot.owner)).length,
+      limit: null,
+      remaining: null,
+      scope: "legacy_pool",
+      source: "legacy",
+    };
+  }
+  const used = bots.filter((bot) => normalizedOwner(bot.owner) === key).length;
+  return {
+    used,
+    limit: policy.limit,
+    remaining: Math.max(0, policy.limit - used),
+    scope: "owner",
+    source: policy.source,
+  };
+}
+
+export class BotOwnerQuotaError extends Error {
+  constructor(readonly owner: string, readonly quota: PersistentBotQuota) {
+    super(
+      `Persistent bot limit reached: ${quota.used} of ${quota.limit} stored bots are in use. ` +
+      "Delete a bot before creating another.",
+    );
+    this.name = "BotOwnerQuotaError";
+  }
+}
+
+export type BotQuotaLimitPayload = {
+  error: string;
+  code: "bot_quota_limit";
+  quota: PersistentBotQuota;
+};
+
+export function botQuotaLimitPayload(error: BotOwnerQuotaError): BotQuotaLimitPayload {
+  return { error: error.message, code: "bot_quota_limit", quota: error.quota };
+}

--- a/src/bots/store.ts
+++ b/src/bots/store.ts
@@ -12,6 +12,13 @@ import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 import { PATHS } from "../config.ts";
 import { sanitizeThinkingLevel } from "../auto/store.ts";
+import {
+  BotOwnerQuotaError,
+  persistentBotQuota,
+  type PersistentBotQuotaPolicy,
+} from "./quota.ts";
+
+export { BotOwnerQuotaError } from "./quota.ts";
 
 /**
  * The mascot avatar: one eye (the species) x a home shape (the individual) x a
@@ -51,16 +58,6 @@ export type Bot = {
   /** Relaunch with persisted profile/workspace data before the next user turn. */
   runtimeRefreshPending?: boolean;
 };
-
-/** A hard per-user fleet bound for persistent bots, including disabled bots. */
-export const BOT_OWNER_QUOTA = 10;
-
-export class BotOwnerQuotaError extends Error {
-  constructor(readonly owner: string, readonly limit: number) {
-    super(`bot quota reached (${limit} persistent bots per assigned user)`);
-    this.name = "BotOwnerQuotaError";
-  }
-}
 
 /**
  * The conversation a bot's next process attaches to.
@@ -142,15 +139,14 @@ export async function createBot(input: {
   owner?: string;
   shape?: BotShape;
   colorway?: BotColorway;
-  ownerQuota?: number;
+  ownerQuota?: PersistentBotQuotaPolicy;
 }): Promise<Bot> {
   // Keep the read, quota check, and write in one synchronous section. Two MCP
   // calls cannot both observe the last free slot before either commits it.
   const bots = readBots();
-  if (input.owner && input.ownerQuota !== undefined) {
-    const owner = input.owner.trim().toLowerCase();
-    const owned = bots.filter((bot) => bot.owner?.trim().toLowerCase() === owner).length;
-    if (owned >= input.ownerQuota) throw new BotOwnerQuotaError(input.owner, input.ownerQuota);
+  if (input.owner && input.ownerQuota) {
+    const quota = persistentBotQuota(bots, input.owner, input.ownerQuota);
+    if (quota.remaining === 0) throw new BotOwnerQuotaError(input.owner, quota);
   }
   let id: string;
   do id = `bot_${randomBytes(4).toString("hex")}`;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -63,7 +63,6 @@ import { runAutoAgent } from "../auto/runner.ts";
 import { routineNudgeText, exceedsMaxFrequency } from "../auto/bot-routine.ts";
 import {
   BOT_COLORWAYS,
-  BOT_OWNER_QUOTA,
   BOT_SHAPES,
   BotOwnerQuotaError,
   botConversationId,
@@ -76,6 +75,11 @@ import {
   type BotColorway,
   type BotShape,
 } from "../bots/store.ts";
+import {
+  botQuotaLimitPayload,
+  persistentBotQuota,
+  persistentBotQuotaPolicy,
+} from "../bots/quota.ts";
 import { botCanonicalSessionId, botConversationRef, findBotMainSession } from "../bots/session.ts";
 import {
   BOT_SELF_CREATE_FIELDS,
@@ -103,6 +107,7 @@ import {
 } from "../bots/unread.ts";
 import {
   assertBotConversationAccess,
+  botCreationOwner,
   botViewerFromRequest,
   localUserSplitEnabled,
   // Aliased: the route already binds `visibleBots` to its own result.
@@ -1664,8 +1669,12 @@ function json(obj: unknown, init?: ResponseInit) {
  * offers to start the agent anyway (`overLimit`) or to go and edit the number.
  * Kept apart from `plan_limit` precisely so a host cannot mistake one for the
  * other and try to sell an upgrade to someone who owns the hardware.
+ *
+ * `bot_quota_limit`: a stored-bot owner allowance. It is never a concurrent
+ * runtime or memory refusal. The response also carries the typed quota
+ * snapshot, so clients do not have to parse this code or the prose for counts.
  */
-export type ApiErrorCode = "plan_limit" | "agent_limit";
+export type ApiErrorCode = "plan_limit" | "agent_limit" | "bot_quota_limit";
 
 function err(status: number, message: string, code?: ApiErrorCode) {
   return json(code ? { error: message, code } : { error: message }, { status });
@@ -3983,6 +3992,7 @@ a{color:#60a5fa}
             return err(409, "calling bot workspace is no longer approved");
           const avatar = readBotAvatar(body);
           if ("error" in avatar) return err(400, avatar.error);
+          const quotaPolicy = persistentBotQuotaPolicy();
           const bot = await createBot({
             name,
             persona,
@@ -3995,17 +4005,19 @@ a{color:#60a5fa}
             thinkingLevel,
             cwd,
             owner: actor.user,
-            ownerQuota: BOT_OWNER_QUOTA,
+            ownerQuota: quotaPolicy,
           });
           evlog("bot_created_by_bot", {
             actorBotId: actor.bot.id,
             createdBotId: bot.id,
             owner: actor.user,
           });
-          return json({ bot }, { status: 201 });
+          const quota = persistentBotQuota(await listBots(), actor.user, quotaPolicy);
+          return json({ bot, quota }, { status: 201 });
         } catch (error) {
           if (error instanceof BotSelfManagementError) return err(error.status, error.message);
-          if (error instanceof BotOwnerQuotaError) return err(409, error.message);
+          if (error instanceof BotOwnerQuotaError)
+            return json(botQuotaLimitPayload(error), { status: 409 });
           throw error;
         }
       }
@@ -4077,6 +4089,12 @@ a{color:#60a5fa}
           // what hid a shared Computer's bots from everyone authorized on it.
           const viewer = botViewerFromRequest(req, requestedUser);
           const visibleBots = visibleBotsForViewer(allBots, viewer, rosterEmails(), requestedUser);
+          const quotaOwner = botCreationOwner(viewer, requestedUser, rosterEmails());
+          const quota = persistentBotQuota(
+            allBots,
+            quotaOwner.ok ? quotaOwner.owner : undefined,
+            persistentBotQuotaPolicy(),
+          );
           const bots = visibleBots.map((bot) => {
             const last = bot.sessionId ? lastIndexedAssistantMessage(bot.sessionId) : null;
             return last?.text
@@ -4134,7 +4152,7 @@ a{color:#60a5fa}
               lastMessageTs: last?.ts ?? null,
             }];
           });
-          return json({ bots, conversations });
+          return json({ bots, conversations, quota });
         }
         if (req.method === "POST") {
           const body = (await req.json().catch(() => null)) as {
@@ -4161,12 +4179,15 @@ a{color:#60a5fa}
           const cwd = typeof body?.cwd === "string" ? body.cwd.trim() || undefined : undefined;
           if (cwd && !(await listRepos()).some((repo) => repo.cwd === cwd))
             return err(400, "unknown repo");
-          const ownerTag = resolveSessionUserTag(typeof body?.user === "string" ? body.user : undefined);
+          const requestedUser = typeof body?.user === "string" ? body.user : undefined;
+          const viewer = botViewerFromRequest(req, requestedUser);
+          const ownerTag = botCreationOwner(viewer, requestedUser, rosterEmails());
           if (!ownerTag.ok)
             return err(400, `unknown user "${ownerTag.unknown}" (expected one of the roster emails)`);
           const avatar = readBotAvatar(body);
           if ("error" in avatar) return err(400, avatar.error);
           let bot: Bot;
+          const quotaPolicy = persistentBotQuotaPolicy();
           try {
             bot = await createBot({
               name,
@@ -4177,14 +4198,18 @@ a{color:#60a5fa}
               model,
               thinkingLevel,
               cwd,
-              owner: ownerTag.user,
-              ownerQuota: ownerTag.user ? BOT_OWNER_QUOTA : undefined,
+              owner: ownerTag.owner,
+              ownerQuota: quotaPolicy,
             });
           } catch (error) {
-            if (error instanceof BotOwnerQuotaError) return err(409, error.message);
+            if (error instanceof BotOwnerQuotaError)
+              return json(botQuotaLimitPayload(error), { status: 409 });
             throw error;
           }
-          return json({ bot });
+          return json({
+            bot,
+            quota: persistentBotQuota(await listBots(), ownerTag.owner, quotaPolicy),
+          });
         }
       }
       {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -66,6 +66,10 @@ import {
 } from "./lib/bot-unread";
 import { resolveRosterUser } from "./lib/roster-user";
 import {
+  botQuotaPresentation,
+  type PersistentBotQuota,
+} from "./lib/bot-quota";
+import {
   botVisibleUserText as botVisibleUserTextFor,
   isBotHiddenLogKind,
   isBotLaunchOnlyText,
@@ -5729,6 +5733,7 @@ export function App() {
   }, [loading]);
   const [autoAgents, setAutoAgents] = useState<AutoAgent[]>([]);
   const [bots, setBots] = useState<PersistentBot[]>([]);
+  const [botQuota, setBotQuota] = useState<PersistentBotQuota | null>(null);
   const [botConversations, setBotConversations] = useState<BotConversationUnread[]>([]);
   const botDirectory = useMemo(
     () => new Map(bots.map((bot) => [bot.id, bot])),
@@ -5996,18 +6001,19 @@ export function App() {
   }, [bare, isMobile, loading, tab, terminalSurface]);
 
   const refreshBots = useCallback(async () => {
-    const payload = await api<{ bots: PersistentBot[]; conversations?: BotConversationUnread[] }>(
+    const payload = await api<{ bots: PersistentBot[]; conversations?: BotConversationUnread[]; quota?: PersistentBotQuota }>(
       `/api/bots?user=${encodeURIComponent(botUnreadIdentity)}`,
       { cache: "no-store" },
     );
     setBots(payload.bots ?? []);
     setBotConversations(payload.conversations ?? []);
+    setBotQuota(payload.quota ?? null);
   }, [botUnreadIdentity]);
 
   const loadCore = useCallback(async () => {
     const [payload, botPayload] = await Promise.all([
       fetchBootstrap<BootstrapPayload>(),
-      api<{ bots: PersistentBot[]; conversations?: BotConversationUnread[] }>(
+      api<{ bots: PersistentBot[]; conversations?: BotConversationUnread[]; quota?: PersistentBotQuota }>(
         `/api/bots?user=${encodeURIComponent(botUnreadIdentity)}`,
         { cache: "no-store" },
       ),
@@ -6055,6 +6061,7 @@ export function App() {
     setAutoAgents(payload.auto?.agents ?? []);
     setBots(botPayload.bots ?? []);
     setBotConversations(botPayload.conversations ?? []);
+    setBotQuota(botPayload.quota ?? null);
     setSchedTz(payload.settings?.timeZone ?? payload.auto?.tz ?? DEFAULT_SCHED_TZ);
     const findingList = payload.auto?.findings ?? [];
     setFindings(findingList);
@@ -7153,11 +7160,12 @@ export function App() {
           : localStorage.getItem("lfg_user"),
         users,
       );
-      await api(endpoint, {
+      const result = await api<{ bot: PersistentBot; quota?: PersistentBotQuota }>(endpoint, {
         method: id ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(id ? body : { ...body, user: owner || undefined }),
       });
+      if (result.quota) setBotQuota(result.quota);
       // Leaving the editor is a navigation now, not a state reset: saving an
       // existing bot lands back in its chat, creating one lands on the list.
       if (id) openBot(id);
@@ -8416,6 +8424,7 @@ export function App() {
             codingAgents={codingAgents}
             autoAgents={autoAgents}
             maxBotSchedules={settings.maxBotSchedules}
+            quota={botQuota}
             tz={schedTz}
             onEditRoutine={setEditingAgent}
             onClose={() => {
@@ -25138,6 +25147,7 @@ function BotEditorPage({
   codingAgents,
   autoAgents = [],
   maxBotSchedules,
+  quota,
   tz,
   onClose,
   onSave,
@@ -25149,6 +25159,7 @@ function BotEditorPage({
   codingAgents: CodingAgentInfo[];
   autoAgents?: AutoAgent[];
   maxBotSchedules?: number;
+  quota?: PersistentBotQuota | null;
   tz?: string;
   onClose: () => void;
   onSave: (input: {
@@ -25203,6 +25214,7 @@ function BotEditorPage({
   const [model, setModel] = useState(editing ? bot.model ?? defaultModel : defaultModel);
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(editing ? bot.thinkingLevel ?? savedThinkingLevel() : savedThinkingLevel());
   const [advanced, setAdvanced] = useState(false);
+  const quotaCopy = !editing && quota ? botQuotaPresentation(quota) : null;
   const models = useAgentModels(backend);
   const backendDefault = useAgentDefaultModel(backend);
   useEffect(() => {
@@ -25219,7 +25231,7 @@ function BotEditorPage({
     };
   }, [isMobile]);
 
-  const canSubmit = !!name.trim() && !!persona.trim();
+  const canSubmit = !!name.trim() && !!persona.trim() && !quotaCopy?.reached;
   const submit = () => {
     if (!canSubmit) return;
     void onSave({
@@ -25261,6 +25273,22 @@ function BotEditorPage({
 
   const fields = (
     <>
+      {!editing && quotaCopy ? (
+        <div
+          role={quotaCopy.reached ? "alert" : "status"}
+          className={cn(
+            "mb-4 rounded-xl border px-3 py-2.5 text-sm",
+            quotaCopy.reached
+              ? "border-destructive/35 bg-destructive/5 text-destructive"
+              : "border-border bg-card/50 text-muted-foreground",
+          )}
+        >
+          <span className="block font-medium text-foreground">{quotaCopy.usage}</span>
+          {quotaCopy.limitMessage ? (
+            <span className="mt-0.5 block">{quotaCopy.limitMessage}</span>
+          ) : null}
+        </div>
+      ) : null}
       {/* The live creature is the preview: it breathes and blinks while you
           pick, so you meet the bot before you create it. It leads the page at
           the size it will never otherwise be seen at — 56px in a row beside the

--- a/web/src/lib/bot-quota.test.ts
+++ b/web/src/lib/bot-quota.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { botQuotaPresentation } from "./bot-quota";
+
+describe("persistent bot quota copy", () => {
+  test("shows usage and remaining capacity before creation", () => {
+    expect(botQuotaPresentation({
+      used: 7,
+      limit: 20,
+      remaining: 13,
+      scope: "owner",
+      source: "default",
+    })).toEqual({
+      usage: "7 of 20 persistent bots used · 13 remaining",
+      limitMessage: null,
+      reached: false,
+    });
+  });
+
+  test("gives a precise action at the limit", () => {
+    expect(botQuotaPresentation({
+      used: 20,
+      limit: 20,
+      remaining: 0,
+      scope: "owner",
+      source: "host_entitlement",
+    })).toEqual({
+      usage: "20 of 20 persistent bots used · 0 remaining",
+      limitMessage: "You have 20 of 20 persistent bots. Delete a bot before creating another.",
+      reached: true,
+    });
+  });
+
+  test("explains why legacy ownerless bots do not consume a personal allowance", () => {
+    expect(botQuotaPresentation({
+      used: 3,
+      limit: null,
+      remaining: null,
+      scope: "legacy_pool",
+      source: "legacy",
+    }).usage).toBe("3 ownerless legacy bots stored. They do not use a personal bot allowance.");
+  });
+});

--- a/web/src/lib/bot-quota.ts
+++ b/web/src/lib/bot-quota.ts
@@ -1,0 +1,33 @@
+export type PersistentBotQuota = {
+  used: number;
+  limit: number | null;
+  remaining: number | null;
+  scope: "owner" | "legacy_pool";
+  source: "default" | "config" | "host_entitlement" | "legacy";
+};
+
+export type BotQuotaPresentation = {
+  usage: string;
+  limitMessage: string | null;
+  reached: boolean;
+};
+
+/** Pure copy model so mobile and desktop render the same quota facts. */
+export function botQuotaPresentation(quota: PersistentBotQuota): BotQuotaPresentation {
+  if (quota.limit === null || quota.remaining === null) {
+    return {
+      usage: `${quota.used} ownerless legacy bot${quota.used === 1 ? "" : "s"} stored. ` +
+        "They do not use a personal bot allowance.",
+      limitMessage: null,
+      reached: false,
+    };
+  }
+  const reached = quota.remaining === 0;
+  return {
+    usage: `${quota.used} of ${quota.limit} persistent bots used · ${quota.remaining} remaining`,
+    limitMessage: reached
+      ? `You have ${quota.used} of ${quota.limit} persistent bots. Delete a bot before creating another.`
+      : null,
+    reached,
+  };
+}


### PR DESCRIPTION
## Summary

- set the default persistent-bot quota to 20 stored bots per verified owner
- accept a trusted `persistentBotLimit` entitlement, then `LFG_PERSISTENT_BOT_LIMIT`, then the default
- exclude ownerless legacy bots from personal quota accounting
- return structured quota data and show clear usage and limit state in the UI
- keep persistent-bot quota separate from `maxLiveAgents`

## Verification

- focused quota and admission tests: 47 passed
- root TypeScript check: passed
- web TypeScript check: passed
- package build: passed
- dependency audit: passed with no unaccepted high or critical advisories
- full suite: 2028 passed, 1 skipped, 2 pre-existing failures

The two full-suite failures reproduce unchanged on clean `origin/main` at `4154b27`:

- `test/embed.test.ts`: stale expected count of 2 for three shell header slots
- `test/bot-unread-wiring.test.ts`: stale source-string assertion for transcript subscription wiring

## Host contract

The default limit of 20 works without a host change. Plan-specific quotas require the host to write `persistentBotLimit` into the trusted entitlement.
