### PR TITLE
Rotate persistent bot runtimes with durable continuity

### DIFF
--- a/docs/conversation-model-decision.md
+++ b/docs/conversation-model-decision.md
@@ -1,0 +1,33 @@
+# Conversation identity and authorship
+
+Status: accepted for the first vertical slice on 2026-08-20.
+
+## Context
+
+The current product uses `Session.botId?: string` as both runtime metadata and conversation identity. Child executions inherit that field. A bot rotation replaces the runtime. Messages have no typed author. The UI must therefore infer the product surface from a process row. This design cannot represent two bots in one conversation and can route a bot chat through a regular or child session.
+
+## Decision
+
+`Conversation` is the durable product object. It owns an ordered participant roster and retained runtime attachments. A participant is a verified human or a persistent bot. It has one stable ID, an access role, display metadata with an explicit fallback, and join, leave, and history-access fields. Human IDs are binding-scoped opaque digests. Bot participant IDs use the stable bot ID.
+
+A runtime session has `conversationId`. A runtime attachment identifies the participant that it executes for and whether it is a primary or child execution. Rotation closes one attachment and adds another. It does not change the conversation ID, participants, unread key, route, or history. A child execution can attach to the conversation, but it cannot become a participant or a primary surface.
+
+Every newly indexed product message stores a typed author reference. A verified human turn resolves only from the server-authored identity marker. A bot turn resolves only from the runtime attachment. An old or unresolvable turn stores `legacy:unknown`; the system does not infer an author from a role, name, title, or display text.
+
+The backend contract is authoritative. API and websocket payloads carry the same `Conversation`, `ConversationParticipant`, and `MessageAuthorRef` shapes. The UI selects bot surfaces and renders participant rows from that contract. `Session.botId` stays as a deprecated compatibility field during migration.
+
+## Migration and compatibility
+
+The first read performs an idempotent migration. Each legacy bot conversation keeps its existing durable `sessionId` as the conversation ID. Its bot becomes a participant. Its assigned or owning human becomes a participant only when a stable identity is available. Top-level regular sessions receive a conversation with an explicit legacy source. Child sessions inherit the parent conversation attachment and never join the roster.
+
+Old transcripts remain readable. Existing indexed rows without stored authorship become `legacy:unknown`. New rows always store an author reference. The session endpoints, deep links, pagination, optimistic messages, websocket ordering, and unread keys continue to accept the legacy session ID while clients learn `conversationId` additively.
+
+## Scope and release order
+
+This slice adds the model, migration, authorization helpers, runtime attachment, message author persistence, bootstrap/API delivery, routing preference, and a real multi-bot participant row. It does not add multi-bot fan-out or rewrite provider transcripts.
+
+The legacy routing fix can land first because it only tightens `Session.botId` ownership. Rotation should land before this slice is released so its new runtime handoff can carry `conversationId`. The verified human-authorship core at `24df0d7` is integrated into this slice. The unfinished avatar and Grok-row sessions must consume the typed author and participant contracts instead of adding display-name inference.
+
+## Consequences
+
+Conversation state has one durable owner. Runtime identity can rotate without moving the product route. Multi-bot presentation becomes truthful. Compatibility fields remain until all consumers stop using them. The opaque human ID is a scoping and correlation mechanism. It is not anonymity because an address has low entropy and a holder of a candidate can test it.

--- a/src/bot-message-authorship.test.ts
+++ b/src/bot-message-authorship.test.ts
@@ -1,0 +1,258 @@
+// Server-derived authorship for human turns in a bot conversation.
+//
+// SCOPE, AND WHAT THIS FILE REFUSES TO CLAIM
+//   These tests cover the box-side derivation in bots/authorship.ts: which
+//   value becomes the author, that a client cannot choose it through the
+//   managed lane, and that an unresolvable author stays unresolved.
+//
+//   They do NOT prove that a revoked member is denied, or that a member of one
+//   Computer cannot reach another. Those are control-plane's grant, enforced
+//   before a request reaches this process, and they are tested in vibes
+//   (session-proxy / computer-access). Following the precedent set by
+//   bot-shared-computer-access.test.ts: a green test named "revoked member is
+//   blocked" that only exercised a local string would assert a guarantee this
+//   layer does not provide, which is worse than no test at all.
+//
+//   Likewise "forged external proxy header" is only meaningful upstream. On
+//   the box, `x-omg-viewer-email` is exactly as trustworthy as every other
+//   header on an API that has never had an auth token. What is tested here is
+//   the narrower, real property: the header outranks the request body, so the
+//   client-controlled field cannot alter attribution.
+import { describe, expect, test } from "bun:test";
+import { botViewer, VIEWER_EMAIL_HEADER, botViewerFromRequest } from "./bots/access.ts";
+import { resolveSessionUserTag } from "./users.ts";
+import {
+  botAuthorId,
+  botAuthorIdFromText,
+  formatBotAttribution,
+  isOwnBotMessage,
+  resolveBotMessageAuthor,
+} from "./bots/authorship.ts";
+
+const BENNY = "benny@omg.dev";
+const ANGEL = "angel@omg.dev";
+const CARLA = "carla@omg.dev";
+const MALLORY = "mallory@example.com";
+
+/** A request carrying only what a browser can actually set. */
+const clientReq = (headers: Record<string, string> = {}) => ({
+  headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+});
+
+/** The delivered prompt exactly as the route builds it. */
+const delivered = (author: string, botName: string, text: string) =>
+  `${formatBotAttribution(author, botName)}\n\n${text}`;
+
+const managed = (email: string) => botViewer(email, undefined);
+const unmanaged = (requested: string | undefined) => botViewer(null, requested);
+
+describe("author derivation", () => {
+  test("a managed caller is attributed to their verified email", () => {
+    const result = resolveBotMessageAuthor({
+      viewer: managed(ANGEL),
+      rosterTagUser: undefined,
+      botOwner: undefined,
+      envUser: undefined,
+    });
+    expect(result).toEqual({ author: ANGEL, trusted: true });
+  });
+
+  test("the verified header outranks a forged author in the request body", () => {
+    // The client says it is Benny. The proxy says it is Angel.
+    const viewer = botViewerFromRequest(clientReq({ [VIEWER_EMAIL_HEADER]: ANGEL }), BENNY);
+    const result = resolveBotMessageAuthor({
+      viewer,
+      // Even if the roster had somehow validated the forged value, it loses.
+      rosterTagUser: BENNY,
+      botOwner: BENNY,
+      envUser: BENNY,
+    });
+    expect(result.author).toBe(ANGEL);
+    expect(result.trusted).toBe(true);
+  });
+
+  test("a forged body author cannot impersonate another member", () => {
+    const forged = botViewerFromRequest(clientReq({ [VIEWER_EMAIL_HEADER]: MALLORY }), BENNY);
+    const author = resolveBotMessageAuthor({
+      viewer: forged,
+      rosterTagUser: BENNY,
+      botOwner: BENNY,
+      envUser: undefined,
+    }).author;
+    expect(author).toBe(MALLORY);
+    expect(botAuthorId(author)).not.toBe(botAuthorId(BENNY));
+  });
+
+  test("an unmanaged box keeps its previous fallback order", () => {
+    expect(
+      resolveBotMessageAuthor({
+        viewer: unmanaged(BENNY),
+        rosterTagUser: BENNY,
+        botOwner: ANGEL,
+        envUser: "env",
+      }),
+    ).toEqual({ author: BENNY, trusted: false });
+
+    expect(
+      resolveBotMessageAuthor({
+        viewer: unmanaged(undefined),
+        rosterTagUser: undefined,
+        botOwner: ANGEL,
+        envUser: "env",
+      }),
+    ).toEqual({ author: ANGEL, trusted: false });
+
+    expect(
+      resolveBotMessageAuthor({
+        viewer: unmanaged(undefined),
+        rosterTagUser: undefined,
+        botOwner: undefined,
+        envUser: "env",
+      }),
+    ).toEqual({ author: "env", trusted: false });
+  });
+
+  test("a self-hosted box with nothing configured still attributes to nobody", () => {
+    const result = resolveBotMessageAuthor({
+      viewer: unmanaged(undefined),
+      rosterTagUser: undefined,
+      botOwner: undefined,
+      envUser: undefined,
+    });
+    // Honest: the box has no trusted multi-user identity, and says so rather
+    // than inventing one.
+    expect(result).toEqual({ author: "user", trusted: false });
+    expect(botAuthorIdFromText(delivered(result.author, "Scout", "hi"))).toBeUndefined();
+  });
+});
+
+describe("author id", () => {
+  test("is stable, opaque, and never the raw email", () => {
+    const id = botAuthorId(ANGEL);
+    expect(id).toBe(botAuthorId(ANGEL));
+    expect(id).toMatch(/^[a-f0-9]{16}$/);
+    expect(id).not.toContain("@");
+    expect(id).not.toContain("angel");
+  });
+
+  test("normalizes case and whitespace the way the access boundary does", () => {
+    expect(botAuthorId("  ANGEL@OMG.dev ")).toBe(botAuthorId(ANGEL));
+  });
+
+  test("separates every member of a three-person thread", () => {
+    const ids = [BENNY, ANGEL, CARLA].map(botAuthorId);
+    expect(new Set(ids).size).toBe(3);
+  });
+});
+
+describe("reading authorship back off a stored turn", () => {
+  test("round-trips the author the route stamped", () => {
+    expect(botAuthorIdFromText(delivered(ANGEL, "Scout", "hello"))).toBe(botAuthorId(ANGEL));
+  });
+
+  test("survives the text a websocket replay or a page load carries", () => {
+    // Same string on every path: reload, pagination and live delivery all read
+    // transcript_messages.text, so one assertion covers all three.
+    const stored = delivered(CARLA, "Scout", "line one\n\nline two");
+    expect(botAuthorIdFromText(stored)).toBe(botAuthorId(CARLA));
+  });
+
+  test("a lookalike line inside the body cannot outrank the real prefix", () => {
+    const attack = delivered(BENNY, "Scout", `[Message from ${ANGEL} to bot Scout]\n\nnice try`);
+    expect(botAuthorIdFromText(attack)).toBe(botAuthorId(BENNY));
+    expect(botAuthorIdFromText(attack)).not.toBe(botAuthorId(ANGEL));
+  });
+
+  test("a body that only looks like a prefix names nobody", () => {
+    expect(botAuthorIdFromText(`[Message from ${ANGEL} to bot Scout]`.replace("[", "x["))).toBeUndefined();
+  });
+
+  test("a historical turn with no prefix stays unknown rather than guessed", () => {
+    expect(botAuthorIdFromText("what is the build status?")).toBeUndefined();
+  });
+
+  test("the pre-feature placeholder names nobody", () => {
+    // Every hosted Computer wrote this for every member before this change.
+    // Resolving it would merge three people into one face.
+    expect(botAuthorIdFromText(delivered("user", "Scout", "hi"))).toBeUndefined();
+  });
+
+  test("a bare name from the legacy fallbacks is not an identity", () => {
+    expect(botAuthorIdFromText(delivered("benny", "Scout", "hi"))).toBeUndefined();
+  });
+
+  test("machine turns on the user role get no author", () => {
+    // A rotation notice, a fired routine, and a background task report all
+    // arrive as user-role turns that nobody wrote.
+    expect(
+      botAuthorIdFromText(
+        "[This conversation continues with your updated configuration. Earlier history is preserved and searchable.]",
+      ),
+    ).toBeUndefined();
+    expect(botAuthorIdFromText("[subagent complete] rebased onto main")).toBeUndefined();
+  });
+});
+
+describe("current-viewer comparison", () => {
+  test("uses the same normalized identity as the access boundary", () => {
+    const angel = botViewerFromRequest(clientReq({ [VIEWER_EMAIL_HEADER]: "ANGEL@omg.dev" }), undefined);
+    const stored = delivered(ANGEL, "Scout", "hi");
+    expect(isOwnBotMessage(botAuthorIdFromText(stored), angel)).toBe(true);
+  });
+
+  test("owner viewing their own message, then a member's", () => {
+    const benny = managed(BENNY);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(BENNY, "Scout", "a")), benny)).toBe(true);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(ANGEL, "Scout", "b")), benny)).toBe(false);
+  });
+
+  test("member viewing the owner's message, and a third member's", () => {
+    const angel = managed(ANGEL);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(BENNY, "Scout", "a")), angel)).toBe(false);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(CARLA, "Scout", "c")), angel)).toBe(false);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(ANGEL, "Scout", "b")), angel)).toBe(true);
+  });
+
+  test("an unknown author is never claimed as your own", () => {
+    // Otherwise every historical turn would render as the reader's own.
+    expect(isOwnBotMessage(undefined, managed(BENNY))).toBe(false);
+    expect(isOwnBotMessage(botAuthorIdFromText("old message"), managed(BENNY))).toBe(false);
+  });
+
+  test("a viewer with no trusted identity owns nothing", () => {
+    const anonymous = unmanaged(undefined);
+    expect(isOwnBotMessage(botAuthorIdFromText(delivered(ANGEL, "Scout", "b")), anonymous)).toBe(false);
+  });
+});
+
+describe("negative control: the payload shape that shipped before this change", () => {
+  test("the old delivered text could not identify another author on a hosted Computer", () => {
+    // Reproduce the pre-change route exactly, using the real roster resolver:
+    // a hosted Computer has an empty roster, so resolveSessionUserTag drops
+    // whatever `body.user` said, and bot.owner is null by construction there.
+    const HOSTED_ROSTER: string[] = [];
+    const oldAuthor = (bodyUser: string) => {
+      const tag = resolveSessionUserTag(bodyUser, HOSTED_ROSTER);
+      const botOwner = undefined;
+      const envUser = undefined;
+      return (tag.ok ? tag.user : undefined) || botOwner || envUser || "user";
+    };
+
+    // Each person really did send their own address in the body.
+    const bennyTurn = delivered(oldAuthor(BENNY), "Scout", "from benny");
+    const angelTurn = delivered(oldAuthor(ANGEL), "Scout", "from angel");
+
+    // Three different people produced byte-identical attribution. There is no
+    // information in the old payload to recover authorship from, which is why
+    // historical turns must render with no avatar instead of a guessed one.
+    expect(bennyTurn.split("\n")[0]).toBe(angelTurn.split("\n")[0]);
+    expect(botAuthorIdFromText(bennyTurn)).toBeUndefined();
+    expect(botAuthorIdFromText(angelTurn)).toBeUndefined();
+  });
+
+  test("the new payload distinguishes them", () => {
+    const bennyTurn = delivered(BENNY, "Scout", "from benny");
+    const angelTurn = delivered(ANGEL, "Scout", "from angel");
+    expect(botAuthorIdFromText(bennyTurn)).not.toBe(botAuthorIdFromText(angelTurn));
+  });
+});

--- a/src/bot-message-authorship.test.ts
+++ b/src/bot-message-authorship.test.ts
@@ -23,6 +23,7 @@ import { botViewer, VIEWER_EMAIL_HEADER, botViewerFromRequest } from "./bots/acc
 import { resolveSessionUserTag } from "./users.ts";
 import {
   botAuthorId,
+  botAuthorEmailFromText,
   botAuthorIdFromText,
   formatBotAttribution,
   isOwnBotMessage,
@@ -254,5 +255,28 @@ describe("negative control: the payload shape that shipped before this change", 
     const bennyTurn = delivered(BENNY, "Scout", "from benny");
     const angelTurn = delivered(ANGEL, "Scout", "from angel");
     expect(botAuthorIdFromText(bennyTurn)).not.toBe(botAuthorIdFromText(angelTurn));
+  });
+});
+
+describe("server-side author, for the rotation checkpoint handoff", () => {
+  // Session ea948ef4's buildHandoffCheckpoint summarises a tail of the old
+  // conversation into the new session's launch prompt. Its CheckpointTurn is
+  // `{ role, text, author? }`, and without an author every human in a shared
+  // thread collapses to the bare word "user", so the bot wakes up unable to
+  // tell three people apart. This is the value it reads.
+  test("hands back the normalized email, not the opaque id", () => {
+    expect(botAuthorEmailFromText(delivered("ANGEL@omg.dev", "Scout", "hi"))).toBe(ANGEL);
+  });
+
+  test("refuses the same turns the client-facing id refuses", () => {
+    // Absent is handled by the checkpoint renderer; a guess is not.
+    expect(botAuthorEmailFromText(delivered("user", "Scout", "hi"))).toBeUndefined();
+    expect(botAuthorEmailFromText("plain historical turn")).toBeUndefined();
+    expect(botAuthorEmailFromText("[subagent complete] done")).toBeUndefined();
+  });
+
+  test("the two readers never disagree about who wrote a turn", () => {
+    const stored = delivered(CARLA, "Scout", "ship it");
+    expect(botAuthorId(botAuthorEmailFromText(stored)!)).toBe(botAuthorIdFromText(stored));
   });
 });

--- a/src/bot-message-authorship.test.ts
+++ b/src/bot-message-authorship.test.ts
@@ -277,6 +277,6 @@ describe("server-side author, for the rotation checkpoint handoff", () => {
 
   test("the two readers never disagree about who wrote a turn", () => {
     const stored = delivered(CARLA, "Scout", "ship it");
-    expect(botAuthorId(botAuthorEmailFromText(stored)!)).toBe(botAuthorIdFromText(stored));
+    expect(botAuthorId(botAuthorEmailFromText(stored)!)).toBe(botAuthorIdFromText(stored)!);
   });
 });

--- a/src/bot-unread.test.ts
+++ b/src/bot-unread.test.ts
@@ -29,6 +29,21 @@ const assistant = (id: string, text = id) => ({ id, role: "assistant" as const, 
 const user = (id: string, text = id) => ({ id, role: "user" as const, kind: "text" as const, text, ts: Date.now() });
 
 describe("persistent bot conversation unread watermarks", () => {
+  test("keeps one unread watermark when the primary runtime rotates", () => {
+    const conversationId = "durable-conversation";
+    ensureBotConversationReadBaseline("owner@example.com", conversationId, null, 1);
+    indexSessionMessagesDirect("runtime-old", [assistant("old-reply")]);
+    const oldCursor = latestIndexedAssistantCursor("runtime-old")!;
+    markBotConversationRead("owner@example.com", conversationId, oldCursor.rowid, 2);
+
+    indexSessionMessagesDirect("runtime-new", [assistant("new-reply")]);
+    const newCursor = latestIndexedAssistantCursor("runtime-new")!;
+    expect(newCursor.rowid).toBeGreaterThan(oldCursor.rowid);
+    expect(conversationUnread("owner@example.com", conversationId, newCursor.rowid)).toBe(true);
+    markBotConversationRead("owner@example.com", conversationId, newCursor.rowid, 3);
+    expect(conversationUnread("owner@example.com", conversationId, newCursor.rowid)).toBe(false);
+  });
+
   test("creates unread only for new assistant output and clears it when viewed", async () => {
     const bot = await createBot({ name: "Scout", persona: "Scout", owner: "owner@example.com" });
     await updateBot(bot.id, { sessionId: "conversation-a" });

--- a/src/bots/authorship.ts
+++ b/src/bots/authorship.ts
@@ -148,7 +148,7 @@ export function formatBotAttribution(author: string, botName: string): string {
  *
  * An unresolvable author is not an error and must not be filled in.
  */
-export function botAuthorIdFromText(text: string): string | undefined {
+export function botAuthorEmailFromText(text: string): string | undefined {
   const match = ATTRIBUTION_AT_START.exec(text);
   if (!match) return undefined;
   const email = normalizeEmail(match[1]);
@@ -159,7 +159,19 @@ export function botAuthorIdFromText(text: string): string | undefined {
   // an OMG_USER value here, which may be a bare name, and a bare name is not
   // an identity the roster can resolve.
   if (!email.includes("@")) return undefined;
-  return botAuthorId(email);
+  return email;
+}
+
+/**
+ * The author of a stored turn, as the opaque id a client payload may carry.
+ *
+ * This is the ONLY form the surface is allowed to receive. The email stays on
+ * the box; see the module note on why the digest is a scope claim and not a
+ * secrecy claim.
+ */
+export function botAuthorIdFromText(text: string): string | undefined {
+  const email = botAuthorEmailFromText(text);
+  return email ? botAuthorId(email) : undefined;
 }
 
 /**

--- a/src/bots/authorship.ts
+++ b/src/bots/authorship.ts
@@ -1,0 +1,178 @@
+// Who wrote a human turn in a bot conversation, and how the UI is allowed to
+// say so.
+//
+// WHAT WAS ACTUALLY BROKEN
+//   `POST /api/bots/:id/messages` decided authorship from `body.user` — a
+//   value the client supplies — and never read the one trusted identity the
+//   box receives. On a self-hosted box with a configured roster that is a
+//   forgeable author: any caller who can reach the API can post as any roster
+//   member, and the resulting `[Message from ...]` line is indistinguishable
+//   from a genuine one. On a hosted Computer it fails the other way: the
+//   roster is empty by construction, so `resolveSessionUserTag` drops the
+//   value and every human turn is attributed to the literal string "user",
+//   from everybody. Neither outcome can support "show me who said this".
+//
+//   bots/access.ts already resolves the trusted caller for the READ routes
+//   (`GET /api/bots`, the read-marking POST). The write route simply never
+//   asked. This module is where the write route asks.
+//
+// THE PREFIX IS THE STORE
+//   Authorship is persisted in the message itself, as the `[Message from X to
+//   bot Y]` line the server has always written onto the delivered prompt. That
+//   is deliberate and it is not a shortcut:
+//
+//     - It is server-authored. The client sends `text`; the server builds the
+//       prefix and puts its own value there.
+//     - It is anchored to the start of the turn, so a client that types a
+//       lookalike line into its own message body cannot outrank the real one:
+//       the parser takes the first match at position zero and nothing else.
+//     - It is already carried, verbatim, by every path that matters — reload,
+//       pagination, websocket replay, and search all read the same
+//       `transcript_messages.text`. A side table keyed on message identity
+//       would have to be re-correlated at each of those, and the correlation
+//       key does not exist: the transcript row is written by the AGENT from
+//       its own JSONL, not by the route that accepted the message.
+//     - Session rotation carries it for free, because rotation does not
+//       rewrite the old transcript (confirmed with the session that owns it).
+//
+//   So there is one owner for "who wrote this" and it is the turn text. This
+//   module owns reading and writing that one representation; nothing else
+//   should pattern-match the prefix.
+//
+// WHY THE CLIENT NEVER SEES THE EMAIL
+//   The prefix holds the raw email because the BOT reads it — it is the only
+//   way the model can tell three humans apart in a shared thread. The client
+//   payload must not carry it: a bot transcript is rendered, quoted, copied
+//   and searched, and a member's address is not something the surface needs in
+//   order to draw a face. So the box emits `authorId` — an opaque, stable
+//   digest of the normalized email — and the surface joins that against the
+//   binding-scoped roster it already receives in `GET /api/bootstrap`.
+//
+//   The digest is not a secrecy claim and must not be described as one: an
+//   email is low-entropy and anyone holding a candidate address can confirm a
+//   match. It is a scope claim. Confirming a match requires already knowing
+//   the address, and on a shared Computer the only people who receive the
+//   roster are the members of that exact Computer, which control-plane scopes
+//   to the (owner, bindingId) pair. The payload adds no reach beyond the
+//   boundary that already exists.
+
+import { createHash } from "node:crypto";
+import type { BotViewer } from "./access.ts";
+
+/**
+ * The attribution line the server writes onto every delivered human turn.
+ *
+ * Anchored at position zero on purpose — see the module note. `[^\]]+` cannot
+ * cross the closing bracket, so a body containing its own bracketed line is
+ * not reachable by this pattern.
+ */
+const ATTRIBUTION_AT_START = /^\s*\[Message from ([^\]]+) to bot [^\]]+\]/i;
+
+/** Normalize an identity the same way the access boundary does. */
+function normalizeEmail(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * The opaque per-person id the client payload carries.
+ *
+ * Versioned in the preimage so this can be rotated later without silently
+ * colliding with ids already rendered by an older surface.
+ */
+export function botAuthorId(email: string): string {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return "";
+  return createHash("sha256").update(`omg-bot-author-v1:${normalized}`).digest("hex").slice(0, 16);
+}
+
+/**
+ * The author the server will stamp onto an accepted human turn.
+ *
+ * Order is the whole point:
+ *
+ *   1. A managed caller's trusted email wins, always. It came from an
+ *      HMAC-verified grant that control-plane issued only after checking the
+ *      share row for this exact machine, and the proxy builds its forwarded
+ *      headers from a fixed whitelist, so a browser cannot put it there. When
+ *      it is present, `body.user` is not consulted at all — that is what makes
+ *      a forged author field inert rather than merely unlikely to be believed.
+ *
+ *   2. Otherwise the box is not managed and there is no trusted multi-user
+ *      identity available. Fall back to exactly the behaviour that shipped
+ *      before this change: the roster-validated tag, then the bot's owner,
+ *      then OMG_USER, then the literal "user". A self-hosted box with a
+ *      roster keeps trusting its own callers because it always has — the
+ *      box's `/api/*` has no auth token and this module does not pretend to
+ *      add one. What it must not do is claim the result is verified.
+ *
+ * `trusted` is what tells the read side whether this attribution is worth
+ * drawing a face next to.
+ */
+export function resolveBotMessageAuthor(input: {
+  viewer: BotViewer;
+  rosterTagUser: string | undefined;
+  botOwner: string | undefined;
+  envUser: string | undefined;
+}): { author: string; trusted: boolean } {
+  if (input.viewer.managed) {
+    const trusted = normalizeEmail(input.viewer.identity);
+    if (trusted) return { author: trusted, trusted: true };
+  }
+  const fallback =
+    input.rosterTagUser?.trim() ||
+    input.botOwner?.trim() ||
+    input.envUser?.trim() ||
+    "user";
+  return { author: fallback, trusted: false };
+}
+
+/** The attribution line, exactly as it has always been written. */
+export function formatBotAttribution(author: string, botName: string): string {
+  return `[Message from ${author} to bot ${botName}]`;
+}
+
+/**
+ * Read the author back off a stored turn, as an opaque id.
+ *
+ * Returns undefined — never a guess — when the turn has no server-authored
+ * prefix. That is the honest answer for three real cases that must stay
+ * distinguishable from "authored by somebody we can name":
+ *
+ *   - Every human turn written before this feature existed. Historical
+ *     transcripts predate the trusted header entirely, and the emails in their
+ *     prefixes were client-supplied, so they are not evidence of authorship.
+ *     They render with no avatar rather than a wrong one.
+ *   - Machine turns that arrive on the user role: a rotation notice, a fired
+ *     routine, a background task report. Nobody wrote them.
+ *   - Anything whose prefix does not sit at position zero.
+ *
+ * An unresolvable author is not an error and must not be filled in.
+ */
+export function botAuthorIdFromText(text: string): string | undefined {
+  const match = ATTRIBUTION_AT_START.exec(text);
+  if (!match) return undefined;
+  const email = normalizeEmail(match[1]);
+  // The pre-feature placeholder. It names no one, so it must not become an id
+  // that three different people would all match.
+  if (!email || email === "user") return undefined;
+  // Only an address can be a person. The legacy fallbacks put a bot owner or
+  // an OMG_USER value here, which may be a bare name, and a bare name is not
+  // an identity the roster can resolve.
+  if (!email.includes("@")) return undefined;
+  return botAuthorId(email);
+}
+
+/**
+ * Whether a turn's author is the person reading it.
+ *
+ * Deliberately takes the SAME normalized identity the access boundary uses
+ * (`BotViewer.identity`, which bots/access.ts derives from the trusted header)
+ * rather than anything the surface knows about itself. If these two ever
+ * disagree, "is this mine" and "may I read this" would be answering questions
+ * about different people.
+ */
+export function isOwnBotMessage(authorId: string | undefined, viewer: BotViewer): boolean {
+  if (!authorId) return false;
+  const self = botAuthorId(viewer.identity);
+  return !!self && self === authorId;
+}

--- a/src/bots/rotation.test.ts
+++ b/src/bots/rotation.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type { Bot } from "./store.ts";
+import {
+  appendArchivedSession,
+  botCompactionDecision,
+  botConfigStatus,
+  botRotationAdmission,
+  buildHandoffCheckpoint,
+  defaultBotCompactionSettings,
+  extractCheckpointSections,
+  formatHandoffCheckpoint,
+  measuredContextPercent,
+  migrateLegacyBotRotationState,
+  queueBlocksBotRotation,
+  redactForCheckpoint,
+  rotationCompareAndSwap,
+  sessionBoundConfigChanged,
+  sessionBoundConfigOf,
+} from "./rotation.ts";
+
+const bot = (patch: Partial<Bot> = {}): Bot => ({
+  id: "bot_one",
+  name: "Scout",
+  persona: "Be concise",
+  agent: "aisdk",
+  enabled: true,
+  createdAt: 1,
+  ...patch,
+});
+
+describe("bot configuration revisions", () => {
+  test("manual persona edits create an update without treating cosmetics as runtime config", () => {
+    const before = bot({ shape: "circle", colorway: "warm" });
+    expect(sessionBoundConfigChanged(
+      sessionBoundConfigOf(before),
+      sessionBoundConfigOf({ ...before, persona: "Use the new instructions" }),
+    )).toBe(true);
+    const cosmeticAfter: Bot = { ...before, shape: "hexagon", colorway: "forest" };
+    expect(sessionBoundConfigChanged(
+      sessionBoundConfigOf(before),
+      sessionBoundConfigOf(cosmeticAfter),
+    )).toBe(false);
+    expect(botConfigStatus({ configRevision: 2, appliedConfigRevision: 1, rotationState: "idle" }))
+      .toBe("update-available");
+  });
+
+  test("CAS makes duplicate clients idempotent and rejects an older unapplied revision", () => {
+    expect(rotationCompareAndSwap({ configRevision: 2, appliedConfigRevision: 1 }, 2))
+      .toEqual({ proceed: true });
+    expect(rotationCompareAndSwap({ configRevision: 2, appliedConfigRevision: 2 }, 2))
+      .toEqual({ proceed: false, outcome: "already-applied" });
+    expect(rotationCompareAndSwap({ configRevision: 3, appliedConfigRevision: 1 }, 2))
+      .toEqual({ proceed: false, outcome: "stale" });
+  });
+
+  test("legacy pending refresh becomes one queued revision on the stable conversation", () => {
+    const migrated = migrateLegacyBotRotationState(bot({
+      sessionId: "legacy-session",
+      runtimeRefreshPending: true,
+    }), 42);
+    expect(migrated).toMatchObject({
+      conversationId: "legacy-session",
+      runtimeRefreshPending: false,
+      configRevision: 2,
+      appliedConfigRevision: 1,
+      rotationState: "queued",
+      rotationReason: "config",
+      rotationUpdatedAt: 42,
+    });
+    expect(migrateLegacyBotRotationState(migrated, 43)).toEqual(migrated);
+  });
+});
+
+describe("safe rotation admission", () => {
+  test("waits for a busy primary and active children, but ignores completed children", () => {
+    expect(botRotationAdmission("bot_one", { sessionId: "old", busy: true }, []))
+      .toEqual({ ready: false, blocked: "primary-busy", children: [] });
+    expect(botRotationAdmission("bot_one", { sessionId: "old", busy: false }, [
+      { sessionId: "child", botId: "bot_one", parentSessionId: "old", pid: 10 },
+    ])).toEqual({ ready: false, blocked: "children-active", children: ["child"] });
+    expect(botRotationAdmission("bot_one", { sessionId: "old", busy: false }, [
+      { sessionId: "child", botId: "bot_one", parentSessionId: "old", pid: 0 },
+    ])).toEqual({ ready: true });
+  });
+
+  test("queued messages block rotation until delivery preserves their order", () => {
+    expect(queueBlocksBotRotation([{ status: "pending" }, { status: "delivered" }])).toBe(true);
+    expect(queueBlocksBotRotation([{ status: "queued" }])).toBe(true);
+    expect(queueBlocksBotRotation([{ status: "delivered" }, { status: "failed" }])).toBe(false);
+  });
+});
+
+describe("automatic context rotation", () => {
+  const settings = defaultBotCompactionSettings();
+
+  test("uses measured token capacity and rotates at the exact threshold", () => {
+    const usage = { available: true, context: { used: 78_000, max: 100_000, percent: 1 } };
+    expect(measuredContextPercent(usage)).toBe(78);
+    expect(botCompactionDecision({ usage, bot: {}, settings, now: 1_000 })).toMatchObject({
+      rotate: true,
+      armed: false,
+      reason: "threshold-crossed",
+    });
+  });
+
+  test("does not guess without token data and hysteresis prevents a loop", () => {
+    expect(botCompactionDecision({ usage: null, bot: {}, settings, now: 1_000 }).reason)
+      .toBe("no-token-data");
+    expect(botCompactionDecision({
+      usage: { context: { used: 90, max: 100 } },
+      bot: { compactionArmed: false },
+      settings,
+      now: 2_000,
+    }).reason).toBe("not-armed");
+    expect(botCompactionDecision({
+      usage: { context: { used: 50, max: 100 } },
+      bot: { compactionArmed: false },
+      settings,
+      now: 3_000,
+    })).toMatchObject({ rotate: false, armed: true });
+  });
+
+  test("minimum interval rejects another automatic rotation", () => {
+    const result = botCompactionDecision({
+      usage: { context: { used: 90, max: 100 } },
+      bot: { compactionArmed: true, lastCompactionAt: 10_000 },
+      settings,
+      now: 10_000 + settings.minIntervalMs - 1,
+    });
+    expect(result.reason).toBe("too-soon");
+  });
+});
+
+describe("continuity checkpoint", () => {
+  test("extracts goals and only explicit durable sections", () => {
+    expect(extractCheckpointSections([
+      { role: "user", text: "Please finish the runtime rotation." },
+      { role: "assistant", text: "Decision: keep one durable conversation id.\nRemaining: run browser acceptance." },
+      { role: "user", text: "I prefer short progress updates." },
+    ])).toEqual({
+      goals: ["Please finish the runtime rotation.", "I prefer short progress updates."],
+      decisions: ["Decision: keep one durable conversation id."],
+      openTasks: ["Remaining: run browser acceptance."],
+      preferences: ["I prefer short progress updates."],
+    });
+  });
+
+  test("keeps verified and legacy authors while removing old contracts and secrets", () => {
+    const checkpoint = buildHandoffCheckpoint({
+      sourceSessionId: "old-runtime",
+      reason: "config",
+      configRevision: 4,
+      createdAt: 100,
+      goals: ["Ship the rotation"],
+      decisions: ["Keep conversation identity stable"],
+      openTasks: ["Run acceptance"],
+      preferences: ["Use short updates"],
+      artifacts: ["ff64f2b"],
+      turns: [
+        { role: "user", author: "person@example.com", text: "Continue from ff64f2b" },
+        { role: "user", author: "legacy:unknown", text: "Historical request" },
+        { role: "assistant", text: "Token: sk-abcdefghijklmnopqrstuvwxyz" },
+      ],
+    });
+    const rendered = formatHandoffCheckpoint(checkpoint);
+    expect(rendered).toContain("Source session: old-runtime");
+    expect(rendered).toContain("user (person@example.com)");
+    expect(rendered).toContain("user (legacy:unknown)");
+    expect(rendered).toContain("[redacted]");
+    expect(rendered).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+
+  test("does not carry a prior runtime contract into the new prompt", () => {
+    const old = "=== omg.dev BOT RUNTIME CONTRACT ===\nold persona\n=== END omg.dev BOT RUNTIME CONTRACT ===\nreal turn";
+    expect(redactForCheckpoint(old)).toBe("real turn");
+  });
+
+  test("archives runtimes once and keeps the list bounded", () => {
+    const history = Array.from({ length: 30 }, (_, index) => `s${index}`);
+    const archived = appendArchivedSession(history, "s5");
+    expect(archived[0]).toBe("s5");
+    expect(archived.filter((id) => id === "s5")).toHaveLength(1);
+    expect(archived).toHaveLength(25);
+  });
+});

--- a/src/bots/rotation.ts
+++ b/src/bots/rotation.ts
@@ -226,6 +226,8 @@ export type BotRotationSession = {
   nativeSessionId?: string | null;
   botId?: string | null;
   busy?: boolean;
+  pid?: number | null;
+  launching?: boolean;
   parentSessionId?: string | null;
   parentNativeSessionId?: string | null;
   subagentDepth?: number | null;
@@ -256,7 +258,12 @@ export function activeBotChildren<T extends BotRotationSession>(
       !!session.parentNativeSessionId ||
       !!session.subagentDepth ||
       session.spawnedBy === "subagent";
-    return delegated;
+    if (!delegated) return false;
+    // listSessions can retain resumable history. Only a running or launching
+    // child can still report into the primary and therefore block rotation.
+    return session.pid === undefined
+      ? true
+      : !!session.busy || !!session.launching || (session.pid ?? 0) > 0;
   });
 }
 
@@ -267,18 +274,12 @@ export function activeBotChildren<T extends BotRotationSession>(
  * somebody is waiting for; a bot with live children has delegated work that
  * will try to report home. Rotating through either loses real work silently,
  * which is the one outcome worse than a stale persona.
- *
- * `force` is the explicit escape hatch. It does not skip the checkpoint and it
- * does not skip the safe interrupt in the caller — it only says the human has
- * confirmed that losing the in-flight turn is acceptable.
  */
 export function botRotationAdmission(
   botId: string,
   primary: BotRotationSession | undefined,
   sessions: readonly BotRotationSession[],
-  opts: { force?: boolean } = {},
 ): BotRotationAdmission {
-  if (opts.force) return { ready: true };
   if (primary?.busy) {
     return {
       ready: false,
@@ -291,6 +292,15 @@ export function botRotationAdmission(
     .filter((id): id is string => !!id);
   if (children.length) return { ready: false, blocked: "children-active", children };
   return { ready: true };
+}
+
+/** A queued turn must keep its original ordering and finish before rotation. */
+export function queueBlocksBotRotation(
+  messages: readonly { status: string }[],
+): boolean {
+  return messages.some((message) =>
+    message.status === "pending" || message.status === "sending" || message.status === "queued"
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -448,8 +458,8 @@ export function measuredContextPercent(usage: BotContextReading | null | undefin
 /**
  * One turn carried across the boundary.
  *
- * `author` is the trusted normalized author identity (an email), server-derived
- * and possibly absent. It exists for multi-user bot threads: when several
+ * `author` is the trusted normalized author identity (an email), server-derived,
+ * or the explicit `legacy:unknown` marker. It exists for multi-user bot threads: when several
  * people share a conversation, collapsing every human turn to the bare word
  * "user" loses who said what, and the bot wakes up in the new session unable to
  * attribute a preference or a request to the person who made it.
@@ -484,6 +494,36 @@ export type BotHandoffCheckpoint = {
   artifacts: string[];
   recentTurns: CheckpointTurn[];
 };
+
+/**
+ * Build conservative structured sections from explicit prose signals.
+ *
+ * The latest human turns are current goals. Decisions, unresolved work, and
+ * preferences require direct wording. This avoids inventing durable facts from
+ * ordinary discussion while still giving the new runtime more than a raw tail.
+ */
+export function extractCheckpointSections(turns: readonly CheckpointTurn[]): Pick<
+  BotHandoffCheckpoint,
+  "goals" | "decisions" | "openTasks" | "preferences"
+> {
+  const human = turns.filter((turn) => turn.role === "user" && turn.text.trim());
+  const goals = human.slice(-3).map((turn) => turn.text);
+  const lines = turns.flatMap((turn) =>
+    turn.text.split(/\n+/).map((line) => line.replace(/^[-*\d.)\s]+/, "").trim()).filter(Boolean)
+  );
+  return {
+    goals,
+    decisions: lines.filter((line) =>
+      /^(?:decision|decided)\s*[:\-]|\b(?:we|the user) (?:decided|will use|will keep)\b|\bmust (?:remain|stay|use|not)\b/i.test(line)
+    ),
+    openTasks: lines.filter((line) =>
+      /^(?:todo|open task|remaining|next|unresolved|blocked)\s*[:\-]|\b(?:still need|remains to|not yet)\b/i.test(line)
+    ),
+    preferences: lines.filter((line) =>
+      /\b(?:I|the user) (?:prefer|always want|never want)\b|^(?:preference|user preference)\s*[:\-]/i.test(line)
+    ),
+  };
+}
 
 /** Hard bounds. A checkpoint that blows the budget defeats the point of rotating. */
 export const CHECKPOINT_MAX_TURNS = 12;
@@ -711,9 +751,25 @@ export function rotationCompareAndSwap(
   // No expectation supplied: compaction and other server-initiated rotations
   // always target whatever is current.
   if (expectedRevision === undefined) return { proceed: true };
-  if (expectedRevision > current) return { proceed: false, outcome: "stale" };
   if (expectedRevision <= applied) return { proceed: false, outcome: "already-applied" };
+  if (expectedRevision !== current) return { proceed: false, outcome: "stale" };
   return { proceed: true };
+}
+
+/** Translate the old deferred-refresh flag without losing its requested edit. */
+export function migrateLegacyBotRotationState(bot: Bot, now = Date.now()): Bot {
+  if (!bot.runtimeRefreshPending) return bot;
+  return {
+    ...bot,
+    conversationId: bot.conversationId?.trim() || bot.sessionId?.trim() || undefined,
+    runtimeRefreshPending: false,
+    configRevision: nextBotConfigRevision(bot),
+    appliedConfigRevision: botConfigRevision(bot),
+    rotationState: "queued",
+    rotationReason: "config",
+    rotationError: undefined,
+    rotationUpdatedAt: now,
+  };
 }
 
 /** Bounded archive of prior canonical sessions, newest first. */

--- a/src/bots/rotation.ts
+++ b/src/bots/rotation.ts
@@ -1,0 +1,728 @@
+// Rotating a persistent bot onto a fresh canonical session.
+//
+// Two different problems land on the same primitive, which is why they live in
+// one file instead of two.
+//
+// 1. CONFIGURATION. A bot's persona, description, capabilities, agent, model,
+//    thinking level and workspace are all baked into the launch prompt
+//    (`botRuntimeContract`, injected once by `ensureBotSession`). Editing any
+//    of them changes what the bot is *supposed* to be, but the running model
+//    session has already read the old text. There is no supported way to
+//    rewrite a system prompt underneath a live model — every harness we drive
+//    treats the launch prompt as immutable for the life of the thread — so the
+//    only honest way to apply a persona edit is a new session.
+//
+//    The previous mechanism (`runtimeRefreshPending`) killed the process and
+//    relaunched it on the SAME conversation id. That reads like a refresh and
+//    is not one: `botConversationRef` deliberately reuses the id so the human's
+//    transcript survives, and for aisdk `sessionHasIndexedMessages` then makes
+//    the harness RESUME its own thread. The new contract text arrives as one
+//    more turn appended to a conversation that still contains, and still obeys,
+//    the old one. Users reported exactly that — "I changed the persona and it's
+//    still acting like the old bot."
+//
+// 2. CONTEXT. A persistent bot is by construction long-lived. Its conversation
+//    only ever grows, and at some point it stops fitting. Failing at the
+//    context wall loses the turn and, worse, leaves the bot wedged: every retry
+//    hits the same wall. Rotating *before* the wall, carrying a summary
+//    forward, keeps the thread alive.
+//
+// Both want the same three steps: capture what matters, start a fresh session
+// with the current config, then rebind. So there is one rotation primitive, and
+// configuration/compaction are just two reasons to invoke it.
+//
+// This module is the pure half — decisions, revision arithmetic, checkpoint
+// assembly and redaction. It spawns nothing and writes nothing, so every rule
+// below is testable without a harness. The effectful half (spawn, rebind,
+// archive) lives in serve.ts's `rotateBotSession`, which is the only writer.
+
+import { stripOmgRuntimeContract } from "../omg-capabilities.ts";
+import { stripBotLaunchEnvelope } from "./transcript.ts";
+import type { Bot } from "./store.ts";
+
+/** Why a rotation was asked for. Recorded so the UI can be truthful. */
+export type BotRotationReason = "config" | "compaction";
+
+/**
+ * Where a bot is in the rotation lifecycle.
+ *
+ * `queued` is the load-bearing one: a rotation that cannot run right now
+ * because the bot is mid-turn is not a failure and must not be silently
+ * dropped. It waits, visibly.
+ */
+export type BotRotationState = "idle" | "queued" | "rotating" | "failed";
+
+/** What the bot editor shows next to its Apply control. */
+export type BotConfigStatus =
+  | "current"
+  | "update-available"
+  | "queued"
+  | "refreshing"
+  | "failed";
+
+/**
+ * Fields whose value is copied into the launch prompt, and which therefore
+ * cannot change without a new session.
+ *
+ * This is the same set the old `runtimeRefreshPending` path used, kept
+ * deliberately identical so the upgrade does not silently change which edits
+ * are considered material. `name`, `description` and `capabilities` are in here
+ * because `botRuntimeContract` interpolates all three; they look cosmetic in
+ * the roster and are not.
+ */
+export const SESSION_BOUND_BOT_FIELDS: ReadonlySet<string> = new Set([
+  "name",
+  "persona",
+  "description",
+  "capabilities",
+  "agent",
+  "model",
+  "thinkingLevel",
+  "cwd",
+  "user",
+]);
+
+/**
+ * Fields that already render live from the bot record on every surface.
+ *
+ * The avatar is read from the record by `BotMascot` at paint time, and
+ * `enabled` is a gate the server checks per message. Neither is in the launch
+ * prompt, so neither may force a rotation — making someone restart their bot's
+ * conversation to change its colour would be absurd, and the requirement is
+ * explicit that cosmetic edits must not rotate.
+ */
+export const COSMETIC_BOT_FIELDS: ReadonlySet<string> = new Set([
+  "shape",
+  "colorway",
+  "enabled",
+]);
+
+/** Does this PATCH body mention anything baked into the launch prompt? */
+export function botPatchTouchesSessionBoundField(body: Record<string, unknown>): boolean {
+  return Object.keys(body).some((field) => SESSION_BOUND_BOT_FIELDS.has(field));
+}
+
+/** The projection of a bot that the launch prompt is built from. */
+export type SessionBoundConfig = Pick<
+  Bot,
+  "name" | "persona" | "description" | "capabilities" | "agent" | "model" | "thinkingLevel" | "cwd" | "owner"
+>;
+
+export function sessionBoundConfigOf(bot: SessionBoundConfig): SessionBoundConfig {
+  return {
+    name: bot.name,
+    persona: bot.persona,
+    description: bot.description,
+    capabilities: bot.capabilities,
+    agent: bot.agent,
+    model: bot.model,
+    thinkingLevel: bot.thinkingLevel,
+    cwd: bot.cwd,
+    owner: bot.owner,
+  };
+}
+
+const norm = (value: string | undefined | null): string => (value ?? "").trim();
+
+/**
+ * Did an edit actually change the launch prompt?
+ *
+ * Presence of a key is not enough, and this is the difference between a feature
+ * that works and one everybody learns to ignore. The bot editor is a single
+ * form that submits every field on Save, so `name`, `persona`, `agent`, `model`
+ * and `cwd` are in the body of *every* PATCH — including one where the user
+ * only picked a new colour. Bumping on key presence would mark the bot
+ * "Update available" after a purely cosmetic save, offer a rotation that would
+ * change nothing, and cost the user their conversation to apply a no-op.
+ *
+ * So compare values. Whitespace is normalised because a stray trailing space in
+ * a textarea is not a persona change, and capabilities compare element-wise
+ * because order is what the contract renders.
+ */
+export function sessionBoundConfigChanged(
+  before: SessionBoundConfig,
+  after: SessionBoundConfig,
+): boolean {
+  if (
+    norm(before.name) !== norm(after.name) ||
+    norm(before.persona) !== norm(after.persona) ||
+    norm(before.description) !== norm(after.description) ||
+    norm(before.agent) !== norm(after.agent) ||
+    norm(before.model) !== norm(after.model) ||
+    norm(before.thinkingLevel) !== norm(after.thinkingLevel) ||
+    norm(before.cwd) !== norm(after.cwd) ||
+    norm(before.owner).toLowerCase() !== norm(after.owner).toLowerCase()
+  ) {
+    return true;
+  }
+  const left = (before.capabilities ?? []).map(norm);
+  const right = (after.capabilities ?? []).map(norm);
+  return left.length !== right.length || left.some((item, index) => item !== right[index]);
+}
+
+/**
+ * The revision arithmetic.
+ *
+ * Legacy bots carry neither field. Defaulting `configRevision` to 1 and
+ * `appliedConfigRevision` to 0 would light up "Update available" on every bot
+ * in the roster the moment this ships, for a change nobody made — so an absent
+ * applied revision reads as "whatever the current revision is", i.e. current.
+ * The first real session-bound edit after the upgrade bumps to 2 and the
+ * difference becomes meaningful.
+ */
+export function botConfigRevision(bot: Pick<Bot, "configRevision">): number {
+  const value = bot.configRevision;
+  return Number.isInteger(value) && (value as number) >= 1 ? value as number : 1;
+}
+
+export function botAppliedConfigRevision(
+  bot: Pick<Bot, "configRevision" | "appliedConfigRevision">,
+): number {
+  const value = bot.appliedConfigRevision;
+  if (Number.isInteger(value) && (value as number) >= 0) return value as number;
+  return botConfigRevision(bot);
+}
+
+/** The revision a session-bound edit moves the bot to. Monotonic by construction. */
+export function nextBotConfigRevision(bot: Pick<Bot, "configRevision">): number {
+  return botConfigRevision(bot) + 1;
+}
+
+/** Is the bot's live configuration older than its record's? */
+export function botHasPendingConfig(
+  bot: Pick<Bot, "configRevision" | "appliedConfigRevision">,
+): boolean {
+  return botAppliedConfigRevision(bot) < botConfigRevision(bot);
+}
+
+/**
+ * The single truthful answer to "what does the Apply control say".
+ *
+ * Order matters. An in-flight rotation outranks a pending edit, because while
+ * it runs the honest word is "Refreshing" even though the revisions still
+ * differ — they only converge at the very end, on rebind. A failure outranks
+ * "update available" for the same reason: the user needs to know the last
+ * attempt did not land, not just that one is outstanding.
+ */
+export function botConfigStatus(
+  bot: Pick<
+    Bot,
+    "configRevision" | "appliedConfigRevision" | "rotationState"
+  >,
+): BotConfigStatus {
+  if (bot.rotationState === "rotating") return "refreshing";
+  if (bot.rotationState === "failed") return "failed";
+  if (!botHasPendingConfig(bot)) return "current";
+  return bot.rotationState === "queued" ? "queued" : "update-available";
+}
+
+// ---------------------------------------------------------------------------
+// Admission: may a rotation run right now?
+// ---------------------------------------------------------------------------
+
+/** A live session as the rotation gate needs to see it. */
+export type BotRotationSession = {
+  sessionId?: string | null;
+  nativeSessionId?: string | null;
+  botId?: string | null;
+  busy?: boolean;
+  parentSessionId?: string | null;
+  parentNativeSessionId?: string | null;
+  subagentDepth?: number | null;
+  spawnedBy?: string | null;
+};
+
+export type BotRotationBlock = "primary-busy" | "children-active";
+
+export type BotRotationAdmission =
+  | { ready: true }
+  | { ready: false; blocked: BotRotationBlock; children: string[] };
+
+/**
+ * Delegated children of this bot that are still running.
+ *
+ * Child sessions inherit `botId` for attribution (see the note atop
+ * session.ts), which is what makes them findable here — and is also why the
+ * primary must be matched by identity rather than by `botId` alone.
+ */
+export function activeBotChildren<T extends BotRotationSession>(
+  botId: string,
+  sessions: readonly T[],
+): T[] {
+  return sessions.filter((session) => {
+    if (session.botId !== botId) return false;
+    const delegated =
+      !!session.parentSessionId ||
+      !!session.parentNativeSessionId ||
+      !!session.subagentDepth ||
+      session.spawnedBy === "subagent";
+    return delegated;
+  });
+}
+
+/**
+ * Whether rotation may proceed, and if not, why.
+ *
+ * Default is to wait, never to kill. A bot mid-turn is producing an answer
+ * somebody is waiting for; a bot with live children has delegated work that
+ * will try to report home. Rotating through either loses real work silently,
+ * which is the one outcome worse than a stale persona.
+ *
+ * `force` is the explicit escape hatch. It does not skip the checkpoint and it
+ * does not skip the safe interrupt in the caller — it only says the human has
+ * confirmed that losing the in-flight turn is acceptable.
+ */
+export function botRotationAdmission(
+  botId: string,
+  primary: BotRotationSession | undefined,
+  sessions: readonly BotRotationSession[],
+  opts: { force?: boolean } = {},
+): BotRotationAdmission {
+  if (opts.force) return { ready: true };
+  if (primary?.busy) {
+    return {
+      ready: false,
+      blocked: "primary-busy",
+      children: [],
+    };
+  }
+  const children = activeBotChildren(botId, sessions)
+    .map((session) => session.sessionId ?? session.nativeSessionId)
+    .filter((id): id is string => !!id);
+  if (children.length) return { ready: false, blocked: "children-active", children };
+  return { ready: true };
+}
+
+// ---------------------------------------------------------------------------
+// Automatic compaction
+// ---------------------------------------------------------------------------
+
+export type BotCompactionSettings = {
+  /** Master switch. Off means a bot only ever rotates when a human applies a change. */
+  enabled: boolean;
+  /** Rotate at or above this share of the model's context window. */
+  thresholdPercent: number;
+  /** Re-arm only after usage falls back to or below this share. */
+  rearmPercent: number;
+  /** Floor between two automatic rotations, whatever the numbers say. */
+  minIntervalMs: number;
+};
+
+export const DEFAULT_BOT_COMPACTION_THRESHOLD_PERCENT = 78;
+export const DEFAULT_BOT_COMPACTION_REARM_PERCENT = 55;
+export const DEFAULT_BOT_COMPACTION_MIN_INTERVAL_MS = 5 * 60_000;
+export const MIN_BOT_COMPACTION_THRESHOLD_PERCENT = 40;
+export const MAX_BOT_COMPACTION_THRESHOLD_PERCENT = 95;
+
+export function defaultBotCompactionSettings(): BotCompactionSettings {
+  return {
+    enabled: true,
+    thresholdPercent: DEFAULT_BOT_COMPACTION_THRESHOLD_PERCENT,
+    rearmPercent: DEFAULT_BOT_COMPACTION_REARM_PERCENT,
+    minIntervalMs: DEFAULT_BOT_COMPACTION_MIN_INTERVAL_MS,
+  };
+}
+
+/**
+ * Clamp an operator-supplied threshold into a range where it still means
+ * something. Below 40% a bot would rotate constantly and never accumulate
+ * enough thread to be useful; above 95% there is not enough headroom left to
+ * write the checkpoint and launch a replacement before the wall.
+ */
+export function sanitizeBotCompactionThreshold(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return DEFAULT_BOT_COMPACTION_THRESHOLD_PERCENT;
+  return Math.min(
+    MAX_BOT_COMPACTION_THRESHOLD_PERCENT,
+    Math.max(MIN_BOT_COMPACTION_THRESHOLD_PERCENT, Math.round(numeric)),
+  );
+}
+
+/** The context reading compaction is allowed to act on. Shape of `SessionTokenUsage`. */
+export type BotContextReading = {
+  available?: boolean;
+  source?: string;
+  context?: {
+    used?: number | null;
+    max?: number | null;
+    percent?: number | null;
+  } | null;
+};
+
+export type BotCompactionDecision = {
+  rotate: boolean;
+  /** The armed flag to persist back onto the bot. */
+  armed: boolean;
+  /** Measured fill, or null when the harness does not report usable numbers. */
+  percent: number | null;
+  reason:
+    | "disabled"
+    | "no-token-data"
+    | "below-threshold"
+    | "not-armed"
+    | "too-soon"
+    | "threshold-crossed";
+};
+
+/**
+ * Should this bot rotate for context pressure?
+ *
+ * Deliberately refuses to guess. When the harness does not report token usage
+ * the answer is "no", not "fall back to counting transcript rows" — a row count
+ * has no fixed relationship to context fill (one tool result can outweigh two
+ * hundred chat turns), so acting on it would rotate healthy bots and miss full
+ * ones. A bot on a harness with no token telemetry keeps the old behaviour of
+ * running until the harness itself complains, which is no worse than today.
+ *
+ * Hysteresis is the other half. A bare threshold thrashes: the checkpoint
+ * carried into the new session is itself context, so a bot that rotates at 78%
+ * may well start life at 30-40%, and any noise around the line would rotate it
+ * again immediately. Usage must fall back to `rearmPercent` before another
+ * automatic rotation can fire, and `minIntervalMs` is the belt-and-braces floor
+ * for a bot whose fresh session somehow still reads above the re-arm mark.
+ */
+export function botCompactionDecision(input: {
+  usage: BotContextReading | null | undefined;
+  bot: Pick<Bot, "compactionArmed" | "lastCompactionAt">;
+  settings: BotCompactionSettings;
+  now: number;
+}): BotCompactionDecision {
+  // An absent flag means armed. A bot that has never rotated must be eligible
+  // the first time it fills up, and persisting `true` for every bot at upgrade
+  // time just to say "not yet used" is state for its own sake.
+  const armed = input.bot.compactionArmed !== false;
+  if (!input.settings.enabled) {
+    return { rotate: false, armed, percent: null, reason: "disabled" };
+  }
+
+  const percent = measuredContextPercent(input.usage);
+  if (percent === null) {
+    return { rotate: false, armed, percent: null, reason: "no-token-data" };
+  }
+
+  // Re-arm first, so a single reading that is both below the re-arm mark and
+  // (impossibly) above the threshold cannot do both. Below re-arm is
+  // unambiguously "healthy", and healthy never rotates.
+  if (percent <= input.settings.rearmPercent) {
+    return { rotate: false, armed: true, percent, reason: "below-threshold" };
+  }
+  if (percent < input.settings.thresholdPercent) {
+    return { rotate: false, armed, percent, reason: "below-threshold" };
+  }
+  // At or above the line from here down.
+  if (!armed) return { rotate: false, armed, percent, reason: "not-armed" };
+  const last = input.bot.lastCompactionAt ?? 0;
+  if (last && input.now - last < input.settings.minIntervalMs) {
+    return { rotate: false, armed, percent, reason: "too-soon" };
+  }
+  return { rotate: true, armed: false, percent, reason: "threshold-crossed" };
+}
+
+/**
+ * Context fill as a percentage, or null when it cannot be established.
+ *
+ * Recomputed from `used`/`max` rather than trusting a reported `percent`,
+ * because the two disagree in practice: some harnesses report a percentage
+ * against a soft "usable" window while `max` is the hard one. The ratio we act
+ * on has to be the ratio against the number that actually overflows. `percent`
+ * alone is accepted only when the raw pair is missing.
+ */
+export function measuredContextPercent(usage: BotContextReading | null | undefined): number | null {
+  const context = usage?.context;
+  if (!context) return null;
+  const used = context.used;
+  const max = context.max;
+  if (typeof used === "number" && Number.isFinite(used) && used >= 0 &&
+      typeof max === "number" && Number.isFinite(max) && max > 0) {
+    return (used / max) * 100;
+  }
+  const percent = context.percent;
+  if (typeof percent === "number" && Number.isFinite(percent) && percent >= 0) return percent;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// The handoff checkpoint
+// ---------------------------------------------------------------------------
+
+/**
+ * One turn carried across the boundary.
+ *
+ * `author` is the trusted normalized author identity (an email), server-derived
+ * and possibly absent. It exists for multi-user bot threads: when several
+ * people share a conversation, collapsing every human turn to the bare word
+ * "user" loses who said what, and the bot wakes up in the new session unable to
+ * attribute a preference or a request to the person who made it.
+ *
+ * It is an email rather than a display name because on a hosted shared Computer
+ * a display name does not exist server-side — the local roster is empty by
+ * construction there, and member profiles live only in the roster control-plane
+ * merges into the bootstrap response. The verified header value is the only
+ * identity the box actually holds. It is also no more disclosure than the
+ * surrounding transcript already carries, since the delivered prompt is already
+ * wrapped in `[Message from <email> to bot <name>]`.
+ */
+export type CheckpointTurn = {
+  role: "user" | "assistant";
+  text: string;
+  author?: string;
+};
+
+/** Attribution is prose in a durable prompt, so it is bounded like everything else. */
+export const CHECKPOINT_MAX_AUTHOR_CHARS = 60;
+
+export type BotHandoffCheckpoint = {
+  /** Where this came from, so the new session can cite it rather than claim it. */
+  sourceSessionId: string;
+  reason: BotRotationReason;
+  configRevision: number;
+  createdAt: number;
+  goals: string[];
+  decisions: string[];
+  openTasks: string[];
+  preferences: string[];
+  artifacts: string[];
+  recentTurns: CheckpointTurn[];
+};
+
+/** Hard bounds. A checkpoint that blows the budget defeats the point of rotating. */
+export const CHECKPOINT_MAX_TURNS = 12;
+export const CHECKPOINT_MAX_TURN_CHARS = 600;
+export const CHECKPOINT_MAX_SECTION_ITEMS = 8;
+export const CHECKPOINT_MAX_ITEM_CHARS = 300;
+export const CHECKPOINT_MAX_TOTAL_CHARS = 12_000;
+
+/**
+ * Patterns that must never cross the boundary.
+ *
+ * A checkpoint is written into the next session's launch prompt, which is
+ * persisted, indexed, and readable anywhere the transcript is. Anything secret
+ * that lands there has been copied into a second durable place. Cheap prefix
+ * matching on the well-known shapes is not a general secret scanner and is not
+ * claimed to be one; it is the floor, and the real defence is that only user
+ * and assistant prose is eligible in the first place (no tool results, no
+ * environment, no contract text).
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{16,}/g,
+  /\bghp_[A-Za-z0-9]{20,}/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{30,}/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g,
+  /\b(?:api[_-]?key|secret|password|passwd|token|bearer)\s*[:=]\s*\S{8,}/gi,
+];
+
+/**
+ * Strip anything that must not be copied forward.
+ *
+ * Four separate things are being removed, in order:
+ *  - the BOT launch envelope: the bot runtime contract, any prior-conversation
+ *    summary, and any earlier handoff checkpoint. This is the one that must not
+ *    be forgotten. The contract carries the bot's persona verbatim, so copying
+ *    a launch turn forward would paste the OLD persona into the new session's
+ *    prompt and the bot would keep behaving like its old self — reintroducing
+ *    the exact bug rotation exists to fix, in the exact code that fixes it.
+ *    Stripping earlier checkpoints also stops summaries nesting inside
+ *    summaries as a long-lived bot rotates for the fifth time;
+ *  - the task-session runtime contract, same reasoning, different envelope;
+ *  - credential-shaped strings;
+ *  - the peer-message envelope header, which carries routing ids that mean
+ *    nothing in a new session.
+ */
+export function redactForCheckpoint(text: string): string {
+  let out = stripOmgRuntimeContract(stripBotLaunchEnvelope(text));
+  out = out.replace(/^\[Peer message from [^\]]*\]\s*/gm, "");
+  out = out.replace(/^Message ID: \S+$/gm, "");
+  out = out.replace(/^Correlation ID: \S+$/gm, "");
+  for (const pattern of SECRET_PATTERNS) out = out.replace(pattern, "[redacted]");
+  return out.replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function clampItems(items: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of items) {
+    const text = redactForCheckpoint(String(raw ?? "")).slice(0, CHECKPOINT_MAX_ITEM_CHARS).trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    out.push(text);
+    if (out.length >= CHECKPOINT_MAX_SECTION_ITEMS) break;
+  }
+  return out;
+}
+
+/**
+ * Assemble a checkpoint from whatever the summarizer produced plus the tail of
+ * the conversation.
+ *
+ * The structured sections are best-effort: when the summarizer is unavailable
+ * or returns nothing usable, the recent turns alone still carry the thread, and
+ * that is a materially better handoff than starting blank. What is NOT
+ * best-effort is the bound — every section is clamped here rather than trusted,
+ * because the input may come from a model.
+ */
+export function buildHandoffCheckpoint(input: {
+  sourceSessionId: string;
+  reason: BotRotationReason;
+  configRevision: number;
+  createdAt: number;
+  goals?: readonly string[];
+  decisions?: readonly string[];
+  openTasks?: readonly string[];
+  preferences?: readonly string[];
+  artifacts?: readonly string[];
+  turns?: readonly CheckpointTurn[];
+}): BotHandoffCheckpoint {
+  const recentTurns = (input.turns ?? [])
+    .filter((turn) => turn.role === "user" || turn.role === "assistant")
+    .slice(-CHECKPOINT_MAX_TURNS)
+    .map((turn) => {
+      const author = redactForCheckpoint(turn.author ?? "")
+        .slice(0, CHECKPOINT_MAX_AUTHOR_CHARS)
+        .trim();
+      return {
+        role: turn.role,
+        text: redactForCheckpoint(turn.text ?? "").slice(0, CHECKPOINT_MAX_TURN_CHARS).trim(),
+        ...(author ? { author } : {}),
+      };
+    })
+    .filter((turn) => !!turn.text);
+
+  return {
+    sourceSessionId: input.sourceSessionId,
+    reason: input.reason,
+    configRevision: input.configRevision,
+    createdAt: input.createdAt,
+    goals: clampItems(input.goals ?? []),
+    decisions: clampItems(input.decisions ?? []),
+    openTasks: clampItems(input.openTasks ?? []),
+    preferences: clampItems(input.preferences ?? []),
+    artifacts: clampItems(input.artifacts ?? []),
+    recentTurns,
+  };
+}
+
+/** Does this checkpoint carry anything at all worth injecting? */
+export function checkpointIsEmpty(checkpoint: BotHandoffCheckpoint): boolean {
+  return (
+    !checkpoint.goals.length &&
+    !checkpoint.decisions.length &&
+    !checkpoint.openTasks.length &&
+    !checkpoint.preferences.length &&
+    !checkpoint.artifacts.length &&
+    !checkpoint.recentTurns.length
+  );
+}
+
+const CHECKPOINT_HEADER = "=== omg.dev BOT HANDOFF CHECKPOINT ===";
+const CHECKPOINT_FOOTER = "=== END omg.dev BOT HANDOFF CHECKPOINT ===";
+
+/**
+ * Render the checkpoint for the launch prompt.
+ *
+ * Provenance is stated first and in the model's own reading order: this is a
+ * summary, it was machine-written, and it came from a specific earlier session.
+ * Without that line a bot reads its own summary as first-hand memory and will
+ * happily assert a "decision" it never witnessed as though it had. Naming the
+ * source session id also gives it something real to cite when the human asks
+ * where something came from.
+ */
+export function formatHandoffCheckpoint(checkpoint: BotHandoffCheckpoint): string {
+  const section = (title: string, items: readonly string[]): string =>
+    items.length ? [`${title}:`, ...items.map((item) => `- ${item}`)].join("\n") : "";
+
+  const turns = checkpoint.recentTurns.length
+    ? [
+        "Recent turns (oldest first, abbreviated):",
+        ...checkpoint.recentTurns.map((turn) =>
+          `- ${turn.author ? `${turn.role} (${turn.author})` : turn.role}: ${turn.text}`
+        ),
+      ].join("\n")
+    : "";
+
+  const body = [
+    CHECKPOINT_HEADER,
+    `- This is a machine-generated summary of an earlier session, not your own memory.`,
+    `- Source session: ${checkpoint.sourceSessionId}`,
+    `- Reason for the new session: ${
+      checkpoint.reason === "config"
+        ? "your configuration was updated"
+        : "the previous conversation was approaching its context limit"
+    }.`,
+    `- Treat it as briefing material. If the human asks about something not covered here, say you are picking the thread back up rather than inventing detail.`,
+    "",
+    section("Current goals", checkpoint.goals),
+    section("Durable decisions", checkpoint.decisions),
+    section("Unresolved tasks", checkpoint.openTasks),
+    section("User preferences", checkpoint.preferences),
+    section("Referenced artifacts and commits", checkpoint.artifacts),
+    turns,
+    CHECKPOINT_FOOTER,
+  ]
+    .filter((part) => part !== "")
+    .join("\n\n");
+
+  return body.length > CHECKPOINT_MAX_TOTAL_CHARS
+    ? `${body.slice(0, CHECKPOINT_MAX_TOTAL_CHARS)}\n${CHECKPOINT_FOOTER}`
+    : body;
+}
+
+/**
+ * The one line the human sees in the new conversation.
+ *
+ * "Visible but quiet" is the requirement, and both halves matter. Silent
+ * rotation is disorienting — the bot appears to forget mid-thread with no
+ * explanation. A loud one makes the machinery the subject of a conversation
+ * that was about something else. One sentence, stated once, at the top.
+ */
+export function rotationNoticeText(reason: BotRotationReason): string {
+  return reason === "config"
+    ? "[This conversation continues with your updated configuration. Earlier history is preserved and searchable.]"
+    : "[This conversation continues in a fresh context window. Earlier history is preserved and searchable.]";
+}
+
+/**
+ * Serialized rotations plus a compare-and-swap on the revision.
+ *
+ * The mutex in serve.ts stops two rotations for one bot overlapping, but it
+ * does not stop the second one being pointless: two browser tabs both clicking
+ * Apply produce two queued rotations, and the first one already applied the
+ * revision the second was asked for. Retrying it would spawn a second session,
+ * throw away the first, and cost the user their thread for nothing.
+ *
+ * So a rotation names the revision it intends to apply, and a rotation whose
+ * target is already applied is a no-op success rather than an error — the
+ * caller asked for "config revision N is live", and it is. A rotation naming a
+ * revision that no longer exists (the record moved on again) is stale and is
+ * rejected so the caller re-reads and retries against the current one.
+ */
+export type RotationCasResult =
+  | { proceed: true }
+  | { proceed: false; outcome: "already-applied" | "stale" };
+
+export function rotationCompareAndSwap(
+  bot: Pick<Bot, "configRevision" | "appliedConfigRevision">,
+  expectedRevision: number | undefined,
+): RotationCasResult {
+  const current = botConfigRevision(bot);
+  const applied = botAppliedConfigRevision(bot);
+  // No expectation supplied: compaction and other server-initiated rotations
+  // always target whatever is current.
+  if (expectedRevision === undefined) return { proceed: true };
+  if (expectedRevision > current) return { proceed: false, outcome: "stale" };
+  if (expectedRevision <= applied) return { proceed: false, outcome: "already-applied" };
+  return { proceed: true };
+}
+
+/** Bounded archive of prior canonical sessions, newest first. */
+export const MAX_ARCHIVED_BOT_SESSIONS = 25;
+
+export function appendArchivedSession(
+  existing: readonly string[] | undefined,
+  sessionId: string,
+): string[] {
+  const rest = (existing ?? []).filter((id) => id && id !== sessionId);
+  return [sessionId, ...rest].slice(0, MAX_ARCHIVED_BOT_SESSIONS);
+}

--- a/src/bots/self-management.ts
+++ b/src/bots/self-management.ts
@@ -124,20 +124,17 @@ export function readDeclaredCapabilities(value: unknown): string[] | { error: st
   return result;
 }
 
-const BOT_RUNTIME_PROFILE_FIELDS = new Set([
-  "name",
-  "persona",
-  "description",
-  "capabilities",
-  "agent",
-  "model",
-  "thinkingLevel",
-  "cwd",
-  "user",
-]);
-
+/**
+ * Which edits are material to the running session.
+ *
+ * One definition, in `src/bots/rotation.ts`, because this set now drives two
+ * things that must never disagree: whether an edit bumps the config revision,
+ * and whether the UI offers to apply it. A second copy here would eventually
+ * let a field bump the revision without ever offering the button, leaving a bot
+ * permanently reading "Update available" with no way to apply it.
+ */
 export function botPatchRequiresRuntimeRefresh(body: Record<string, unknown>): boolean {
-  return Object.keys(body).some((field) => BOT_RUNTIME_PROFILE_FIELDS.has(field));
+  return botPatchTouchesSessionBoundField(body);
 }
 
 export function botRuntimeRefreshDecision(

--- a/src/bots/self-management.ts
+++ b/src/bots/self-management.ts
@@ -1,4 +1,5 @@
 import type { Bot } from "./store.ts";
+import { botPatchTouchesSessionBoundField } from "./rotation.ts";
 
 export type BotRuntimeSession = {
   sessionId?: string | null;

--- a/src/bots/store.ts
+++ b/src/bots/store.ts
@@ -52,6 +52,9 @@ export type Bot = {
    */
   owner?: string;
   enabled: boolean;
+  /** Durable product conversation. Runtime session ids can rotate beneath it. */
+  conversationId?: string;
+  /** Current canonical primary runtime session. */
   sessionId?: string;
   createdAt: number;
   lastMessageAt?: number;
@@ -216,7 +219,7 @@ export type BotPatch = Partial<Pick<
   Bot,
   | "name" | "shape" | "colorway" | "persona" | "description" | "capabilities"
   | "agent" | "model" | "thinkingLevel" | "cwd" | "owner" | "enabled"
-  | "sessionId" | "lastMessageAt" | "runtimeRefreshPending"
+  | "conversationId" | "sessionId" | "lastMessageAt" | "runtimeRefreshPending"
   | "configRevision" | "appliedConfigRevision" | "rotationState"
   | "rotationReason" | "rotationError" | "rotationUpdatedAt" | "lastRotatedAt"
   | "archivedSessionIds" | "compactionArmed" | "lastCompactionAt"

--- a/src/bots/store.ts
+++ b/src/bots/store.ts
@@ -55,8 +55,43 @@ export type Bot = {
   sessionId?: string;
   createdAt: number;
   lastMessageAt?: number;
-  /** Relaunch with persisted profile/workspace data before the next user turn. */
+  /**
+   * Legacy deferred-relaunch flag, kept only so a record written by an older
+   * build still applies its pending edit after upgrade. New writes use the
+   * revision pair below; see `src/bots/rotation.ts` for why a relaunch onto the
+   * same conversation id was never a real refresh.
+   */
   runtimeRefreshPending?: boolean;
+
+  // ---- configuration versioning and rotation (src/bots/rotation.ts) ----
+  /**
+   * Monotonic revision of everything baked into the launch prompt. Bumped by
+   * any edit touching SESSION_BOUND_BOT_FIELDS, never by a cosmetic one.
+   */
+  configRevision?: number;
+  /** The revision actually live in the current canonical session. */
+  appliedConfigRevision?: number;
+  /** Lifecycle of an in-flight or deferred rotation. Absent means idle. */
+  rotationState?: "idle" | "queued" | "rotating" | "failed";
+  /** Why the pending/last rotation was requested. */
+  rotationReason?: "config" | "compaction";
+  /** Human-readable reason the last rotation attempt did not land. */
+  rotationError?: string;
+  rotationUpdatedAt?: number;
+  lastRotatedAt?: number;
+  /**
+   * Prior canonical sessions, newest first and bounded. These stay resumable
+   * and searchable through history; they are explicitly NOT roster rows and
+   * never carry independent unread state.
+   */
+  archivedSessionIds?: string[];
+  /**
+   * Hysteresis latch for automatic compaction. `false` means the bot has
+   * already rotated for context pressure and must fall back below the re-arm
+   * mark before it may do so again. Absent means armed.
+   */
+  compactionArmed?: boolean;
+  lastCompactionAt?: number;
 };
 
 /**
@@ -177,15 +212,19 @@ export async function createBot(input: {
   return bot;
 }
 
-export async function updateBot(
-  id: string,
-  patch: Partial<Pick<Bot, "name" | "shape" | "colorway" | "persona" | "description" | "capabilities" | "agent" | "model" | "thinkingLevel" | "cwd" | "owner" | "enabled" | "sessionId" | "lastMessageAt" | "runtimeRefreshPending">>,
-): Promise<Bot | null> {
-  const bots = await listBots();
-  const current = bots.find((bot) => bot.id === id);
-  if (!current) return null;
+export type BotPatch = Partial<Pick<
+  Bot,
+  | "name" | "shape" | "colorway" | "persona" | "description" | "capabilities"
+  | "agent" | "model" | "thinkingLevel" | "cwd" | "owner" | "enabled"
+  | "sessionId" | "lastMessageAt" | "runtimeRefreshPending"
+  | "configRevision" | "appliedConfigRevision" | "rotationState"
+  | "rotationReason" | "rotationError" | "rotationUpdatedAt" | "lastRotatedAt"
+  | "archivedSessionIds" | "compactionArmed" | "lastCompactionAt"
+>>;
+
+function applyPatch(current: Bot, patch: BotPatch): Bot {
   const agent = patch.agent ?? current.agent;
-  const bot: Bot = {
+  return {
     ...current,
     ...patch,
     agent,
@@ -194,8 +233,42 @@ export async function updateBot(
       agent,
     ),
   };
-  writeBots(bots.map((item) => item.id === id ? bot : item));
-  return bot;
+}
+
+export async function updateBot(id: string, patch: BotPatch): Promise<Bot | null> {
+  return mutateBot(id, (current) => applyPatch(current, patch));
+}
+
+/**
+ * Read-modify-write a single bot in one synchronous section.
+ *
+ * `updateBot` used to `await listBots()` and then write. The await is a real
+ * yield point, so two overlapping updates could both read the pre-state and the
+ * second write would silently drop the first one's field — the classic lost
+ * update. That was survivable when every patch was a whole-record form submit,
+ * and stops being survivable once rotation writes a revision that a concurrent
+ * writer must not clobber.
+ *
+ * There is no await between the read and the write here, so within this process
+ * the mutation is atomic. `writeBots` is already atomic on disk (temp file plus
+ * rename plus fsync), which covers the cross-process case as far as it can be
+ * covered by a single-writer JSON store.
+ *
+ * `mutate` returning null aborts the write and reports the abort, which is what
+ * makes a compare-and-swap expressible: read the current revision, decide, and
+ * either commit or decline without ever leaving the critical section.
+ */
+export function mutateBot(
+  id: string,
+  mutate: (current: Bot) => Bot | null,
+): Bot | null {
+  const bots = readBots();
+  const current = bots.find((bot) => bot.id === id);
+  if (!current) return null;
+  const next = mutate(current);
+  if (!next) return null;
+  writeBots(bots.map((item) => item.id === id ? next : item));
+  return next;
 }
 
 export async function deleteBot(id: string): Promise<void> {

--- a/src/bots/transcript.ts
+++ b/src/bots/transcript.ts
@@ -1,0 +1,122 @@
+/**
+ * What of a bot session's transcript the human is meant to see.
+ *
+ * A bot's backing session is an ordinary session, so its transcript carries
+ * launch plumbing the bot chat must not show: the runtime contract, a prior
+ * conversation summary on relaunch, and the `[Message from ...]` attribution
+ * wrapper on every turn.
+ *
+ * The subtle part is the launch turn. The first user message is deliberately
+ * bundled *into* the launch prompt — sending it separately raced the boot and
+ * the bot answered neither, so the greeting went unanswered. That makes the
+ * launch turn simultaneously plumbing and a real user message, and the two
+ * have to be separated rather than the whole turn dropped. Hiding it wholesale
+ * opens every conversation with a reply to an invisible question.
+ */
+
+const CONTRACT_HEADER = "=== omg.dev BOT RUNTIME CONTRACT";
+
+const CONTRACT_BLOCK =
+  /===\s*omg\.dev BOT RUNTIME CONTRACT[\s\S]*?===\s*END omg\.dev BOT RUNTIME CONTRACT\s*===/i;
+const SUMMARY_BLOCK =
+  /===\s*PRIOR CONVERSATION SUMMARY\s*===[\s\S]*?===\s*END PRIOR CONVERSATION SUMMARY\s*===/i;
+/**
+ * The structured handoff a rotation carries into the new session
+ * (`src/bots/rotation.ts`). It is briefing material for the model, in the same
+ * category as the contract and the prior-conversation summary, and it is hidden
+ * for the same reason: a rotated conversation would otherwise open with a wall
+ * of bulleted summary in the human's own message bubble.
+ *
+ * What the human is meant to see instead is the one-line notice the rotation
+ * puts *outside* this block — see `rotationNoticeText`. Hiding the block and
+ * showing the line is the whole of "visible but quiet".
+ */
+const CHECKPOINT_BLOCK =
+  /===\s*omg\.dev BOT HANDOFF CHECKPOINT\s*===[\s\S]*?===\s*END omg\.dev BOT HANDOFF CHECKPOINT\s*===/i;
+const ATTRIBUTION = /^\s*\[Message from [^\]]+ to bot [^\]]+\]\s*/i;
+
+/** Remove the launch envelope, leaving whatever real message rode with it. */
+export function stripBotLaunchEnvelope(text: string): string {
+  return text
+    .replace(CONTRACT_BLOCK, "")
+    .replace(SUMMARY_BLOCK, "")
+    .replace(CHECKPOINT_BLOCK, "")
+    .trim();
+}
+
+/**
+ * The quiet one-liner a rotated conversation opens with.
+ *
+ * Recognised here so the renderer can set it apart from something the human
+ * typed. It rides in the launch turn as ordinary user text — the same way a
+ * fired routine's `[Scheduled routine: ...]` message does — because that is
+ * what puts it in front of the model as well as the reader.
+ */
+const ROTATION_NOTICE = /^\s*\[This conversation continues (?:with your updated configuration|in a fresh context window)\b[^\]]*\]\s*$/i;
+
+export function isBotRotationNoticeText(text: string): boolean {
+  return ROTATION_NOTICE.test(stripBotLaunchEnvelope(text).replace(ATTRIBUTION, ""));
+}
+
+/** The text of a user turn as the human should read it back in the bot chat. */
+export function botVisibleUserText(text: string, isBotChat = true): string {
+  if (!isBotChat) return text;
+  return stripBotLaunchEnvelope(text).replace(ATTRIBUTION, "");
+}
+
+/**
+ * True only for a launch turn that is *pure* plumbing. A launch turn carrying
+ * the first user message is a real turn and must render.
+ */
+export function isBotLaunchOnlyText(text: string): boolean {
+  return text.trimStart().startsWith(CONTRACT_HEADER) && stripBotLaunchEnvelope(text) === "";
+}
+
+/**
+ * A background task session reporting home to the bot that spawned it.
+ *
+ * Heavy work does not run in a chat turn — the bot hands it to a task session,
+ * which reports back with the markers from the subagent operating contract
+ * (`[subagent progress]`, and one of complete/blocked/failed at the end). Those
+ * arrive on the bot's session as ordinary user turns, so without this they
+ * render as though the human typed `[subagent complete] rebased onto main…`
+ * into their own chat.
+ *
+ * They are machinery, like the launch envelope and the attribution wrapper, and
+ * they are hidden for the same reason. What the human should read is the bot's
+ * own next message, which the bot contract requires it to write in plain words
+ * — the report is the bot's source, not its output.
+ */
+const SUBAGENT_UPDATE = /^\s*\[subagent (?:progress|complete|blocked|failed)\]/i;
+// The attribution wrapper the server puts on an agent-authored update, naming
+// which background task is reporting. Older transcripts carry the bare marker
+// with no wrapper, so both forms have to be recognised forever.
+const BACKGROUND_ATTRIBUTION = /^\s*\[Background task [^\]]*\]/i;
+
+export function isSubagentUpdateText(text: string): boolean {
+  return BACKGROUND_ATTRIBUTION.test(text) || SUBAGENT_UPDATE.test(text);
+}
+
+/**
+ * Transcript kinds a bot chat does not show.
+ *
+ * A task session's transcript is a log you read: every tool call, every result,
+ * every reasoning block, because the point is auditing what the agent did. A bot
+ * chat is a conversation you are having, and a conversation does not narrate its
+ * own mechanics — nobody wants `$ rg -n "persistent bot" src` in the middle of
+ * being answered.
+ *
+ * Nothing is lost, only relocated: the bot's session is still an ordinary
+ * session, so opening it from the sessions rail shows the whole log, tools and
+ * reasoning included. The bot chat is a view of that session, not a different
+ * recording of it — and heavy work does not run here anyway, it runs in a
+ * background session that has its own row in the fleet.
+ *
+ * Images, video and artifacts stay. A bot that answers you with a picture chose
+ * to hand you that picture; it is the reply, not the machinery behind it.
+ */
+const HIDDEN_IN_BOT_CHAT = new Set(["tool_use", "tool_result", "thinking"]);
+
+export function isBotHiddenLogKind(kind: string | undefined): boolean {
+  return !!kind && HIDDEN_IN_BOT_CHAT.has(kind);
+}

--- a/src/commands/auto-agent-route-wiring.test.ts
+++ b/src/commands/auto-agent-route-wiring.test.ts
@@ -69,7 +69,7 @@ describe("POST /api/auto/agents/:id/run", () => {
 
 describe("DELETE /api/bots/:id — deletion cascade", () => {
   test("removes the bot's own routines before/alongside deleting the bot itself", () => {
-    const handler = block('if (req.method === "DELETE") {\n            const sessions = await listSessions();', 1600);
+    const handler = block('if (req.method === "DELETE") {\n            return serializeBotWork(id', 2100);
     const cascadeAt = handler.indexOf("deleteAutoAgentsOwnedByBot(id)");
     const deleteBotAt = handler.indexOf("await deleteBot(id)");
     expect(cascadeAt, "deleteAutoAgentsOwnedByBot not called from bot deletion").toBeGreaterThanOrEqual(0);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -136,6 +136,7 @@ import {
   // Aliased: the route already binds `visibleBots` to its own result.
   visibleBots as visibleBotsForViewer,
 } from "../bots/access.ts";
+import { formatBotAttribution, resolveBotMessageAuthor } from "../bots/authorship.ts";
 import { startAutoScheduler, setBotRoutineDelivery } from "../auto/scheduler.ts";
 import { handleWakeTick } from "../auto/wake-tick.ts";
 import { pushWakeHooksNow, setWakeHooksBootId } from "../auto/wake-hooks-push.ts";
@@ -4644,8 +4645,17 @@ a{color:#60a5fa}
           const body = (await req.json().catch(() => null)) as { text?: unknown; user?: unknown } | null;
           const text = typeof body?.text === "string" ? body.text.trim() : "";
           if (!text) return err(400, "text is required");
-          const tag = resolveSessionUserTag(typeof body?.user === "string" ? body.user : undefined);
-          if (!tag.ok)
+          const requestedUser = typeof body?.user === "string" ? body.user : undefined;
+          // The write route now asks the same question the read routes ask.
+          // When control-plane vouched for this caller, their email decides
+          // authorship and `body.user` is never consulted — see
+          // bots/authorship.ts for why that ordering is the security property.
+          const viewer = botViewerFromRequest(req, requestedUser);
+          const tag = resolveSessionUserTag(requestedUser);
+          // A managed caller's `body.user` is inert, so validating it can only
+          // produce a spurious 400 on a shared Computer that also happens to
+          // have a local roster. Unmanaged callers keep the original contract.
+          if (!tag.ok && !viewer.managed)
             return err(400, `unknown user "${tag.unknown}" (expected one of the roster emails)`);
           // A rotation the human already asked for lands here, at the first
           // moment the bot is demonstrably reachable. Rotating before the
@@ -4660,8 +4670,13 @@ a{color:#60a5fa}
           }
           // Attribute before launching: when the session has to be started, this
           // exact text rides inside the launch prompt instead of racing it.
-          const author = tag.user || bot.owner || process.env.OMG_USER?.trim() || "user";
-          const attributed = `[Message from ${author} to bot ${bot.name}]\n\n${text}`;
+          const { author } = resolveBotMessageAuthor({
+            viewer,
+            rosterTagUser: tag.ok ? tag.user : undefined,
+            botOwner: bot.owner,
+            envUser: process.env.OMG_USER,
+          });
+          const attributed = `${formatBotAttribution(author, bot.name)}\n\n${text}`;
           const delivery = await deliverBotMessage(bot, attributed);
           if ("error" in delivery) return err(delivery.status, delivery.error);
           return json({ sessionId: delivery.sessionId });

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -70,6 +70,7 @@ import {
   deleteBot,
   getBot,
   listBots,
+  mutateBot,
   updateBot,
   type Bot,
   type BotColorway,
@@ -81,6 +82,28 @@ import {
   persistentBotQuotaPolicy,
 } from "../bots/quota.ts";
 import { botCanonicalSessionId, botConversationRef, findBotMainSession } from "../bots/session.ts";
+import { botVisibleUserText } from "../bots/transcript.ts";
+import {
+  CHECKPOINT_MAX_TURNS,
+  appendArchivedSession,
+  botCompactionDecision,
+  botAppliedConfigRevision,
+  botConfigRevision,
+  botConfigStatus,
+  botRotationAdmission,
+  buildHandoffCheckpoint,
+  checkpointIsEmpty,
+  defaultBotCompactionSettings,
+  formatHandoffCheckpoint,
+  measuredContextPercent,
+  nextBotConfigRevision,
+  rotationCompareAndSwap,
+  rotationNoticeText,
+  type BotHandoffCheckpoint,
+  type BotRotationBlock,
+  type BotRotationReason,
+  type CheckpointTurn,
+} from "../bots/rotation.ts";
 import {
   BOT_SELF_CREATE_FIELDS,
   BOT_SELF_UPDATE_FIELDS,
@@ -430,23 +453,31 @@ const EVLOG_DIR = join(PATHS.data, "evlogs");
 const SERVER_INSTANCE_ID = randomBytes(8).toString("hex");
 let selfUpdateRunning = false;
 
-// Peer sends to one bot share one critical section. This prevents two offline
-// sends from launching duplicate backing sessions and preserves enqueue order.
-const botPeerDeliveryTails = new Map<string, Promise<void>>();
+// Everything that can start, stop, or rebind one bot's backing session shares a
+// single critical section per bot.
+//
+// It began as peer-delivery-only: two offline sends could otherwise launch
+// duplicate backing sessions and scramble enqueue order. Rotation joins the
+// same lock rather than taking its own, because a separate lock would not be a
+// lock at all — a rotation tearing a session down while a peer delivery is
+// bringing one up interleaves two writers on `bot.sessionId`, and the loser's
+// write silently wins. One queue per bot makes "which session is this bot's"
+// answerable at every instant.
+const botWorkTails = new Map<string, Promise<void>>();
 
-async function serializeBotPeerDelivery<T>(targetBotId: string, task: () => Promise<T>): Promise<T> {
-  const previous = botPeerDeliveryTails.get(targetBotId) ?? Promise.resolve();
+async function serializeBotWork<T>(botId: string, task: () => Promise<T>): Promise<T> {
+  const previous = botWorkTails.get(botId) ?? Promise.resolve();
   let release!: () => void;
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
-  botPeerDeliveryTails.set(targetBotId, current);
+  botWorkTails.set(botId, current);
   await previous;
   try {
     return await task();
   } finally {
     release();
-    if (botPeerDeliveryTails.get(targetBotId) === current) botPeerDeliveryTails.delete(targetBotId);
+    if (botWorkTails.get(botId) === current) botWorkTails.delete(botId);
   }
 }
 
@@ -2309,7 +2340,46 @@ async function ensureBotSession(
     }
     return { session: live, delivered: false };
   }
+  // botConversationRef repairs a saved id that names one of this bot's own
+  // subagents, recovering the conversation the human has actually been talking
+  // to instead of resuming a delegated task's thread.
+  return launchBotSession(bot, {
+    conversationId: botConversationRef(bot, sessions).sessionId,
+    firstMessage,
+  });
+}
 
+/**
+ * Start one backing process for a bot and bind the record to it.
+ *
+ * Split out of `ensureBotSession` so cold start and rotation cannot drift.
+ * They differ in exactly two ways — which conversation id the process attaches
+ * to, and what continuity material rides in the launch prompt — and everything
+ * else (agent validation, repo resolution, the activation gate, account
+ * picking, the managed-registry rows, user assignment, the spawn, the binding
+ * write) is identical. Two copies of that would be two places to forget
+ * `assignUser`, and the first Scout session already went missing once for
+ * exactly that reason.
+ *
+ * `conversationId` omitted means mint a fresh one, which is what makes this the
+ * rotation primitive's launcher: a new id is a new conversation by
+ * construction, because the transcript read model is keyed on it
+ * (`lfg://session/<id>`, sessionIndexKey). That is precisely the property
+ * rotation needs and cold start must never have.
+ */
+async function launchBotSession(
+  bot: Bot,
+  opts: {
+    /** Conversation to attach to. Omitted mints a fresh one. */
+    conversationId?: string;
+    /** Pre-rendered blocks injected after the contract, in order. */
+    injectedBlocks?: readonly string[];
+    /** Skip the automatic prior-conversation summary (rotation brings its own). */
+    skipContinuity?: boolean;
+    firstMessage?: string;
+  } = {},
+): Promise<{ session: Session; delivered: boolean } | Response> {
+  const firstMessage = opts.firstMessage;
   const config = validateBotAgent(bot.agent, bot.model, bot.thinkingLevel);
   if ("error" in config) return err(400, config.error);
   const repos = await listRepos();
@@ -2349,10 +2419,10 @@ async function ensureBotSession(
     // turns append to the history that is already there — no change to the
     // transcript API, the live socket, or the client, because none of them ever
     // cared which process produced a turn.
-    // botConversationRef repairs a saved id that names one of this bot's own
-    // subagents, recovering the conversation the human has actually been
-    // talking to instead of resuming a delegated task's thread.
-    const conversation = botConversationRef(bot, sessions);
+    // An omitted conversation id is a deliberate fresh start (rotation), not a
+    // missing value: the caller has already decided the old thread is being
+    // left behind and archived.
+    const conversation = { sessionId: opts.conversationId?.trim() || undefined };
     const sessionId = botConversationId(conversation, () => crypto.randomUUID());
     // aisdk decides resume-vs-fresh by asking the index itself
     // (sessionHasIndexedMessages, aisdk-session.ts), so reusing the id restores
@@ -2371,10 +2441,13 @@ async function ensureBotSession(
     // Summarize the repaired conversation, never the corrupt id: a bot rebound
     // to its own subagent would otherwise be reintroduced to that task's
     // transcript as if it were its own history.
-    const continuity = !resumesOwnThread && conversation.sessionId
+    const continuity = !opts.skipContinuity && !resumesOwnThread && conversation.sessionId
       ? await botContinuitySummary(conversation.sessionId)
       : null;
     const prompt = [
+      // Regenerated from the bot record on every launch, which is the whole
+      // reason a config change needs a new session: this text is read once, at
+      // boot, and nothing can revise it afterwards.
       botRuntimeContract(bot.name, bot.persona, {
         awaitingFirstMessage: !firstMessage,
         description: bot.description,
@@ -2382,6 +2455,7 @@ async function ensureBotSession(
         maxBotSchedules: getGlobalSettingsSync().maxBotSchedules,
       }),
       continuity ? `=== PRIOR CONVERSATION SUMMARY ===\n${continuity}\n=== END PRIOR CONVERSATION SUMMARY ===` : "",
+      ...(opts.injectedBlocks ?? []),
       firstMessage ?? "",
     ].filter(Boolean).join("\n\n");
     for (const stale of listManaged().filter((row) => row.botId === bot.id)) {
@@ -2445,6 +2519,325 @@ async function ensureBotSession(
   } finally {
     gate.release();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Bot session rotation
+// ---------------------------------------------------------------------------
+
+/**
+ * Commit-ish and link-ish references worth naming in a handoff.
+ *
+ * Deliberately high-precision and low-recall. A checkpoint that invents context
+ * is worse than one that omits it, because the bot will state the invention as
+ * fact on its first turn.
+ */
+function extractCheckpointArtifacts(turns: readonly CheckpointTurn[]): string[] {
+  const found: string[] = [];
+  const push = (value: string) => {
+    if (value && !found.includes(value)) found.push(value);
+  };
+  for (const turn of turns) {
+    for (const url of turn.text.match(/https?:\/\/[^\s)>\]]+/g) ?? []) push(url);
+    for (const ref of turn.text.match(/\B#\d{1,6}\b/g) ?? []) push(ref);
+    for (const sha of turn.text.match(/\b[0-9a-f]{7,40}\b/g) ?? []) {
+      // A run of hex that is all digits is a number, not a sha, and a 12-digit
+      // timestamp would otherwise be reported as a commit.
+      if (/[a-f]/.test(sha) && /\d/.test(sha)) push(sha);
+    }
+  }
+  return found;
+}
+
+/**
+ * Read a bounded tail of a conversation and assemble the handoff.
+ *
+ * Only user and assistant prose is eligible. Tool calls, tool results and
+ * reasoning are excluded at the source rather than filtered later — they are
+ * the bulk of a long session, they are the most likely place for a credential
+ * or a customer record to appear, and none of them is the thread a human is
+ * trying to keep.
+ *
+ * The structured sections are populated only from what a caller supplies. This
+ * build extracts artifacts deterministically and carries the recent turns
+ * verbatim-but-clamped, and leaves goals/decisions/tasks/preferences empty
+ * rather than guessing them from keyword heuristics: a regex that reports
+ * "durable decision: we will not use Postgres" because someone typed the words
+ * produces a briefing that is confidently wrong, and the bot has no way to
+ * check it. Recent turns carry the real continuity; an empty section renders as
+ * nothing at all.
+ */
+async function buildBotHandoffCheckpoint(
+  sessionId: string,
+  input: { reason: BotRotationReason; configRevision: number; now: number },
+): Promise<BotHandoffCheckpoint> {
+  const transcript = await resolveTranscript(sessionId) ?? sessionIndexKey(sessionId);
+  const page = await indexedMessagePage(transcript, sessionId, { limit: 60 });
+  const turns: CheckpointTurn[] = page.messages
+    .filter((message) =>
+      (message.role === "user" || message.role === "assistant") &&
+      (!message.kind || message.kind === "text")
+    )
+    .map((message) => ({
+      role: message.role as "user" | "assistant",
+      text: botVisibleUserText(message.text ?? ""),
+    }))
+    .filter((turn) => !!turn.text.trim());
+
+  return buildHandoffCheckpoint({
+    sourceSessionId: sessionId,
+    reason: input.reason,
+    configRevision: input.configRevision,
+    createdAt: input.now,
+    artifacts: extractCheckpointArtifacts(turns.slice(-CHECKPOINT_MAX_TURNS)),
+    turns,
+  });
+}
+
+export type BotRotationOutcome =
+  | {
+      ok: true;
+      rotated: true;
+      sessionId: string;
+      previousSessionId: string | null;
+      appliedConfigRevision: number;
+    }
+  | { ok: true; rotated: false; reason: "already-applied"; sessionId: string | null }
+  | { ok: false; deferred: true; blocked: BotRotationBlock; children: string[] }
+  | { ok: false; deferred?: false; status: number; error: string };
+
+/**
+ * Move a bot onto a brand new canonical session carrying its current config.
+ *
+ * The one server-owned rotation primitive. Manual apply and automatic
+ * compaction both come through here, so the ordering guarantees below are
+ * stated once and hold for both.
+ *
+ * Order is the whole design:
+ *
+ *  1. Serialize on the bot. Two browser tabs clicking Apply cannot produce two
+ *     primaries, because the second one runs after the first has committed and
+ *     then finds its revision already applied.
+ *  2. Compare-and-swap the revision. A request naming a revision that is
+ *     already live is a no-op *success* — the caller asked for "revision N is
+ *     running" and it is, so spawning a second session to satisfy it would cost
+ *     the user their thread for nothing. A request naming a revision that no
+ *     longer exists is stale and is rejected so the client re-reads.
+ *  3. Admit or defer. Busy primary or live delegated children means queue, not
+ *     kill. The pending state is persisted so the UI can say so.
+ *  4. Build the checkpoint BEFORE anything is torn down. A checkpoint failure
+ *     here costs nothing: the old session is still running and still bound.
+ *  5. Close the old session. `closeLiveSession` persists a resume record first,
+ *     so "archived" means resumable and auditable, not destroyed.
+ *  6. Launch the replacement. If this fails the record still points at the old
+ *     conversation id, whose transcript is on disk and whose process the next
+ *     message will restart. A failed rotation therefore degrades to "the bot is
+ *     cold", never to "the bot is gone".
+ *  7. Commit. Only now does the binding move.
+ */
+async function rotateBotSession(
+  botId: string,
+  opts: {
+    reason: BotRotationReason;
+    expectedRevision?: number;
+    force?: boolean;
+  },
+): Promise<BotRotationOutcome> {
+  return serializeBotWork(botId, async () => {
+    const bot = await getBot(botId);
+    if (!bot) return { ok: false, status: 404, error: "bot not found" };
+
+    const cas = rotationCompareAndSwap(bot, opts.expectedRevision);
+    if (!cas.proceed) {
+      if (cas.outcome === "already-applied") {
+        evlog("bot_rotation_noop", { botId, reason: opts.reason, revision: opts.expectedRevision });
+        return { ok: true, rotated: false, reason: "already-applied", sessionId: bot.sessionId ?? null };
+      }
+      return {
+        ok: false,
+        status: 409,
+        error: "bot configuration has changed since this request was made; re-read the bot and retry",
+      };
+    }
+
+    const sessions = await listSessions();
+    const primary = findBotMainSession(bot, sessions);
+    const admission = botRotationAdmission(bot.id, primary, sessions, { force: opts.force });
+    if (!admission.ready) {
+      mutateBot(bot.id, (current) => ({
+        ...current,
+        rotationState: "queued",
+        rotationReason: opts.reason,
+        rotationError: undefined,
+        rotationUpdatedAt: Date.now(),
+      }));
+      evlog("bot_rotation_deferred", {
+        botId,
+        reason: opts.reason,
+        blocked: admission.blocked,
+        children: admission.children.length,
+      });
+      return { ok: false, deferred: true, blocked: admission.blocked, children: admission.children };
+    }
+
+    // The revision this rotation is applying. Captured before any await, and
+    // used verbatim at commit time: an edit that lands WHILE the rotation runs
+    // bumps configRevision again, and that newer edit is genuinely not in the
+    // session being launched. Committing `botConfigRevision(current)` instead
+    // would mark it applied and the user would never be offered the button.
+    const targetRevision = botConfigRevision(bot);
+    const previousSessionId = botCanonicalSessionId(bot, sessions);
+    const now = Date.now();
+
+    mutateBot(bot.id, (current) => ({
+      ...current,
+      rotationState: "rotating",
+      rotationReason: opts.reason,
+      rotationError: undefined,
+      rotationUpdatedAt: now,
+    }));
+
+    const fail = (status: number, error: string): BotRotationOutcome => {
+      mutateBot(bot.id, (current) => ({
+        ...current,
+        rotationState: "failed",
+        rotationReason: opts.reason,
+        rotationError: error.slice(0, 400),
+        rotationUpdatedAt: Date.now(),
+      }));
+      evlog("bot_rotation_failed", { botId, reason: opts.reason, error: error.slice(0, 200) });
+      return { ok: false, status, error };
+    };
+
+    // 4. Checkpoint first, while the old session is still intact.
+    let injectedBlocks: string[];
+    try {
+      const checkpoint = previousSessionId
+        ? await buildBotHandoffCheckpoint(previousSessionId, {
+            reason: opts.reason,
+            configRevision: targetRevision,
+            now,
+          })
+        : null;
+      injectedBlocks = [
+        ...(checkpoint && !checkpointIsEmpty(checkpoint) ? [formatHandoffCheckpoint(checkpoint)] : []),
+        rotationNoticeText(opts.reason),
+      ];
+    } catch (error) {
+      // A bot with no readable history is not a failure — it has nothing to
+      // carry. A checkpoint that throws is, because it means the transcript
+      // read model is unhealthy and continuing would silently drop the thread.
+      return fail(
+        502,
+        `handoff checkpoint could not be generated: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    // 5. Retire the old process. Its transcript and resume record survive.
+    if (primary?.sessionId) {
+      const outcome = await closeLiveSession(primary, primary.sessionId, {
+        sessionId: primary.sessionId,
+        source: `bot_rotation_${opts.reason}`,
+        botId: bot.id,
+      });
+      if (!outcome.ok) return fail(outcome.status, outcome.reason);
+    }
+
+    // 6. Fresh conversation id, current config, checkpoint aboard.
+    const launched = await launchBotSession(bot, { injectedBlocks, skipContinuity: true });
+    if (launched instanceof Response) {
+      const body = (await launched.json().catch(() => null)) as { error?: string } | null;
+      return fail(launched.status, body?.error ?? "failed to start the replacement session");
+    }
+    const newSessionId = launched.session.sessionId;
+    if (!newSessionId) return fail(502, "replacement session did not report an id");
+
+    // 7. Commit. `launchBotSession` has already pointed the record at the new
+    // conversation, which is what makes this safe to do in two writes: the
+    // binding moved only after a successful spawn, and the worst a crash
+    // between the two can leave behind is a bot that still offers an Apply
+    // button for a change that is in fact live. Clicking it again is a no-op
+    // success via the compare-and-swap above.
+    const committed = mutateBot(bot.id, (current) => ({
+      ...current,
+      sessionId: newSessionId,
+      appliedConfigRevision: targetRevision,
+      configRevision: botConfigRevision(current),
+      rotationState: "idle",
+      rotationReason: undefined,
+      rotationError: undefined,
+      rotationUpdatedAt: Date.now(),
+      lastRotatedAt: Date.now(),
+      runtimeRefreshPending: false,
+      archivedSessionIds: previousSessionId && previousSessionId !== newSessionId
+        ? appendArchivedSession(current.archivedSessionIds, previousSessionId)
+        : current.archivedSessionIds,
+      ...(opts.reason === "compaction"
+        ? { compactionArmed: false, lastCompactionAt: Date.now() }
+        : {}),
+    }));
+    if (!committed) return fail(404, "bot not found");
+
+    evlog("bot_rotation_done", {
+      botId,
+      reason: opts.reason,
+      previousSessionId,
+      sessionId: newSessionId,
+      appliedConfigRevision: targetRevision,
+      archived: committed.archivedSessionIds?.length ?? 0,
+    });
+    return {
+      ok: true,
+      rotated: true,
+      sessionId: newSessionId,
+      previousSessionId,
+      appliedConfigRevision: targetRevision,
+    };
+  });
+}
+
+/**
+ * Run a rotation that was deferred, if the bot is now able to take it.
+ *
+ * Called on the paths that already know a bot just became reachable — a human
+ * message, a peer delivery — so a queued rotation lands at the first safe
+ * moment instead of waiting for a poll. Returns the (possibly refreshed) bot so
+ * the caller keeps using a current record.
+ */
+async function applyPendingBotRotation(bot: Bot): Promise<Bot> {
+  // Only a rotation somebody actually asked for resumes here. A bot merely
+  // sitting on an unapplied edit is left alone: "Update available" means the
+  // human has not decided yet, and quietly restarting their conversation the
+  // next time they say hello is precisely the surprise this design removes.
+  if (bot.rotationState !== "queued") return bot;
+  await rotateBotSession(bot.id, {
+    reason: bot.rotationReason ?? "config",
+    expectedRevision: botConfigRevision(bot),
+  });
+  // Re-read either way. A rotation that lands moves the binding; one that
+  // defers again refreshes the pending state; one that fails records why.
+  return (await getBot(bot.id)) ?? bot;
+}
+
+/**
+ * Migrate a record written before configuration was versioned.
+ *
+ * An older build's `runtimeRefreshPending` is a real, unapplied user edit. It
+ * has no revision attached, so it is translated into one: bump the revision so
+ * the gap exists, and mark it queued so it applies the way its author expected
+ * rather than silently evaporating on upgrade.
+ */
+function migrateLegacyBotRefreshFlag(bot: Bot): Bot {
+  if (!bot.runtimeRefreshPending) return bot;
+  return mutateBot(bot.id, (current) => ({
+    ...current,
+    runtimeRefreshPending: false,
+    configRevision: nextBotConfigRevision(current),
+    appliedConfigRevision: botConfigRevision(current),
+    rotationState: "queued",
+    rotationReason: "config",
+    rotationUpdatedAt: Date.now(),
+  })) ?? bot;
 }
 
 /** Pure half of callerBotId, split out so the id-matching logic is testable
@@ -3859,7 +4252,7 @@ a{color:#60a5fa}
         if (replyToMessageId === null) return err(400, "replyToMessageId must be a string");
 
         try {
-          return await serializeBotPeerDelivery(targetBotId, async () => {
+          return await serializeBotWork(targetBotId, async () => {
             const sessions = await listSessions();
             const bots = await listBots();
             const actor = resolveBotRuntimeActor(callerSessionHeader(req), sessions, bots);
@@ -3872,29 +4265,22 @@ a{color:#60a5fa}
             });
             let enqueued = false;
             try {
-              let target = reservedTarget;
-              if (target.runtimeRefreshPending) {
-                // Only the bot's own conversation may be closed for a profile
-                // refresh. A delegated child matches on inherited `botId` and
-                // would be killed mid-task.
-                const live = findBotMainSession(target, sessions);
-                if (botRuntimeRefreshDecision(target, live) === "wait") {
-                  throw new BotPeerMessageError(
-                    409,
-                    "target bot profile update is still settling; retry after its current turn completes",
-                  );
-                }
-                if (live?.sessionId) {
-                  const outcome = await closeLiveSession(live, live.sessionId, {
-                    sessionId: live.sessionId,
-                    source: "bot_peer_runtime_refresh",
-                    botId: target.id,
-                  });
-                  if (!outcome.ok) throw new BotPeerMessageError(outcome.status, outcome.reason);
-                }
-                const refreshed = await updateBot(target.id, { runtimeRefreshPending: false });
-                if (!refreshed) throw new BotPeerMessageError(404, "target bot not found");
-                target = refreshed;
+              // Same rule as a human message: apply a rotation the owner
+              // already requested before the peer turn is enqueued, so the
+              // envelope is answered under the current configuration.
+              //
+              // Note this runs INSIDE the per-bot critical section already held
+              // by this delivery, and `rotateBotSession` takes that same lock.
+              // It is called through `applyPendingBotRotation` only on paths
+              // that do not already hold it; here the pending state is checked
+              // and the rotation is left to the message path, because
+              // re-entering the lock would deadlock.
+              let target = migrateLegacyBotRefreshFlag(reservedTarget);
+              if (target.rotationState === "queued") {
+                throw new BotPeerMessageError(
+                  409,
+                  "target bot refresh is still settling; retry after its current turn completes",
+                );
               }
 
               // Start or revive the persistent conversation, then hand the
@@ -4097,9 +4483,20 @@ a{color:#60a5fa}
           );
           const bots = visibleBots.map((bot) => {
             const last = bot.sessionId ? lastIndexedAssistantMessage(bot.sessionId) : null;
+            // The status is derived here rather than in the client so every
+            // surface agrees on one answer. A client computing it from the
+            // revision pair alone would miss an in-flight or failed rotation
+            // and cheerfully render "Update available" over a running one.
+            const decorated = {
+              ...bot,
+              configRevision: botConfigRevision(bot),
+              appliedConfigRevision: botAppliedConfigRevision(bot),
+              configStatus: botConfigStatus(bot),
+              rotationError: bot.rotationError,
+            };
             return last?.text
-              ? { ...bot, lastMessagePreview: last.text.slice(0, 400), lastMessageTs: last.ts ?? null }
-              : bot;
+              ? { ...decorated, lastMessagePreview: last.text.slice(0, 400), lastMessageTs: last.ts ?? null }
+              : decorated;
           });
           // Exactly one conversation per bot — the roster invariant, decided
           // here rather than left to the client.
@@ -4250,28 +4647,16 @@ a{color:#60a5fa}
           const tag = resolveSessionUserTag(typeof body?.user === "string" ? body.user : undefined);
           if (!tag.ok)
             return err(400, `unknown user "${tag.unknown}" (expected one of the roster emails)`);
-          if (bot.runtimeRefreshPending) {
-            const pendingBot = bot;
-            const sessions = await listSessions();
-            // The bot's own conversation only — a delegated child inherits
-            // `botId` and must not be closed to apply a profile change.
-            const live = findBotMainSession(pendingBot, sessions);
-            // Never kill or rewrite the prompt of the turn that requested the
-            // update. A client that races the next message retries once that
-            // turn settles, and the message is never run under stale rules.
-            if (botRuntimeRefreshDecision(pendingBot, live) === "wait")
-              return err(409, "bot profile update is still settling; retry after the current turn completes");
-            if (live?.sessionId) {
-              const outcome = await closeLiveSession(live, live.sessionId, {
-                sessionId: live.sessionId,
-                source: "bot_runtime_refresh",
-                botId: pendingBot.id,
-              });
-              if (!outcome.ok) return err(outcome.status, outcome.reason);
-            }
-            const refreshed = await updateBot(pendingBot.id, { runtimeRefreshPending: false });
-            if (!refreshed) return err(404, "bot not found");
-            bot = refreshed;
+          // A rotation the human already asked for lands here, at the first
+          // moment the bot is demonstrably reachable. Rotating before the
+          // message is sent is what guarantees the message is answered under
+          // the new configuration rather than the old one.
+          bot = await applyPendingBotRotation(migrateLegacyBotRefreshFlag(bot));
+          if (bot.rotationState === "queued") {
+            return err(
+              409,
+              "bot refresh is waiting for the current turn to finish; retry in a moment",
+            );
           }
           // Attribute before launching: when the session has to be started, this
           // exact text rides inside the launch prompt instead of racing it.
@@ -4280,6 +4665,66 @@ a{color:#60a5fa}
           const delivery = await deliverBotMessage(bot, attributed);
           if ("error" in delivery) return err(delivery.status, delivery.error);
           return json({ sessionId: delivery.sessionId });
+        }
+      }
+      {
+        // Apply a pending configuration change by rotating the bot onto a fresh
+        // canonical session. The explicit half of the feature: the human decides
+        // when their conversation restarts, and gets told what happened.
+        const match = path.match(/^\/api\/bots\/([^/]+)\/rotate$/);
+        if (match && req.method === "POST") {
+          const id = decodeURIComponent(match[1]);
+          const existing = await getBot(id);
+          if (!existing) return err(404, "bot not found");
+          const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+          const allowed = new Set(["expectedRevision", "force"]);
+          const unknown = Object.keys(body ?? {}).filter((key) => !allowed.has(key)).sort();
+          if (unknown.length) return err(400, `unsupported rotate fields: ${unknown.join(", ")}`);
+          if (body?.force !== undefined && typeof body.force !== "boolean")
+            return err(400, "force must be a boolean");
+          if (
+            body?.expectedRevision !== undefined &&
+            (!Number.isInteger(body.expectedRevision) || (body.expectedRevision as number) < 1)
+          ) {
+            return err(400, "expectedRevision must be a positive integer");
+          }
+          const bot = migrateLegacyBotRefreshFlag(existing);
+          const outcome = await rotateBotSession(id, {
+            reason: "config",
+            expectedRevision: body?.expectedRevision as number | undefined,
+            // Force is destructive — it interrupts a turn in flight — so it is
+            // never inferred. The client sends it only behind an explicit
+            // confirmation, and the default path queues instead.
+            force: body?.force === true,
+          });
+          const after = (await getBot(id)) ?? bot;
+          if (outcome.ok) {
+            return json({
+              ok: true,
+              rotated: outcome.rotated,
+              sessionId: outcome.rotated ? outcome.sessionId : outcome.sessionId,
+              previousSessionId: outcome.rotated ? outcome.previousSessionId : null,
+              configStatus: botConfigStatus(after),
+              configRevision: botConfigRevision(after),
+            });
+          }
+          if (outcome.deferred) {
+            // 202: accepted and pending, not refused. The rotation is recorded
+            // on the record and applies at the next safe moment.
+            return json(
+              {
+                ok: true,
+                rotated: false,
+                queued: true,
+                blocked: outcome.blocked,
+                activeChildren: outcome.children.length,
+                configStatus: botConfigStatus(after),
+                configRevision: botConfigRevision(after),
+              },
+              { status: 202 },
+            );
+          }
+          return err(outcome.status, outcome.error);
         }
       }
       {
@@ -4325,22 +4770,52 @@ a{color:#60a5fa}
             }
             const avatar = readBotAvatar(body);
             if ("error" in avatar) return err(400, avatar.error);
-            const bot = await updateBot(id, {
+            // Version the edit by what actually changed, not by which keys the
+            // form happened to submit. A cosmetic-only save must leave the
+            // revision alone so the bot keeps reading "Current" and is never
+            // offered a rotation that would change nothing.
+            const nextConfig = {
               name,
               persona,
-              shape: body.shape === undefined ? current.shape : avatar.shape,
-              colorway: body.colorway === undefined ? current.colorway : avatar.colorway,
+              description: current.description,
+              capabilities: current.capabilities,
               agent: config.agent,
               model,
               thinkingLevel,
               cwd,
               owner,
+            };
+            const materiallyChanged = sessionBoundConfigChanged(
+              sessionBoundConfigOf(current),
+              nextConfig,
+            );
+            const bot = await updateBot(id, {
+              ...nextConfig,
+              shape: body.shape === undefined ? current.shape : avatar.shape,
+              colorway: body.colorway === undefined ? current.colorway : avatar.colorway,
               enabled: body.enabled === undefined ? current.enabled : body.enabled,
-              runtimeRefreshPending: botPatchRequiresRuntimeRefresh(body)
-                ? true
-                : current.runtimeRefreshPending,
+              ...(materiallyChanged
+                ? {
+                    configRevision: nextBotConfigRevision(current),
+                    // Editing does NOT start a rotation. The revision gap alone
+                    // makes the status read "Update available", and applying it
+                    // is the human's explicit call — that is the whole point of
+                    // the control. Any queued-or-failed state from a previous
+                    // revision is cleared here rather than left up, because it
+                    // describes a target that no longer exists and would report
+                    // the wrong revision's error against the new edit.
+                    rotationState: "idle" as const,
+                    rotationReason: undefined,
+                    rotationError: undefined,
+                    rotationUpdatedAt: Date.now(),
+                  }
+                : {}),
             });
-            return json({ bot });
+            return json({
+              bot,
+              configStatus: bot ? botConfigStatus(bot) : "current",
+              configRevision: bot ? botConfigRevision(bot) : 1,
+            });
           }
           if (req.method === "DELETE") {
             const sessions = await listSessions();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -65,7 +65,6 @@ import {
   BOT_COLORWAYS,
   BOT_SHAPES,
   BotOwnerQuotaError,
-  botConversationId,
   createBot,
   deleteBot,
   getBot,
@@ -85,20 +84,27 @@ import { botCanonicalSessionId, botConversationRef, findBotMainSession } from ".
 import { botVisibleUserText } from "../bots/transcript.ts";
 import {
   CHECKPOINT_MAX_TURNS,
+  MAX_BOT_COMPACTION_THRESHOLD_PERCENT,
+  MIN_BOT_COMPACTION_THRESHOLD_PERCENT,
   appendArchivedSession,
   botCompactionDecision,
   botAppliedConfigRevision,
   botConfigRevision,
   botConfigStatus,
+  botHasPendingConfig,
   botRotationAdmission,
   buildHandoffCheckpoint,
   checkpointIsEmpty,
   defaultBotCompactionSettings,
+  extractCheckpointSections,
   formatHandoffCheckpoint,
-  measuredContextPercent,
+  migrateLegacyBotRotationState,
   nextBotConfigRevision,
+  queueBlocksBotRotation,
   rotationCompareAndSwap,
   rotationNoticeText,
+  sessionBoundConfigChanged,
+  sessionBoundConfigOf,
   type BotHandoffCheckpoint,
   type BotRotationBlock,
   type BotRotationReason,
@@ -109,7 +115,6 @@ import {
   BOT_SELF_UPDATE_FIELDS,
   BotSelfManagementError,
   botPatchRequiresRuntimeRefresh,
-  botRuntimeRefreshDecision,
   ownedBotPeers,
   readDeclaredCapabilities,
   resolveBotRuntimeActor,
@@ -136,7 +141,11 @@ import {
   // Aliased: the route already binds `visibleBots` to its own result.
   visibleBots as visibleBotsForViewer,
 } from "../bots/access.ts";
-import { formatBotAttribution, resolveBotMessageAuthor } from "../bots/authorship.ts";
+import {
+  botAuthorEmailFromText,
+  formatBotAttribution,
+  resolveBotMessageAuthor,
+} from "../bots/authorship.ts";
 import {
   attachRuntimeSession,
   botParticipantId,
@@ -144,11 +153,13 @@ import {
   canReadConversation,
   conversationBotParticipant,
   conversationHumanParticipantId,
+  detachRuntimeSession,
   ensureBotConversation,
   ensureConversationHuman,
   getConversation,
   leaveConversationParticipant,
   listConversations,
+  replaceConversationPrimaryRuntime,
   upsertConversationParticipant,
 } from "../conversations.ts";
 import { startAutoScheduler, setBotRoutineDelivery } from "../auto/scheduler.ts";
@@ -1963,6 +1974,66 @@ export function startIdleAgentArchiveSweep(): void {
   idleArchiveTimer.unref?.();
 }
 
+const BOT_COMPACTION_SWEEP_MS = 15_000;
+let botCompactionTimer: ReturnType<typeof setInterval> | null = null;
+let botCompactionRunning = false;
+
+/** Check measured context usage and rotate eligible persistent bots. */
+export async function checkBotCompactionOnce(now = Date.now()): Promise<number> {
+  const global = getGlobalSettingsSync();
+  const defaults = defaultBotCompactionSettings();
+  const threshold = global.botCompactionThresholdPercent;
+  const settings = {
+    ...defaults,
+    enabled: global.botAutoCompactionEnabled,
+    thresholdPercent: threshold,
+    // Keep a real hysteresis gap even when the operator lowers the threshold.
+    rearmPercent: Math.min(defaults.rearmPercent, threshold - 10),
+  };
+  if (!settings.enabled) return 0;
+
+  const [bots, sessions] = await Promise.all([listBots(), listSessions().catch(() => [])]);
+  let rotated = 0;
+  for (const bot of bots) {
+    if (!bot.enabled || bot.rotationState === "rotating" || bot.rotationState === "failed") continue;
+    if (bot.rotationState === "queued" && bot.rotationReason === "config") continue;
+
+    if (bot.rotationState === "queued" && bot.rotationReason === "compaction") {
+      const outcome = await rotateBotSession(bot.id, { reason: "compaction" });
+      if (outcome.ok && outcome.rotated) rotated++;
+      continue;
+    }
+
+    const primary = findBotMainSession(bot, sessions);
+    const sessionId = primary?.sessionId ?? bot.sessionId?.trim();
+    if (!sessionId) continue;
+    const transcriptPath = await resolveTranscript(sessionId).catch(() => null);
+    const usage = await sessionTokenUsage(sessionId, transcriptPath);
+    const decision = botCompactionDecision({ usage, bot, settings, now });
+    if (decision.armed !== (bot.compactionArmed !== false)) {
+      mutateBot(bot.id, (current) => ({ ...current, compactionArmed: decision.armed }));
+    }
+    if (!decision.rotate) continue;
+    const outcome = await rotateBotSession(bot.id, { reason: "compaction" });
+    if (outcome.ok && outcome.rotated) rotated++;
+  }
+  return rotated;
+}
+
+export function startBotCompactionSweep(): void {
+  if (botCompactionTimer) return;
+  botCompactionTimer = setInterval(() => {
+    if (botCompactionRunning) return;
+    botCompactionRunning = true;
+    void checkBotCompactionOnce()
+      .catch((error) => console.error(`[bot-compaction] ${error instanceof Error ? error.message : String(error)}`))
+      .finally(() => {
+        botCompactionRunning = false;
+      });
+  }, BOT_COMPACTION_SWEEP_MS);
+  botCompactionTimer.unref?.();
+}
+
 // When an agent explicitly chooses to close after publishing, the POST response
 // has to reach it before its tmux session disappears. Persist the resumable
 // record synchronously at the call site, then close from a short deferred task.
@@ -2350,8 +2421,12 @@ async function ensureBotSession(
   if (live) {
     // Heal a record an older broad `botId` match rebound to a delegated child,
     // so the corrupt id stops being handed to the next reader.
-    if (live.sessionId && live.sessionId !== bot.sessionId) {
-      await updateBot(bot.id, { sessionId: live.sessionId });
+    const conversationId = bot.conversationId?.trim() || live.conversationId?.trim() || bot.sessionId?.trim();
+    if (
+      live.sessionId &&
+      (live.sessionId !== bot.sessionId || (conversationId && conversationId !== bot.conversationId))
+    ) {
+      await updateBot(bot.id, { sessionId: live.sessionId, conversationId });
     }
     return { session: live, delivered: false };
   }
@@ -2359,7 +2434,8 @@ async function ensureBotSession(
   // subagents, recovering the conversation the human has actually been talking
   // to instead of resuming a delegated task's thread.
   return launchBotSession(bot, {
-    conversationId: botConversationRef(bot, sessions).sessionId,
+    conversationId: bot.conversationId?.trim() || botConversationRef(bot, sessions).sessionId,
+    runtimeSessionId: botConversationRef(bot, sessions).sessionId,
     firstMessage,
   });
 }
@@ -2376,17 +2452,23 @@ async function ensureBotSession(
  * `assignUser`, and the first Scout session already went missing once for
  * exactly that reason.
  *
- * `conversationId` omitted means mint a fresh one, which is what makes this the
- * rotation primitive's launcher: a new id is a new conversation by
- * construction, because the transcript read model is keyed on it
- * (`lfg://session/<id>`, sessionIndexKey). That is precisely the property
- * rotation needs and cold start must never have.
+ * Rotation changes `runtimeSessionId` while preserving `conversationId`.
+ * Cold restart preserves both. The two ids were historically the same, so an
+ * old bot record is migrated by treating its saved session id as both values.
  */
 async function launchBotSession(
   bot: Bot,
   opts: {
-    /** Conversation to attach to. Omitted mints a fresh one. */
+    /** Durable product conversation. */
     conversationId?: string;
+    /** Runtime transcript/provider thread. Omitted mints a fresh runtime. */
+    runtimeSessionId?: string;
+    /** Rotation commits the binding itself after all preparation succeeds. */
+    bindRecord?: boolean;
+    /** Keep the old primary live while a replacement is prepared. */
+    preserveExistingPrimary?: boolean;
+    /** Revision loaded into this runtime's launch contract. */
+    appliedConfigRevision?: number;
     /** Pre-rendered blocks injected after the contract, in order. */
     injectedBlocks?: readonly string[];
     /** Skip the automatic prior-conversation summary (rotation brings its own). */
@@ -2427,24 +2509,24 @@ async function launchBotSession(
               : agent === "pi"
                 ? resolvedModel ?? PI_DEFAULT_MODEL
                 : resolvedModel;
-    // The bot's id IS its conversation. A relaunch used to mint a fresh one,
-    // which is why a bot that died came back with an empty chat: the transcript
-    // read model is keyed on the id (`lfg://session/<id>`, sessionIndexKey), so
-    // a new id is a new conversation by construction. Reusing it makes new
-    // turns append to the history that is already there — no change to the
-    // transcript API, the live socket, or the client, because none of them ever
-    // cared which process produced a turn.
-    // An omitted conversation id is a deliberate fresh start (rotation), not a
-    // missing value: the caller has already decided the old thread is being
-    // left behind and archived.
-    const conversation = { sessionId: opts.conversationId?.trim() || undefined };
-    const sessionId = botConversationId(conversation, () => crypto.randomUUID());
-    ensureBotConversation({
-      conversationId: sessionId,
+    const legacyId = bot.sessionId?.trim();
+    const sessionId = opts.runtimeSessionId?.trim() || crypto.randomUUID();
+    const conversationId = opts.conversationId?.trim() || bot.conversationId?.trim() || legacyId || sessionId;
+    const durableConversation = ensureBotConversation({
+      conversationId,
       bot,
       ownerIdentity: bot.owner,
       roster: userRoster(),
     });
+    const botParticipant = durableConversation.participants.find((row) => row.id === botParticipantId(bot.id));
+    upsertConversationParticipant(
+      conversationId,
+      conversationBotParticipant(bot, {
+        role: botParticipant?.role,
+        joinedAt: botParticipant?.joinedAt,
+        historyAccess: botParticipant?.historyAccess,
+      }),
+    );
     // aisdk decides resume-vs-fresh by asking the index itself
     // (sessionHasIndexedMessages, aisdk-session.ts), so reusing the id restores
     // the model's own thread too and a summary would only repeat what it can
@@ -2462,8 +2544,8 @@ async function launchBotSession(
     // Summarize the repaired conversation, never the corrupt id: a bot rebound
     // to its own subagent would otherwise be reintroduced to that task's
     // transcript as if it were its own history.
-    const continuity = !opts.skipContinuity && !resumesOwnThread && conversation.sessionId
-      ? await botContinuitySummary(conversation.sessionId)
+    const continuity = !opts.skipContinuity && !resumesOwnThread && legacyId
+      ? await botContinuitySummary(legacyId)
       : null;
     const prompt = [
       // Regenerated from the bot record on every launch, which is the whole
@@ -2479,9 +2561,16 @@ async function launchBotSession(
       ...(opts.injectedBlocks ?? []),
       firstMessage ?? "",
     ].filter(Boolean).join("\n\n");
-    for (const stale of listManaged().filter((row) => row.botId === bot.id)) {
-      removeManaged(stale.tmuxName);
-      assignUser(stale.tmuxName, null);
+    if (!opts.preserveExistingPrimary) {
+      for (const stale of listManaged().filter((row) =>
+        row.botId === bot.id &&
+        !row.parentSessionId &&
+        !row.parentNativeSessionId &&
+        row.spawnedBy !== "subagent"
+      )) {
+        removeManaged(stale.tmuxName);
+        assignUser(stale.tmuxName, null);
+      }
     }
     const tmuxName = `lfg-${randomBytes(3).toString("hex")}`;
     const createdAt = Date.now();
@@ -2500,15 +2589,19 @@ async function launchBotSession(
       title: bot.name,
       project: repo.project,
       spawnedBy: "bot",
-      conversationId: sessionId,
+      conversationId,
+      appliedConfigRevision: opts.appliedConfigRevision ?? botConfigRevision(bot),
       botId: bot.id,
       persistent: true,
     });
+    // Attach provisionally before the harness can write its launch turn. This
+    // gives transcript indexing a verified bot author without selecting this
+    // runtime as the product surface before startup succeeds.
     attachRuntimeSession({
-      conversationId: sessionId,
+      conversationId,
       sessionId,
       participantId: botParticipantId(bot.id),
-      kind: "primary",
+      kind: "execution",
       attachedAt: createdAt,
     });
     // Tag before spawn, same as /api/sessions/new: an unassigned bot session is
@@ -2531,13 +2624,32 @@ async function launchBotSession(
     if (!launched.ok) {
       removeManaged(tmuxName);
       assignUser(tmuxName, null);
+      detachRuntimeSession(conversationId, sessionId);
       return err(502, launched.error || "failed to start bot session");
     }
     if (launched.nativeSessionId) patchManaged(tmuxName, { nativeSessionId: launched.nativeSessionId });
     if (CODING_AGENT_ADAPTERS[agent].transport === "command-file")
       patchManaged(tmuxName, { launchState: "running" });
-    const saved = await updateBot(bot.id, { sessionId });
-    if (!saved) return err(404, "bot not found");
+    if (opts.bindRecord !== false) {
+      const attached = replaceConversationPrimaryRuntime({
+        conversationId,
+        sessionId,
+        participantId: botParticipantId(bot.id),
+        attachedAt: createdAt,
+      });
+      if (!attached) {
+        removeManaged(tmuxName);
+        assignUser(tmuxName, null);
+        detachRuntimeSession(conversationId, sessionId);
+        return err(502, "bot conversation could not attach the runtime");
+      }
+      const saved = await updateBot(bot.id, {
+        conversationId,
+        sessionId,
+        appliedConfigRevision: opts.appliedConfigRevision ?? botConfigRevision(bot),
+      });
+      if (!saved) return err(404, "bot not found");
+    }
     invalidateListSessionsCache();
     const record = listManaged().find((row) => row.tmuxName === tmuxName);
     const row = record
@@ -2610,14 +2722,23 @@ async function buildBotHandoffCheckpoint(
     .map((message) => ({
       role: message.role as "user" | "assistant",
       text: botVisibleUserText(message.text ?? ""),
+      ...(message.role === "user"
+        ? {
+            author:
+              botAuthorEmailFromText(message.text ?? "") ||
+              (message.author?.kind === "legacy" ? "legacy:unknown" : undefined),
+          }
+        : {}),
     }))
     .filter((turn) => !!turn.text.trim());
+  const sections = extractCheckpointSections(turns.slice(-CHECKPOINT_MAX_TURNS));
 
   return buildHandoffCheckpoint({
     sourceSessionId: sessionId,
     reason: input.reason,
     configRevision: input.configRevision,
     createdAt: input.now,
+    ...sections,
     artifacts: extractCheckpointArtifacts(turns.slice(-CHECKPOINT_MAX_TURNS)),
     turns,
   });
@@ -2656,20 +2777,18 @@ export type BotRotationOutcome =
  *     kill. The pending state is persisted so the UI can say so.
  *  4. Build the checkpoint BEFORE anything is torn down. A checkpoint failure
  *     here costs nothing: the old session is still running and still bound.
- *  5. Close the old session. `closeLiveSession` persists a resume record first,
- *     so "archived" means resumable and auditable, not destroyed.
- *  6. Launch the replacement. If this fails the record still points at the old
- *     conversation id, whose transcript is on disk and whose process the next
- *     message will restart. A failed rotation therefore degrades to "the bot is
- *     cold", never to "the bot is gone".
- *  7. Commit. Only now does the binding move.
+ *  5. Launch and provisionally attach the replacement while the old primary
+ *     remains live. A failed spawn changes no canonical binding.
+ *  6. Promote and stage the replacement binding while the old process remains
+ *     live. A staging failure restores the old attachment and stops the candidate.
+ *  7. Close the old primary, then finalize. A close failure rolls the staged
+ *     binding back to the still-live old runtime.
  */
 async function rotateBotSession(
   botId: string,
   opts: {
     reason: BotRotationReason;
     expectedRevision?: number;
-    force?: boolean;
   },
 ): Promise<BotRotationOutcome> {
   return serializeBotWork(botId, async () => {
@@ -2691,7 +2810,7 @@ async function rotateBotSession(
 
     const sessions = await listSessions();
     const primary = findBotMainSession(bot, sessions);
-    const admission = botRotationAdmission(bot.id, primary, sessions, { force: opts.force });
+    const admission = botRotationAdmission(bot.id, primary, sessions);
     if (!admission.ready) {
       mutateBot(bot.id, (current) => ({
         ...current,
@@ -2709,6 +2828,22 @@ async function rotateBotSession(
       return { ok: false, deferred: true, blocked: admission.blocked, children: admission.children };
     }
 
+    const queueSessionId = primary?.sessionId ?? botCanonicalSessionId(bot, sessions);
+    if (queueSessionId) {
+      await reconcileQueued(queueSessionId).catch(() => false);
+      const queueBusy = queueBlocksBotRotation(listQueue(queueSessionId));
+      if (queueBusy) {
+        mutateBot(bot.id, (current) => ({
+          ...current,
+          rotationState: "queued",
+          rotationReason: opts.reason,
+          rotationError: undefined,
+          rotationUpdatedAt: Date.now(),
+        }));
+        return { ok: false, deferred: true, blocked: "primary-busy", children: [] };
+      }
+    }
+
     // The revision this rotation is applying. Captured before any await, and
     // used verbatim at commit time: an edit that lands WHILE the rotation runs
     // bumps configRevision again, and that newer edit is genuinely not in the
@@ -2716,6 +2851,11 @@ async function rotateBotSession(
     // would mark it applied and the user would never be offered the button.
     const targetRevision = botConfigRevision(bot);
     const previousSessionId = botCanonicalSessionId(bot, sessions);
+    const conversationId =
+      bot.conversationId?.trim() ||
+      primary?.conversationId?.trim() ||
+      previousSessionId ||
+      crypto.randomUUID();
     const now = Date.now();
 
     mutateBot(bot.id, (current) => ({
@@ -2762,18 +2902,19 @@ async function rotateBotSession(
       );
     }
 
-    // 5. Retire the old process. Its transcript and resume record survive.
-    if (primary?.sessionId) {
-      const outcome = await closeLiveSession(primary, primary.sessionId, {
-        sessionId: primary.sessionId,
-        source: `bot_rotation_${opts.reason}`,
-        botId: bot.id,
-      });
-      if (!outcome.ok) return fail(outcome.status, outcome.reason);
-    }
-
-    // 6. Fresh conversation id, current config, checkpoint aboard.
-    const launched = await launchBotSession(bot, { injectedBlocks, skipContinuity: true });
+    // 5. Prepare a fresh runtime under the same durable conversation while the
+    // old primary remains live. A spawn failure therefore leaves the old bot
+    // fully usable, not merely resumable from disk.
+    // The checkpoint is aboard. The record and conversation binding remain unchanged
+    // until the process has started successfully.
+    const launched = await launchBotSession(bot, {
+      conversationId,
+      injectedBlocks,
+      skipContinuity: true,
+      bindRecord: false,
+      preserveExistingPrimary: true,
+      appliedConfigRevision: targetRevision,
+    });
     if (launched instanceof Response) {
       const body = (await launched.json().catch(() => null)) as { error?: string } | null;
       return fail(launched.status, body?.error ?? "failed to start the replacement session");
@@ -2781,17 +2922,86 @@ async function rotateBotSession(
     const newSessionId = launched.session.sessionId;
     if (!newSessionId) return fail(502, "replacement session did not report an id");
 
-    // 7. Commit. `launchBotSession` has already pointed the record at the new
-    // conversation, which is what makes this safe to do in two writes: the
-    // binding moved only after a successful spawn, and the worst a crash
-    // between the two can leave behind is a bot that still offers an Apply
-    // button for a change that is in fact live. Clicking it again is a no-op
-    // success via the compare-and-swap above.
-    const committed = mutateBot(bot.id, (current) => ({
+    const stopReplacement = async (source: string): Promise<void> => {
+      await closeLiveSession(launched.session, newSessionId, {
+        sessionId: newSessionId,
+        source,
+        botId: bot.id,
+      }).catch(() => undefined);
+    };
+
+    const attached = replaceConversationPrimaryRuntime({
+      conversationId,
+      sessionId: newSessionId,
+      participantId: botParticipantId(bot.id),
+      attachedAt: Date.now(),
+    });
+    if (!attached) {
+      await stopReplacement("bot_rotation_attach_rollback");
+      return fail(502, "replacement runtime could not attach to the bot conversation");
+    }
+
+    // 6. Stage the canonical record while the old process is still live. This
+    // closes the old rollback gap: if the record write fails, no live runtime
+    // has been destroyed and the old attachment can remain canonical.
+    const staged = mutateBot(bot.id, (current) => ({
       ...current,
+      conversationId,
       sessionId: newSessionId,
       appliedConfigRevision: targetRevision,
       configRevision: botConfigRevision(current),
+      rotationState: "rotating",
+      rotationReason: opts.reason,
+      rotationError: undefined,
+      rotationUpdatedAt: Date.now(),
+    }));
+    if (!staged) {
+      if (previousSessionId) {
+        replaceConversationPrimaryRuntime({
+          conversationId,
+          sessionId: previousSessionId,
+          participantId: botParticipantId(bot.id),
+        });
+      }
+      await stopReplacement("bot_rotation_record_stage_rollback");
+      return fail(404, "bot not found");
+    }
+
+    // 7. Retire the old process only after its replacement is running,
+    // attached, and staged. A close failure restores both durable pointers to
+    // the still-live old primary before the candidate is stopped.
+    if (primary?.sessionId) {
+      const outcome = await closeLiveSession(primary, primary.sessionId, {
+        sessionId: primary.sessionId,
+        source: `bot_rotation_${opts.reason}`,
+        botId: bot.id,
+      });
+      if (!outcome.ok) {
+        replaceConversationPrimaryRuntime({
+          conversationId,
+          sessionId: primary.sessionId,
+          participantId: botParticipantId(bot.id),
+        });
+        mutateBot(bot.id, (current) => ({
+          ...current,
+          conversationId,
+          sessionId: previousSessionId ?? bot.sessionId,
+          appliedConfigRevision: botAppliedConfigRevision(bot),
+          rotationState: "failed",
+          rotationReason: opts.reason,
+          rotationError: outcome.reason.slice(0, 400),
+          rotationUpdatedAt: Date.now(),
+        }));
+        await stopReplacement("bot_rotation_close_rollback");
+        return fail(outcome.status, outcome.reason);
+      }
+    }
+
+    // Finalize only after the new process is live and the old process has
+    // retired. Session-bound edits that arrived while rotation ran remain a
+    // newer configRevision, so the UI still offers their unapplied revision.
+    const committed = mutateBot(bot.id, (current) => ({
+      ...current,
       rotationState: "idle",
       rotationReason: undefined,
       rotationError: undefined,
@@ -2805,13 +3015,19 @@ async function rotateBotSession(
         ? { compactionArmed: false, lastCompactionAt: Date.now() }
         : {}),
     }));
-    if (!committed) return fail(404, "bot not found");
+    if (!committed) {
+      // Deletion uses the same bot critical section, so this branch only
+      // protects against a store failure. The replacement stays attached and
+      // running because the staged record already names it.
+      return fail(404, "bot not found");
+    }
 
     evlog("bot_rotation_done", {
       botId,
       reason: opts.reason,
       previousSessionId,
       sessionId: newSessionId,
+      conversationId,
       appliedConfigRevision: targetRevision,
       archived: committed.archivedSessionIds?.length ?? 0,
     });
@@ -2858,15 +3074,7 @@ async function applyPendingBotRotation(bot: Bot): Promise<Bot> {
  */
 function migrateLegacyBotRefreshFlag(bot: Bot): Bot {
   if (!bot.runtimeRefreshPending) return bot;
-  return mutateBot(bot.id, (current) => ({
-    ...current,
-    runtimeRefreshPending: false,
-    configRevision: nextBotConfigRevision(current),
-    appliedConfigRevision: botConfigRevision(current),
-    rotationState: "queued",
-    rotationReason: "config",
-    rotationUpdatedAt: Date.now(),
-  })) ?? bot;
+  return mutateBot(bot.id, (current) => migrateLegacyBotRotationState(current)) ?? bot;
 }
 
 /** Pure half of callerBotId, split out so the id-matching logic is testable
@@ -3881,6 +4089,25 @@ a{color:#60a5fa}
               );
             patch.idleAgentArchiveMinutes = minutes;
           }
+          if (b?.botAutoCompactionEnabled !== undefined) {
+            if (typeof b.botAutoCompactionEnabled !== "boolean")
+              return err(400, "botAutoCompactionEnabled must be a boolean");
+            patch.botAutoCompactionEnabled = b.botAutoCompactionEnabled;
+          }
+          if (b?.botCompactionThresholdPercent !== undefined) {
+            const threshold = Number(b.botCompactionThresholdPercent);
+            if (
+              !Number.isInteger(threshold) ||
+              threshold < MIN_BOT_COMPACTION_THRESHOLD_PERCENT ||
+              threshold > MAX_BOT_COMPACTION_THRESHOLD_PERCENT
+            ) {
+              return err(
+                400,
+                `botCompactionThresholdPercent must be an integer from ${MIN_BOT_COMPACTION_THRESHOLD_PERCENT} to ${MAX_BOT_COMPACTION_THRESHOLD_PERCENT}`,
+              );
+            }
+            patch.botCompactionThresholdPercent = threshold;
+          }
           if (b?.skippedUpdateVersion !== undefined) {
             if (typeof b.skippedUpdateVersion !== "string" || b.skippedUpdateVersion.length > 100)
               return err(400, "skippedUpdateVersion must be a string of 100 characters or fewer");
@@ -4319,10 +4546,16 @@ a{color:#60a5fa}
               // and the rotation is left to the message path, because
               // re-entering the lock would deadlock.
               let target = migrateLegacyBotRefreshFlag(reservedTarget);
-              if (target.rotationState === "queued") {
+              if (
+                target.rotationState === "queued" ||
+                target.rotationState === "rotating" ||
+                (target.rotationState === "failed" && target.rotationReason === "config")
+              ) {
                 throw new BotPeerMessageError(
                   409,
-                  "target bot refresh is still settling; retry after its current turn completes",
+                  target.rotationState === "failed"
+                    ? `target bot refresh failed: ${target.rotationError || "retry the refresh"}`
+                    : "target bot refresh is still settling; retry after its current turn completes",
                 );
               }
 
@@ -4481,15 +4714,29 @@ a{color:#60a5fa}
           if (capabilities && !Array.isArray(capabilities)) return err(400, capabilities.error);
           const avatar = readBotAvatar(body);
           if ("error" in avatar) return err(400, avatar.error);
-          const refreshRuntime = botPatchRequiresRuntimeRefresh(body);
-          const bot = await updateBot(actor.bot.id, {
+          const nextConfig = {
+            ...sessionBoundConfigOf(actor.bot),
             name,
             persona,
             description,
             capabilities,
+          };
+          const refreshRuntime = botPatchRequiresRuntimeRefresh(body) &&
+            sessionBoundConfigChanged(sessionBoundConfigOf(actor.bot), nextConfig);
+          const bot = await updateBot(actor.bot.id, {
+            ...nextConfig,
             shape: body.shape === undefined ? actor.bot.shape : avatar.shape,
             colorway: body.colorway === undefined ? actor.bot.colorway : avatar.colorway,
-            runtimeRefreshPending: refreshRuntime ? true : actor.bot.runtimeRefreshPending,
+            ...(refreshRuntime
+              ? {
+                  configRevision: nextBotConfigRevision(actor.bot),
+                  rotationState: "queued" as const,
+                  rotationReason: "config" as const,
+                  rotationError: undefined,
+                  rotationUpdatedAt: Date.now(),
+                  runtimeRefreshPending: false,
+                }
+              : {}),
           });
           if (!bot) return err(404, "bot not found");
           evlog("bot_updated_self", {
@@ -4580,14 +4827,19 @@ a{color:#60a5fa}
             if (scoped && assigned && botOwner && botReadUser(assigned) !== botReadUser(botOwner)) return [];
             const conversationUser = botReadUser(assigned || botOwner);
             if (scoped && requestedUser != null && conversationUser !== user) return [];
+            const conversationId =
+              bot.conversationId?.trim() ||
+              session?.conversationId?.trim() ||
+              sessionId;
             const cursor = latestIndexedAssistantCursor(sessionId);
-            ensureBotConversationReadBaseline(user, sessionId, cursor?.rowid ?? null);
+            ensureBotConversationReadBaseline(user, conversationId, cursor?.rowid ?? null);
             const last = lastIndexedAssistantMessage(sessionId);
             return [{
               sessionId,
+              conversationId,
               botId: bot.id,
               assignedUser: assigned ?? bot.owner ?? null,
-              unread: conversationUnread(user, sessionId, cursor?.rowid ?? null),
+              unread: conversationUnread(user, conversationId, cursor?.rowid ?? null),
               lastMessagePreview: last?.text?.slice(0, 400),
               lastMessageTs: last?.ts ?? null,
             }];
@@ -4670,8 +4922,12 @@ a{color:#60a5fa}
               bots,
             );
             const cursor = latestIndexedAssistantCursor(sessionId);
-            const read = markBotConversationRead(owner.user, sessionId, cursor?.rowid ?? null);
-            return json({ ok: true, sessionId, readThroughRowid: read.readThroughRowid });
+            const conversationId =
+              owner.bot.conversationId?.trim() ||
+              sessions.find((row) => row.sessionId === sessionId)?.conversationId?.trim() ||
+              sessionId;
+            const read = markBotConversationRead(owner.user, conversationId, cursor?.rowid ?? null);
+            return json({ ok: true, sessionId, conversationId, readThroughRowid: read.readThroughRowid });
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             return err(message.includes("another user") ? 403 : 404, message);
@@ -4745,36 +5001,47 @@ a{color:#60a5fa}
           // message is sent is what guarantees the message is answered under
           // the new configuration rather than the old one.
           bot = await applyPendingBotRotation(migrateLegacyBotRefreshFlag(bot));
-          if (bot.rotationState === "queued") {
-            return err(
-              409,
-              "bot refresh is waiting for the current turn to finish; retry in a moment",
-            );
-          }
-          // Attribute before launching: when the session has to be started, this
-          // exact text rides inside the launch prompt instead of racing it.
-          const { author, trusted } = resolveBotMessageAuthor({
-            viewer,
-            rosterTagUser: tag.ok ? tag.user : undefined,
-            botOwner: bot.owner,
-            envUser: process.env.OMG_USER,
-          });
-          const attributed = `${formatBotAttribution(author, bot.name)}\n\n${text}`;
-          const delivery = await deliverBotMessage(bot, attributed);
-          if ("error" in delivery) return err(delivery.status, delivery.error);
-          if (trusted) {
-            const profile = userRoster().find(
-              (user) => user.email.trim().toLowerCase() === author.trim().toLowerCase(),
-            );
-            ensureConversationHuman({
-              conversationId: bot.sessionId?.trim() || delivery.sessionId,
-              identity: author,
-              name: profile?.name,
-              avatar: profile?.avatar,
-              role: "member",
+          const botId = bot.id;
+          return serializeBotWork(botId, async () => {
+            const activeBot = (await getBot(botId)) ?? bot!;
+            if (activeBot.rotationState === "queued") {
+              return err(
+                409,
+                "bot refresh is waiting for the current turn to finish; retry in a moment",
+              );
+            }
+            if (activeBot.rotationState === "rotating") return err(409, "bot refresh is in progress; retry in a moment");
+            if (activeBot.rotationState === "failed" && activeBot.rotationReason === "config") {
+              return err(409, `bot refresh failed: ${activeBot.rotationError || "apply the update again"}`);
+            }
+            // Attribute before launching: when the session has to be started,
+            // this text rides inside the launch prompt instead of racing it.
+            const { author, trusted } = resolveBotMessageAuthor({
+              viewer,
+              rosterTagUser: tag.ok ? tag.user : undefined,
+              botOwner: activeBot.owner,
+              envUser: process.env.OMG_USER,
             });
-          }
-          return json({ sessionId: delivery.sessionId });
+            const attributed = `${formatBotAttribution(author, activeBot.name)}\n\n${text}`;
+            const delivery = await deliverBotMessage(activeBot, attributed);
+            if ("error" in delivery) return err(delivery.status, delivery.error);
+            if (trusted) {
+              const profile = userRoster().find(
+                (user) => user.email.trim().toLowerCase() === author.trim().toLowerCase(),
+              );
+              ensureConversationHuman({
+                conversationId:
+                  activeBot.conversationId?.trim() ||
+                  (await getBot(botId))?.conversationId?.trim() ||
+                  delivery.sessionId,
+                identity: author,
+                name: profile?.name,
+                avatar: profile?.avatar,
+                role: "member",
+              });
+            }
+            return json({ sessionId: delivery.sessionId });
+          });
         }
       }
       {
@@ -4787,11 +5054,9 @@ a{color:#60a5fa}
           const existing = await getBot(id);
           if (!existing) return err(404, "bot not found");
           const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
-          const allowed = new Set(["expectedRevision", "force"]);
+          const allowed = new Set(["expectedRevision"]);
           const unknown = Object.keys(body ?? {}).filter((key) => !allowed.has(key)).sort();
           if (unknown.length) return err(400, `unsupported rotate fields: ${unknown.join(", ")}`);
-          if (body?.force !== undefined && typeof body.force !== "boolean")
-            return err(400, "force must be a boolean");
           if (
             body?.expectedRevision !== undefined &&
             (!Number.isInteger(body.expectedRevision) || (body.expectedRevision as number) < 1)
@@ -4799,13 +5064,14 @@ a{color:#60a5fa}
             return err(400, "expectedRevision must be a positive integer");
           }
           const bot = migrateLegacyBotRefreshFlag(existing);
+          const retryingCompaction =
+            bot.rotationReason === "compaction" &&
+            !botHasPendingConfig(bot);
           const outcome = await rotateBotSession(id, {
-            reason: "config",
-            expectedRevision: body?.expectedRevision as number | undefined,
-            // Force is destructive — it interrupts a turn in flight — so it is
-            // never inferred. The client sends it only behind an explicit
-            // confirmation, and the default path queues instead.
-            force: body?.force === true,
+            reason: retryingCompaction ? "compaction" : "config",
+            expectedRevision: retryingCompaction
+              ? undefined
+              : body?.expectedRevision as number | undefined,
           });
           const after = (await getBot(id)) ?? bot;
           if (outcome.ok) {
@@ -4928,32 +5194,39 @@ a{color:#60a5fa}
             });
           }
           if (req.method === "DELETE") {
-            const sessions = await listSessions();
-            const live = sessions.find((session) =>
-              session.botId === id ||
-              (current.sessionId && (session.sessionId === current.sessionId || session.nativeSessionId === current.sessionId))
-            );
-            if (live?.sessionId) {
-              const outcome = await closeLiveSession(live, live.sessionId, {
-                sessionId: live.sessionId,
-                source: "bot_delete",
-                botId: id,
-              });
-              if (!outcome.ok) return err(outcome.status, outcome.reason);
-            }
-            for (const stale of listManaged().filter((row) => row.botId === id)) {
-              removeManaged(stale.tmuxName);
-              assignUser(stale.tmuxName, null);
-            }
-            // A deleted bot can never receive its own routine nudges again —
-            // leaving its rows behind would otherwise make "deleted bot with
-            // live routines" the steady state instead of the rare transient
-            // window the scheduler already tolerates (missing/disabled bot:
-            // skip, log, stamp lastRunAt so it doesn't retry every tick).
-            const removedRoutines = await deleteAutoAgentsOwnedByBot(id);
-            await deleteBot(id);
-            invalidateListSessionsCache();
-            return json({ ok: true, removedRoutines });
+            return serializeBotWork(id, async () => {
+              const deleting = await getBot(id);
+              if (!deleting) return err(404, "bot not found");
+              const sessions = await listSessions();
+              const live = sessions.find((session) =>
+                session.botId === id ||
+                (deleting.sessionId && (
+                  session.sessionId === deleting.sessionId ||
+                  session.nativeSessionId === deleting.sessionId
+                ))
+              );
+              if (live?.sessionId) {
+                const outcome = await closeLiveSession(live, live.sessionId, {
+                  sessionId: live.sessionId,
+                  source: "bot_delete",
+                  botId: id,
+                });
+                if (!outcome.ok) return err(outcome.status, outcome.reason);
+              }
+              for (const stale of listManaged().filter((row) => row.botId === id)) {
+                removeManaged(stale.tmuxName);
+                assignUser(stale.tmuxName, null);
+              }
+              // A deleted bot can never receive its own routine nudges again —
+              // leaving its rows behind would otherwise make "deleted bot with
+              // live routines" the steady state instead of the rare transient
+              // window the scheduler already tolerates (missing/disabled bot:
+              // skip, log, stamp lastRunAt so it doesn't retry every tick).
+              const removedRoutines = await deleteAutoAgentsOwnedByBot(id);
+              await deleteBot(id);
+              invalidateListSessionsCache();
+              return json({ ok: true, removedRoutines });
+            });
           }
         }
       }
@@ -8740,7 +9013,15 @@ a{color:#60a5fa}
       console.error(`[auto-sched] routine ${agent.id} owner bot ${agent.owner.botId} is gone or disabled — skipping`);
       return;
     }
-    const result = await deliverBotMessage(bot, routineNudgeText(agent));
+    const prepared = await applyPendingBotRotation(migrateLegacyBotRefreshFlag(bot));
+    if (prepared.rotationState === "failed" && prepared.rotationReason === "config") {
+      console.error(`[auto-sched] routine ${agent.id} is waiting for bot ${bot.id} to refresh`);
+      return;
+    }
+    const result = await serializeBotWork(bot.id, async () => {
+      const current = (await getBot(bot.id)) ?? prepared;
+      return deliverBotMessage(current, routineNudgeText(agent));
+    });
     if ("error" in result) {
       console.error(`[auto-sched] routine ${agent.id} delivery failed: ${result.error}`);
     }
@@ -8769,6 +9050,7 @@ a{color:#60a5fa}
   startWorktreeSweep((l) => console.log(l));
   startTmpSweep((l) => console.log(l));
   startIdleAgentArchiveSweep();
+  startBotCompactionSweep();
   // Watch the fleet for busy -> idle transitions and fan "completed" events out
   // to fleet subscribers (Web Push). Idempotent + best-effort.
   startFleetWatcher();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -137,6 +137,20 @@ import {
   visibleBots as visibleBotsForViewer,
 } from "../bots/access.ts";
 import { formatBotAttribution, resolveBotMessageAuthor } from "../bots/authorship.ts";
+import {
+  attachRuntimeSession,
+  botParticipantId,
+  canManageConversation,
+  canReadConversation,
+  conversationBotParticipant,
+  conversationHumanParticipantId,
+  ensureBotConversation,
+  ensureConversationHuman,
+  getConversation,
+  leaveConversationParticipant,
+  listConversations,
+  upsertConversationParticipant,
+} from "../conversations.ts";
 import { startAutoScheduler, setBotRoutineDelivery } from "../auto/scheduler.ts";
 import { handleWakeTick } from "../auto/wake-tick.ts";
 import { pushWakeHooksNow, setWakeHooksBootId } from "../auto/wake-hooks-push.ts";
@@ -2425,6 +2439,12 @@ async function launchBotSession(
     // left behind and archived.
     const conversation = { sessionId: opts.conversationId?.trim() || undefined };
     const sessionId = botConversationId(conversation, () => crypto.randomUUID());
+    ensureBotConversation({
+      conversationId: sessionId,
+      bot,
+      ownerIdentity: bot.owner,
+      roster: userRoster(),
+    });
     // aisdk decides resume-vs-fresh by asking the index itself
     // (sessionHasIndexedMessages, aisdk-session.ts), so reusing the id restores
     // the model's own thread too and a summary would only repeat what it can
@@ -2480,8 +2500,16 @@ async function launchBotSession(
       title: bot.name,
       project: repo.project,
       spawnedBy: "bot",
+      conversationId: sessionId,
       botId: bot.id,
       persistent: true,
+    });
+    attachRuntimeSession({
+      conversationId: sessionId,
+      sessionId,
+      participantId: botParticipantId(bot.id),
+      kind: "primary",
+      attachedAt: createdAt,
     });
     // Tag before spawn, same as /api/sessions/new: an unassigned bot session is
     // invisible under the rail's default per-user filter, which is exactly how
@@ -3869,6 +3897,17 @@ a{color:#60a5fa}
           warmChatTranscripts(sessions);
           return sessions;
         });
+        const viewer = botViewerFromRequest(req, undefined);
+        const conversationsTask = sessionsTask.then(() => {
+          let conversations = listConversations();
+          if (viewer.managed && viewer.identity) {
+            const participantId = conversationHumanParticipantId(viewer.identity);
+            conversations = conversations.filter((conversation) =>
+              canReadConversation(conversation, participantId),
+            );
+          }
+          return conversations;
+        });
         const reposTask = listRepos();
         const codingAgentsTask = listCodingAgentsCached();
         const settingsTask = getGlobalSettings();
@@ -3878,6 +3917,7 @@ a{color:#60a5fa}
           models: codingAgentsTask.then((agents) => listModelCatalog(agents)),
           settings: settingsTask,
           sessions: sessionsTask,
+          conversations: conversationsTask,
           users: Promise.resolve(userRoster()),
           repos: reposTask,
           autoAgents: listAutoAgents(),
@@ -3897,6 +3937,7 @@ a{color:#60a5fa}
           models?: ReturnType<typeof listModelCatalog> | null;
           settings?: GlobalSettings | null;
           sessions?: Awaited<ReturnType<typeof listSessionsCached>> | null;
+          conversations?: Awaited<typeof conversationsTask> | null;
           users?: ReturnType<typeof userRoster> | null;
           repos?: Awaited<ReturnType<typeof listRepos>> | null;
           autoAgents?: Awaited<ReturnType<typeof listAutoAgents>> | null;
@@ -3910,6 +3951,7 @@ a{color:#60a5fa}
             models: boot.models ?? null,
             settings: boot.settings ?? null,
             sessions: boot.sessions ? boot.sessions.map(sessionListRow) : null,
+            conversations: boot.conversations ?? null,
             users: boot.users ?? null,
             repos: boot.repos ?? null,
             auto: {
@@ -4637,6 +4679,47 @@ a{color:#60a5fa}
         }
       }
       {
+        const match = path.match(/^\/api\/conversations\/([^/]+)\/participants(?:\/([^/]+))?$/);
+        if (match) {
+          const conversationId = decodeURIComponent(match[1]);
+          const participantPathId = match[2] ? decodeURIComponent(match[2]) : null;
+          const conversation = getConversation(conversationId);
+          if (!conversation) return err(404, "conversation not found");
+          const viewer = botViewerFromRequest(req, undefined);
+          if (viewer.managed) {
+            const viewerParticipantId = conversationHumanParticipantId(viewer.identity);
+            if (!canManageConversation(conversation, viewerParticipantId)) {
+              return err(403, "conversation management access denied");
+            }
+          }
+          if (req.method === "POST" && !participantPathId) {
+            const body = (await req.json().catch(() => null)) as {
+              botId?: unknown;
+              historyAccess?: unknown;
+            } | null;
+            const botId = typeof body?.botId === "string" ? body.botId.trim() : "";
+            if (!botId) return err(400, "botId is required");
+            const bot = await getBot(botId);
+            if (!bot || !bot.enabled) return err(404, "bot not found");
+            const historyAccess = body?.historyAccess === "from_join" ? "from_join" : "all";
+            const updated = upsertConversationParticipant(
+              conversationId,
+              conversationBotParticipant(bot, { historyAccess }),
+            );
+            return json({ conversation: updated });
+          }
+          if (req.method === "DELETE" && participantPathId) {
+            const participant = conversation.participants.find((row) => row.id === participantPathId);
+            if (!participant) return err(404, "participant not found");
+            if (participant.role === "owner") return err(409, "conversation owner cannot leave");
+            return json({
+              conversation: leaveConversationParticipant(conversationId, participantPathId),
+            });
+          }
+          return err(405, "method not allowed");
+        }
+      }
+      {
         const match = path.match(/^\/api\/bots\/([^/]+)\/messages$/);
         if (match && req.method === "POST") {
           let bot = await getBot(decodeURIComponent(match[1]));
@@ -4670,7 +4753,7 @@ a{color:#60a5fa}
           }
           // Attribute before launching: when the session has to be started, this
           // exact text rides inside the launch prompt instead of racing it.
-          const { author } = resolveBotMessageAuthor({
+          const { author, trusted } = resolveBotMessageAuthor({
             viewer,
             rosterTagUser: tag.ok ? tag.user : undefined,
             botOwner: bot.owner,
@@ -4679,6 +4762,18 @@ a{color:#60a5fa}
           const attributed = `${formatBotAttribution(author, bot.name)}\n\n${text}`;
           const delivery = await deliverBotMessage(bot, attributed);
           if ("error" in delivery) return err(delivery.status, delivery.error);
+          if (trusted) {
+            const profile = userRoster().find(
+              (user) => user.email.trim().toLowerCase() === author.trim().toLowerCase(),
+            );
+            ensureConversationHuman({
+              conversationId: bot.sessionId?.trim() || delivery.sessionId,
+              identity: author,
+              name: profile?.name,
+              avatar: profile?.avatar,
+              role: "member",
+            });
+          }
           return json({ sessionId: delivery.sessionId });
         }
       }

--- a/src/conversation-contract.ts
+++ b/src/conversation-contract.ts
@@ -1,0 +1,42 @@
+export type ConversationParticipantRole = "owner" | "member" | "observer";
+export type ConversationHistoryAccess = "all" | "from_join";
+
+export type ConversationParticipant = {
+  id: string;
+  kind: "human" | "bot";
+  role: ConversationParticipantRole;
+  display: {
+    name?: string | null;
+    avatar?: string | null;
+    fallback: string;
+  };
+  joinedAt: number;
+  leftAt?: number | null;
+  historyAccess: ConversationHistoryAccess;
+};
+
+export type ConversationRuntimeAttachment = {
+  sessionId: string;
+  participantId?: string | null;
+  kind: "primary" | "execution";
+  attachedAt: number;
+  detachedAt?: number | null;
+};
+
+export type Conversation = {
+  id: string;
+  title?: string | null;
+  participants: ConversationParticipant[];
+  runtimeSessions: ConversationRuntimeAttachment[];
+  createdAt: number;
+  updatedAt: number;
+  legacy?: {
+    source: "bot_session" | "regular_session";
+    botId?: string | null;
+    sessionId: string;
+  };
+};
+
+export type MessageAuthorRef =
+  | { kind: "human" | "bot"; participantId: string; verified: true }
+  | { kind: "legacy"; participantId: "legacy:unknown"; verified: false };

--- a/src/conversations.test.ts
+++ b/src/conversations.test.ts
@@ -11,6 +11,7 @@ import {
   canWriteConversation,
   conversationBotParticipant,
   conversationHumanParticipantId,
+  detachRuntimeSession,
   ensureBotConversation,
   ensureConversationHuman,
   getConversation,
@@ -18,6 +19,7 @@ import {
   listConversations,
   messageAuthorForSession,
   migrateLegacyConversations,
+  replaceConversationPrimaryRuntime,
   upsertConversationParticipant,
 } from "./conversations.ts";
 import { formatBotAttribution } from "./bots/authorship.ts";
@@ -48,6 +50,65 @@ afterEach(() => {
 });
 
 describe("conversation migration and identity", () => {
+  test("rotation replaces only the primary runtime and keeps participants and children", () => {
+    ensureBotConversation({
+      conversationId: "conversation-1",
+      bot: scout,
+      ownerIdentity: scout.owner,
+      roster: [{ email: scout.owner!, name: "Owner" }],
+      now: 10,
+    });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "runtime-old",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+      attachedAt: 11,
+    });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "child-active",
+      participantId: botParticipantId(scout.id),
+      kind: "execution",
+      attachedAt: 12,
+    });
+
+    const before = getConversation("conversation-1")!;
+    const participantIds = before.participants.map((row) => row.id);
+    replaceConversationPrimaryRuntime({
+      conversationId: "conversation-1",
+      sessionId: "runtime-new",
+      participantId: botParticipantId(scout.id),
+      attachedAt: 20,
+      now: 21,
+    });
+
+    const after = getConversation("conversation-1")!;
+    expect(after.id).toBe("conversation-1");
+    expect(after.participants.map((row) => row.id)).toEqual(participantIds);
+    expect(after.runtimeSessions.find((row) => row.sessionId === "runtime-old")?.detachedAt).toBe(21);
+    expect(after.runtimeSessions.find((row) => row.sessionId === "runtime-new")).toMatchObject({
+      kind: "primary",
+      participantId: botParticipantId(scout.id),
+    });
+    const child = after.runtimeSessions.find((row) => row.sessionId === "child-active");
+    expect(child?.kind).toBe("execution");
+    expect(child?.detachedAt).toBeUndefined();
+    expect(after.runtimeSessions.filter((row) => row.kind === "primary" && !row.detachedAt)).toHaveLength(1);
+
+    // A failed commit can restore the old primary without changing the roster.
+    replaceConversationPrimaryRuntime({
+      conversationId: "conversation-1",
+      sessionId: "runtime-old",
+      participantId: botParticipantId(scout.id),
+      now: 30,
+    });
+    detachRuntimeSession("conversation-1", "runtime-new", 30);
+    const rolledBack = getConversation("conversation-1")!;
+    expect(rolledBack.runtimeSessions.find((row) => row.sessionId === "runtime-old")?.detachedAt).toBeNull();
+    expect(rolledBack.runtimeSessions.find((row) => row.sessionId === "runtime-new")?.detachedAt).toBe(30);
+  });
+
   test("migrates Session.botId once and makes children execution attachments, not participants", () => {
     const rows = migrateLegacyConversations({
       now: 1_000,

--- a/src/conversations.test.ts
+++ b/src/conversations.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import {
+  attachRuntimeSession,
+  botParticipantId,
+  canManageConversation,
+  canReadConversation,
+  canWriteConversation,
+  conversationBotParticipant,
+  conversationHumanParticipantId,
+  ensureBotConversation,
+  ensureConversationHuman,
+  getConversation,
+  leaveConversationParticipant,
+  listConversations,
+  messageAuthorForSession,
+  migrateLegacyConversations,
+  upsertConversationParticipant,
+} from "./conversations.ts";
+import { formatBotAttribution } from "./bots/authorship.ts";
+import {
+  indexedMessagePage,
+  indexedMessagesAfterRowid,
+  indexSessionMessagesDirect,
+  resetTranscriptIndexConnectionForTests,
+} from "./transcript-index.ts";
+import type { SessionMsg } from "./sessions.ts";
+
+const originalData = PATHS.data;
+let root = "";
+
+const scout = { id: "bot_scout", name: "Scout", owner: "owner@example.com", sessionId: "conversation-1" };
+const analyst = { id: "bot_analyst", name: "Analyst" };
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "omg-conversation-"));
+  PATHS.data = root;
+  resetTranscriptIndexConnectionForTests();
+});
+
+afterEach(() => {
+  resetTranscriptIndexConnectionForTests();
+  PATHS.data = originalData;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("conversation migration and identity", () => {
+  test("migrates Session.botId once and makes children execution attachments, not participants", () => {
+    const rows = migrateLegacyConversations({
+      now: 1_000,
+      bots: [scout],
+      roster: [{ email: "owner@example.com", name: "Owner", avatar: "/owner.png" }],
+      sessions: [
+        { sessionId: "conversation-1", botId: scout.id, assignedUser: scout.owner, startedAt: 100 },
+        {
+          sessionId: "child-1",
+          botId: scout.id,
+          parentSessionId: "conversation-1",
+          spawnedBy: "subagent",
+          startedAt: 200,
+        },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("conversation-1");
+    expect(rows[0].participants.map((row) => row.id)).toEqual([
+      conversationHumanParticipantId("owner@example.com"),
+      botParticipantId(scout.id),
+    ]);
+    expect(rows[0].runtimeSessions).toEqual([
+      expect.objectContaining({ sessionId: "conversation-1", kind: "primary" }),
+      expect.objectContaining({ sessionId: "child-1", kind: "execution" }),
+    ]);
+    expect(rows[0].participants.some((row) => row.id === "child-1")).toBe(false);
+
+    // A reload repeats the migration without duplicating durable state.
+    expect(migrateLegacyConversations({ bots: [scout], sessions: [] })).toEqual(rows);
+    expect(listConversations()).toHaveLength(1);
+  });
+
+  test("runtime rotation retains conversation identity, participants, and attachment history", () => {
+    ensureBotConversation({ conversationId: "conversation-1", bot: scout });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "runtime-old",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+      attachedAt: 10,
+    });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "runtime-new",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+      attachedAt: 20,
+    });
+    migrateLegacyConversations({
+      bots: [scout],
+      sessions: [
+        {
+          sessionId: "runtime-rotated",
+          conversationId: "conversation-1",
+          botId: scout.id,
+          startedAt: 30,
+        },
+      ],
+    });
+    const conversation = getConversation("conversation-1")!;
+    expect(conversation.id).toBe("conversation-1");
+    expect(conversation.runtimeSessions.map((row) => row.sessionId)).toEqual([
+      "runtime-old",
+      "runtime-new",
+      "runtime-rotated",
+    ]);
+    expect(conversation.participants.map((row) => row.id)).toEqual([
+      conversationHumanParticipantId("owner@example.com"),
+      botParticipantId(scout.id),
+    ]);
+  });
+
+  test("a stale saved bot session cannot claim another conversation", () => {
+    const rows = migrateLegacyConversations({
+      bots: [scout],
+      sessions: [
+        { sessionId: "conversation-1", assignedUser: "someone@example.com" },
+        { sessionId: "scout-real", botId: scout.id, assignedUser: scout.owner },
+      ],
+    });
+    const conversation = rows.find((row) =>
+      row.participants.some((participant) => participant.id === botParticipantId(scout.id)),
+    );
+    expect(conversation?.id).toBe("scout-real");
+    expect(conversation?.runtimeSessions.map((row) => row.sessionId)).toEqual(["scout-real"]);
+  });
+
+  test("supports two real bot participants with leave and history semantics", () => {
+    ensureBotConversation({ conversationId: "conversation-1", bot: scout });
+    upsertConversationParticipant(
+      "conversation-1",
+      conversationBotParticipant(analyst, { historyAccess: "from_join", joinedAt: 500 }),
+    );
+    const analystId = botParticipantId(analyst.id);
+    const joined = getConversation("conversation-1")!;
+    expect(joined.participants.filter((row) => row.kind === "bot")).toHaveLength(2);
+    expect(canReadConversation(joined, analystId, 499)).toBe(false);
+    expect(canReadConversation(joined, analystId, 500)).toBe(true);
+    expect(canWriteConversation(joined, analystId)).toBe(true);
+    leaveConversationParticipant("conversation-1", analystId, 700);
+    const left = getConversation("conversation-1")!;
+    expect(canReadConversation(left, analystId, 650)).toBe(true);
+    expect(canReadConversation(left, analystId, 701)).toBe(false);
+    expect(canWriteConversation(left, analystId)).toBe(false);
+  });
+
+  test("a verified human must be on the roster before access is granted", () => {
+    ensureBotConversation({ conversationId: "conversation-1", bot: scout });
+    const memberId = conversationHumanParticipantId("member@example.com");
+    expect(canReadConversation(getConversation("conversation-1")!, memberId)).toBe(false);
+    ensureConversationHuman({
+      conversationId: "conversation-1",
+      identity: "member@example.com",
+      name: "Member",
+      role: "observer",
+      historyAccess: "from_join",
+      joinedAt: 900,
+    });
+    const conversation = getConversation("conversation-1")!;
+    expect(canReadConversation(conversation, memberId, 899)).toBe(false);
+    expect(canReadConversation(conversation, memberId, 901)).toBe(true);
+    expect(canWriteConversation(conversation, memberId)).toBe(false);
+    expect(canManageConversation(conversation, memberId)).toBe(false);
+    expect(canManageConversation(
+      conversation,
+      conversationHumanParticipantId("owner@example.com"),
+    )).toBe(true);
+  });
+});
+
+describe("persisted message authors", () => {
+  const humanText = `${formatBotAttribution("member@example.com", "Scout")}\n\nhello`;
+
+  function message(id: string, role: string, text: string): SessionMsg {
+    return { id, role, kind: "text", text, ts: Date.now() };
+  }
+
+  test("resolves only server-authored human markers and attached bot runtimes", () => {
+    ensureBotConversation({ conversationId: "conversation-1", bot: scout });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "runtime-1",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+    });
+    expect(messageAuthorForSession("runtime-1", message("u", "user", humanText))).toEqual({
+      kind: "human",
+      participantId: conversationHumanParticipantId("member@example.com"),
+      verified: true,
+    });
+    expect(messageAuthorForSession("runtime-1", message("a", "assistant", "hello"))).toEqual({
+      kind: "bot",
+      participantId: botParticipantId(scout.id),
+      verified: true,
+    });
+    expect(messageAuthorForSession("runtime-1", message("old", "user", "plain old message"))).toEqual({
+      kind: "legacy",
+      participantId: "legacy:unknown",
+      verified: false,
+    });
+  });
+
+  test("pagination and live-row reads return the same durable author references", async () => {
+    ensureBotConversation({ conversationId: "conversation-1", bot: scout });
+    attachRuntimeSession({
+      conversationId: "conversation-1",
+      sessionId: "runtime-1",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+    });
+    indexSessionMessagesDirect("runtime-1", [
+      message("u", "user", humanText),
+      message("a", "assistant", "answer"),
+    ]);
+    const page = await indexedMessagePage("lfg://session/runtime-1", "runtime-1", { limit: 1 });
+    expect(page.messages[0].author).toEqual({
+      kind: "bot",
+      participantId: botParticipantId(scout.id),
+      verified: true,
+    });
+    expect(page.nextBefore).not.toBeNull();
+    const live = indexedMessagesAfterRowid("lfg://session/runtime-1", "runtime-1", 0);
+    expect(live.messages.map((row) => row.author)).toEqual([
+      {
+        kind: "human",
+        participantId: conversationHumanParticipantId("member@example.com"),
+        verified: true,
+      },
+      {
+        kind: "bot",
+        participantId: botParticipantId(scout.id),
+        verified: true,
+      },
+    ]);
+  });
+
+  test("an authorless row stays explicit legacy unknown after the roster appears", async () => {
+    indexSessionMessagesDirect("runtime-legacy", [message("old", "user", "historical")]);
+    ensureBotConversation({ conversationId: "conversation-legacy", bot: scout });
+    attachRuntimeSession({
+      conversationId: "conversation-legacy",
+      sessionId: "runtime-legacy",
+      participantId: botParticipantId(scout.id),
+      kind: "primary",
+    });
+    const page = await indexedMessagePage("lfg://session/runtime-legacy", "runtime-legacy");
+    expect(page.messages[0].author).toEqual({
+      kind: "legacy",
+      participantId: "legacy:unknown",
+      verified: false,
+    });
+  });
+});

--- a/src/conversations.ts
+++ b/src/conversations.ts
@@ -409,6 +409,67 @@ export function attachRuntimeSession(input: {
   return conversation;
 }
 
+export function detachRuntimeSession(
+  conversationId: string,
+  sessionId: string,
+  detachedAt = Date.now(),
+): Conversation | null {
+  const rows = readStore();
+  const conversation = rows.find((row) => row.id === conversationId);
+  const runtime = conversation?.runtimeSessions.find((row) => row.sessionId === sessionId);
+  if (!conversation || !runtime) return conversation ?? null;
+  runtime.detachedAt = detachedAt;
+  conversation.updatedAt = detachedAt;
+  writeStore(rows);
+  return conversation;
+}
+
+/**
+ * Move one participant's canonical runtime inside a durable conversation.
+ *
+ * The conversation is written once. Child executions remain attached, while
+ * every older active primary for this participant receives the same detach
+ * timestamp. Calling this again with the same session is idempotent.
+ */
+export function replaceConversationPrimaryRuntime(input: {
+  conversationId: string;
+  sessionId: string;
+  participantId: string;
+  attachedAt?: number;
+  now?: number;
+}): Conversation | null {
+  const rows = readStore();
+  const conversation = rows.find((row) => row.id === input.conversationId);
+  if (!conversation) return null;
+  const now = input.now ?? Date.now();
+  for (const runtime of conversation.runtimeSessions) {
+    if (
+      runtime.kind === "primary" &&
+      runtime.participantId === input.participantId &&
+      runtime.sessionId !== input.sessionId &&
+      !runtime.detachedAt
+    ) {
+      runtime.detachedAt = now;
+    }
+  }
+  const existing = conversation.runtimeSessions.find((row) => row.sessionId === input.sessionId);
+  if (existing) {
+    existing.participantId = input.participantId;
+    existing.kind = "primary";
+    existing.detachedAt = null;
+  } else {
+    conversation.runtimeSessions.push({
+      sessionId: input.sessionId,
+      participantId: input.participantId,
+      kind: "primary",
+      attachedAt: input.attachedAt ?? now,
+    });
+  }
+  conversation.updatedAt = now;
+  writeStore(rows);
+  return conversation;
+}
+
 export function upsertConversationParticipant(
   conversationId: string,
   participant: ConversationParticipant,

--- a/src/conversations.ts
+++ b/src/conversations.ts
@@ -1,0 +1,491 @@
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { PATHS } from "./config.ts";
+import { botAuthorId, botAuthorIdFromText } from "./bots/authorship.ts";
+import type {
+  Conversation,
+  ConversationHistoryAccess,
+  ConversationParticipant,
+  ConversationParticipantRole,
+  MessageAuthorRef,
+} from "./conversation-contract.ts";
+export type {
+  Conversation,
+  ConversationHistoryAccess,
+  ConversationParticipant,
+  ConversationParticipantRole,
+  MessageAuthorRef,
+} from "./conversation-contract.ts";
+
+export const UNKNOWN_LEGACY_AUTHOR: MessageAuthorRef = {
+  kind: "legacy",
+  participantId: "legacy:unknown",
+  verified: false,
+};
+
+type LegacySession = {
+  sessionId?: string | null;
+  conversationId?: string | null;
+  parentSessionId?: string | null;
+  parentNativeSessionId?: string | null;
+  spawnedBy?: string | null;
+  botId?: string | null;
+  assignedUser?: string | null;
+  title?: string | null;
+  startedAt?: number | null;
+};
+
+type LegacyBot = {
+  id: string;
+  name: string;
+  owner?: string | null;
+  sessionId?: string | null;
+  shape?: string | null;
+  colorway?: string | null;
+};
+
+type RosterUser = { email: string; name?: string | null; avatar?: string | null };
+
+const storePath = () => join(PATHS.data, "conversations", "conversations.json");
+
+function normalizeIdentity(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function conversationHumanParticipantId(identity: string): string {
+  const digest = botAuthorId(identity);
+  return digest ? `human:${digest}` : "";
+}
+
+export function botParticipantId(botId: string): string {
+  return `bot:${botId}`;
+}
+
+function isConversation(value: unknown): value is Conversation {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<Conversation>;
+  return typeof row.id === "string" && Array.isArray(row.participants) && Array.isArray(row.runtimeSessions);
+}
+
+function readStore(): Conversation[] {
+  try {
+    const parsed = JSON.parse(readFileSync(storePath(), "utf8"));
+    return Array.isArray(parsed) ? parsed.filter(isConversation) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(conversations: Conversation[]): void {
+  const path = storePath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  const temp = `${path}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  writeFileSync(temp, JSON.stringify(conversations, null, 2), { mode: 0o600 });
+  try {
+    const fd = openSync(temp, "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(temp, path);
+    try {
+      const dirFd = openSync(dir, "r");
+      try {
+        fsyncSync(dirFd);
+      } finally {
+        closeSync(dirFd);
+      }
+    } catch {}
+  } finally {
+    try {
+      unlinkSync(temp);
+    } catch {}
+  }
+}
+
+export function listConversations(): Conversation[] {
+  return readStore();
+}
+
+export function getConversation(id: string): Conversation | null {
+  return readStore().find((row) => row.id === id) ?? null;
+}
+
+export function ensureBotConversation(input: {
+  conversationId: string;
+  bot: LegacyBot;
+  ownerIdentity?: string | null;
+  roster?: readonly RosterUser[];
+  now?: number;
+}): Conversation {
+  const existing = getConversation(input.conversationId);
+  if (existing) return existing;
+  const now = input.now ?? Date.now();
+  const participants = [botParticipant(input.bot, now)];
+  const human = rosterParticipant(input.ownerIdentity ?? input.bot.owner ?? "", input.roster ?? [], now);
+  if (human) participants.unshift(human);
+  const conversation: Conversation = {
+    id: input.conversationId,
+    title: input.bot.name,
+    participants,
+    runtimeSessions: [],
+    createdAt: now,
+    updatedAt: now,
+    legacy: {
+      source: "bot_session",
+      botId: input.bot.id,
+      sessionId: input.conversationId,
+    },
+  };
+  writeStore([...readStore(), conversation]);
+  return conversation;
+}
+
+export function ensureConversationHuman(input: {
+  conversationId: string;
+  identity: string;
+  name?: string | null;
+  avatar?: string | null;
+  role?: ConversationParticipantRole;
+  historyAccess?: ConversationHistoryAccess;
+  joinedAt?: number;
+}): Conversation | null {
+  const conversation = getConversation(input.conversationId);
+  const id = conversationHumanParticipantId(input.identity);
+  if (!conversation || !id) return conversation;
+  const existing = conversation.participants.find((row) => row.id === id);
+  if (existing) return conversation;
+  return upsertConversationParticipant(input.conversationId, {
+    id,
+    kind: "human",
+    role: input.role ?? (conversation.participants.some((row) => row.kind === "human") ? "member" : "owner"),
+    display: {
+      name: input.name ?? null,
+      avatar: input.avatar ?? null,
+      fallback: input.name?.trim() || normalizeIdentity(input.identity).split("@")[0] || "Member",
+    },
+    joinedAt: input.joinedAt ?? Date.now(),
+    historyAccess: input.historyAccess ?? "all",
+  });
+}
+
+function rosterParticipant(identity: string, roster: readonly RosterUser[], now: number): ConversationParticipant | null {
+  const normalized = normalizeIdentity(identity);
+  const id = conversationHumanParticipantId(normalized);
+  if (!id) return null;
+  const profile = roster.find((user) => normalizeIdentity(user.email) === normalized);
+  return {
+    id,
+    kind: "human",
+    role: "owner",
+    display: {
+      name: profile?.name ?? null,
+      avatar: profile?.avatar ?? null,
+      fallback: profile?.name?.trim() || normalized.split("@")[0] || "Member",
+    },
+    joinedAt: now,
+    historyAccess: "all",
+  };
+}
+
+function botParticipant(bot: LegacyBot, now: number): ConversationParticipant {
+  return {
+    id: botParticipantId(bot.id),
+    kind: "bot",
+    role: "member",
+    display: { name: bot.name, fallback: bot.name || "Bot" },
+    joinedAt: now,
+    historyAccess: "all",
+  };
+}
+
+export function conversationBotParticipant(
+  bot: LegacyBot,
+  input: { role?: ConversationParticipantRole; joinedAt?: number; historyAccess?: ConversationHistoryAccess } = {},
+): ConversationParticipant {
+  const participant = botParticipant(bot, input.joinedAt ?? Date.now());
+  participant.role = input.role ?? participant.role;
+  participant.historyAccess = input.historyAccess ?? participant.historyAccess;
+  return participant;
+}
+
+function delegated(session: LegacySession): boolean {
+  return !!(
+    session.parentSessionId ||
+    session.parentNativeSessionId ||
+    session.spawnedBy === "subagent" ||
+    session.spawnedBy === "fork"
+  );
+}
+
+/**
+ * Idempotently materialize the old session-shaped product state.
+ *
+ * Child sessions receive an execution attachment to their parent's
+ * conversation. They never become participants and never become primary.
+ */
+export function migrateLegacyConversations(input: {
+  sessions: readonly LegacySession[];
+  bots: readonly LegacyBot[];
+  roster?: readonly RosterUser[];
+  now?: number;
+}): Conversation[] {
+  const now = input.now ?? Date.now();
+  const roster = input.roster ?? [];
+  const rows = readStore();
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const sessionToConversation = new Map<string, string>();
+  let changed = false;
+
+  const ensure = (conversation: Conversation): Conversation => {
+    const existing = byId.get(conversation.id);
+    if (existing) return existing;
+    rows.push(conversation);
+    byId.set(conversation.id, conversation);
+    changed = true;
+    return conversation;
+  };
+
+  for (const bot of input.bots) {
+    const primary = input.sessions.find(
+      (session) => !delegated(session) && session.botId === bot.id && !!session.sessionId,
+    );
+    const savedId = bot.sessionId?.trim();
+    const savedSession = savedId
+      ? input.sessions.find((session) => session.sessionId === savedId)
+      : undefined;
+    // A saved bot session id is a compatibility pointer, not product identity.
+    // If it resolves to another product row, verified bot ownership wins. This
+    // mirrors the hardened legacy routing boundary.
+    const trustedSavedId = savedId && (!savedSession || (!delegated(savedSession) && savedSession.botId === bot.id))
+      ? savedId
+      : undefined;
+    const id = trustedSavedId || primary?.sessionId?.trim();
+    if (!id) continue;
+    const createdAt = primary?.startedAt ?? now;
+    const participants = [botParticipant(bot, createdAt)];
+    const human = rosterParticipant(primary?.assignedUser || bot.owner || "", roster, createdAt);
+    if (human) participants.unshift(human);
+    const conversation = ensure({
+      id,
+      title: bot.name,
+      participants,
+      runtimeSessions: [],
+      createdAt,
+      updatedAt: now,
+      legacy: { source: "bot_session", botId: bot.id, sessionId: id },
+    });
+    for (const participant of participants) {
+      if (conversation.participants.some((row) => row.id === participant.id)) continue;
+      conversation.participants.push(participant);
+      conversation.updatedAt = now;
+      changed = true;
+    }
+    for (const session of input.sessions.filter((row) => row.botId === bot.id && row.sessionId)) {
+      const sessionId = session.sessionId!;
+      sessionToConversation.set(sessionId, conversation.id);
+      if (!conversation.runtimeSessions.some((entry) => entry.sessionId === sessionId)) {
+        conversation.runtimeSessions.push({
+          sessionId,
+          participantId: botParticipantId(bot.id),
+          kind: delegated(session) ? "execution" : "primary",
+          attachedAt: session.startedAt ?? now,
+        });
+        conversation.updatedAt = now;
+        changed = true;
+      }
+    }
+  }
+
+  // New runtimes can already carry the durable id even while legacy botId
+  // remains in circulation. Rotation uses this path when it gives a bot a new
+  // runtime session id under the same conversation.
+  for (const session of input.sessions) {
+    const sessionId = session.sessionId?.trim();
+    const conversationId = session.conversationId?.trim();
+    const conversation = conversationId ? byId.get(conversationId) : undefined;
+    if (!sessionId || !conversation) continue;
+    sessionToConversation.set(sessionId, conversationId!);
+    if (conversation.runtimeSessions.some((entry) => entry.sessionId === sessionId)) continue;
+    const botId = session.botId ? botParticipantId(session.botId) : null;
+    conversation.runtimeSessions.push({
+      sessionId,
+      participantId: conversation.participants.some((row) => row.id === botId) ? botId : null,
+      kind: delegated(session) ? "execution" : "primary",
+      attachedAt: session.startedAt ?? now,
+    });
+    conversation.updatedAt = now;
+    changed = true;
+  }
+
+  for (const session of input.sessions) {
+    const sessionId = session.sessionId?.trim();
+    if (!sessionId || sessionToConversation.has(sessionId) || delegated(session)) continue;
+    const createdAt = session.startedAt ?? now;
+    const human = rosterParticipant(session.assignedUser || "", roster, createdAt);
+    const conversation = ensure({
+      id: sessionId,
+      title: session.title ?? null,
+      participants: human ? [human] : [],
+      runtimeSessions: [{ sessionId, participantId: human?.id, kind: "primary", attachedAt: createdAt }],
+      createdAt,
+      updatedAt: now,
+      legacy: { source: "regular_session", sessionId },
+    });
+    if (human && !conversation.participants.some((row) => row.id === human.id)) {
+      conversation.participants.push(human);
+      conversation.updatedAt = now;
+      changed = true;
+    }
+    sessionToConversation.set(sessionId, conversation.id);
+  }
+
+  // Attach children only after all primary mappings exist.
+  for (const session of input.sessions.filter(delegated)) {
+    const sessionId = session.sessionId?.trim();
+    const parentId = session.parentSessionId ?? session.parentNativeSessionId;
+    const conversationId = parentId ? sessionToConversation.get(parentId) : undefined;
+    const conversation = conversationId ? byId.get(conversationId) : undefined;
+    if (!sessionId || !conversation) continue;
+    sessionToConversation.set(sessionId, conversation.id);
+    if (conversation.runtimeSessions.some((entry) => entry.sessionId === sessionId)) continue;
+    const parentAttachment = conversation.runtimeSessions.find((entry) => entry.sessionId === parentId);
+    conversation.runtimeSessions.push({
+      sessionId,
+      participantId: parentAttachment?.participantId,
+      kind: "execution",
+      attachedAt: session.startedAt ?? now,
+    });
+    conversation.updatedAt = now;
+    changed = true;
+  }
+
+  if (changed) writeStore(rows);
+  return rows;
+}
+
+export function conversationForSession(sessionId: string): Conversation | null {
+  return readStore().find((conversation) =>
+    conversation.runtimeSessions.some((entry) => entry.sessionId === sessionId),
+  ) ?? null;
+}
+
+export function attachRuntimeSession(input: {
+  conversationId: string;
+  sessionId: string;
+  participantId?: string | null;
+  kind: "primary" | "execution";
+  attachedAt?: number;
+}): Conversation | null {
+  const rows = readStore();
+  const conversation = rows.find((row) => row.id === input.conversationId);
+  if (!conversation) return null;
+  const existing = conversation.runtimeSessions.find((entry) => entry.sessionId === input.sessionId);
+  if (existing) {
+    existing.participantId = input.participantId ?? existing.participantId;
+    existing.kind = input.kind;
+    existing.detachedAt = null;
+  } else {
+    conversation.runtimeSessions.push({
+      sessionId: input.sessionId,
+      participantId: input.participantId,
+      kind: input.kind,
+      attachedAt: input.attachedAt ?? Date.now(),
+    });
+  }
+  conversation.updatedAt = Date.now();
+  writeStore(rows);
+  return conversation;
+}
+
+export function upsertConversationParticipant(
+  conversationId: string,
+  participant: ConversationParticipant,
+): Conversation | null {
+  const rows = readStore();
+  const conversation = rows.find((row) => row.id === conversationId);
+  if (!conversation) return null;
+  const index = conversation.participants.findIndex((row) => row.id === participant.id);
+  if (index >= 0) conversation.participants[index] = participant;
+  else conversation.participants.push(participant);
+  conversation.updatedAt = Date.now();
+  writeStore(rows);
+  return conversation;
+}
+
+export function leaveConversationParticipant(
+  conversationId: string,
+  participantId: string,
+  leftAt = Date.now(),
+): Conversation | null {
+  const conversation = getConversation(conversationId);
+  const participant = conversation?.participants.find((row) => row.id === participantId);
+  if (!conversation || !participant) return null;
+  return upsertConversationParticipant(conversationId, { ...participant, leftAt });
+}
+
+export function canReadConversation(
+  conversation: Conversation,
+  participantId: string,
+  messageTs?: number | null,
+): boolean {
+  const participant = conversation.participants.find((row) => row.id === participantId);
+  if (!participant) return false;
+  if (participant.leftAt && (!messageTs || messageTs > participant.leftAt)) return false;
+  if (messageTs && participant.historyAccess === "from_join" && messageTs < participant.joinedAt) return false;
+  return true;
+}
+
+export function canWriteConversation(conversation: Conversation, participantId: string): boolean {
+  const participant = conversation.participants.find((row) => row.id === participantId);
+  return !!participant && !participant.leftAt && participant.role !== "observer";
+}
+
+export function canManageConversation(conversation: Conversation, participantId: string): boolean {
+  const participant = conversation.participants.find((row) => row.id === participantId);
+  return !!participant && !participant.leftAt && participant.role === "owner";
+}
+
+export function messageAuthorForSession(
+  sessionId: string,
+  message: { role: string; text: string },
+): MessageAuthorRef {
+  const conversation = conversationForSession(sessionId);
+  if (!conversation) return UNKNOWN_LEGACY_AUTHOR;
+  if (message.role === "user") {
+    const digest = botAuthorIdFromText(message.text);
+    const participantId = digest ? `human:${digest}` : "";
+    // The server-authored marker is the verification boundary. The roster can
+    // be updated a few milliseconds later on a first-message cold launch, but
+    // that does not make the durable author reference less true.
+    return participantId
+      ? { kind: "human", participantId, verified: true }
+      : UNKNOWN_LEGACY_AUTHOR;
+  }
+  if (message.role === "assistant") {
+    const attachment = conversation.runtimeSessions.find((row) => row.sessionId === sessionId);
+    const participant = attachment?.participantId
+      ? conversation.participants.find((row) => row.id === attachment.participantId)
+      : undefined;
+    if (participant?.kind === "bot") {
+      return { kind: "bot", participantId: participant.id, verified: true };
+    }
+  }
+  return UNKNOWN_LEGACY_AUTHOR;
+}
+
+export function resetConversationsForTests(): void {
+  // The store has no process cache. This exported no-op documents that tests
+  // can move PATHS.data safely between cases, like the other local stores.
+}

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -52,6 +52,8 @@ export type ManagedSession = {
   parentNativeSessionId?: string;
   parentAgent?: string;
   spawnedBy?: "subagent" | "fork" | "finding" | "voice" | string;
+  /** Durable product conversation. Runtime ids may rotate without changing it. */
+  conversationId?: string;
   botId?: string;
   persistent?: boolean;
   /** LFG agent capability contract/tool catalog present when this process launched. */

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -54,6 +54,8 @@ export type ManagedSession = {
   spawnedBy?: "subagent" | "fork" | "finding" | "voice" | string;
   /** Durable product conversation. Runtime ids may rotate without changing it. */
   conversationId?: string;
+  /** Bot configuration revision loaded when this runtime started. */
+  appliedConfigRevision?: number;
   botId?: string;
   persistent?: boolean;
   /** LFG agent capability contract/tool catalog present when this process launched. */

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -319,6 +319,8 @@ export type Session = {
   spawnedBy?: string | null;
   /** Durable product identity. This, not the runtime id, selects the surface. */
   conversationId?: string | null;
+  /** Bot configuration revision loaded when this runtime started. */
+  appliedConfigRevision?: number | null;
   /** Additive product contract used by clients during the legacy migration. */
   conversation?: Conversation | null;
   botId?: string;
@@ -570,6 +572,7 @@ export function managedLaunchRow(
     parentAgent: m.parentAgent ?? null,
     spawnedBy: m.spawnedBy ?? null,
     conversationId: m.conversationId ?? null,
+    appliedConfigRevision: m.appliedConfigRevision ?? null,
     botId: m.botId,
     persistent: m.persistent,
     capabilityVersion: m.capabilityVersion ?? null,
@@ -616,6 +619,7 @@ function managedLineage(m: ManagedSession | undefined): Pick<
   | "parentAgent"
   | "spawnedBy"
   | "conversationId"
+  | "appliedConfigRevision"
   | "botId"
   | "persistent"
   | "capabilityVersion"
@@ -628,6 +632,7 @@ function managedLineage(m: ManagedSession | undefined): Pick<
     parentAgent: m?.parentAgent ?? null,
     spawnedBy: m?.spawnedBy ?? null,
     conversationId: m?.conversationId ?? null,
+    appliedConfigRevision: m?.appliedConfigRevision ?? null,
     botId: m?.botId,
     persistent: m?.persistent,
     capabilityVersion: m?.capabilityVersion ?? null,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -13,7 +13,7 @@ import {
   isEntryBusy as isAisdkEntryBusy,
 } from "./aisdk-registry";
 import { isClosing } from "./closing";
-import { userAssignments } from "./users";
+import { userAssignments, userRoster } from "./users";
 import { PATHS } from "./config";
 import { homedir } from "node:os";
 import { projectName } from "./projects";
@@ -45,6 +45,11 @@ import {
 } from "./transcript-index";
 import { isProviderAuthError } from "./provider-auth-error";
 import { listBots } from "./bots/store.ts";
+import {
+  migrateLegacyConversations,
+  type Conversation,
+  type MessageAuthorRef,
+} from "./conversations.ts";
 
 const HOME = process.env.HOME ?? homedir();
 const PROJECTS_DIR = join(HOME, ".claude", "projects");
@@ -289,6 +294,8 @@ export type SessionMsg = {
   // exactly what lets computeStatus avoid false "build paused" banners on
   // sessions that are debugging or summarizing those errors.
   apiError?: boolean;
+  /** Persisted product author. Old rows use explicit legacy:unknown. */
+  author?: MessageAuthorRef;
 };
 
 export type Session = {
@@ -310,6 +317,10 @@ export type Session = {
   parentNativeSessionId?: string | null;
   parentAgent?: string | null;
   spawnedBy?: string | null;
+  /** Durable product identity. This, not the runtime id, selects the surface. */
+  conversationId?: string | null;
+  /** Additive product contract used by clients during the legacy migration. */
+  conversation?: Conversation | null;
   botId?: string;
   botName?: string;
   persistent?: boolean;
@@ -558,6 +569,7 @@ export function managedLaunchRow(
     parentNativeSessionId: m.parentNativeSessionId ?? null,
     parentAgent: m.parentAgent ?? null,
     spawnedBy: m.spawnedBy ?? null,
+    conversationId: m.conversationId ?? null,
     botId: m.botId,
     persistent: m.persistent,
     capabilityVersion: m.capabilityVersion ?? null,
@@ -603,6 +615,7 @@ function managedLineage(m: ManagedSession | undefined): Pick<
   | "parentNativeSessionId"
   | "parentAgent"
   | "spawnedBy"
+  | "conversationId"
   | "botId"
   | "persistent"
   | "capabilityVersion"
@@ -614,6 +627,7 @@ function managedLineage(m: ManagedSession | undefined): Pick<
     parentNativeSessionId: m?.parentNativeSessionId ?? null,
     parentAgent: m?.parentAgent ?? null,
     spawnedBy: m?.spawnedBy ?? null,
+    conversationId: m?.conversationId ?? null,
     botId: m?.botId,
     persistent: m?.persistent,
     capabilityVersion: m?.capabilityVersion ?? null,
@@ -3028,6 +3042,31 @@ export async function listSessions(): Promise<Session[]> {
       session.botId = parentBot.id;
       session.botName = parentBot.name;
     }
+  }
+  // Materialize the product model only after lineage has been resolved. Child
+  // runtimes can then inherit the parent's conversation attachment without
+  // ever joining its participant roster or becoming its selected surface.
+  const conversations = migrateLegacyConversations({
+    sessions: out,
+    bots,
+    roster: userRoster(),
+  });
+  const conversationByRuntime = new Map<string, Conversation>();
+  for (const conversation of conversations) {
+    for (const attachment of conversation.runtimeSessions) {
+      conversationByRuntime.set(attachment.sessionId, conversation);
+    }
+  }
+  for (const session of out) {
+    const explicit = session.conversationId
+      ? conversations.find((row) => row.id === session.conversationId)
+      : undefined;
+    const conversation = explicit ?? (session.sessionId
+      ? conversationByRuntime.get(session.sessionId)
+      : undefined);
+    if (!conversation) continue;
+    session.conversationId = conversation.id;
+    session.conversation = conversation;
   }
   profile?.end(out.length);
   return out;

--- a/src/settings-bot-schedule-cap.test.ts
+++ b/src/settings-bot-schedule-cap.test.ts
@@ -80,3 +80,24 @@ describe("maxBotSchedules sanitize clamp", () => {
     expect(saved.maxBotSchedules).toBe(7);
   });
 });
+
+describe("persistent bot compaction settings", () => {
+  test("defaults to proactive compaction at a conservative threshold", () => {
+    const value = settings.getGlobalSettingsSync();
+    expect(value.botAutoCompactionEnabled).toBe(true);
+    expect(value.botCompactionThresholdPercent).toBeGreaterThanOrEqual(70);
+    expect(value.botCompactionThresholdPercent).toBeLessThan(90);
+  });
+
+  test("persists the switch and threshold across reads", async () => {
+    await settings.setGlobalSettings({
+      botAutoCompactionEnabled: false,
+      botCompactionThresholdPercent: 84,
+    });
+    settings.resetSettingsDbConnectionForTests();
+    expect(settings.getGlobalSettingsSync()).toMatchObject({
+      botAutoCompactionEnabled: false,
+      botCompactionThresholdPercent: 84,
+    });
+  });
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,6 +31,17 @@ export type GlobalSettings = {
   // Global transcript rendering preference. The focused mode is experimental
   // and projects the loaded transcript down to user turns + lfg_output.
   transcriptView: TranscriptView;
+  // Rotate a persistent bot onto a fresh session before its context window
+  // fills, carrying a handoff summary across. Off means a bot only ever
+  // rotates when a human applies a configuration change, and a long-lived
+  // conversation eventually fails at the wall the way it does today.
+  botAutoCompactionEnabled: boolean;
+  // Share of the model's context window at which that rotation fires. Bounded
+  // well away from both ends: see sanitizeBotCompactionThreshold for why 40 and
+  // 95 are the limits. There is no matching setting for the re-arm mark, which
+  // is derived, because two independently editable water marks can be crossed
+  // over and produce a bot that rotates on every single turn.
+  botCompactionThresholdPercent: number;
   // The update the "What's new" drawer's Skip button last dismissed (a
   // version, tag, or sha — whatever /api/install reported as latestVersion /
   // latestTag / latestSha at the time). "" means nothing has been skipped.
@@ -106,6 +117,10 @@ function sanitize(input: Partial<GlobalSettings> | null | undefined): GlobalSett
   const skippedUpdateVersion = typeof input?.skippedUpdateVersion === "string"
     ? input.skippedUpdateVersion
     : "";
+  const botAutoCompactionEnabled = input?.botAutoCompactionEnabled !== false;
+  const botCompactionThresholdPercent = sanitizeBotCompactionThreshold(
+    input?.botCompactionThresholdPercent,
+  );
   return {
     timeZone,
     maxLiveAgents,
@@ -113,6 +128,8 @@ function sanitize(input: Partial<GlobalSettings> | null | undefined): GlobalSett
     agentsPaused,
     idleAgentArchiveMinutes,
     transcriptView,
+    botAutoCompactionEnabled,
+    botCompactionThresholdPercent,
     skippedUpdateVersion,
   };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import {
   sanitizeIdleArchiveMinutes,
 } from "./idle-archive.ts";
 import { join } from "node:path";
+import { sanitizeBotCompactionThreshold } from "./bots/rotation.ts";
 
 export type GlobalSettings = {
   timeZone: string;
@@ -238,6 +239,8 @@ export async function setGlobalSettings(patch: Partial<GlobalSettings>): Promise
     write.run("agentsPaused", JSON.stringify(next.agentsPaused), now);
     write.run("idleAgentArchiveMinutes", JSON.stringify(next.idleAgentArchiveMinutes), now);
     write.run("transcriptView", JSON.stringify(next.transcriptView), now);
+    write.run("botAutoCompactionEnabled", JSON.stringify(next.botAutoCompactionEnabled), now);
+    write.run("botCompactionThresholdPercent", JSON.stringify(next.botCompactionThresholdPercent), now);
     write.run("skippedUpdateVersion", JSON.stringify(next.skippedUpdateVersion), now);
   })();
   return next;

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -5,6 +5,11 @@ import { PATHS } from "./config.ts";
 import { isCursorTurnEndedLine, normalizeLineMessages, type SessionMsg } from "./sessions.ts";
 import { traceLog } from "./trace-log.ts";
 import {
+  messageAuthorForSession,
+  UNKNOWN_LEGACY_AUTHOR,
+  type MessageAuthorRef,
+} from "./conversations.ts";
+import {
   imageArtifactToMessage,
   listAllArtifacts,
   type ImageArtifact,
@@ -30,6 +35,7 @@ type IndexedMessageRow = {
   text: string;
   byte_offset: number;
   order_seq: number;
+  author_json: string;
   // Joined from the artifacts table when present (same SQLite DB).
   artifact_id?: string | null;
   artifact_media?: string | null;
@@ -109,7 +115,7 @@ export function subscribeIndexedArtifactMessages(
 // come from the same query path as prose — never a second poll stream that
 // re-sorts by timestamp and lands media out of place.
 const ARTIFACT_MESSAGE_SELECT = `
-  m.id, m.message_id, m.role, m.kind, m.ts, m.text, m.byte_offset, m.order_seq,
+  m.id, m.message_id, m.role, m.kind, m.ts, m.text, m.byte_offset, m.order_seq, m.author_json,
   a.id AS artifact_id,
   a.media AS artifact_media,
   a.name AS artifact_name,
@@ -558,6 +564,15 @@ function init(busyTimeoutMs = TRANSCRIPT_BUSY_TIMEOUT_MS) {
       d.exec("ALTER TABLE artifacts ADD COLUMN height INTEGER");
     }
   }
+  if (version < 12) {
+    const columns = d.query<{ name: string }, []>("PRAGMA table_info(transcript_messages)").all();
+    if (!columns.some((column) => column.name === "author_json")) {
+      // Existing rows cannot be made trustworthy after the fact. Mark them
+      // explicitly instead of inferring a person from a role or display text.
+      d.exec(`ALTER TABLE transcript_messages ADD COLUMN author_json TEXT NOT NULL DEFAULT '{"kind":"legacy","participantId":"legacy:unknown","verified":false}'`);
+    }
+    d.exec("PRAGMA user_version = 12");
+  }
   if (version < 6) {
     const columns = d.query<{ name: string }, []>("PRAGMA table_info(transcript_messages)").all();
     if (!columns.some((column) => column.name === "order_seq")) {
@@ -740,12 +755,18 @@ function clippedText(message: SessionMsg): string {
 }
 
 function rowMessage(row: IndexedMessageRow): SessionMsg | ImageArtifactMessage {
+  let author: MessageAuthorRef = UNKNOWN_LEGACY_AUTHOR;
+  try {
+    const parsed = JSON.parse(row.author_json) as MessageAuthorRef;
+    if (parsed && typeof parsed === "object" && typeof parsed.participantId === "string") author = parsed;
+  } catch {}
   const base: SessionMsg = {
     id: row.message_id || row.id,
     role: row.role,
     kind: row.kind,
     text: row.text,
     ts: row.ts,
+    author,
   };
   if (row.kind !== "image" && row.kind !== "video" && row.kind !== "html") return base;
 
@@ -898,6 +919,7 @@ export function indexTranscriptMessages(
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const ftsStmt = d.query(FTS_MIRROR_INSERT);
+    const authorStmt = d.query("UPDATE transcript_messages SET author_json = ? WHERE id = ?");
     let insertedRows = 0;
     for (const row of pending) {
       const result = msgStmt.run(
@@ -913,6 +935,9 @@ export function indexTranscriptMessages(
         row.text,
       );
       insertedRows += Number(result.changes ?? 0);
+      if (Number(result.changes ?? 0)) {
+        authorStmt.run(JSON.stringify(messageAuthorForSession(sessionId, row.msg)), row.id);
+      }
       ftsStmt.run(row.id);
     }
     if (cursor) updateCursorInDb(d, path, sessionId, cursor);
@@ -981,6 +1006,7 @@ export function indexSessionMessagesDirect(sessionId: string, messages: SessionM
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const ftsStmt = d.query(FTS_MIRROR_INSERT);
+    const authorStmt = d.query("UPDATE transcript_messages SET author_json = ? WHERE id = ?");
     let insertedRows = 0;
     for (const row of pending) {
       const result = msgStmt.run(
@@ -996,6 +1022,9 @@ export function indexSessionMessagesDirect(sessionId: string, messages: SessionM
         row.text,
       );
       insertedRows += Number(result.changes ?? 0);
+      if (Number(result.changes ?? 0)) {
+        authorStmt.run(JSON.stringify(messageAuthorForSession(sessionId, row.msg)), row.id);
+      }
       ftsStmt.run(row.id);
     }
     return insertedRows;
@@ -1102,10 +1131,10 @@ export function reindexFileHistoryUnderSessionKey(
   if (d.query("SELECT 1 FROM transcript_messages WHERE path = ? LIMIT 1").get(key)) return 0;
   const src = d
     .query<
-      { message_id: string | null; role: string; kind: string; ts: number; text: string },
+      { message_id: string | null; role: string; kind: string; ts: number; text: string; author_json: string },
       [string]
     >(
-      `SELECT message_id, role, kind, ts, text
+      `SELECT message_id, role, kind, ts, text, author_json
          FROM transcript_messages
         WHERE session_id = ? AND path NOT LIKE 'lfg://%'
         ORDER BY order_seq ASC, id ASC`,
@@ -1116,14 +1145,14 @@ export function reindexFileHistoryUnderSessionKey(
   const inserted = d.transaction((rows: typeof src) => {
     const msgStmt = d.query(`
       INSERT OR IGNORE INTO transcript_messages
-        (id, session_id, path, message_id, byte_offset, order_seq, ts, role, kind, text)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (id, session_id, path, message_id, byte_offset, order_seq, ts, role, kind, text, author_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const ftsStmt = d.query(FTS_MIRROR_INSERT);
     let n = 0;
     for (const r of rows) {
       const id = `${key}\0${r.message_id ?? String(seq)}\0${seq}`;
-      const result = msgStmt.run(id, sessionId, key, r.message_id, seq, seq, r.ts, r.role, r.kind, r.text);
+      const result = msgStmt.run(id, sessionId, key, r.message_id, seq, seq, r.ts, r.role, r.kind, r.text, r.author_json);
       n += Number(result.changes ?? 0);
       ftsStmt.run(id);
       seq++;
@@ -1203,8 +1232,9 @@ async function indexTranscriptOnce(path: string, sessionId: string): Promise<{
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const ftsStmt = d.query(FTS_MIRROR_INSERT);
+    const authorStmt = d.query("UPDATE transcript_messages SET author_json = ? WHERE id = ?");
     for (const row of rows) {
-      msgStmt.run(
+      const result = msgStmt.run(
         row.id,
         sessionId,
         path,
@@ -1216,6 +1246,9 @@ async function indexTranscriptOnce(path: string, sessionId: string): Promise<{
         row.msg.kind,
         row.text,
       );
+      if (Number(result.changes ?? 0)) {
+        authorStmt.run(JSON.stringify(messageAuthorForSession(sessionId, row.msg)), row.id);
+      }
       ftsStmt.run(row.id);
     }
     updateCursorInDb(d, path, sessionId, { size: st.size, offset: committed, mtimeMs: st.mtimeMs });

--- a/test/bot-rotation-wiring.test.ts
+++ b/test/bot-rotation-wiring.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SERVE = readFileSync(new URL("../src/commands/serve.ts", import.meta.url), "utf8");
+const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+const MANAGED = readFileSync(new URL("../src/managed.ts", import.meta.url), "utf8");
+
+describe("persistent bot runtime rotation wiring", () => {
+  test("manual apply and automatic compaction use the same server primitive", () => {
+    expect(SERVE).toContain('path.match(/^\\/api\\/bots\\/([^/]+)\\/rotate$/)');
+    expect(SERVE).toContain("const outcome = await rotateBotSession(id, {");
+    expect(SERVE).toContain('reason: retryingCompaction ? "compaction" : "config"');
+    expect(SERVE).toContain('rotateBotSession(bot.id, { reason: "compaction" }');
+    expect(SERVE).toContain("startBotCompactionSweep();");
+  });
+
+  test("rotation preserves conversation identity and records the applied runtime revision", () => {
+    expect(SERVE).toContain("preserveExistingPrimary: true");
+    expect(SERVE).toContain("replaceConversationPrimaryRuntime({");
+    expect(SERVE).toContain("conversationId,");
+    expect(MANAGED).toContain("appliedConfigRevision?: number;");
+  });
+
+  test("stages before closing and restores the live primary on close failure", () => {
+    const staged = SERVE.indexOf("const staged = mutateBot(bot.id");
+    const closed = SERVE.indexOf('source: `bot_rotation_${opts.reason}`');
+    expect(staged).toBeGreaterThan(-1);
+    expect(closed).toBeGreaterThan(staged);
+    expect(SERVE).toContain("sessionId: previousSessionId ?? bot.sessionId");
+    expect(SERVE).toContain('await stopReplacement("bot_rotation_close_rollback")');
+    expect(SERVE).toContain('return serializeBotWork(id, async () => {\n              const deleting');
+    const rotationBlock = SERVE.slice(
+      SERVE.indexOf("async function rotateBotSession"),
+      SERVE.indexOf("async function applyPendingBotRotation"),
+    );
+    expect(rotationBlock).not.toContain("force?: boolean");
+  });
+
+  test("the editor exposes truthful apply states", () => {
+    expect(APP).toContain('data-bot-config-status={configStatus}');
+    expect(APP).toContain('configStatus === "update-available" ? "Update available"');
+    expect(APP).toContain('configStatus === "queued" ? "Refresh queued"');
+    expect(APP).toContain('configStatus === "refreshing" ? "Refreshing"');
+    expect(APP).toContain("Apply changes");
+  });
+
+  test("durable conversation ids, not rotating runtime ids, stay in bot routes", () => {
+    expect(APP).toContain("onOpen(item.id, row.conversationId)");
+    expect(APP).toContain("onOpenBot?.(bot.id, row.conversationId)");
+  });
+});

--- a/test/bot-unread-wiring.test.ts
+++ b/test/bot-unread-wiring.test.ts
@@ -31,7 +31,8 @@ describe("bot unread surface wiring", () => {
 
   test("selection marks one server conversation and websocket arrivals refresh it", () => {
     expect(APP).toContain("/api/bot-conversations/${encodeURIComponent(sessionId)}/read");
-    expect(APP).toContain("wsLiveStream.subscribeTranscript(conversation.sessionId");
+    expect(APP).toContain("botConversationSubscriptionIds(botConversations)");
+    expect(APP).toContain("wsLiveStream.subscribeTranscript(sessionId");
     expect(SERVE).toContain('path.match(/^\\/api\\/bot-conversations\\/([^/]+)\\/read$/)');
   });
 });

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -197,9 +197,9 @@ describe("host bottom inset contract", () => {
     // repos, one hand-maintained number: it drifted ~1rem and the islands
     // overlapped on a phone. One island cannot overlap itself.
     expect(app).toContain('data-lfg-host-slot="header-actions"');
-    // Both embedded mobile headers carry it. If only Live did, the host's
-    // chrome would jump back to floating the moment you opened Notifications.
-    expect(app.match(/data-lfg-host-slot="header-actions"/g)?.length).toBe(2);
+    // Both embedded mobile headers carry it. The tablet header carries the
+    // third slot added in v0.2.14, so host controls stay docked at every width.
+    expect(app.match(/data-lfg-host-slot="header-actions"/g)?.length).toBe(3);
     // Backward compatibility is the whole design: an older host that still
     // floats its own island must see no change. The slot is inert until the
     // host portals into it, and :empty is what makes that continuous.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -690,7 +690,12 @@ export type PersistentBot = {
   thinkingLevel?: string;
   cwd?: string;
   enabled: boolean;
+  conversationId?: string;
   sessionId?: string;
+  configRevision?: number;
+  appliedConfigRevision?: number;
+  configStatus?: "current" | "update-available" | "queued" | "refreshing" | "failed";
+  rotationError?: string;
   createdAt: number;
   lastMessageAt?: number;
   /**
@@ -870,6 +875,8 @@ type GlobalSettings = {
   maxBotSchedules: number;
   agentsPaused: boolean;
   idleAgentArchiveMinutes: number;
+  botAutoCompactionEnabled: boolean;
+  botCompactionThresholdPercent: number;
   transcriptView: TranscriptView;
   // The update the "What's new" drawer's Skip button last dismissed. See
   // UpdateProvider in components/update-drawer.tsx.
@@ -5760,6 +5767,8 @@ export function App() {
     maxBotSchedules: 5,
     agentsPaused: false,
     idleAgentArchiveMinutes: 0,
+    botAutoCompactionEnabled: true,
+    botCompactionThresholdPercent: 78,
     transcriptView: "full",
     skippedUpdateVersion: "",
   });
@@ -6063,6 +6072,8 @@ export function App() {
       maxBotSchedules: 5,
       agentsPaused: false,
       idleAgentArchiveMinutes: 0,
+      botAutoCompactionEnabled: true,
+      botCompactionThresholdPercent: 78,
       transcriptView: "full",
       skippedUpdateVersion: "",
     });
@@ -6862,8 +6873,11 @@ export function App() {
     };
   }, [useWsLive, liveStatus, loadCore]);
 
-  const selectedConversationSid = selectedBotConversationId ??
-    (selectedBotId ? bots.find((bot) => bot.id === selectedBotId)?.sessionId ?? null : null);
+  const selectedConversationSid = selectedBotConversationId
+    ? botConversations.find((row) =>
+        row.conversationId === selectedBotConversationId || row.sessionId === selectedBotConversationId
+      )?.sessionId ?? null
+    : selectedBotId ? bots.find((bot) => bot.id === selectedBotId)?.sessionId ?? null : null;
   // Clearing a dot must not sit in front of the conversation the human just
   // opened. This used to await the POST and then await a full `/api/bots`
   // refetch, so every bot open queued a roster rebuild behind a write on the
@@ -7162,7 +7176,7 @@ export function App() {
     thinkingLevel?: string;
     cwd?: string;
     enabled: boolean;
-  }) {
+  }): Promise<PersistentBot | null> {
     try {
       const endpoint = input.id ? `/api/bots/${encodeURIComponent(input.id)}` : "/api/bots";
       const { id, ...body } = input;
@@ -7174,20 +7188,54 @@ export function App() {
           : localStorage.getItem("lfg_user"),
         users,
       );
-      const result = await api<{ bot: PersistentBot; quota?: PersistentBotQuota }>(endpoint, {
+      const result = await api<{
+        bot: PersistentBot;
+        quota?: PersistentBotQuota;
+        configStatus?: PersistentBot["configStatus"];
+        configRevision?: number;
+      }>(endpoint, {
         method: id ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(id ? body : { ...body, user: owner || undefined }),
       });
       if (result.quota) setBotQuota(result.quota);
-      // Leaving the editor is a navigation now, not a state reset: saving an
-      // existing bot lands back in its chat, creating one lands on the list.
-      if (id) openBot(id);
-      else closeBot();
+      // Keep an existing bot's editor open when a session-bound change created
+      // a revision gap. The next action is Apply changes, and hiding that state
+      // behind a second trip into settings made the explicit refresh unusable.
+      if (!id) closeBot();
       await refreshBots();
       toast.success(id ? "Bot saved" : "Bot created");
+      return {
+        ...result.bot,
+        configStatus: result.configStatus ?? result.bot.configStatus,
+        configRevision: result.configRevision ?? result.bot.configRevision,
+      };
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }
+
+  async function applyBotChanges(bot: PersistentBot): Promise<{
+    configStatus: NonNullable<PersistentBot["configStatus"]>;
+    rotationError?: string;
+  } | null> {
+    try {
+      const result = await api<{
+        configStatus: NonNullable<PersistentBot["configStatus"]>;
+        queued?: boolean;
+      }>(`/api/bots/${encodeURIComponent(bot.id)}/rotate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ expectedRevision: bot.configRevision ?? 1 }),
+      });
+      await Promise.all([refreshBots(), refreshSessions()]);
+      toast.success(result.queued ? "Bot refresh queued" : "Bot refreshed");
+      return { configStatus: result.configStatus };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      toast.error(message);
+      return { configStatus: "failed", rotationError: message };
     }
   }
 
@@ -8446,6 +8494,7 @@ export function App() {
               else openBot(botEditor.id, selectedBotConversationId);
             }}
             onSave={saveBot}
+            onRefresh={applyBotChanges}
             onDelete={deletePersistentBot}
           />
         ) : null}
@@ -11677,7 +11726,12 @@ function RailStage({
     [bots, selectedBotId],
   );
   const selectedBotSid = selectedBotId
-    ? selectedBotConversationForRail ?? sidForBot(selectedBotId)
+    ? botConversationsForRail.find((row) =>
+        row.botId === selectedBotId && (
+          row.conversationId === selectedBotConversationForRail ||
+          row.sessionId === selectedBotConversationForRail
+        )
+      )?.sessionId ?? sidForBot(selectedBotId)
     : null;
 
   // Selecting a bot in the rail is selecting its session on the stage. Runs on
@@ -12317,7 +12371,10 @@ function RailStage({
         const sid = row.sessionId;
         const session = row.session;
         const busy = !!(sid && busyBySid[sid]);
-        const active = selectedBotId === bot.id && (!selectedBotConversationForRail || selectedBotConversationForRail === sid);
+        const active = selectedBotId === bot.id &&
+          (!selectedBotConversationForRail ||
+            selectedBotConversationForRail === row.conversationId ||
+            selectedBotConversationForRail === row.sessionId);
         const rawPreview = session?.last?.text || session?.lastUserText || row.lastMessagePreview || bot.lastMessagePreview || "";
         // A background task's report is machinery, not conversation: it is
         // hidden inside the chat, so it must not surface as the roster preview
@@ -12333,7 +12390,7 @@ function RailStage({
             type="button"
             title={railCollapsed ? bot.name : undefined}
             onClick={() => {
-              onOpenBot?.(bot.id, sid);
+              onOpenBot?.(bot.id, row.conversationId);
               if (sid) activate(sid, false);
             }}
             className={cn(
@@ -22634,6 +22691,7 @@ const LIVE_AGENT_LIMIT_OPTIONS = [0, 4, 8, 10, 12, 16, 24, 32];
 
 // No 0/unlimited option here on purpose — see GlobalSettings.maxBotSchedules.
 const BOT_SCHEDULE_LIMIT_OPTIONS = [1, 2, 3, 5, 8, 10, 15, 20];
+const BOT_COMPACTION_THRESHOLD_OPTIONS = [60, 70, 75, 78, 80, 85, 90, 95];
 
 // Idle windows, in minutes. Nothing below 15 is offered: an agent pausing
 // between turns must never look abandoned.
@@ -22656,6 +22714,7 @@ function AgentConcurrencySettingsSection({
   const [savingBotCap, setSavingBotCap] = useState(false);
   const [pausing, setPausing] = useState(false);
   const [archiving, setArchiving] = useState(false);
+  const [savingCompaction, setSavingCompaction] = useState(false);
   const stats = useServerStats(true);
 
   async function saveIdleArchive(idleAgentArchiveMinutes: number) {
@@ -22715,6 +22774,22 @@ function AgentConcurrencySettingsSection({
       toast.error(e instanceof Error ? e.message : "Could not update pause state");
     } finally {
       setPausing(false);
+    }
+  }
+
+  async function saveBotCompaction(patch: Partial<Pick<
+    GlobalSettings,
+    "botAutoCompactionEnabled" | "botCompactionThresholdPercent"
+  >>) {
+    if (savingCompaction) return;
+    setSavingCompaction(true);
+    try {
+      await onChange(patch);
+      toast.success("Bot context refresh settings updated");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Could not update bot context refresh settings");
+    } finally {
+      setSavingCompaction(false);
     }
   }
 
@@ -22800,6 +22875,48 @@ function AgentConcurrencySettingsSection({
             </select>
             <ChevronDown className="size-3 text-muted-foreground/70" />
           </label>
+        </div>
+        <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-[7px] text-white transition-colors duration-200 ease-apple",
+              settings.botAutoCompactionEnabled ? "bg-primary" : "bg-foreground/70",
+            )}>
+              <RotateCcw className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <div className="text-sm font-medium">Refresh full bot contexts</div>
+              <div className="text-xs text-muted-foreground">
+                {settings.botAutoCompactionEnabled
+                  ? `At ${settings.botCompactionThresholdPercent}% measured context use`
+                  : "Off — bots keep one runtime until manually refreshed"}
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <label className="flex items-center gap-1 rounded-full bg-muted px-3 py-1.5">
+              <select
+                value={settings.botCompactionThresholdPercent}
+                onChange={(event) => void saveBotCompaction({
+                  botCompactionThresholdPercent: Number(event.target.value),
+                })}
+                disabled={savingCompaction || !settings.botAutoCompactionEnabled}
+                aria-label="Bot context refresh threshold"
+                className="appearance-none bg-transparent text-right text-xs font-medium outline-none disabled:opacity-50"
+              >
+                {BOT_COMPACTION_THRESHOLD_OPTIONS.map((percent) => (
+                  <option key={percent} value={percent}>{percent}%</option>
+                ))}
+              </select>
+              <ChevronDown className="size-3 text-muted-foreground/70" />
+            </label>
+            <Switch
+              checked={settings.botAutoCompactionEnabled}
+              onCheckedChange={(next) => void saveBotCompaction({ botAutoCompactionEnabled: next })}
+              disabled={savingCompaction}
+              aria-label="Automatically refresh full bot contexts"
+            />
+          </div>
         </div>
         <div className="flex w-full items-center justify-between gap-3 px-4 py-2.5 text-left">
           <div className="flex min-w-0 items-center gap-3">
@@ -25007,7 +25124,12 @@ function BotsView({
 
   if (bot) {
     const mainSid = botChatSessionId(bot, sessions);
-    const sid = selectedConversationId ?? mainSid;
+    const selectedRow = selectedConversationId
+      ? conversations.find((row) => row.botId === bot.id && (
+          row.conversationId === selectedConversationId || row.sessionId === selectedConversationId
+        ))
+      : undefined;
+    const sid = selectedRow?.sessionId ?? mainSid;
     const backingSession =
       sid === mainSid
         ? findBotMainSession(bot, sessions)
@@ -25182,7 +25304,7 @@ function BotsView({
           <button
             key={row.key}
             type="button"
-            onClick={() => onOpen(item.id, row.sessionId)}
+            onClick={() => onOpen(item.id, row.conversationId)}
             aria-label={`${item.name}${row.unread ? ", unread conversation" : ""}`}
             className={MOBILE_BOT_ROSTER_ROW_CLASS}
           >
@@ -25236,6 +25358,7 @@ function BotEditorPage({
   tz,
   onClose,
   onSave,
+  onRefresh,
   onDelete,
   onEditRoutine,
 }: {
@@ -25258,7 +25381,11 @@ function BotEditorPage({
     thinkingLevel?: string;
     cwd?: string;
     enabled: boolean;
-  }) => void | Promise<void>;
+  }) => Promise<PersistentBot | null>;
+  onRefresh: (bot: PersistentBot) => Promise<{
+    configStatus: NonNullable<PersistentBot["configStatus"]>;
+    rotationError?: string;
+  } | null>;
   onDelete: (id: string) => void | Promise<void>;
   onEditRoutine?: (agent: AutoAgent) => void;
 }) {
@@ -25300,6 +25427,13 @@ function BotEditorPage({
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(editing ? bot.thinkingLevel ?? savedThinkingLevel() : savedThinkingLevel());
   const [advanced, setAdvanced] = useState(false);
   const quotaCopy = !editing && quota ? botQuotaPresentation(quota) : null;
+  const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [configRevision, setConfigRevision] = useState(editing ? bot.configRevision ?? 1 : 1);
+  const [configStatus, setConfigStatus] = useState<NonNullable<PersistentBot["configStatus"]>>(
+    editing ? bot.configStatus ?? "current" : "current",
+  );
+  const [rotationError, setRotationError] = useState(editing ? bot.rotationError : undefined);
   const models = useAgentModels(backend);
   const backendDefault = useAgentDefaultModel(backend);
   useEffect(() => {
@@ -25317,9 +25451,10 @@ function BotEditorPage({
   }, [isMobile]);
 
   const canSubmit = !!name.trim() && !!persona.trim() && !quotaCopy?.reached;
-  const submit = () => {
-    if (!canSubmit) return;
-    void onSave({
+  const submit = async () => {
+    if (!canSubmit || saving) return;
+    setSaving(true);
+    const saved = await onSave({
       id: editing ? bot.id : undefined,
       name: name.trim(),
       shape,
@@ -25331,6 +25466,22 @@ function BotEditorPage({
       cwd: cwd || undefined,
       enabled,
     });
+    setSaving(false);
+    if (!saved) return;
+    setConfigRevision(saved.configRevision ?? configRevision);
+    setConfigStatus(saved.configStatus ?? "current");
+    setRotationError(saved.rotationError);
+  };
+
+  const applyChanges = async () => {
+    if (!editing || refreshing) return;
+    setRefreshing(true);
+    setConfigStatus("refreshing");
+    const result = await onRefresh({ ...bot, configRevision });
+    setRefreshing(false);
+    if (!result) return;
+    setConfigStatus(result.configStatus);
+    setRotationError(result.rotationError);
   };
 
   // Back, title, commit — the header every other full-screen surface in the app
@@ -25350,7 +25501,8 @@ function BotEditorPage({
       <span className="min-w-0 flex-1 truncate text-[15px] font-semibold">
         {editing ? "Edit bot" : "New bot"}
       </span>
-      <Button size="sm" variant="brand" disabled={!canSubmit} onClick={submit}>
+      <Button size="sm" variant="brand" disabled={!canSubmit || saving} onClick={() => void submit()}>
+        {saving ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : null}
         {editing ? "Save" : "Create"}
       </Button>
     </>
@@ -25464,6 +25616,44 @@ function BotEditorPage({
         placeholder="How this bot should think and talk…"
         className="lfg-gfield mt-1 w-full resize-none rounded-2xl px-3 py-2 text-sm outline-none"
       />
+
+      {editing ? (
+        <div
+          className={cn(
+            "mt-3 rounded-xl border px-3 py-2.5",
+            configStatus === "failed" ? "border-destructive/40 bg-destructive/5" : "border-border",
+          )}
+          data-bot-config-status={configStatus}
+        >
+          <div className="flex items-center gap-3">
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm font-medium">
+                {configStatus === "current" ? "Current" :
+                  configStatus === "update-available" ? "Update available" :
+                  configStatus === "queued" ? "Refresh queued" :
+                  configStatus === "refreshing" ? "Refreshing" : "Refresh failed"}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {configStatus === "current"
+                  ? "The active bot uses these instructions."
+                  : configStatus === "queued"
+                    ? "The bot will refresh after its current work and child tasks finish."
+                    : configStatus === "refreshing"
+                      ? "A fresh runtime is starting with the latest instructions."
+                      : configStatus === "failed"
+                        ? rotationError || "The old runtime is still active. Try again."
+                        : "Apply the saved instructions to a fresh runtime."}
+              </span>
+            </span>
+            {configStatus === "update-available" || configStatus === "failed" ? (
+              <Button size="sm" variant="outline" disabled={refreshing} onClick={() => void applyChanges()}>
+                {refreshing ? <Loader2 className="mr-1 size-3.5 animate-spin" /> : null}
+                Apply changes
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {editing ? (
         <div className="mt-3 flex items-center justify-between rounded-xl border border-border px-3 py-2">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,10 @@
 import { Component, createContext, type ComponentProps, forwardRef, memo, Suspense, useCallback, useContext, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import type {
+  Conversation as ProductConversation,
+  ConversationParticipant,
+  MessageAuthorRef,
+} from "../../src/conversation-contract";
 import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 import {
   DEFAULT_TAB,
@@ -55,6 +60,11 @@ import {
   shouldShowMobileSurfaceToggle,
 } from "./lib/mobile-bots-nav";
 import { botChatSessionId, botStageSession, findBotMainSession } from "./lib/bot-session";
+import {
+  activeConversationParticipants,
+  isBotConversation,
+  productBotId,
+} from "./lib/conversation-ui";
 import {
   BOT_UNREAD_DOT_CLASS,
   botConversationRows,
@@ -610,6 +620,8 @@ export type Session = {
   parentNativeSessionId?: string | null;
   parentAgent?: string | null;
   spawnedBy?: string | null;
+  conversationId?: string | null;
+  conversation?: ProductConversation | null;
   botId?: string | null;
   botName?: string | null;
   capabilityVersion?: string | null;
@@ -746,6 +758,7 @@ type Message = {
   // accumulated when we connected, so it renders settled instead of replaying
   // the word-by-word streaming reveal. See DRAFT_CATCHUP_MIN_CHARS.
   catchUp?: boolean;
+  author?: MessageAuthorRef;
 };
 
 type AiStreamPart = {
@@ -980,6 +993,7 @@ type BootstrapPayload = {
   models?: ModelCatalogItem[] | null;
   settings?: GlobalSettings | null;
   sessions?: Session[] | null;
+  conversations?: ProductConversation[] | null;
   users?: User[] | null;
   repos?: Repo[] | null;
   auto?: { agents?: AutoAgent[] | null; tz?: string; findings?: AutoFinding[] | null };
@@ -10858,7 +10872,7 @@ function LiveView({
   const pinnedSet = new Set(topPinned);
   const nodeContainsPin = (node: SessionTreeNode): boolean =>
     pinnedSet.has(sessionStableId(node.session)) || node.children.some(nodeContainsPin);
-  const nodeIsBot = (node: SessionTreeNode): boolean => !!node.session.botId;
+  const nodeIsBot = (node: SessionTreeNode): boolean => isBotConversation(node.session);
   // Mobile has a dedicated Bots surface. Keep bot-owned families out of Chat,
   // even when a bot session or one of its delegated children was pinned.
   const pinnedNodes = tree.roots.filter(
@@ -11689,7 +11703,7 @@ function RailStage({
   // spoken to since Tuesday is not "idle" in the sense the rest of that group
   // means. Bots get their own category above the fleet, and are held out of
   // the project groups for the same reason.
-  const railNodeIsBot = (node: SessionTreeNode): boolean => !!node.session.botId;
+  const railNodeIsBot = (node: SessionTreeNode): boolean => isBotConversation(node.session);
   const botNodes = railTree.roots.filter(
     (node) => !railNodeContainsTopPin(node) && railNodeIsBot(node),
   );
@@ -12782,7 +12796,8 @@ const RailItem = memo(function RailItem({
   onTogglePin: () => void;
 }) {
   const botDirectory = useContext(BotDirectoryContext);
-  const drivingBot = session.botId ? botDirectory.get(session.botId) : undefined;
+  const drivingBotId = productBotId(session);
+  const drivingBot = drivingBotId ? botDirectory.get(drivingBotId) : undefined;
   // Touch swipe: drag right to pin, left to unpin. The foreground row slides
   // and a pin glyph is revealed behind it; past ~52px on release it commits.
   // A horizontal drag suppresses the tap-to-open; vertical is left to scroll.
@@ -13770,7 +13785,8 @@ function SessionChat(rawProps: SessionChatProps) {
   // from the session list would show the launch contract as a real message
   // and wait on anonymous dots instead of the creature.
   const directory = useContext(BotDirectoryContext);
-  const contextBot = rawProps.session.botId ? directory.get(rawProps.session.botId) : undefined;
+  const contextBotId = productBotId(rawProps.session);
+  const contextBot = contextBotId ? directory.get(contextBotId) : undefined;
   const props = rawProps.bot ? rawProps : { ...rawProps, bot: contextBot };
   const sid = props.session.sessionId;
   const botId = props.bot?.id;
@@ -15883,6 +15899,68 @@ function ForkSessionDialog({
   );
 }
 
+function ConversationParticipantRow({ session, compact = false }: { session: Session; compact?: boolean }) {
+  const botDirectory = useContext(BotDirectoryContext);
+  const participants = activeConversationParticipants(session);
+  if (participants.length < 2) return null;
+  return (
+    <div
+      className="mt-0.5 flex min-w-0 max-w-full items-center gap-1 overflow-hidden"
+      aria-label={`Conversation participants: ${participants.map((participant) => participant.display.name || participant.display.fallback).join(", ")}`}
+    >
+      {participants.slice(0, 5).map((participant) => {
+        const name = participant.display.name?.trim() || participant.display.fallback;
+        if (participant.kind === "bot") {
+          const botId = participant.id.startsWith("bot:") ? participant.id.slice(4) : participant.id;
+          const bot = botDirectory.get(botId);
+          return (
+            <span
+              key={participant.id}
+              className={cn(
+                "flex min-w-0 shrink items-center rounded-full bg-muted text-[10px] leading-none text-muted-foreground",
+                compact ? "size-4 justify-center" : "gap-1 px-1.5 py-0.5",
+              )}
+              title={`${name} · bot`}
+              aria-label={`${name}, bot`}
+            >
+              <BotMascot
+                shape={bot?.shape}
+                colorway={bot?.colorway}
+                size={14}
+                state="idle"
+                seed={botId.length}
+              />
+              {!compact ? <span className="max-w-20 truncate">{name}</span> : null}
+            </span>
+          );
+        }
+        const fallback = name.slice(0, 1).toUpperCase() || "M";
+        return (
+          <span
+            key={participant.id}
+            className="relative grid size-4 shrink-0 place-items-center overflow-hidden rounded-full bg-primary/12 text-[9px] font-semibold text-primary"
+            title={`${name} · ${participant.role}`}
+            aria-label={`${name}, ${participant.role}`}
+          >
+            {fallback}
+            {participant.display.avatar ? (
+              <img
+                src={participant.display.avatar}
+                alt=""
+                className="absolute inset-0 size-full object-cover"
+                onError={(event) => event.currentTarget.remove()}
+              />
+            ) : null}
+          </span>
+        );
+      })}
+      {participants.length > 5 ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">+{participants.length - 5}</span>
+      ) : null}
+    </div>
+  );
+}
+
 // memo'd: an SSE event for one session replaces the messagesBySid/etc. Record
 // reference, re-rendering LiveView's map. Without memo every card re-renders;
 // with it, only the card whose own message/busy/prompt reference changed does —
@@ -15944,7 +16022,8 @@ const SessionCard = memo(function SessionCard({
   // name in the header rather than a generated session title, wherever it is
   // opened from.
   const botDirectory = useContext(BotDirectoryContext);
-  const headerBot = session.botId ? botDirectory.get(session.botId) ?? null : null;
+  const headerBotId = productBotId(session);
+  const headerBot = headerBotId ? botDirectory.get(headerBotId) ?? null : null;
   const editBot = useContext(EditBotContext);
 
   const sid = session.sessionId;
@@ -16271,6 +16350,7 @@ const onTouchStart = (e: ReactTouchEvent) => {
                     {latest}
                   </div>
                 ) : null}
+                <ConversationParticipantRow session={session} compact={isMobile} />
               </div>
             </button>
           )}
@@ -24695,7 +24775,10 @@ function SessionHeaderIdentity({
   size?: number;
 }) {
   const botDirectory = useContext(BotDirectoryContext);
-  const identity = resolveSessionHeaderIdentity(session, botDirectory);
+  const identity = resolveSessionHeaderIdentity(
+    { ...session, botId: productBotId(session) },
+    botDirectory,
+  );
 
   if (identity.kind === "bot") {
     return (
@@ -25015,6 +25098,7 @@ function BotsView({
                 <span className="block truncate text-xs text-muted-foreground">
                   {bot.enabled ? (busy ? "working" : "idle") : "disabled"}
                 </span>
+                {session ? <ConversationParticipantRow session={session} compact /> : null}
               </span>
               <Button
                 variant="tint"
@@ -25045,6 +25129,7 @@ function BotsView({
             <span className="block truncate text-xs text-muted-foreground">
               {bot.persona.slice(0, 60)} · {bot.enabled ? (busy ? "working" : "idle") : "disabled"}
             </span>
+            {session ? <ConversationParticipantRow session={session} /> : null}
           </span>
           <Button variant="tint" size="icon-sm" onClick={() => onEdit(bot)} aria-label="Bot settings">
             <Settings className="size-4" />

--- a/web/src/lib/bot-transcript.ts
+++ b/web/src/lib/bot-transcript.ts
@@ -1,91 +1,18 @@
-/**
- * What of a bot session's transcript the human is meant to see.
- *
- * A bot's backing session is an ordinary session, so its transcript carries
- * launch plumbing the bot chat must not show: the runtime contract, a prior
- * conversation summary on relaunch, and the `[Message from ...]` attribution
- * wrapper on every turn.
- *
- * The subtle part is the launch turn. The first user message is deliberately
- * bundled *into* the launch prompt — sending it separately raced the boot and
- * the bot answered neither, so the greeting went unanswered. That makes the
- * launch turn simultaneously plumbing and a real user message, and the two
- * have to be separated rather than the whole turn dropped. Hiding it wholesale
- * opens every conversation with a reply to an invisible question.
- */
-
-const CONTRACT_HEADER = "=== omg.dev BOT RUNTIME CONTRACT";
-
-const CONTRACT_BLOCK =
-  /===\s*omg\.dev BOT RUNTIME CONTRACT[\s\S]*?===\s*END omg\.dev BOT RUNTIME CONTRACT\s*===/i;
-const SUMMARY_BLOCK =
-  /===\s*PRIOR CONVERSATION SUMMARY\s*===[\s\S]*?===\s*END PRIOR CONVERSATION SUMMARY\s*===/i;
-const ATTRIBUTION = /^\s*\[Message from [^\]]+ to bot [^\]]+\]\s*/i;
-
-/** Remove the launch envelope, leaving whatever real message rode with it. */
-export function stripBotLaunchEnvelope(text: string): string {
-  return text.replace(CONTRACT_BLOCK, "").replace(SUMMARY_BLOCK, "").trim();
-}
-
-/** The text of a user turn as the human should read it back in the bot chat. */
-export function botVisibleUserText(text: string, isBotChat = true): string {
-  if (!isBotChat) return text;
-  return stripBotLaunchEnvelope(text).replace(ATTRIBUTION, "");
-}
-
-/**
- * True only for a launch turn that is *pure* plumbing. A launch turn carrying
- * the first user message is a real turn and must render.
- */
-export function isBotLaunchOnlyText(text: string): boolean {
-  return text.trimStart().startsWith(CONTRACT_HEADER) && stripBotLaunchEnvelope(text) === "";
-}
-
-/**
- * A background task session reporting home to the bot that spawned it.
- *
- * Heavy work does not run in a chat turn — the bot hands it to a task session,
- * which reports back with the markers from the subagent operating contract
- * (`[subagent progress]`, and one of complete/blocked/failed at the end). Those
- * arrive on the bot's session as ordinary user turns, so without this they
- * render as though the human typed `[subagent complete] rebased onto main…`
- * into their own chat.
- *
- * They are machinery, like the launch envelope and the attribution wrapper, and
- * they are hidden for the same reason. What the human should read is the bot's
- * own next message, which the bot contract requires it to write in plain words
- * — the report is the bot's source, not its output.
- */
-const SUBAGENT_UPDATE = /^\s*\[subagent (?:progress|complete|blocked|failed)\]/i;
-// The attribution wrapper the server puts on an agent-authored update, naming
-// which background task is reporting. Older transcripts carry the bare marker
-// with no wrapper, so both forms have to be recognised forever.
-const BACKGROUND_ATTRIBUTION = /^\s*\[Background task [^\]]*\]/i;
-
-export function isSubagentUpdateText(text: string): boolean {
-  return BACKGROUND_ATTRIBUTION.test(text) || SUBAGENT_UPDATE.test(text);
-}
-
-/**
- * Transcript kinds a bot chat does not show.
- *
- * A task session's transcript is a log you read: every tool call, every result,
- * every reasoning block, because the point is auditing what the agent did. A bot
- * chat is a conversation you are having, and a conversation does not narrate its
- * own mechanics — nobody wants `$ rg -n "persistent bot" src` in the middle of
- * being answered.
- *
- * Nothing is lost, only relocated: the bot's session is still an ordinary
- * session, so opening it from the sessions rail shows the whole log, tools and
- * reasoning included. The bot chat is a view of that session, not a different
- * recording of it — and heavy work does not run here anyway, it runs in a
- * background session that has its own row in the fleet.
- *
- * Images, video and artifacts stay. A bot that answers you with a picture chose
- * to hand you that picture; it is the reply, not the machinery behind it.
- */
-const HIDDEN_IN_BOT_CHAT = new Set(["tool_use", "tool_result", "thinking"]);
-
-export function isBotHiddenLogKind(kind: string | undefined): boolean {
-  return !!kind && HIDDEN_IN_BOT_CHAT.has(kind);
-}
+// The client hides exactly what the server considers launch plumbing.
+//
+// This used to be a client-only module, and that was wrong in a way that only
+// showed up once rotation started writing a new kind of block into the launch
+// prompt: the server had no way to ask "would a human see this?", so the
+// checkpoint builder happily copied the previous session's runtime contract —
+// old persona and all — into the next session's prompt. Same failure shape as
+// the one bot-session.ts records: two copies of one rule, drifting.
+//
+// So the rules live in src/bots/transcript.ts and both sides use them.
+export {
+  botVisibleUserText,
+  isBotHiddenLogKind,
+  isBotLaunchOnlyText,
+  isBotRotationNoticeText,
+  isSubagentUpdateText,
+  stripBotLaunchEnvelope,
+} from "../../../src/bots/transcript.ts";

--- a/web/src/lib/bot-unread.ts
+++ b/web/src/lib/bot-unread.ts
@@ -2,6 +2,7 @@ import { botCanonicalSessionId, type BotSessionCandidate } from "./bot-session";
 
 export type BotConversationUnread = {
   sessionId: string;
+  conversationId?: string;
   botId: string;
   assignedUser?: string | null;
   unread: boolean;
@@ -14,6 +15,7 @@ export type BotConversationRow<B, S> = {
   bot: B;
   session: S | undefined;
   sessionId: string | null;
+  conversationId: string | null;
   unread: boolean;
   lastMessagePreview?: string;
   lastMessageTs?: number | null;
@@ -55,6 +57,7 @@ export function botConversationRows<
       bot,
       session: sessions.find((item) => item.sessionId === canonical),
       sessionId: canonical,
+      conversationId: conversation?.conversationId ?? canonical,
       unread: !!conversation?.unread,
       lastMessagePreview: conversation?.lastMessagePreview,
       lastMessageTs: conversation?.lastMessageTs,

--- a/web/src/lib/conversation-ui.test.ts
+++ b/web/src/lib/conversation-ui.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { activeConversationParticipants, isBotConversation, productBotId } from "./conversation-ui";
+import type { Conversation } from "../../../src/conversation-contract";
+
+function conversation(): Conversation {
+  return {
+    id: "conversation-1",
+    participants: [
+      {
+        id: "human:member",
+        kind: "human",
+        role: "owner",
+        display: { name: "Member", fallback: "Member" },
+        joinedAt: 1,
+        historyAccess: "all",
+      },
+      {
+        id: "bot:scout",
+        kind: "bot",
+        role: "member",
+        display: { name: "Scout", fallback: "Scout" },
+        joinedAt: 1,
+        historyAccess: "all",
+      },
+      {
+        id: "bot:analyst",
+        kind: "bot",
+        role: "member",
+        display: { name: "Analyst", fallback: "Analyst" },
+        joinedAt: 2,
+        historyAccess: "all",
+      },
+    ],
+    runtimeSessions: [
+      { sessionId: "primary", participantId: "bot:scout", kind: "primary", attachedAt: 1 },
+      { sessionId: "child", participantId: "bot:scout", kind: "execution", attachedAt: 2 },
+    ],
+    createdAt: 1,
+    updatedAt: 2,
+  };
+}
+
+describe("conversation product routing", () => {
+  test("uses the primary participant instead of a conflicting runtime botId", () => {
+    expect(productBotId({ sessionId: "primary", conversation: conversation(), botId: "wrong" })).toBe("scout");
+  });
+
+  test("a child execution cannot select a different product surface", () => {
+    expect(productBotId({ sessionId: "child", conversation: conversation(), botId: "child-bot" })).toBe("scout");
+  });
+
+  test("a typed regular conversation ignores stale Session.botId", () => {
+    const regular = conversation();
+    regular.participants = regular.participants.filter((participant) => participant.kind === "human");
+    expect(productBotId({ sessionId: "primary", conversation: regular, botId: "stale" })).toBeNull();
+    expect(isBotConversation({ sessionId: "primary", conversation: regular, botId: "stale" })).toBe(false);
+  });
+
+  test("keeps legacy routing until the typed conversation arrives", () => {
+    expect(productBotId({ sessionId: "legacy", botId: "scout" })).toBe("scout");
+  });
+
+  test("returns the full active multi-bot roster and excludes departed members", () => {
+    const row = conversation();
+    row.participants[2].leftAt = 3;
+    expect(activeConversationParticipants({ conversation: row }).map((participant) => participant.display.fallback)).toEqual([
+      "Member",
+      "Scout",
+    ]);
+  });
+});

--- a/web/src/lib/conversation-ui.ts
+++ b/web/src/lib/conversation-ui.ts
@@ -1,0 +1,44 @@
+import type { Conversation, ConversationParticipant } from "../../../src/conversation-contract";
+
+export type ConversationSessionIdentity = {
+  sessionId?: string | null;
+  conversation?: Conversation | null;
+  botId?: string | null;
+};
+
+export function activeConversationParticipants(
+  session: Pick<ConversationSessionIdentity, "conversation">,
+): ConversationParticipant[] {
+  return session.conversation?.participants.filter((participant) => !participant.leftAt) ?? [];
+}
+
+/** Product routing prefers the durable roster and never a child runtime tag. */
+export function productBotId(session: ConversationSessionIdentity): string | null {
+  const conversation = session.conversation;
+  if (conversation) {
+    const attachment = conversation.runtimeSessions.find(
+      (row) => row.sessionId === session.sessionId && row.kind === "primary",
+    );
+    const attached = attachment?.participantId?.startsWith("bot:")
+      ? attachment.participantId.slice(4)
+      : null;
+    if (
+      attached &&
+      conversation.participants.some(
+        (participant) => participant.id === attachment?.participantId && participant.kind === "bot" && !participant.leftAt,
+      )
+    ) return attached;
+    const first = conversation.participants.find(
+      (participant) => participant.kind === "bot" && !participant.leftAt,
+    );
+    if (first?.id.startsWith("bot:")) return first.id.slice(4);
+    // A typed conversation with no active bot is a regular conversation. Do
+    // not let a stale inherited Session.botId override its product identity.
+    return null;
+  }
+  return session.botId ?? null;
+}
+
+export function isBotConversation(session: ConversationSessionIdentity): boolean {
+  return !!productBotId(session);
+}

--- a/web/src/useLiveSocket.ts
+++ b/web/src/useLiveSocket.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MessageAuthorRef } from "../../src/conversation-contract";
 import { visibilityRecoveryAction } from "./live-visibility";
 import { api, omgFetch, openOmgLiveSocket } from "./lib/omg-client";
 import type { OmgQueueMessage } from "./lib/omg-chat-transport";
@@ -47,6 +48,7 @@ export type Message = {
   queueId?: string;
   seed?: boolean;
   catchUp?: boolean;
+  author?: MessageAuthorRef;
 };
 
 export type AiStreamPart = {


### PR DESCRIPTION
## Summary

- rotate persona and runtime configuration changes onto a fresh runtime while keeping one durable conversation ID
- rotate proactively from measured context use with a configurable safe threshold and hysteresis
- preserve structured continuity, verified authorship, participants, unread state, queued messages, and child execution attachments
- serialize rotation, CAS revisions, stage replacement bindings before close, and roll back to the live old primary on failure
- expose Apply, queued, refreshing, failed, and automatic context settings in the UI

## Migration

Legacy bots treat the prior `sessionId` as the initial durable `conversationId`. A legacy `runtimeRefreshPending` flag becomes one queued configuration revision. Old transcript rows remain intact, and authorless legacy rows remain `legacy:unknown`.

## Verification

- `bun test` — 2,090 pass, 1 skipped, 0 failed
- root and web type checks
- web production build
- package builds
- dependency audit and exception audit
- ego-browser acceptance for settings persistence, Update available / Apply changes, and stable conversation URLs