### PR TITLE
fix(sessions): make dead sessions resumable again

### DIFF
--- a/src/aisdk-registry-liveness.test.ts
+++ b/src/aisdk-registry-liveness.test.ts
@@ -1,0 +1,33 @@
+// isPidAlive decides whether a session can be resumed. POSIX kill() reads 0 and
+// negative pids as PROCESS GROUPS rather than processes, so kill(0, 0) signals
+// the caller's own group and succeeds. A dead or unrecorded harness is recorded
+// as pid 0, so an unguarded implementation answers "alive" for exactly the
+// sessions that are dead — which made them permanently unresumable: the resume
+// endpoint saw a live match, queued the prompt into a command file nobody was
+// tailing, and never cold-started a replacement.
+import { describe, expect, test } from "bun:test";
+import { isPidAlive } from "./aisdk-registry.ts";
+
+describe("isPidAlive", () => {
+  test("pid 0 is not alive (kill(0,0) targets the caller's process group)", () => {
+    expect(isPidAlive(0)).toBe(false);
+  });
+
+  test("negative pids are not alive (they address process groups)", () => {
+    expect(isPidAlive(-1)).toBe(false);
+    expect(isPidAlive(-4242)).toBe(false);
+  });
+
+  test("non-integers are not alive", () => {
+    expect(isPidAlive(1.5)).toBe(false);
+    expect(isPidAlive(NaN)).toBe(false);
+  });
+
+  test("this process is alive", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+  });
+
+  test("a pid that cannot exist is not alive", () => {
+    expect(isPidAlive(0x7fffffff)).toBe(false);
+  });
+});

--- a/src/aisdk-registry.ts
+++ b/src/aisdk-registry.ts
@@ -265,6 +265,12 @@ export function appendCmd(sessionId: string, cmd: AisdkCommand): void {
 
 // Liveness: a harness entry is only real if its process is still running.
 export function isPidAlive(pid: number): boolean {
+  // process.kill() reads 0 and negatives as PROCESS GROUPS, not processes:
+  // kill(0, 0) signals the caller's own group and kill(-N, 0) signals group N,
+  // so both return true and report a dead harness as alive. A dead or
+  // unrecorded harness is exactly the pid 0 case, so without this guard the
+  // function answers "alive" precisely when it matters most.
+  if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
     process.kill(pid, 0);
     return true;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -6463,8 +6463,21 @@ a{color:#60a5fa}
         if (!sessionId) return err(400, "sessionId required");
         const model = body?.model?.trim() || undefined;
         // Already running? Don't double-spawn — point the client at the live one.
+        //
+        // listSessions() returns HISTORICAL sessions too, so identity alone does
+        // not mean "live". A session whose harness died is still listed, with
+        // pid 0. Matching on identity alone made every such session permanently
+        // unresumable: this branch queued the prompt into a command file no
+        // process was tailing, reported alreadyLive, and never cold-started.
+        // That is how a run of `database is locked` harness deaths turned into
+        // sessions that could not be recovered by any supported path.
+        //
+        // The pid is an unambiguous signal here: every live session carries a
+        // running harness pid, and every dead one reports 0.
         const live = (await listSessions()).find(
-          (s) => s.sessionId === sessionId || s.nativeSessionId === sessionId,
+          (s) =>
+            (s.sessionId === sessionId || s.nativeSessionId === sessionId) &&
+            isAisdkPidAlive(s.pid),
         );
         if (live) {
           if (body?.user && live.tmuxName) assignUser(live.tmuxName, body.user);


### PR DESCRIPTION
A session whose harness died became permanently unrecoverable by every supported path. Messages sent to it queued into a command file no process was tailing. Five sessions on this box are in that state right now.

## Two defects

**1. `isPidAlive(0)` returned `true`.**

POSIX `kill()` reads `0` and negative pids as process *groups*, not processes. `kill(0, 0)` signals the callers own group and succeeds. A dead or unrecorded harness is recorded as **pid 0**, so the function answered "alive" for exactly the sessions that were dead.

```
isPidAlive(0)  = true   <-- before
isPidAlive(-1) = true   <-- before
```

This also silently disabled **session recovery**: `session-recovery.ts:216` skips any entry it believes is still running, so crashed sessions were never recovered.

**2. The resume guard matched on identity alone.**

```js
const live = (await listSessions()).find(
  (s) => s.sessionId === sessionId || s.nativeSessionId === sessionId,
);
```

`listSessions()` returns historical sessions too. A dead session matched, so `/api/sessions/resume` reported `alreadyLive: true`, queued the prompt, and never cold-started a replacement.

## Evidence

Measured across every session on this box: **11 live sessions all carried a running harness pid; all 5 dead ones reported 0.** The pid is an unambiguous signal.

Reproduced end to end on session `92b88231`: harness dead, no worker process, no tmux session, `pid: 0`, `busy: false` — and resume still returned `alreadyLive: true` and refused to start it.

## Verification

- New `src/aisdk-registry-liveness.test.ts`, 5 tests pinning pid 0, negative pids, non-integers, self, and an impossible pid.
- Focused recovery/session suites: 30 pass.
- Full suite: 2041 pass, 10 fail, 9 errors — byte-identical failure set to baseline `origin/main`, all pre-existing in `web/` and the embed build.

Both fixes make every other `isPidAlive` caller strictly more correct; all pass a real `harnessPid` today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)