### PR TITLE
feat(bots): add explicit runtime restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - Persistent bot chats can restart their runtime (v0.2.18)
+
+- **A persistent bot conversation now has an explicit Restart session action.**
+  It replaces the execution runtime while it keeps the same conversation ID,
+  route, transcript, participants, verified authors, unread state, and queued
+  messages. The action is separate from Apply changes, Stop, automatic context
+  refresh, and starting a fresh conversation.
+- **Restart waits for a safe lifecycle boundary.** Active primary work, child
+  work, and queued messages defer the restart. A per-bot lock and runtime
+  compare-and-swap prevent duplicate replacements. Failed staging or shutdown
+  restores the old primary when it remains usable.
+- **The action is limited to the persistent bot conversation menu.** Verified
+  shared-Computer access uses the existing bot control policy. Regular session
+  and child task controls and APIs are unchanged.
+
 ## August 20, 2026 - Codex sessions could not start after a Computer update (v0.2.17)
 
 - **Release bundles contain the Codex runtime again.** The bundle removed
@@ -18,7 +33,6 @@ Recent product updates and deployment notes.
   messages. Interrupt could not stop it. The session now ends the turn, writes
   the reason in the transcript, keeps the conversation, and accepts the next
   message.
-
 ## August 20, 2026 - Persistent bots rotate without losing the conversation (v0.2.16)
 
 - **Persona and runtime changes now start a fresh model runtime instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Recent product updates and deployment notes.
   messages. Interrupt could not stop it. The session now ends the turn, writes
   the reason in the transcript, keeps the conversation, and accepts the next
   message.
+
 ## August 20, 2026 - Persistent bots rotate without losing the conversation (v0.2.16)
 
 - **Persona and runtime changes now start a fresh model runtime instead of

--- a/docs/bot-runtime-restart.md
+++ b/docs/bot-runtime-restart.md
@@ -1,0 +1,59 @@
+# Restart a persistent bot runtime
+
+`Restart session` replaces the execution runtime for one persistent bot chat.
+It does not create a new conversation.
+
+The conversation remains the durable owner of these records:
+
+- `conversationId`
+- transcript and message history
+- participants and message authors
+- unread state
+- queued messages
+
+The old runtime session ID becomes archived history. A new runtime session ID
+becomes the primary runtime for the same conversation.
+
+## Safety
+
+The server serializes restart work for each bot. It compares the runtime ID
+that the client saw with the current primary runtime ID. A repeated request is
+therefore a successful no-op after the first restart commits.
+
+A restart does not stop an active turn. The server queues the restart when the
+primary runtime is busy, when queued messages are pending, or when a delegated
+child is active. The request runs at the next safe lifecycle boundary.
+
+The server starts and attaches the replacement before it stops the old runtime.
+If launch, attachment, persistence, or old-runtime shutdown fails, the server
+keeps or restores the old primary binding and returns a typed error.
+
+A dead runtime can restart immediately. A healthy runtime requires confirmation
+in the user interface because restart discards process-local runtime state.
+
+## Authorization
+
+The server uses the verified Computer viewer and the existing bot control
+policy. It does not accept a client-supplied user identity for restart access.
+A verified Shared-Computer member can restart a bot chat that the member can
+control under that policy.
+
+## Boundaries
+
+`Restart session` is available only in a persistent bot conversation.
+
+It is not `Start fresh conversation`. Restart keeps the same durable
+conversation and transcript.
+
+It is not `Apply changes`. Apply changes exists because saved bot instructions
+or runtime configuration are newer than the active runtime. Restart exists to
+replace the runtime on demand. Both actions use the same rotation owner.
+
+It is not `Stop`. Stop ends a task runtime. A persistent bot chat has no Stop
+action in the chat interface.
+
+It is not automatic compaction. Compaction rotates a bot when measured context
+usage reaches the configured threshold. Restart is an explicit user action.
+
+Regular task sessions and nested child task sessions do not expose this action.
+Their existing UI and API contracts do not change.

--- a/src/bots/rotation.test.ts
+++ b/src/bots/rotation.test.ts
@@ -14,6 +14,8 @@ import {
   queueBlocksBotRotation,
   redactForCheckpoint,
   rotationCompareAndSwap,
+  rotationNoticeText,
+  runtimeRotationCompareAndSwap,
   sessionBoundConfigChanged,
   sessionBoundConfigOf,
 } from "./rotation.ts";
@@ -53,6 +55,35 @@ describe("bot configuration revisions", () => {
       .toEqual({ proceed: false, outcome: "stale" });
   });
 
+  test("runtime CAS makes a repeated manual restart a no-op", () => {
+    expect(runtimeRotationCompareAndSwap({ sessionId: "runtime-old" }, "runtime-old"))
+      .toEqual({ proceed: true });
+    expect(runtimeRotationCompareAndSwap({ sessionId: "runtime-new" }, "runtime-old"))
+      .toEqual({ proceed: false, outcome: "already-rotated" });
+    expect(runtimeRotationCompareAndSwap({}, null)).toEqual({ proceed: true });
+  });
+
+  test("manual restart has a distinct continuity notice", () => {
+    expect(rotationNoticeText("restart")).toContain("runtime restart");
+    expect(rotationNoticeText("restart")).not.toBe(rotationNoticeText("config"));
+    expect(rotationNoticeText("restart")).not.toBe(rotationNoticeText("compaction"));
+  });
+
+  test("manual restart state does not impersonate Apply changes in the editor", () => {
+    expect(botConfigStatus({
+      configRevision: 2,
+      appliedConfigRevision: 2,
+      rotationState: "failed",
+      rotationReason: "restart",
+    })).toBe("current");
+    expect(botConfigStatus({
+      configRevision: 3,
+      appliedConfigRevision: 2,
+      rotationState: "queued",
+      rotationReason: "restart",
+    })).toBe("update-available");
+  });
+
   test("legacy pending refresh becomes one queued revision on the stable conversation", () => {
     const migrated = migrateLegacyBotRotationState(bot({
       sessionId: "legacy-session",
@@ -87,6 +118,29 @@ describe("safe rotation admission", () => {
     expect(queueBlocksBotRotation([{ status: "pending" }, { status: "delivered" }])).toBe(true);
     expect(queueBlocksBotRotation([{ status: "queued" }])).toBe(true);
     expect(queueBlocksBotRotation([{ status: "delivered" }, { status: "failed" }])).toBe(false);
+  });
+});
+
+describe("manual restart lifecycle", () => {
+  test("accepts a healthy idle primary", () => {
+    expect(runtimeRotationCompareAndSwap({ sessionId: "runtime-live" }, "runtime-live"))
+      .toEqual({ proceed: true });
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: false, pid: 10 }, []))
+      .toEqual({ ready: true });
+  });
+
+  test("accepts a dead primary binding for clean relaunch", () => {
+    expect(runtimeRotationCompareAndSwap({ sessionId: "runtime-dead" }, "runtime-dead"))
+      .toEqual({ proceed: true });
+    expect(botRotationAdmission("bot_one", undefined, [])).toEqual({ ready: true });
+  });
+
+  test("queues instead of interrupting busy work or promoting a child", () => {
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: true }, []))
+      .toEqual({ ready: false, blocked: "primary-busy", children: [] });
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: false }, [
+      { sessionId: "child-live", botId: "bot_one", parentSessionId: "runtime-live", pid: 11 },
+    ])).toEqual({ ready: false, blocked: "children-active", children: ["child-live"] });
   });
 });
 

--- a/src/bots/rotation.ts
+++ b/src/bots/rotation.ts
@@ -41,7 +41,7 @@ import { stripBotLaunchEnvelope } from "./transcript.ts";
 import type { Bot } from "./store.ts";
 
 /** Why a rotation was asked for. Recorded so the UI can be truthful. */
-export type BotRotationReason = "config" | "compaction";
+export type BotRotationReason = "config" | "compaction" | "restart";
 
 /**
  * Where a bot is in the rotation lifecycle.
@@ -207,13 +207,17 @@ export function botHasPendingConfig(
 export function botConfigStatus(
   bot: Pick<
     Bot,
-    "configRevision" | "appliedConfigRevision" | "rotationState"
+    "configRevision" | "appliedConfigRevision" | "rotationState" | "rotationReason"
   >,
 ): BotConfigStatus {
-  if (bot.rotationState === "rotating") return "refreshing";
-  if (bot.rotationState === "failed") return "failed";
+  // Restart and compaction are runtime lifecycle states, not configuration
+  // status. Letting either turn the editor into "Refresh failed" would merge
+  // the three actions back together in the one place their distinction matters.
+  const applyingConfig = bot.rotationReason === "config";
+  if (applyingConfig && bot.rotationState === "rotating") return "refreshing";
+  if (applyingConfig && bot.rotationState === "failed") return "failed";
   if (!botHasPendingConfig(bot)) return "current";
-  return bot.rotationState === "queued" ? "queued" : "update-available";
+  return applyingConfig && bot.rotationState === "queued" ? "queued" : "update-available";
 }
 
 // ---------------------------------------------------------------------------
@@ -718,9 +722,13 @@ export function formatHandoffCheckpoint(checkpoint: BotHandoffCheckpoint): strin
  * that was about something else. One sentence, stated once, at the top.
  */
 export function rotationNoticeText(reason: BotRotationReason): string {
-  return reason === "config"
-    ? "[This conversation continues with your updated configuration. Earlier history is preserved and searchable.]"
-    : "[This conversation continues in a fresh context window. Earlier history is preserved and searchable.]";
+  if (reason === "config") {
+    return "[This conversation continues with your updated configuration. Earlier history is preserved and searchable.]";
+  }
+  if (reason === "restart") {
+    return "[This conversation continues after a runtime restart. Earlier history is preserved and searchable.]";
+  }
+  return "[This conversation continues in a fresh context window. Earlier history is preserved and searchable.]";
 }
 
 /**
@@ -754,6 +762,25 @@ export function rotationCompareAndSwap(
   if (expectedRevision <= applied) return { proceed: false, outcome: "already-applied" };
   if (expectedRevision !== current) return { proceed: false, outcome: "stale" };
   return { proceed: true };
+}
+
+/**
+ * Compare the runtime a manual restart was requested against with the current
+ * primary binding. The per-bot mutex prevents overlap; this comparison prevents
+ * a duplicate request that waited on that mutex from restarting the replacement
+ * a second time.
+ */
+export function runtimeRotationCompareAndSwap(
+  bot: Pick<Bot, "sessionId">,
+  expectedSessionId: string | null | undefined,
+): { proceed: true } | { proceed: false; outcome: "already-rotated" } {
+  // Server-owned automatic rotations do not use this CAS. A manual route must
+  // always send the runtime identity it observed, including null.
+  if (expectedSessionId === undefined) return { proceed: true };
+  const current = bot.sessionId?.trim() || null;
+  return current === expectedSessionId
+    ? { proceed: true }
+    : { proceed: false, outcome: "already-rotated" };
 }
 
 /** Translate the old deferred-refresh flag without losing its requested edit. */

--- a/src/bots/store.ts
+++ b/src/bots/store.ts
@@ -77,7 +77,9 @@ export type Bot = {
   /** Lifecycle of an in-flight or deferred rotation. Absent means idle. */
   rotationState?: "idle" | "queued" | "rotating" | "failed";
   /** Why the pending/last rotation was requested. */
-  rotationReason?: "config" | "compaction";
+  rotationReason?: "config" | "compaction" | "restart";
+  /** Primary runtime observed when an explicit restart was requested. */
+  rotationExpectedSessionId?: string | null;
   /** Human-readable reason the last rotation attempt did not land. */
   rotationError?: string;
   rotationUpdatedAt?: number;
@@ -221,7 +223,7 @@ export type BotPatch = Partial<Pick<
   | "agent" | "model" | "thinkingLevel" | "cwd" | "owner" | "enabled"
   | "conversationId" | "sessionId" | "lastMessageAt" | "runtimeRefreshPending"
   | "configRevision" | "appliedConfigRevision" | "rotationState"
-  | "rotationReason" | "rotationError" | "rotationUpdatedAt" | "lastRotatedAt"
+  | "rotationReason" | "rotationExpectedSessionId" | "rotationError" | "rotationUpdatedAt" | "lastRotatedAt"
   | "archivedSessionIds" | "compactionArmed" | "lastCompactionAt"
 >>;
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -103,6 +103,7 @@ import {
   queueBlocksBotRotation,
   rotationCompareAndSwap,
   rotationNoticeText,
+  runtimeRotationCompareAndSwap,
   sessionBoundConfigChanged,
   sessionBoundConfigOf,
   type BotHandoffCheckpoint,
@@ -1731,7 +1732,14 @@ function json(obj: unknown, init?: ResponseInit) {
  * runtime or memory refusal. The response also carries the typed quota
  * snapshot, so clients do not have to parse this code or the prose for counts.
  */
-export type ApiErrorCode = "plan_limit" | "agent_limit" | "bot_quota_limit";
+export type ApiErrorCode =
+  | "plan_limit"
+  | "agent_limit"
+  | "bot_quota_limit"
+  | "bot_restart_forbidden"
+  | "bot_restart_unavailable"
+  | "bot_restart_conflict"
+  | "bot_restart_failed";
 
 function err(status: number, message: string, code?: ApiErrorCode) {
   return json(code ? { error: message, code } : { error: message }, { status });
@@ -1990,13 +1998,20 @@ export async function checkBotCompactionOnce(now = Date.now()): Promise<number> 
     // Keep a real hysteresis gap even when the operator lowers the threshold.
     rearmPercent: Math.min(defaults.rearmPercent, threshold - 10),
   };
-  if (!settings.enabled) return 0;
-
   const [bots, sessions] = await Promise.all([listBots(), listSessions().catch(() => [])]);
   let rotated = 0;
   for (const bot of bots) {
     if (!bot.enabled || bot.rotationState === "rotating" || bot.rotationState === "failed") continue;
     if (bot.rotationState === "queued" && bot.rotationReason === "config") continue;
+
+    if (bot.rotationState === "queued" && bot.rotationReason === "restart") {
+      const outcome = await rotateBotSession(bot.id, {
+        reason: "restart",
+        expectedRuntimeSessionId: bot.rotationExpectedSessionId,
+      });
+      if (outcome.ok && outcome.rotated) rotated++;
+      continue;
+    }
 
     if (bot.rotationState === "queued" && bot.rotationReason === "compaction") {
       const outcome = await rotateBotSession(bot.id, { reason: "compaction" });
@@ -2752,7 +2767,7 @@ export type BotRotationOutcome =
       previousSessionId: string | null;
       appliedConfigRevision: number;
     }
-  | { ok: true; rotated: false; reason: "already-applied"; sessionId: string | null }
+  | { ok: true; rotated: false; reason: "already-applied" | "already-rotated"; sessionId: string | null }
   | { ok: false; deferred: true; blocked: BotRotationBlock; children: string[] }
   | { ok: false; deferred?: false; status: number; error: string };
 
@@ -2789,17 +2804,35 @@ async function rotateBotSession(
   opts: {
     reason: BotRotationReason;
     expectedRevision?: number;
+    expectedRuntimeSessionId?: string | null;
   },
 ): Promise<BotRotationOutcome> {
   return serializeBotWork(botId, async () => {
     const bot = await getBot(botId);
     if (!bot) return { ok: false, status: 404, error: "bot not found" };
 
-    const cas = rotationCompareAndSwap(bot, opts.expectedRevision);
+    const cas = opts.reason === "restart"
+      ? runtimeRotationCompareAndSwap(bot, opts.expectedRuntimeSessionId)
+      : rotationCompareAndSwap(bot, opts.expectedRevision);
     if (!cas.proceed) {
-      if (cas.outcome === "already-applied") {
-        evlog("bot_rotation_noop", { botId, reason: opts.reason, revision: opts.expectedRevision });
-        return { ok: true, rotated: false, reason: "already-applied", sessionId: bot.sessionId ?? null };
+      if (cas.outcome === "already-applied" || cas.outcome === "already-rotated") {
+        if (cas.outcome === "already-rotated" && bot.rotationState === "queued") {
+          mutateBot(bot.id, (current) => ({
+            ...current,
+            rotationState: "idle",
+            rotationReason: undefined,
+            rotationExpectedSessionId: undefined,
+            rotationError: undefined,
+            rotationUpdatedAt: Date.now(),
+          }));
+        }
+        evlog("bot_rotation_noop", {
+          botId,
+          reason: opts.reason,
+          revision: opts.expectedRevision,
+          expectedRuntimeSessionId: opts.expectedRuntimeSessionId,
+        });
+        return { ok: true, rotated: false, reason: cas.outcome, sessionId: bot.sessionId ?? null };
       }
       return {
         ok: false,
@@ -2816,6 +2849,7 @@ async function rotateBotSession(
         ...current,
         rotationState: "queued",
         rotationReason: opts.reason,
+        rotationExpectedSessionId: opts.reason === "restart" ? opts.expectedRuntimeSessionId : undefined,
         rotationError: undefined,
         rotationUpdatedAt: Date.now(),
       }));
@@ -2837,6 +2871,7 @@ async function rotateBotSession(
           ...current,
           rotationState: "queued",
           rotationReason: opts.reason,
+          rotationExpectedSessionId: opts.reason === "restart" ? opts.expectedRuntimeSessionId : undefined,
           rotationError: undefined,
           rotationUpdatedAt: Date.now(),
         }));
@@ -2862,6 +2897,7 @@ async function rotateBotSession(
       ...current,
       rotationState: "rotating",
       rotationReason: opts.reason,
+      rotationExpectedSessionId: opts.reason === "restart" ? opts.expectedRuntimeSessionId : undefined,
       rotationError: undefined,
       rotationUpdatedAt: now,
     }));
@@ -3004,6 +3040,7 @@ async function rotateBotSession(
       ...current,
       rotationState: "idle",
       rotationReason: undefined,
+      rotationExpectedSessionId: undefined,
       rotationError: undefined,
       rotationUpdatedAt: Date.now(),
       lastRotatedAt: Date.now(),
@@ -3055,9 +3092,11 @@ async function applyPendingBotRotation(bot: Bot): Promise<Bot> {
   // human has not decided yet, and quietly restarting their conversation the
   // next time they say hello is precisely the surprise this design removes.
   if (bot.rotationState !== "queued") return bot;
+  const reason = bot.rotationReason ?? "config";
   await rotateBotSession(bot.id, {
-    reason: bot.rotationReason ?? "config",
-    expectedRevision: botConfigRevision(bot),
+    reason,
+    expectedRevision: reason === "config" ? botConfigRevision(bot) : undefined,
+    expectedRuntimeSessionId: reason === "restart" ? bot.rotationExpectedSessionId : undefined,
   });
   // Re-read either way. A rotation that lands moves the binding; one that
   // defers again refreshes the pending state; one that fails records why.
@@ -4555,7 +4594,9 @@ a{color:#60a5fa}
                   409,
                   target.rotationState === "failed"
                     ? `target bot refresh failed: ${target.rotationError || "retry the refresh"}`
-                    : "target bot refresh is still settling; retry after its current turn completes",
+                    : target.rotationReason === "restart"
+                      ? "target bot restart is queued; retry after its current work completes"
+                      : "target bot refresh is still settling; retry after its current turn completes",
                 );
               }
 
@@ -5007,10 +5048,19 @@ a{color:#60a5fa}
             if (activeBot.rotationState === "queued") {
               return err(
                 409,
-                "bot refresh is waiting for the current turn to finish; retry in a moment",
+                activeBot.rotationReason === "restart"
+                  ? "bot restart is queued; retry after the current work completes"
+                  : "bot refresh is waiting for the current turn to finish; retry in a moment",
               );
             }
-            if (activeBot.rotationState === "rotating") return err(409, "bot refresh is in progress; retry in a moment");
+            if (activeBot.rotationState === "rotating") {
+              return err(
+                409,
+                activeBot.rotationReason === "restart"
+                  ? "bot restart is in progress; retry in a moment"
+                  : "bot refresh is in progress; retry in a moment",
+              );
+            }
             if (activeBot.rotationState === "failed" && activeBot.rotationReason === "config") {
               return err(409, `bot refresh failed: ${activeBot.rotationError || "apply the update again"}`);
             }
@@ -5042,6 +5092,75 @@ a{color:#60a5fa}
             }
             return json({ sessionId: delivery.sessionId });
           });
+        }
+      }
+      {
+        // Explicit runtime lifecycle action for a persistent bot conversation.
+        // This is not the configuration Apply route below. Both converge on
+        // rotateBotSession so locking, safe-state admission, continuity and
+        // rollback have one owner.
+        const match = path.match(/^\/api\/bots\/([^/]+)\/restart$/);
+        if (match && req.method === "POST") {
+          const id = decodeURIComponent(match[1]);
+          const existing = await getBot(id);
+          if (!existing) return err(404, "bot not found", "bot_restart_unavailable");
+
+          // Managed access was already verified by the Computer proxy, which
+          // supplies this viewer header. The request body cannot choose an
+          // identity. Local installs keep the same machine-level control policy
+          // as every existing bot mutation.
+          const viewer = botViewerFromRequest(req, undefined);
+          if (!visibleBotsForViewer([existing], viewer, rosterEmails(), undefined).length) {
+            return err(403, "you cannot control this bot conversation", "bot_restart_forbidden");
+          }
+          if (!existing.enabled) {
+            return err(409, "enable this bot before restarting its runtime", "bot_restart_unavailable");
+          }
+          if (!existing.conversationId?.trim() && !existing.sessionId?.trim()) {
+            return err(409, "start this bot conversation before restarting its runtime", "bot_restart_unavailable");
+          }
+
+          const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+          const allowed = new Set(["expectedRuntimeSessionId"]);
+          const unknown = Object.keys(body ?? {}).filter((key) => !allowed.has(key)).sort();
+          if (unknown.length) {
+            return err(400, `unsupported restart fields: ${unknown.join(", ")}`, "bot_restart_conflict");
+          }
+          if (!body || !Object.hasOwn(body, "expectedRuntimeSessionId")) {
+            return err(400, "expectedRuntimeSessionId is required", "bot_restart_conflict");
+          }
+          const rawExpected = body.expectedRuntimeSessionId;
+          if (rawExpected !== null && (typeof rawExpected !== "string" || !rawExpected.trim())) {
+            return err(400, "expectedRuntimeSessionId must be a non-empty string or null", "bot_restart_conflict");
+          }
+          const expectedRuntimeSessionId = typeof rawExpected === "string" ? rawExpected.trim() : null;
+          const outcome = await rotateBotSession(id, {
+            reason: "restart",
+            expectedRuntimeSessionId,
+          });
+          const after = (await getBot(id)) ?? existing;
+          const conversationId = after.conversationId?.trim() || existing.conversationId?.trim() || null;
+
+          if (outcome.ok) {
+            return json({
+              ok: true,
+              state: outcome.rotated ? "restarted" : "already-restarted",
+              conversationId,
+              runtimeSessionId: outcome.sessionId,
+              previousRuntimeSessionId: outcome.rotated ? outcome.previousSessionId : null,
+            });
+          }
+          if (outcome.deferred) {
+            return json({
+              ok: true,
+              state: "queued",
+              conversationId,
+              runtimeSessionId: after.sessionId ?? expectedRuntimeSessionId,
+              blocked: outcome.blocked,
+              activeChildren: outcome.children.length,
+            }, { status: 202 });
+          }
+          return err(outcome.status, outcome.error, "bot_restart_failed");
         }
       }
       {
@@ -5182,6 +5301,7 @@ a{color:#60a5fa}
                     // the wrong revision's error against the new edit.
                     rotationState: "idle" as const,
                     rotationReason: undefined,
+                    rotationExpectedSessionId: undefined,
                     rotationError: undefined,
                     rotationUpdatedAt: Date.now(),
                   }

--- a/test/bot-restart-wiring.test.ts
+++ b/test/bot-restart-wiring.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SERVE = readFileSync(new URL("../src/commands/serve.ts", import.meta.url), "utf8");
+const STORE = readFileSync(new URL("../src/bots/store.ts", import.meta.url), "utf8");
+const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+
+const restartRoute = SERVE.slice(
+  SERVE.indexOf("Explicit runtime lifecycle action for a persistent bot conversation"),
+  SERVE.indexOf("Apply a pending configuration change by rotating the bot"),
+);
+const botMenu = APP.slice(
+  APP.indexOf("function BotConversationMenu("),
+  APP.indexOf("function BotsView("),
+);
+const regularSessionMenu = APP.slice(
+  APP.indexOf("function SessionActionsMenu("),
+  APP.indexOf("function RailSessionContextMenu("),
+);
+
+describe("persistent bot manual restart wiring", () => {
+  test("uses the conversation-aware rotation owner with runtime CAS", () => {
+    expect(restartRoute).toContain('path.match(/^\\/api\\/bots\\/([^/]+)\\/restart$/)');
+    expect(restartRoute).toContain('reason: "restart"');
+    expect(restartRoute).toContain("expectedRuntimeSessionId");
+    expect(restartRoute).toContain("const outcome = await rotateBotSession(id");
+  });
+
+  test("uses verified viewer access and rejects client-selected identity", () => {
+    expect(restartRoute).toContain("botViewerFromRequest(req, undefined)");
+    expect(restartRoute).toContain("visibleBotsForViewer([existing], viewer, rosterEmails(), undefined)");
+    expect(restartRoute).not.toContain("body.user");
+    expect(restartRoute).toContain('"bot_restart_forbidden"');
+  });
+
+  test("returns typed success, queued and failure states", () => {
+    expect(restartRoute).toContain('state: outcome.rotated ? "restarted" : "already-restarted"');
+    expect(restartRoute).toContain('state: "queued"');
+    expect(restartRoute).toContain('"bot_restart_failed"');
+    expect(restartRoute).toContain("activeChildren: outcome.children.length");
+  });
+
+  test("persists enough state to resume a queued restart after reload", () => {
+    expect(STORE).toContain("rotationExpectedSessionId?: string | null;");
+    expect(SERVE).toContain('bot.rotationState === "queued" && bot.rotationReason === "restart"');
+    expect(SERVE).toContain("expectedRuntimeSessionId: bot.rotationExpectedSessionId");
+  });
+
+  test("inherits stage-before-stop and rollback from the one rotation owner", () => {
+    const rotation = SERVE.slice(
+      SERVE.indexOf("async function rotateBotSession"),
+      SERVE.indexOf("async function applyPendingBotRotation"),
+    );
+    expect(rotation.indexOf("const staged = mutateBot(bot.id")).toBeGreaterThan(-1);
+    expect(rotation.indexOf('source: `bot_rotation_${opts.reason}`')).toBeGreaterThan(
+      rotation.indexOf("const staged = mutateBot(bot.id"),
+    );
+    expect(rotation).toContain('await stopReplacement("bot_rotation_attach_rollback")');
+    expect(rotation).toContain('await stopReplacement("bot_rotation_close_rollback")');
+  });
+
+  test("exposes the accessible action only in the bot conversation menu", () => {
+    expect(botMenu).toContain('label="Restart session"');
+    expect(botMenu).toContain('aria-label="Restart session"');
+    expect(botMenu).toContain("Queue restart after current work");
+    expect(regularSessionMenu).not.toContain("Restart session");
+    expect(SERVE).not.toContain("/api/sessions/:id/restart");
+  });
+
+  test("uses the same bot menu in desktop and mobile chat headers", () => {
+    const botsView = APP.slice(APP.indexOf("function BotsView("));
+    const selectedBotView = botsView.slice(botsView.indexOf("if (bot) {"), botsView.indexOf("No bots yet."));
+    expect(selectedBotView.match(/<BotConversationMenu/g)).toHaveLength(2);
+    expect(botMenu).toContain("Restart unavailable — bot is disabled");
+    expect(botMenu).toContain("Restart unavailable — start the conversation first");
+  });
+});

--- a/test/bot-restart-wiring.test.ts
+++ b/test/bot-restart-wiring.test.ts
@@ -67,9 +67,16 @@ describe("persistent bot manual restart wiring", () => {
     expect(SERVE).not.toContain("/api/sessions/:id/restart");
   });
 
-  test("uses the same bot menu in desktop and mobile chat headers", () => {
+  test("uses the same bot menu in wide desktop and responsive chat headers", () => {
+    const sessionCard = APP.slice(
+      APP.indexOf("const SessionCard = memo("),
+      APP.indexOf("const ChatStream = memo("),
+    );
     const botsView = APP.slice(APP.indexOf("function BotsView("));
     const selectedBotView = botsView.slice(botsView.indexOf("if (bot) {"), botsView.indexOf("No bots yet."));
+    expect(sessionCard).toContain("!collapsedView && headerBot && editBot");
+    expect(sessionCard).toContain("<BotConversationMenu");
+    expect(sessionCard).not.toContain('aria-label={`${headerBot.name} settings`}');
     expect(selectedBotView.match(/<BotConversationMenu/g)).toHaveLength(2);
     expect(botMenu).toContain("Restart unavailable — bot is disabled");
     expect(botMenu).toContain("Restart unavailable — start the conversation first");

--- a/test/session-actions.test.ts
+++ b/test/session-actions.test.ts
@@ -51,9 +51,9 @@ describe("session lifecycle actions", () => {
     );
 
     expect(actions).not.toContain("appDialog.confirm");
-    // Two session archive actions plus the bot sheet's delete. Every
-    // destructive action arms inline through this one primitive; no dialogs.
-    expect(app.match(/<DoubleConfirmAction/g)?.length).toBe(3);
+    // Two session archive actions remain unchanged. The bot conversation
+    // restart and bot sheet delete use the same inline primitive too.
+    expect(app.match(/<DoubleConfirmAction/g)?.length).toBe(4);
     expect(app.match(/confirmLabel="Confirm archive"/g)?.length).toBe(2);
     expect(doubleConfirm).toContain("closeOnClick: armed && !pending");
     expect(doubleConfirm).toContain("setTimeout(() => setArmed(false), timeoutMs)");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -695,6 +695,8 @@ export type PersistentBot = {
   configRevision?: number;
   appliedConfigRevision?: number;
   configStatus?: "current" | "update-available" | "queued" | "refreshing" | "failed";
+  rotationState?: "idle" | "queued" | "rotating" | "failed";
+  rotationReason?: "config" | "compaction" | "restart";
   rotationError?: string;
   createdAt: number;
   lastMessageAt?: number;
@@ -25081,6 +25083,96 @@ function reportBotChatError(message: string | null) {
   if (message) toast.error(message);
 }
 
+type BotRestartResponse = {
+  ok: true;
+  state: "restarted" | "queued" | "already-restarted";
+  conversationId: string | null;
+  runtimeSessionId: string | null;
+  previousRuntimeSessionId?: string | null;
+  blocked?: "primary-busy" | "children-active";
+  activeChildren?: number;
+};
+
+/** The bot-chat-only lifecycle menu, shared by desktop and mobile headers. */
+function BotConversationMenu({
+  bot,
+  runtimeHealthy,
+  busy,
+  restarting,
+  onEdit,
+  onRestart,
+}: {
+  bot: PersistentBot;
+  runtimeHealthy: boolean;
+  busy: boolean;
+  restarting: boolean;
+  onEdit: () => void;
+  onRestart: () => Promise<void>;
+}) {
+  const unavailable = !bot.enabled
+    ? "Restart unavailable — bot is disabled"
+    : !bot.conversationId && !bot.sessionId
+      ? "Restart unavailable — start the conversation first"
+      : null;
+  const persistedRestartState = bot.rotationReason === "restart" ? bot.rotationState : null;
+  const restartItem = unavailable ? (
+    <DropdownMenuItem disabled aria-label={unavailable}>
+      <RotateCcw className="size-4" />
+      {unavailable}
+    </DropdownMenuItem>
+  ) : restarting || persistedRestartState === "rotating" ? (
+    <DropdownMenuItem disabled aria-label="Restarting session">
+      <Loader2 className="size-4 animate-spin" />
+      Restarting…
+    </DropdownMenuItem>
+  ) : persistedRestartState === "queued" ? (
+    <DropdownMenuItem disabled aria-label="Restart queued">
+      <Clock3 className="size-4" />
+      Restart queued
+    </DropdownMenuItem>
+  ) : runtimeHealthy ? (
+    <DoubleConfirmAction
+      resetKey={`${bot.id}:${bot.sessionId ?? "none"}:${busy ? "busy" : "idle"}`}
+      label="Restart session"
+      confirmLabel={busy ? "Queue restart after current work" : "Confirm restart"}
+      pendingLabel={busy ? "Queuing restart…" : "Restarting…"}
+      icon={<RotateCcw className="size-4" />}
+      confirmIcon={<RotateCcw className="size-4" />}
+      render={<DropdownMenuItem />}
+      onConfirm={onRestart}
+    />
+  ) : (
+    <DropdownMenuItem onClick={() => void onRestart()} aria-label="Restart session">
+      <RotateCcw className="size-4" />
+      Restart session
+    </DropdownMenuItem>
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted"
+            aria-label={`${bot.name} conversation menu`}
+          />
+        }
+      >
+        <MoreVertical className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        <DropdownMenuItem onClick={onEdit} aria-label="Bot settings">
+          <Settings className="size-4" />
+          Bot settings
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {restartItem}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function BotsView({
   bots,
   sessions,
@@ -25113,6 +25205,38 @@ function BotsView({
   const isMobile = useIsMobile();
   const { conversations } = useContext(BotUnreadContext);
   const bot = selectedBotId ? bots.find((item) => item.id === selectedBotId) ?? null : null;
+  const [restartingBotId, setRestartingBotId] = useState<string | null>(null);
+  const restartBot = useCallback(async (target: PersistentBot) => {
+    if (restartingBotId === target.id) return;
+    setRestartingBotId(target.id);
+    const toastId = `bot-restart-${target.id}`;
+    toast.loading("Restarting the bot runtime…", { id: toastId });
+    try {
+      const result = await api<BotRestartResponse>(`/api/bots/${encodeURIComponent(target.id)}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ expectedRuntimeSessionId: target.sessionId ?? null }),
+      });
+      // The lifecycle response is authoritative. A transient roster refresh
+      // failure must not turn a completed restart into a false failure toast;
+      // the normal poll/live stream will reconcile the view.
+      await Promise.all([onRefreshBots(), onRefreshSessions()]).catch(() => {});
+      if (result.state === "queued") {
+        const detail = result.blocked === "children-active"
+          ? ` after ${result.activeChildren || 1} active child task${result.activeChildren === 1 ? "" : "s"} finish`
+          : " after the current work and queued messages finish";
+        toast.success(`Restart queued${detail}.`, { id: toastId });
+      } else if (result.state === "already-restarted") {
+        toast.success("The runtime was already restarted.", { id: toastId });
+      } else {
+        toast.success("Runtime restarted. Conversation and history were preserved.", { id: toastId });
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not restart the bot runtime", { id: toastId });
+    } finally {
+      setRestartingBotId((current) => current === target.id ? null : current);
+    }
+  }, [onRefreshBots, onRefreshSessions, restartingBotId]);
   useEffect(() => {
     if (!isMobile || !bot) return;
     const previousOverflow = document.body.style.overflow;
@@ -25222,15 +25346,14 @@ function BotsView({
                 </span>
                 {session ? <ConversationParticipantRow session={session} compact /> : null}
               </span>
-              <Button
-                variant="tint"
-                size="icon-sm"
-                onClick={() => onEdit(bot)}
-                aria-label="Bot settings"
-                className="size-9 shrink-0"
-              >
-                <Settings className="size-4" />
-              </Button>
+              <BotConversationMenu
+                bot={bot}
+                runtimeHealthy={!!backingSession}
+                busy={busy}
+                restarting={restartingBotId === bot.id}
+                onEdit={() => onEdit(bot)}
+                onRestart={() => restartBot(bot)}
+              />
             </header>
             <div className="flex min-h-0 flex-1 flex-col">{chat}</div>
           </section>
@@ -25253,9 +25376,14 @@ function BotsView({
             </span>
             {session ? <ConversationParticipantRow session={session} /> : null}
           </span>
-          <Button variant="tint" size="icon-sm" onClick={() => onEdit(bot)} aria-label="Bot settings">
-            <Settings className="size-4" />
-          </Button>
+          <BotConversationMenu
+            bot={bot}
+            runtimeHealthy={!!backingSession}
+            busy={busy}
+            restarting={restartingBotId === bot.id}
+            onEdit={() => onEdit(bot)}
+            onRestart={() => restartBot(bot)}
+          />
         </header>
         {chat}
       </section>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16422,20 +16422,17 @@ const onTouchStart = (e: ReactTouchEvent) => {
             <Pin className="size-3.5" fill="currentColor" />
           </span>
         ) : null}
-        {/* The badge is a way back to a bot you are not looking at. Once the
-            header wears the bot's own face, it would only link here — so it
-            becomes the way into that bot's settings instead. */}
+        {/* A bot-backed card is the authoritative desktop bot conversation.
+            Keep its lifecycle menu on the same header instead of exposing the
+            regular session menu or a settings-only shortcut. */}
         {!collapsedView && headerBot && editBot ? (
-          <Button
-            variant="tint"
-            size="icon-sm"
-            onClick={() => editBot(headerBot)}
-            aria-label={`${headerBot.name} settings`}
-            title={`${headerBot.name} settings`}
-            className="shrink-0"
-          >
-            <Settings className="size-4" />
-          </Button>
+          <BotConversationMenu
+            bot={headerBot}
+            runtimeHealthy
+            busy={busy}
+            onEdit={() => editBot(headerBot)}
+            onRefresh={onRefresh}
+          />
         ) : null}
         {!collapsedView && !headerBot && session.botId && session.botName ? (
           <DrivenByBotBadge session={session} />
@@ -25098,17 +25095,47 @@ function BotConversationMenu({
   bot,
   runtimeHealthy,
   busy,
-  restarting,
   onEdit,
-  onRestart,
+  onRefresh,
 }: {
   bot: PersistentBot;
   runtimeHealthy: boolean;
   busy: boolean;
-  restarting: boolean;
   onEdit: () => void;
-  onRestart: () => Promise<void>;
+  onRefresh: () => Promise<void>;
 }) {
+  const [restarting, setRestarting] = useState(false);
+  const restart = useCallback(async () => {
+    if (restarting) return;
+    setRestarting(true);
+    const toastId = `bot-restart-${bot.id}`;
+    toast.loading("Restarting the bot runtime…", { id: toastId });
+    try {
+      const result = await api<BotRestartResponse>(`/api/bots/${encodeURIComponent(bot.id)}/restart`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ expectedRuntimeSessionId: bot.sessionId ?? null }),
+      });
+      // The lifecycle response is authoritative. A transient roster refresh
+      // failure must not turn a completed restart into a false failure toast;
+      // the normal poll/live stream will reconcile the view.
+      await onRefresh().catch(() => {});
+      if (result.state === "queued") {
+        const detail = result.blocked === "children-active"
+          ? ` after ${result.activeChildren || 1} active child task${result.activeChildren === 1 ? "" : "s"} finish`
+          : " after the current work and queued messages finish";
+        toast.success(`Restart queued${detail}.`, { id: toastId });
+      } else if (result.state === "already-restarted") {
+        toast.success("The runtime was already restarted.", { id: toastId });
+      } else {
+        toast.success("Runtime restarted. Conversation and history were preserved.", { id: toastId });
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not restart the bot runtime", { id: toastId });
+    } finally {
+      setRestarting(false);
+    }
+  }, [bot, onRefresh, restarting]);
   const unavailable = !bot.enabled
     ? "Restart unavailable — bot is disabled"
     : !bot.conversationId && !bot.sessionId
@@ -25139,10 +25166,10 @@ function BotConversationMenu({
       icon={<RotateCcw className="size-4" />}
       confirmIcon={<RotateCcw className="size-4" />}
       render={<DropdownMenuItem />}
-      onConfirm={onRestart}
+      onConfirm={restart}
     />
   ) : (
-    <DropdownMenuItem onClick={() => void onRestart()} aria-label="Restart session">
+    <DropdownMenuItem onClick={() => void restart()} aria-label="Restart session">
       <RotateCcw className="size-4" />
       Restart session
     </DropdownMenuItem>
@@ -25205,38 +25232,6 @@ function BotsView({
   const isMobile = useIsMobile();
   const { conversations } = useContext(BotUnreadContext);
   const bot = selectedBotId ? bots.find((item) => item.id === selectedBotId) ?? null : null;
-  const [restartingBotId, setRestartingBotId] = useState<string | null>(null);
-  const restartBot = useCallback(async (target: PersistentBot) => {
-    if (restartingBotId === target.id) return;
-    setRestartingBotId(target.id);
-    const toastId = `bot-restart-${target.id}`;
-    toast.loading("Restarting the bot runtime…", { id: toastId });
-    try {
-      const result = await api<BotRestartResponse>(`/api/bots/${encodeURIComponent(target.id)}/restart`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ expectedRuntimeSessionId: target.sessionId ?? null }),
-      });
-      // The lifecycle response is authoritative. A transient roster refresh
-      // failure must not turn a completed restart into a false failure toast;
-      // the normal poll/live stream will reconcile the view.
-      await Promise.all([onRefreshBots(), onRefreshSessions()]).catch(() => {});
-      if (result.state === "queued") {
-        const detail = result.blocked === "children-active"
-          ? ` after ${result.activeChildren || 1} active child task${result.activeChildren === 1 ? "" : "s"} finish`
-          : " after the current work and queued messages finish";
-        toast.success(`Restart queued${detail}.`, { id: toastId });
-      } else if (result.state === "already-restarted") {
-        toast.success("The runtime was already restarted.", { id: toastId });
-      } else {
-        toast.success("Runtime restarted. Conversation and history were preserved.", { id: toastId });
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Could not restart the bot runtime", { id: toastId });
-    } finally {
-      setRestartingBotId((current) => current === target.id ? null : current);
-    }
-  }, [onRefreshBots, onRefreshSessions, restartingBotId]);
   useEffect(() => {
     if (!isMobile || !bot) return;
     const previousOverflow = document.body.style.overflow;
@@ -25350,9 +25345,10 @@ function BotsView({
                 bot={bot}
                 runtimeHealthy={!!backingSession}
                 busy={busy}
-                restarting={restartingBotId === bot.id}
                 onEdit={() => onEdit(bot)}
-                onRestart={() => restartBot(bot)}
+                onRefresh={async () => {
+                  await Promise.all([onRefreshBots(), onRefreshSessions()]);
+                }}
               />
             </header>
             <div className="flex min-h-0 flex-1 flex-col">{chat}</div>
@@ -25380,9 +25376,10 @@ function BotsView({
             bot={bot}
             runtimeHealthy={!!backingSession}
             busy={busy}
-            restarting={restartingBotId === bot.id}
             onEdit={() => onEdit(bot)}
-            onRestart={() => restartBot(bot)}
+            onRefresh={async () => {
+              await Promise.all([onRefreshBots(), onRefreshSessions()]);
+            }}
           />
         </header>
         {chat}


### PR DESCRIPTION
## Summary
- add Restart session only to persistent bot conversation menus on wide desktop, responsive desktop, and mobile
- reuse the conversation-aware rotateBotSession owner with a per-bot lock, runtime compare-and-swap, safe busy/child/queue deferral, reload recovery, and rollback
- preserve conversationId, transcript history, participants, verified authorship, unread state, and queued messages
- keep regular and child session lifecycle UI and APIs unchanged
- document the boundary from Apply changes, Stop, automatic compaction, and a fresh conversation

## Verification
- bun run test: 2113 pass, 1 skip, 0 fail
- bun run typecheck
- bun run --cwd web typecheck
- bun run build:packages
- bun run --cwd web build
- bun run audit: no unaccepted high or critical advisories
- bun run chat:smoke
- ego-browser desktop and mobile menu acceptance
- ego-browser stale runtime CAS: already-restarted with conversationId and runtime binding unchanged

## Release
- prepared as v0.2.18 because the concurrent Codex bundle fix used v0.2.17
