### PR TITLE
fix(bots): trust navigated botId for bot-stage chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - Opening a bot from the roster could show the wrong chat surface (v0.2.19)
+
+- **Selecting a persistent bot on the desktop layout could render a plain
+  session instead of the bot's own chat.** The header showed a generic agent
+  icon and model badge instead of the bot's avatar and settings, and the
+  composer read "Add a note" instead of the bot's name. The bot the roster
+  resolved is now trusted for the whole surface — header, composer, and
+  message routing — instead of being re-derived from data that could lag
+  behind a rotated, nested, or same-named session.
+- **The bot chat back button on mobile is now a single chevron**, dropping
+  the "Bots" label text (still announced as "Back to bots" for screen
+  readers).
+- **Bot replies are chat-shaped instead of essay-shaped.** Short replies,
+  separate message beats, confident framing, and no more bolded lead-ins,
+  markdown headings, bulleted recaps, or "want me to do X or Y?" closers.
+- **A session with a dead harness can be resumed again.** Two bugs combined
+  to make some dead sessions permanently stuck: a liveness check misread pid
+  0 as "running," and the resume endpoint trusted that same misread to skip
+  restarting them. Messages sent to a stuck session now reach a running
+  process again.
+- **Fewer "database is locked" errors during heavy concurrent use.**
+  Transcript search no longer maintains a full-text mirror of every message;
+  it now scans the same per-session index search already needed, which
+  removed a second write on every message ingested while the write lock was
+  held.
+
 ## August 20, 2026 - Persistent bot chats can restart their runtime (v0.2.18)
 
 - **A persistent bot conversation now has an explicit Restart session action.**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,7 @@ import {
   activeConversationParticipants,
   isBotConversation,
   productBotId,
+  renderedBotId,
 } from "./lib/conversation-ui";
 import {
   BOT_UNREAD_DOT_CLASS,
@@ -12261,6 +12262,14 @@ function RailStage({
     onCloseColumn?: () => void,
   ) => {
     const sid = session.sessionId ?? "";
+    // The bot stage renders exactly one column — the bot the rail resolved
+    // via botCanonicalSessionId/botStageSession (see botStageColumns above).
+    // That resolution is already verified; hand it to SessionCard as the
+    // trusted identity instead of letting it re-derive one from this
+    // session's own (possibly stale/nested/child-attached) conversation
+    // snapshot. Every other stage column (railSurface !== "chat") passes
+    // undefined and keeps the existing productBotId-derived behavior.
+    const stageBotId = railSurface === "chat" ? (selectedBot?.id ?? null) : undefined;
     return (
       <div
         key={sessionStableId(session)}
@@ -12294,6 +12303,7 @@ function RailStage({
             focusGlow={focusGlow?.sid === sid ? focusGlow.n : 0}
             pinned={!session.shippedReview && topPinnedSet.has(sid)}
             onTogglePin={session.shippedReview ? undefined : onToggleTopPin}
+            stageBotId={stageBotId}
           />
         </ErrorBoundary>
       </div>
@@ -16041,6 +16051,7 @@ const SessionCard = memo(function SessionCard({
   focusGlow = 0,
   pinned = false,
   onTogglePin,
+  stageBotId,
 }: {
   session: Session;
   users: User[];
@@ -16069,6 +16080,15 @@ const SessionCard = memo(function SessionCard({
   // Narrow/mobile list preference. Desktop stage pinning is owned by RailStage.
   pinned?: boolean;
   onTogglePin?: (sid: string) => void;
+  // Set only by the dedicated bot-stage column (RailStage, railSurface ===
+  // "chat"): the id of the bot the caller resolved and navigated to. That
+  // resolution already went through the canonical, botId-verified picker
+  // (botCanonicalSessionId / botStageSession) — trust it outright rather than
+  // re-derive identity from this session's own conversation snapshot, which
+  // can lag behind rotation or point at a same-sessionId/child/stale
+  // attachment. Undefined (every other caller: grid cards, regular stage
+  // columns) keeps the existing productBotId-derived behavior unchanged.
+  stageBotId?: string | null;
 }) {
   const appDialog = useAppDialog();
   const catalog = useAgentModelCatalog();
@@ -16081,7 +16101,7 @@ const SessionCard = memo(function SessionCard({
   // name in the header rather than a generated session title, wherever it is
   // opened from.
   const botDirectory = useContext(BotDirectoryContext);
-  const headerBotId = productBotId(session);
+  const headerBotId = renderedBotId(session, stageBotId);
   const headerBot = headerBotId ? botDirectory.get(headerBotId) ?? null : null;
   const editBot = useContext(EditBotContext);
 
@@ -16366,7 +16386,7 @@ const onTouchStart = (e: ReactTouchEvent) => {
               bot's face instead of the harness mark: the creature already says
               which agent it is, and it carries busy in its own posture, so the
               spinner would be saying it twice. See SessionHeaderIdentity. */}
-          <SessionHeaderIdentity session={session} busy={busy} size={28} />
+          <SessionHeaderIdentity session={session} busy={busy} size={28} trustedBotId={headerBotId} />
           {renamingInline ? (
             <SessionTitleInlineEditor
               initial={session.title?.trim() || titleForSession(session)}
@@ -16530,6 +16550,11 @@ const onTouchStart = (e: ReactTouchEvent) => {
       {!collapsedView && (
         <SessionChat
           session={session}
+          // Same trusted identity as the header: on the bot-stage column this
+          // is the bot the caller already resolved, not whatever SessionChat's
+          // own productBotId fallback would re-derive from the session's
+          // conversation snapshot.
+          bot={headerBot ?? undefined}
           busy={busy}
           prompt={prompt}
           error={error}
@@ -24885,14 +24910,21 @@ function SessionHeaderIdentity({
   session,
   busy,
   size = 28,
+  trustedBotId,
 }: {
   session: Session;
   busy: boolean;
   size?: number;
+  // Passed by SessionCard on the bot-stage column, where the caller already
+  // resolved and verified the bot via the canonical picker. When present
+  // (including explicitly null) it wins outright; productBotId only runs for
+  // callers that never resolved a trusted id themselves (e.g. the mobile
+  // session detail sheet, opened generically from the session list).
+  trustedBotId?: string | null;
 }) {
   const botDirectory = useContext(BotDirectoryContext);
   const identity = resolveSessionHeaderIdentity(
-    { ...session, botId: productBotId(session) },
+    { ...session, botId: renderedBotId(session, trustedBotId) },
     botDirectory,
   );
 
@@ -25323,15 +25355,18 @@ function BotsView({
                   own header is the only way out. An open conversation owns the
                   surface: the Chat/Bots switch belongs to the roster and the
                   list pages, never inside a conversation, so this Back button
-                  is the exit. */}
+                  is the exit. Icon-only — the "Bots" label used to ride along
+                  with the chevron, but the destination is already implied by
+                  what the button is exiting. Kept a square, thumb-sized hit
+                  target (size-9, matching the other icon-only header controls)
+                  so the label's removal doesn't shrink what's tappable. */}
               <button
                 type="button"
                 onClick={onBack}
                 aria-label="Back to bots"
-                className="-ml-2 flex h-9 shrink-0 items-center gap-0.5 rounded-full pl-1 pr-2 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
+                className="-ml-2 flex size-9 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
               >
                 <ChevronLeft className="size-[18px]" />
-                <span>Bots</span>
               </button>
               <BotAvatar bot={bot} working={busy} size={28} />
               <span className="min-w-0 flex-1">

--- a/web/src/lib/conversation-ui.test.ts
+++ b/web/src/lib/conversation-ui.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { activeConversationParticipants, isBotConversation, productBotId } from "./conversation-ui";
+import {
+  activeConversationParticipants,
+  isBotConversation,
+  productBotId,
+  renderedBotId,
+} from "./conversation-ui";
 import type { Conversation } from "../../../src/conversation-contract";
 
 function conversation(): Conversation {
@@ -67,5 +72,79 @@ describe("conversation product routing", () => {
       "Member",
       "Scout",
     ]);
+  });
+});
+
+// The reported bug: the "Engineer" bot's roster row resolved a real,
+// verified canonical sessionId (via botCanonicalSessionId / botStageSession —
+// see bot-stage-session.test.ts), but the desktop stage column then
+// re-derived identity from that session's own `conversation` snapshot via
+// productBotId, which can disagree with the verified resolution — a rotated
+// / nested / child / same-name / already-open-regular session's runtime
+// attachment shows up in this exact session's `conversation` object, and
+// productBotId, seeing no confirmed active bot on it, falls back to the
+// harness's generic chrome even though the caller already knows this is the
+// bot's own column. renderedBotId is the fix: a trusted id from navigation
+// wins outright over whatever this session's own data would derive.
+describe("renderedBotId — trusted navigation identity vs. re-derived session data", () => {
+  test("undefined trustedBotId is unchanged: falls through to productBotId (regular sessions keep existing UI)", () => {
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, undefined)).toBe("scout");
+    expect(renderedBotId({ sessionId: "legacy", botId: "scout" }, undefined)).toBe("scout");
+    const regular = conversation();
+    regular.participants = regular.participants.filter((participant) => participant.kind === "human");
+    expect(renderedBotId({ sessionId: "primary", conversation: regular, botId: "stale" }, undefined)).toBeNull();
+  });
+
+  test("a trusted id overrides a WRONG botId productBotId would have derived from this session's own data", () => {
+    // productBotId on its own would resolve "scout" (the conversation's
+    // active bot) — the caller's verified resolution (a different bot
+    // entirely) must win instead of being second-guessed.
+    expect(productBotId({ sessionId: "primary", conversation: conversation() })).toBe("scout");
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, "engineer")).toBe("engineer");
+  });
+
+  test("a NESTED/CHILD session's runtime attachment does not decide the surface once trusted", () => {
+    // Simulates the unfinished-rotation shape: the resolved canonical session
+    // ("engineer-new") is not the one the conversation's runtimeSessions
+    // still calls "primary" (a stale/rotated-out id), and — unlike the
+    // single-bot conversation() fixture — this conversation has no active
+    // bot participant at all (the case productBotId cannot see past).
+    const nested: Conversation = {
+      id: "conv-engineer",
+      participants: [
+        { id: "human:member", kind: "human", role: "owner", display: { name: "Member", fallback: "Member" }, joinedAt: 1, historyAccess: "all" },
+      ],
+      runtimeSessions: [
+        { sessionId: "engineer-old", participantId: "bot:engineer", kind: "primary", attachedAt: 1 },
+        { sessionId: "engineer-child", participantId: "bot:engineer", kind: "execution", attachedAt: 2 },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const session = { sessionId: "engineer-new", conversation: nested, botId: "engineer" };
+    // Without a trusted id, productBotId cannot confirm this exact session
+    // against the conversation snapshot and falls back to generic chrome.
+    expect(productBotId(session)).toBeNull();
+    // The bot-stage column already knows the answer from navigation.
+    expect(renderedBotId(session, "engineer")).toBe("engineer");
+  });
+
+  test("a SAME-NAME/already-open regular session's stale botId is not trusted just because it is undefined-passed", () => {
+    // A regular session that happens to carry a stale inherited botId (e.g.
+    // reused sessionId, or a bot that later left) must still show regular
+    // UI when nothing has resolved a trusted bot for this render.
+    const left = conversation();
+    left.participants = left.participants.map((participant) =>
+      participant.kind === "bot" ? { ...participant, leftAt: 5 } : participant,
+    );
+    const session = { sessionId: "primary", conversation: left, botId: "scout" };
+    expect(renderedBotId(session, undefined)).toBeNull();
+    // But once a caller resolves and trusts an id explicitly, that decision
+    // is authoritative even over a conversation that looks "regular".
+    expect(renderedBotId(session, "scout")).toBe("scout");
+  });
+
+  test("an explicit null trustedBotId forces regular chrome even when the session's own data would resolve a bot", () => {
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, null)).toBeNull();
   });
 });

--- a/web/src/lib/conversation-ui.ts
+++ b/web/src/lib/conversation-ui.ts
@@ -42,3 +42,31 @@ export function productBotId(session: ConversationSessionIdentity): string | nul
 export function isBotConversation(session: ConversationSessionIdentity): boolean {
   return !!productBotId(session);
 }
+
+/**
+ * The botId a render should trust for bot chrome (header avatar/settings,
+ * composer, message-send endpoint) — the single place that decides between
+ * "trust the caller" and "derive it from this session's own data."
+ *
+ * `trustedBotId` is anything other than `undefined` (including explicit
+ * `null`) when the caller already resolved and verified which bot this
+ * render belongs to — the bot-stage column, reached via the canonical,
+ * botId-verified picker (botCanonicalSessionId / botStageSession in
+ * ../../../src/bots/session.ts and ./bot-session.ts). That resolution wins
+ * outright over re-deriving identity from this session's own conversation
+ * snapshot, which can lag behind rotation, or share a runtime attachment
+ * with a nested, child, same-name, or already-open regular session —
+ * exactly the cases `productBotId` cannot tell apart from this session's
+ * data alone, because it only has this session's data to look at.
+ *
+ * Every other caller (a grid card, the generic mobile session-detail sheet
+ * opened from the plain session list) never resolved a bot from navigation
+ * and passes `undefined`, so it keeps deriving from `productBotId` exactly
+ * as before — a regular session's chrome does not change.
+ */
+export function renderedBotId(
+  session: ConversationSessionIdentity,
+  trustedBotId: string | null | undefined,
+): string | null {
+  return trustedBotId !== undefined ? trustedBotId : productBotId(session);
+}


### PR DESCRIPTION
## Summary
- Selecting a persistent bot (Engineer) from the roster on the desktop workspace layout could render generic session chrome (agent icon, model badge, "Add a note" composer) instead of the bot's own avatar/settings/composer — the bot-stage column re-derived identity via `productBotId(session)` (this session's own `conversation` snapshot) instead of trusting the botId the roster had already verified via `botCanonicalSessionId`/`botStageSession`.
- Added `renderedBotId(session, trustedBotId)` (web/src/lib/conversation-ui.ts): an explicit trusted id wins outright over `productBotId`. Threaded through as `stageBotId` (SessionCard, set only on the bot stage) / `trustedBotId` (SessionHeaderIdentity), and into `SessionCard`'s `<SessionChat bot=.../>` so the composer and message-send endpoint follow the same identity as the header. Every other caller (grid cards, generic mobile session sheet) is unchanged — regular sessions keep existing UI.
- Simplified the bot-chat mobile back button to a standalone chevron, dropped the visible "Bots" text (`aria-label="Back to bots"` preserved, size-9 tap target kept).

## Test plan
- [x] `bun test web/src/lib/conversation-ui.test.ts web/src/lib/bot-stage-session.test.ts web/src/lib/session-ui.test.ts web/src/lib/bot-session.test.ts web/src/lib/bot-open-performance.test.ts web/src/lib/bot-roster-duplicates.test.ts web/src/lib/bot-unread.test.ts` — new regression tests cover wrong / nested-child / same-name / stale-left-bot cases
- [x] `bun run test` (full suite) — 2128 pass, 0 fail
- [x] root + web `tsc --noEmit` clean
- [x] `web` production build (`vite build`) succeeds; verified the new code path is present in the emitted bundle
- [x] Checked open PRs against `main` for file/line overlap — none touch `web/src/lib/conversation-ui.ts`; the three that touch `web/src/App.tsx` (#100, #104, #145) are in unrelated areas (coding-agents page, ask badge nav, folder browser)
- [ ] Live cross-browser desktop/390px visual check — not reachable from this sandbox (ego-browser drives the user's Mac browser over SSH; this fix requires a locally-running dev server, and exposing it beyond `127.0.0.1` would violate the repo's loopback-only rule for temporary servers). Substituted with the pure-function regression tests above, consistent with this codebase's existing pattern of testing header/identity logic as extracted pure functions rather than full component renders (see `resolveSessionHeaderIdentity` / `session-ui.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)