### PR TITLE
bots: chat-shaped reply style in the bot runtime contract

### DIFF
--- a/src/omg-capabilities.test.ts
+++ b/src/omg-capabilities.test.ts
@@ -105,6 +105,31 @@ describe("omg.dev runtime capabilities", () => {
     expect(contract).toContain("do not apply here");
   });
 
+  // Benny's direct feedback: replies read as essays (multi-paragraph, headed,
+  // bolded lead-ins, hedged) instead of chat. Each rule below is asserted
+  // because each one is a habit he named explicitly.
+  test("gives a bot chat-shaped reply style: short, beat-by-beat, confident", () => {
+    const contract = botRuntimeContract("Scout", "Be concise and curious.");
+    // Length is earned by the question, not by everything the bot knows.
+    expect(contract).toContain("Length is earned by the question");
+    // The multi-bubble mechanism is real: sessions.ts splits each content
+    // block of an assistant turn (text around a tool call) into its own
+    // message, and chat-render-items.ts never coalesces separate text
+    // messages back into one bubble — the contract names what already
+    // happens instead of inventing a tool that doesn't exist.
+    expect(contract).toContain("becomes its own bubble");
+    expect(contract).toContain("never call a tool just to force a break");
+    // Confidence: no hedging, no both-sides framing, no performed uncertainty.
+    expect(contract).toContain("Say what you think, once, plainly");
+    expect(contract).toContain("No hedging");
+    // The concrete habits Benny named to cut.
+    expect(contract).toContain("a bolded label leading every paragraph");
+    expect(contract).toContain("markdown headings in a chat reply");
+    expect(contract).toContain("a bulleted recap of what you just did");
+    expect(contract).toContain("restating the question before you answer it");
+    expect(contract).toContain("want me to do X or Y?");
+  });
+
   // Two envelopes reach a bot: this contract and the MCP server's instructions,
   // which used to order "ship or stay invisible" at every session indiscriminately.
   test("the MCP instructions scope shipping to task sessions", () => {

--- a/src/omg-capabilities.ts
+++ b/src/omg-capabilities.ts
@@ -4,7 +4,7 @@ import { DEFAULT_MAX_BOT_SCHEDULES } from "./settings.ts";
 // Bump whenever an agent-facing omg.dev capability or its operating guidance
 // changes. Managed sessions persist the value they launched with, which lets
 // the UI identify long-lived sessions whose MCP/tool catalog predates a ship.
-export const OMG_CAPABILITY_VERSION = "2026-08-19.3";
+export const OMG_CAPABILITY_VERSION = "2026-08-19.4";
 
 export const OMG_CAPABILITIES = [
   {
@@ -113,6 +113,22 @@ export function omgRuntimeContract(): string {
  * analytics store, and still had not said a word to the human. A chat turn is
  * answered, not investigated; work that needs an investigation belongs in a
  * task session that reports back here.
+ *
+ * The reply-style rules (2026-08-19) exist because replies read as essays, not
+ * chat: multi-paragraph, headed, bolded lead-ins on every point, a bulleted
+ * recap of what just happened, a hedge on every claim, and a "want me to do X
+ * or Y?" tacked onto the end regardless of whether the question called for it.
+ * The fix is not a new tool. Every distinct piece of text a bot sends mid-turn
+ * — the narration before and after a tool call — is already rendered as its
+ * own chat bubble: verified against sessions.ts's transcript parsing, which
+ * splits each content block of an assistant turn (text separated by a
+ * tool_use block, or a fresh turn after a tool result) into its own message
+ * with its own id, and against web/src/lib/chat-render-items.ts, which never
+ * coalesces separate text messages back into one bubble. So the contract asks
+ * for what the runtime already does — short beats instead of one long final
+ * block — rather than inventing a mechanism that does not exist. It does not
+ * tell a bot to call tools it does not need just to manufacture breaks; a
+ * reply with no tool calls is one message of a couple of short lines.
  */
 export function botRuntimeContract(
   name: string,
@@ -134,7 +150,14 @@ export function botRuntimeContract(
       ? `- Your declared coordination capabilities are: ${options.capabilities.join(", ")}`
       : "",
     "- Reply to the human through normal assistant messages. Every message gets a reply in that same turn; the reply IS the deliverable, and a turn that ends without one has failed.",
-    "- Talk like a person in a chat: a few sentences, in character, plain words. Answer from what you already know whenever you can.",
+    "- Talk like a person in a chat, not a report: a couple of short sentences by default, plain words, in character. Length is earned by the question, not by everything you know — most replies are one or two lines. Answer from what you already know whenever you can.",
+    // Every distinct piece of text you send lands as its own bubble in the chat —
+    // that already happens automatically whenever you pause mid-turn to use a
+    // tool, it is not a special tool or a format you opt into. Say so plainly
+    // instead of describing it as a trick.
+    "- Land it in short beats instead of one block. A message you send mid-turn — the way you already do when you pause to use a tool — becomes its own bubble; let that show instead of saving everything for one long final message. \"it's been a long stretch on the last version\" / \"this adds tools, not just fixes\" / \"so a bump like this felt right\" beats a five-paragraph writeup. A reply that needs no tools at all can just be a couple of short lines in one message — never call a tool just to force a break.",
+    "- Say what you think, once, plainly. No hedging, no both-sides framing, no performing uncertainty as depth. If something is genuinely unclear, say so in one line and move on.",
+    "- Cut these, they read as machine-written: a bolded label leading every paragraph, markdown headings in a chat reply, a bulleted recap of what you just did, restating the question before you answer it, and a closing \"want me to do X or Y?\" tacked onto every message.",
     "- Looking something up is fine when the answer depends on it — a couple of reads, then answer. Never open an investigation in a chat turn.",
     "- Anything bigger than that — test suites, builds, refactors, multi-repo digs, production or customer data, anything past a minute or two of tool calls — is not chat work. Say so in one line, hand it to a background session with `omg_create_subagent`, and end your turn there. Do not wait for it; the conversation stays open while it runs.",
     "- That session reports back into this conversation by itself. When its update arrives, say what happened in your own words, the way you would tell a colleague. Never paste the raw report.",


### PR DESCRIPTION
## Why

Benny's feedback on bot replies today: they read as essays, not chat.

1. Too long — multi-paragraph, headed sections, bolded lead-ins, exhaustive caveats. He wants a few sentences by default, length earned by the question.
2. Not chunked — one long block instead of a thought per message, the way a person types in chat.
3. Hedged — "worth noting", "one honest caveat", reflexive both-sides framing instead of stating a view.
4. Specific habits to kill: bolded label lead-ins on every paragraph, markdown headings in chat replies, bulleted recaps of what was just done, a closing "want me to do X or Y?" on every message, restating the question before answering.

This is a global, single-source-of-truth change: `botRuntimeContract` in `src/omg-capabilities.ts` is the one place every bot session's prompt is assembled (`src/commands/serve.ts:2355`), for every bot regardless of persona. No duplicate copy of this guidance exists elsewhere (checked `src/bots/*`, `web/src`).

## Verified before writing it

Benny's ask #2 (chunking) hinges on a mechanism claim, so I verified it against the code instead of taking the earlier draft's word for it:

- `src/sessions.ts`'s transcript parser splits every content block of an assistant turn — text separated by a `tool_use` block, or a fresh turn after a tool result — into its own message with its own id.
- `web/src/lib/chat-render-items.ts` never coalesces separate text messages back into one bubble; each renders as its own `type: "msg"` item.

So a bot's turn **can** emit multiple bubbles, and it already does today whenever the model pauses mid-turn to use a tool. The contract asks for what the runtime already supports — short beats instead of one long final block — rather than describing a mechanism that doesn't exist. It also says explicitly not to call a tool just to manufacture a break: a no-tool reply is one message of a couple of short lines.

## Before → after (`botRuntimeContract`)

Before:
```
- Talk like a person in a chat: a few sentences, in character, plain words. Answer from what you already know whenever you can.
```

After:
```
- Talk like a person in a chat, not a report: a couple of short sentences by default, plain words, in character. Length is earned by the question, not by everything you know — most replies are one or two lines. Answer from what you already know whenever you can.
- Land it in short beats instead of one block. A message you send mid-turn — the way you already do when you pause to use a tool — becomes its own bubble; let that show instead of saving everything for one long final message. "it's been a long stretch on the last version" / "this adds tools, not just fixes" / "so a bump like this felt right" beats a five-paragraph writeup. A reply that needs no tools at all can just be a couple of short lines in one message — never call a tool just to force a break.
- Say what you think, once, plainly. No hedging, no both-sides framing, no performing uncertainty as depth. If something is genuinely unclear, say so in one line and move on.
- Cut these, they read as machine-written: a bolded label leading every paragraph, markdown headings in a chat reply, a bulleted recap of what you just did, restating the question before you answer it, and a closing "want me to do X or Y?" tacked onto every message.
```

Everything load-bearing is untouched: reply-every-turn, background-handoff for real work, never `omg_ship`, never close the session, peer messaging, routines. This is a style change, not a permissions change.

`OMG_CAPABILITY_VERSION` bumped `2026-08-19.3` → `2026-08-19.4` per the existing rule ("bump whenever an agent-facing... operating guidance changes").

## Test plan

- [x] `bun test src/omg-capabilities.test.ts` — includes a new test asserting every rule Benny named explicitly
- [x] `bun run typecheck` — clean
- [x] `bun run build:packages` — clean
- [x] `bun run test` (full suite) on this branch, rebased on current `main` (v0.2.18): **2114 pass / 0 fail / 1 skip**
- [x] Same full suite against a bare `main` baseline (`git worktree` off `origin/main`, same build:packages step): **2113 pass / 0 fail / 1 skip** — the only delta is the one new test, no regressions, no pre-existing failures surfaced in this run

Not merging or tagging — leaving that to Benny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)