### PR TITLE
fix(bots): message-level sender avatars for shared bot conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 Recent product updates and deployment notes.
 
+## August 20, 2026 - Opening a bot from the roster could show the wrong chat surface (v0.2.19)
+
+- **Selecting a persistent bot on the desktop layout could render a plain
+  session instead of the bot's own chat.** The header showed a generic agent
+  icon and model badge instead of the bot's avatar and settings, and the
+  composer read "Add a note" instead of the bot's name. The bot the roster
+  resolved is now trusted for the whole surface — header, composer, and
+  message routing — instead of being re-derived from data that could lag
+  behind a rotated, nested, or same-named session.
+- **The bot chat back button on mobile is now a single chevron**, dropping
+  the "Bots" label text (still announced as "Back to bots" for screen
+  readers).
+- **Bot replies are chat-shaped instead of essay-shaped.** Short replies,
+  separate message beats, confident framing, and no more bolded lead-ins,
+  markdown headings, bulleted recaps, or "want me to do X or Y?" closers.
+- **A session with a dead harness can be resumed again.** Two bugs combined
+  to make some dead sessions permanently stuck: a liveness check misread pid
+  0 as "running," and the resume endpoint trusted that same misread to skip
+  restarting them. Messages sent to a stuck session now reach a running
+  process again.
+- **Fewer "database is locked" errors during heavy concurrent use.**
+  Transcript search no longer maintains a full-text mirror of every message;
+  it now scans the same per-session index search already needed, which
+  removed a second write on every message ingested while the write lock was
+  held.
+
 ## August 20, 2026 - Persistent bot chats can restart their runtime (v0.2.18)
 
 - **A persistent bot conversation now has an explicit Restart session action.**

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -162,6 +162,7 @@ import {
   listConversations,
   replaceConversationPrimaryRuntime,
   upsertConversationParticipant,
+  viewerConversationParticipantId,
 } from "../conversations.ts";
 import { startAutoScheduler, setBotRoutineDelivery } from "../auto/scheduler.ts";
 import { handleWakeTick } from "../auto/wake-tick.ts";
@@ -4163,7 +4164,13 @@ a{color:#60a5fa}
           warmChatTranscripts(sessions);
           return sessions;
         });
-        const viewer = botViewerFromRequest(req, undefined);
+        // Unmanaged callers have no trusted header, so the client tells us which
+        // locally-selected roster profile it's using (the same identity it
+        // already sends to /api/bots?user= and to bot message sends) — this
+        // is a view preference on a box that already has no auth between its
+        // local users, not a new trust boundary. A managed caller's trusted
+        // header always wins over this regardless (see botViewer).
+        const viewer = botViewerFromRequest(req, url.searchParams.get("user"));
         const conversationsTask = sessionsTask.then(() => {
           let conversations = listConversations();
           if (viewer.managed && viewer.identity) {
@@ -4174,6 +4181,9 @@ a{color:#60a5fa}
           }
           return conversations;
         });
+        // Which participant, if any, the *messages* the UI is about to render
+        // belong to "me" — see viewerConversationParticipantId.
+        const viewerParticipantId = viewerConversationParticipantId(viewer.identity);
         const reposTask = listRepos();
         const codingAgentsTask = listCodingAgentsCached();
         const settingsTask = getGlobalSettings();
@@ -4218,6 +4228,13 @@ a{color:#60a5fa}
             settings: boot.settings ?? null,
             sessions: boot.sessions ? boot.sessions.map(sessionListRow) : null,
             conversations: boot.conversations ?? null,
+            // Not an authorization signal — never gates what the UI is allowed
+            // to show. It only tells the transcript renderer which already-
+            // delivered MessageAuthorRef.participantId is "mine", so a shared
+            // bot conversation's message list can skip drawing a redundant
+            // avatar on the viewer's own turns. See conversation-ui.ts on the
+            // client for the comparison.
+            viewer: { managed: viewer.managed, participantId: viewerParticipantId },
             users: boot.users ?? null,
             repos: boot.repos ?? null,
             auto: {

--- a/src/conversations.test.ts
+++ b/src/conversations.test.ts
@@ -21,6 +21,7 @@ import {
   migrateLegacyConversations,
   replaceConversationPrimaryRuntime,
   upsertConversationParticipant,
+  viewerConversationParticipantId,
 } from "./conversations.ts";
 import { formatBotAttribution } from "./bots/authorship.ts";
 import {
@@ -321,5 +322,40 @@ describe("persisted message authors", () => {
       participantId: "legacy:unknown",
       verified: false,
     });
+  });
+});
+
+describe("the bootstrap viewer identity", () => {
+  // What GET /api/bootstrap stamps as `viewer.participantId` — the id the UI
+  // compares each verified human MessageAuthorRef against to decide "is this
+  // my own turn" (see isOtherHumanMessageAuthor on the client). It must agree
+  // with the id a verified human turn actually resolves to, or a shared bot
+  // conversation would draw a redundant avatar on the viewer's own messages,
+  // or (worse) skip drawing one on someone else's.
+  test("resolves the same id a verified human turn resolves to", () => {
+    expect(viewerConversationParticipantId("member@example.com")).toBe(
+      conversationHumanParticipantId("member@example.com"),
+    );
+  });
+
+  test("is case/whitespace-insensitive, matching the access boundary", () => {
+    expect(viewerConversationParticipantId("  MEMBER@Example.com ")).toBe(
+      conversationHumanParticipantId("member@example.com"),
+    );
+  });
+
+  test("a non-email placeholder resolves to null, not a hash of the placeholder", () => {
+    // botViewer's unmanaged-with-nothing-selected fallback is a fixed
+    // sentinel string ("__local__"), never an address. Hashing it would
+    // produce a stable id that happens to name nobody real — worse than null,
+    // because a caller could mistake it for a resolved identity.
+    expect(viewerConversationParticipantId("__local__")).toBeNull();
+    expect(viewerConversationParticipantId("")).toBeNull();
+  });
+
+  test("two different local placeholders never collide with each other or a real member", () => {
+    const real = viewerConversationParticipantId("member@example.com");
+    expect(viewerConversationParticipantId("__local__")).not.toBe(real);
+    expect(viewerConversationParticipantId("also-not-an-email")).toBeNull();
   });
 });

--- a/src/conversations.ts
+++ b/src/conversations.ts
@@ -66,6 +66,22 @@ export function conversationHumanParticipantId(identity: string): string {
   return digest ? `human:${digest}` : "";
 }
 
+/**
+ * The participant id a viewer's own bootstrap response should carry as "me".
+ *
+ * Only an address can be a person — the same rule bots/authorship.ts's
+ * botAuthorIdFromText uses reading a stored turn's author back off its text.
+ * A BotViewer's `identity` is not always one: on an unmanaged box with nobody
+ * picked as the active local profile, or the anonymous/local placeholder
+ * bucket, it is a fixed sentinel string, not an email. Hashing that sentinel
+ * would produce a stable id that happens to name nobody real, which invites a
+ * caller to treat it as a resolved identity instead of the honest "unknown"
+ * that null makes it read as (see isOtherHumanMessageAuthor on the client).
+ */
+export function viewerConversationParticipantId(identity: string): string | null {
+  return identity.includes("@") ? conversationHumanParticipantId(identity) : null;
+}
+
 export function botParticipantId(botId: string): string {
   return `bot:${botId}`;
 }

--- a/test/bootstrap-payload.test.ts
+++ b/test/bootstrap-payload.test.ts
@@ -37,4 +37,19 @@ describe("the bootstrap payload", () => {
         .toContain(`boot.${key}`);
     }
   });
+
+  // The transcript renderer's own-vs-other-human avatar split (see
+  // isOtherHumanMessageAuthor in web/src/lib/conversation-ui.ts) reads
+  // `viewer.participantId` off this same payload. If a future edit here drops
+  // it, or derives it from something other than the request's own trusted
+  // viewer, that split silently breaks for every shared bot conversation with
+  // no type error anywhere — the same class of "gathered but discarded" bug
+  // the task test above exists for.
+  test("carries the requesting viewer's own conversation participant id, from the trusted viewer only", () => {
+    const block = bootstrapBlock();
+    expect(block).toContain("botViewerFromRequest(req, url.searchParams.get(\"user\"))");
+    expect(block).toContain("viewerConversationParticipantId(viewer.identity)");
+    const response = block.slice(block.indexOf("return json("));
+    expect(response).toContain("viewer: { managed: viewer.managed, participantId: viewerParticipantId }");
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,8 +62,12 @@ import {
 import { botChatSessionId, botStageSession, findBotMainSession } from "./lib/bot-session";
 import {
   activeConversationParticipants,
+  conversationParticipantById,
+  conversationParticipantDisplayName,
   isBotConversation,
+  isOtherHumanMessageAuthor,
   productBotId,
+  unknownConversationParticipant,
 } from "./lib/conversation-ui";
 import {
   BOT_UNREAD_DOT_CLASS,
@@ -711,6 +715,15 @@ export type PersistentBot = {
 };
 
 const BotDirectoryContext = createContext<Map<string, PersistentBot>>(new Map());
+/**
+ * "Me", as a conversation participant id — see the `viewerParticipantId`
+ * state in App and BootstrapPayload["viewer"]. Read by the transcript
+ * renderer to skip drawing a redundant avatar on the viewer's own turns in a
+ * shared bot conversation. Null means "unknown", never "nobody" — a message
+ * whose author cannot be compared against this renders unattributed rather
+ * than guessed either way.
+ */
+const ViewerIdentityContext = createContext<string | null>(null);
 const BotUnreadContext = createContext<{ conversations: BotConversationUnread[]; any: boolean; selectedConversationId: string | null }>({ conversations: [], any: false, selectedConversationId: null });
 const OpenBotContext = createContext<(id: string) => void>(() => {});
 /**
@@ -1003,6 +1016,8 @@ type BootstrapPayload = {
   settings?: GlobalSettings | null;
   sessions?: Session[] | null;
   conversations?: ProductConversation[] | null;
+  /** Which conversation participant, if any, "I" am — see fetchBootstrap. */
+  viewer?: { managed: boolean; participantId: string | null } | null;
   users?: User[] | null;
   repos?: Repo[] | null;
   auto?: { agents?: AutoAgent[] | null; tz?: string; findings?: AutoFinding[] | null };
@@ -2604,9 +2619,14 @@ function sessionReference(sessionId: string): string {
 // Which "speaker" a chat row reads as, for grouping consecutive same-speaker
 // rows closer together than a change of speaker (see the transcript render
 // loop). Tool calls/results and any non-user message all read as the
-// assistant talking, same as MessageBubble's own user/assistant split.
-function chatRenderItemSpeaker(item: ChatRenderItem<Message>): "user" | "assistant" {
-  return item.type === "msg" && item.message.role === "user" ? "user" : "assistant";
+// assistant talking, same as MessageBubble's own user/assistant split. A
+// verified human author further splits "user" by participant, so two
+// different people's turns in a shared bot conversation still get the
+// speaker-changed spacing between them instead of reading as one run.
+function chatRenderItemSpeaker(item: ChatRenderItem<Message>): string {
+  if (item.type !== "msg" || item.message.role !== "user") return "assistant";
+  const author = item.message.author;
+  return author?.kind === "human" && author.verified ? `user:${author.participantId}` : "user";
 }
 
 // The most recent activity condensed to one line — used as the collapsed-card
@@ -5553,6 +5573,11 @@ export function App() {
   // vanishes on the first refresh whose snapshot predates it.
   const seededSessionsRef = useRef(new Map<string, { session: Session; at: number }>());
   const [users, setUsers] = useState<User[]>([]);
+  // "Me", as a conversation participant id — resolved server-side (trusted
+  // header on a managed Computer, the selected local profile otherwise) and
+  // used only to skip drawing a redundant avatar on the viewer's own turns in
+  // a shared bot conversation. Never an authorization signal.
+  const [viewerParticipantId, setViewerParticipantId] = useState<string | null>(null);
   // Server-side first-run state (profiles/steps/completion) + whether the
   // full-screen onboarding flow is showing. See loadCore for the gate.
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
@@ -6037,7 +6062,7 @@ export function App() {
 
   const loadCore = useCallback(async () => {
     const [payload, botPayload] = await Promise.all([
-      fetchBootstrap<BootstrapPayload>(),
+      fetchBootstrap<BootstrapPayload>(botUnreadIdentity),
       api<{ bots: PersistentBot[]; conversations?: BotConversationUnread[]; quota?: PersistentBotQuota }>(
         `/api/bots?user=${encodeURIComponent(botUnreadIdentity)}`,
         { cache: "no-store" },
@@ -6083,6 +6108,7 @@ export function App() {
     // call `.filter()` unconditionally on render, so a malformed/empty payload
     // must degrade to an empty live view rather than crash.
     setSessions(payload.sessions ?? []);
+    setViewerParticipantId(payload.viewer?.participantId ?? null);
     setUsers(payload.users ?? []);
     setRepos(payload.repos ?? []);
     setAutoAgents(payload.auto?.agents ?? []);
@@ -8044,6 +8070,7 @@ export function App() {
     <SessionTerminalContext.Provider value={setTerminalSid}>
     <OpenSettingsPageContext.Provider value={setTab}>
     <BotDirectoryContext.Provider value={botDirectory}>
+    <ViewerIdentityContext.Provider value={viewerParticipantId}>
     <BotUnreadContext.Provider value={{ conversations: botConversations, any: hasUnreadBotConversation(botConversations), selectedConversationId: selectedBotConversationId }}>
     <OpenBotContext.Provider value={openBot}>
     <EditBotContext.Provider value={openBotEditor}>
@@ -8808,6 +8835,7 @@ export function App() {
     </EditBotContext.Provider>
     </OpenBotContext.Provider>
     </BotUnreadContext.Provider>
+    </ViewerIdentityContext.Provider>
     </BotDirectoryContext.Provider>
     </OpenSettingsPageContext.Provider>
     </SessionTerminalContext.Provider>
@@ -14228,6 +14256,7 @@ function SessionChatBody({
         onLoadOlderMessages={loadOlderMessages}
         onRetryQueued={retryQueued}
         bot={bot}
+        conversation={session.conversation}
       />
 
       <SessionQuestionPanel sessionIds={[session.sessionId, session.nativeSessionId]} />
@@ -16409,7 +16438,13 @@ const onTouchStart = (e: ReactTouchEvent) => {
                     {latest}
                   </div>
                 ) : null}
-                <ConversationParticipantRow session={session} compact={isMobile} />
+                {/* A persistent bot conversation's header shows the bot's own
+                    identity and settings only — never who created or owns it.
+                    ConversationParticipantRow's human chip belongs beside each
+                    message that sender actually wrote (see
+                    OtherHumanMessageBubble), not on the card that represents
+                    the bot itself. */}
+                {headerBot ? null : <ConversationParticipantRow session={session} compact={isMobile} />}
               </div>
             </button>
           )}
@@ -16552,6 +16587,7 @@ const ChatStream = memo(function ChatStream({
   onLoadOlderMessages,
   onRetryQueued,
   bot,
+  conversation,
 }: {
   sid: string | null;
   messages: Message[];
@@ -16560,6 +16596,10 @@ const ChatStream = memo(function ChatStream({
   onLoadOlderMessages: LoadOlderMessages;
   onRetryQueued?: (message: Message) => void;
   bot?: PersistentBot;
+  // Only present for a shared bot conversation — see MessageBubble's own-vs-
+  // other-human split. A plain session never has more than one human
+  // participant, so there is nothing here to resolve.
+  conversation?: ProductConversation | null;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const transcriptView = useContext(TranscriptViewContext);
@@ -16739,6 +16779,7 @@ const ChatStream = memo(function ChatStream({
                     entering={!!item.message.id && enteringIdsRef.current.has(item.message.id)}
                     onRetryQueued={onRetryQueued}
                     bot={bot}
+                    conversation={conversation}
                   />
                 )}
               </div>
@@ -16754,6 +16795,7 @@ const ChatStream = memo(function ChatStream({
                 message={item.message}
                 onRetryQueued={onRetryQueued}
                 bot={bot}
+                conversation={conversation}
               />
             ) : null,
           )}
@@ -17190,11 +17232,16 @@ function UserBubble({
   pending,
   queued,
   failed,
+  otherAuthor,
 }: {
   html: string;
   pending?: boolean;
   queued?: boolean;
   failed?: boolean;
+  // Someone else's turn in a shared bot conversation, not the viewer's own —
+  // see OtherHumanMessageBubble. Same shape, a different tint (is-other in
+  // index.css) so the two remain visually distinct at a glance.
+  otherAuthor?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [overflowing, setOverflowing] = useState(false);
@@ -17230,6 +17277,7 @@ function UserBubble({
         pending && !queued && "is-pending",
         queued && "is-queued",
         failed && "is-failed",
+        otherAuthor && "is-other",
       )}
     >
       {/* The organic shimmer means "in flight". A queued turn is deliberately
@@ -17535,6 +17583,7 @@ function MessageBubble({
   entering = false,
   onRetryQueued,
   bot,
+  conversation,
 }: {
   message: Message;
   // Whether the session is actively working on THIS turn — drives the thinking
@@ -17546,8 +17595,21 @@ function MessageBubble({
   // Retry a failed queue send through the server queue's retry endpoint.
   onRetryQueued?: (message: Message) => void;
   bot?: PersistentBot;
+  conversation?: ProductConversation | null;
 }) {
   const openArtifact = useContext(ArtifactViewerContext);
+  const viewerParticipantId = useContext(ViewerIdentityContext);
+  // A group-chat-style human turn: authored by someone other than the current
+  // viewer, per the server-verified MessageAuthorRef — never inferred from the
+  // bot's owner/creator, the current bot, or anything client-supplied. A
+  // historical turn with no verified author (message.author is undefined or
+  // `legacy`) falls through to the unchanged "own" rendering below rather than
+  // guessing whose it was.
+  const otherHumanSender =
+    message.role === "user" && isOtherHumanMessageAuthor(message.author, viewerParticipantId)
+      ? (conversationParticipantById(conversation, message.author!.participantId) ??
+        unknownConversationParticipant(message.author!.participantId))
+      : null;
   // Must run before the early returns below — hooks can't be conditional. The
   // effect itself no-ops for anything that isn't a just-sent user turn.
   const sendMorphRef = useSendMorph<HTMLDivElement>(
@@ -17700,6 +17762,17 @@ function MessageBubble({
     );
   }
 
+  if (otherHumanSender) {
+    return (
+      <OtherHumanMessageBubble
+        message={message}
+        html={userContent.html}
+        attachments={userContent.attachments}
+        participant={otherHumanSender}
+        entering={entering}
+      />
+    );
+  }
   const isUser = message.role === "user";
   if (isUser) {
     const queued = !!message.queued && !!message.pending;
@@ -17824,6 +17897,98 @@ function MessageBubble({
       from="assistant"
     >
       {body}
+    </AiMessage>
+  );
+}
+
+/**
+ * A round face for one human conversation participant — the same visual
+ * language as the header's (removed) participant row and the desktop card's
+ * ConversationParticipantRow, so a sender reads consistently wherever their
+ * face shows up. Falls back to their initial when there is no avatar, or the
+ * avatar 404s (a deleted upload, a profile removed after the message was
+ * sent): the fallback letter sits underneath the image the whole time, so a
+ * broken <img> just uncovers it instead of leaving a blank circle.
+ */
+function HumanParticipantAvatar({
+  participant,
+  size = 20,
+  className,
+}: {
+  participant: ConversationParticipant;
+  size?: number;
+  className?: string;
+}) {
+  const name = conversationParticipantDisplayName(participant);
+  const initial = name.slice(0, 1).toUpperCase() || "M";
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "relative grid shrink-0 place-items-center overflow-hidden rounded-full bg-primary/12 text-[10px] font-semibold text-primary",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      {initial}
+      {participant.display.avatar ? (
+        <img
+          src={participant.display.avatar}
+          alt=""
+          className="absolute inset-0 size-full object-cover"
+          onError={(event) => event.currentTarget.remove()}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * A human turn authored by someone other than the current viewer, in a shared
+ * bot conversation — the "group chat inside a bot conversation" case (spec:
+ * message-level sender avatars, never a header identity chip). Left-aligned
+ * like an assistant turn so it never collides with the viewer's own
+ * right-aligned turns, and carries its own name label + avatar so it can't be
+ * mistaken for either "my message" or the bot's reply.
+ *
+ * The bubble reuses UserBubble (same clamp/attachments/pending affordances as
+ * the viewer's own turns — this is still plain user prose, just not the
+ * viewer's) with an `otherAuthor` tint so the two remain visually distinct at
+ * a glance even though they share a shape.
+ */
+function OtherHumanMessageBubble({
+  message,
+  html,
+  attachments,
+  participant,
+  entering,
+}: {
+  message: Message;
+  html: string;
+  attachments: MessageAttachment[];
+  participant: ConversationParticipant;
+  entering?: boolean;
+}) {
+  const name = conversationParticipantDisplayName(participant);
+  return (
+    <AiMessage
+      className={cn("msg", entering && "lfg-msg-in")}
+      from="assistant"
+      role="group"
+      aria-label={`Message from ${name}`}
+    >
+      <div className="flex w-full min-w-0 items-end gap-2">
+        <HumanParticipantAvatar participant={participant} size={22} className="mb-0.5" />
+        <div className="flex min-w-0 max-w-[calc(100%-1.75rem)] flex-col items-start gap-1">
+          <span className="px-0.5 text-[11px] font-medium leading-none text-muted-foreground">{name}</span>
+          {attachments.length > 0 ? <UserAttachments attachments={attachments} /> : null}
+          {html ? (
+            <MessageActions text={message.text || ""} isUser={false}>
+              <UserBubble html={html} otherAuthor />
+            </MessageActions>
+          ) : null}
+        </div>
+      </div>
     </AiMessage>
   );
 }
@@ -25334,12 +25499,15 @@ function BotsView({
                 <span>Bots</span>
               </button>
               <BotAvatar bot={bot} working={busy} size={28} />
+              {/* This header is the bot's identity and settings — never who
+                  created or owns the conversation. A shared thread's other
+                  humans get their face beside the messages they actually
+                  wrote (see OtherHumanMessageBubble), not a chip up here. */}
               <span className="min-w-0 flex-1">
                 <span className="block truncate text-[15px] font-semibold leading-tight">{bot.name}</span>
                 <span className="block truncate text-xs text-muted-foreground">
                   {bot.enabled ? (busy ? "working" : "idle") : "disabled"}
                 </span>
-                {session ? <ConversationParticipantRow session={session} compact /> : null}
               </span>
               <BotConversationMenu
                 bot={bot}
@@ -25365,12 +25533,13 @@ function BotsView({
             <ChevronLeft className="size-5" />
           </Button>
           <BotAvatar bot={bot} working={busy} size={32} />
+          {/* Bot identity + settings only — see the note on the mobile header
+              above. */}
           <span className="min-w-0 flex-1">
             <span className="block truncate text-[15px] font-semibold leading-tight">{bot.name}</span>
             <span className="block truncate text-xs text-muted-foreground">
               {bot.persona.slice(0, 60)} · {bot.enabled ? (busy ? "working" : "idle") : "disabled"}
             </span>
-            {session ? <ConversationParticipantRow session={session} /> : null}
           </span>
           <BotConversationMenu
             bot={bot}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,7 @@ import {
   activeConversationParticipants,
   isBotConversation,
   productBotId,
+  renderedBotId,
 } from "./lib/conversation-ui";
 import {
   BOT_UNREAD_DOT_CLASS,
@@ -12261,6 +12262,14 @@ function RailStage({
     onCloseColumn?: () => void,
   ) => {
     const sid = session.sessionId ?? "";
+    // The bot stage renders exactly one column — the bot the rail resolved
+    // via botCanonicalSessionId/botStageSession (see botStageColumns above).
+    // That resolution is already verified; hand it to SessionCard as the
+    // trusted identity instead of letting it re-derive one from this
+    // session's own (possibly stale/nested/child-attached) conversation
+    // snapshot. Every other stage column (railSurface !== "chat") passes
+    // undefined and keeps the existing productBotId-derived behavior.
+    const stageBotId = railSurface === "chat" ? (selectedBot?.id ?? null) : undefined;
     return (
       <div
         key={sessionStableId(session)}
@@ -12294,6 +12303,7 @@ function RailStage({
             focusGlow={focusGlow?.sid === sid ? focusGlow.n : 0}
             pinned={!session.shippedReview && topPinnedSet.has(sid)}
             onTogglePin={session.shippedReview ? undefined : onToggleTopPin}
+            stageBotId={stageBotId}
           />
         </ErrorBoundary>
       </div>
@@ -16041,6 +16051,7 @@ const SessionCard = memo(function SessionCard({
   focusGlow = 0,
   pinned = false,
   onTogglePin,
+  stageBotId,
 }: {
   session: Session;
   users: User[];
@@ -16069,6 +16080,15 @@ const SessionCard = memo(function SessionCard({
   // Narrow/mobile list preference. Desktop stage pinning is owned by RailStage.
   pinned?: boolean;
   onTogglePin?: (sid: string) => void;
+  // Set only by the dedicated bot-stage column (RailStage, railSurface ===
+  // "chat"): the id of the bot the caller resolved and navigated to. That
+  // resolution already went through the canonical, botId-verified picker
+  // (botCanonicalSessionId / botStageSession) — trust it outright rather than
+  // re-derive identity from this session's own conversation snapshot, which
+  // can lag behind rotation or point at a same-sessionId/child/stale
+  // attachment. Undefined (every other caller: grid cards, regular stage
+  // columns) keeps the existing productBotId-derived behavior unchanged.
+  stageBotId?: string | null;
 }) {
   const appDialog = useAppDialog();
   const catalog = useAgentModelCatalog();
@@ -16081,7 +16101,7 @@ const SessionCard = memo(function SessionCard({
   // name in the header rather than a generated session title, wherever it is
   // opened from.
   const botDirectory = useContext(BotDirectoryContext);
-  const headerBotId = productBotId(session);
+  const headerBotId = renderedBotId(session, stageBotId);
   const headerBot = headerBotId ? botDirectory.get(headerBotId) ?? null : null;
   const editBot = useContext(EditBotContext);
 
@@ -16366,7 +16386,7 @@ const onTouchStart = (e: ReactTouchEvent) => {
               bot's face instead of the harness mark: the creature already says
               which agent it is, and it carries busy in its own posture, so the
               spinner would be saying it twice. See SessionHeaderIdentity. */}
-          <SessionHeaderIdentity session={session} busy={busy} size={28} />
+          <SessionHeaderIdentity session={session} busy={busy} size={28} trustedBotId={headerBotId} />
           {renamingInline ? (
             <SessionTitleInlineEditor
               initial={session.title?.trim() || titleForSession(session)}
@@ -16530,6 +16550,11 @@ const onTouchStart = (e: ReactTouchEvent) => {
       {!collapsedView && (
         <SessionChat
           session={session}
+          // Same trusted identity as the header: on the bot-stage column this
+          // is the bot the caller already resolved, not whatever SessionChat's
+          // own productBotId fallback would re-derive from the session's
+          // conversation snapshot.
+          bot={headerBot ?? undefined}
           busy={busy}
           prompt={prompt}
           error={error}
@@ -24885,14 +24910,21 @@ function SessionHeaderIdentity({
   session,
   busy,
   size = 28,
+  trustedBotId,
 }: {
   session: Session;
   busy: boolean;
   size?: number;
+  // Passed by SessionCard on the bot-stage column, where the caller already
+  // resolved and verified the bot via the canonical picker. When present
+  // (including explicitly null) it wins outright; productBotId only runs for
+  // callers that never resolved a trusted id themselves (e.g. the mobile
+  // session detail sheet, opened generically from the session list).
+  trustedBotId?: string | null;
 }) {
   const botDirectory = useContext(BotDirectoryContext);
   const identity = resolveSessionHeaderIdentity(
-    { ...session, botId: productBotId(session) },
+    { ...session, botId: renderedBotId(session, trustedBotId) },
     botDirectory,
   );
 
@@ -25323,15 +25355,18 @@ function BotsView({
                   own header is the only way out. An open conversation owns the
                   surface: the Chat/Bots switch belongs to the roster and the
                   list pages, never inside a conversation, so this Back button
-                  is the exit. */}
+                  is the exit. Icon-only — the "Bots" label used to ride along
+                  with the chevron, but the destination is already implied by
+                  what the button is exiting. Kept a square, thumb-sized hit
+                  target (size-9, matching the other icon-only header controls)
+                  so the label's removal doesn't shrink what's tappable. */}
               <button
                 type="button"
                 onClick={onBack}
                 aria-label="Back to bots"
-                className="-ml-2 flex h-9 shrink-0 items-center gap-0.5 rounded-full pl-1 pr-2 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
+                className="-ml-2 flex size-9 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
               >
                 <ChevronLeft className="size-[18px]" />
-                <span>Bots</span>
               </button>
               <BotAvatar bot={bot} working={busy} size={28} />
               <span className="min-w-0 flex-1">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -68,6 +68,7 @@ import {
   isOtherHumanMessageAuthor,
   productBotId,
   renderedBotId,
+  speakerRunEdges,
   unknownConversationParticipant,
 } from "./lib/conversation-ui";
 import {
@@ -16673,6 +16674,7 @@ const ChatStream = memo(function ChatStream({
     () => splitQueuedRenderItems(buildChatRenderItems(visibleMessages)),
     [visibleMessages],
   );
+  const speakers = useMemo(() => items.map(chatRenderItemSpeaker), [items]);
   // Historical reasoning can remain in the transcript after its turn is done.
   // Only let reasoning at the active tail replace the typing dots; otherwise an
   // old thinking block would make a newly-busy session look idle. The tail here
@@ -16791,8 +16793,8 @@ const ChatStream = memo(function ChatStream({
             // follow-up sits close to the turn before it, the way a real chat
             // reads. ConversationContent's own gap is the tight same-speaker
             // baseline — this only adds the extra space on top of it.
-            const speakerChanged =
-              index > 0 && chatRenderItemSpeaker(items[index - 1]) !== chatRenderItemSpeaker(item);
+            const { firstOfRun, lastOfRun } = speakerRunEdges(speakers, index);
+            const speakerChanged = index > 0 && firstOfRun;
             return (
               <div key={item.key} className={speakerChanged ? "pt-2.5" : undefined}>
                 {item.type === "tools" ? (
@@ -16805,6 +16807,8 @@ const ChatStream = memo(function ChatStream({
                     onRetryQueued={onRetryQueued}
                     bot={bot}
                     conversation={conversation}
+                    firstOfRun={firstOfRun}
+                    lastOfRun={lastOfRun}
                   />
                 )}
               </div>
@@ -17609,6 +17613,8 @@ function MessageBubble({
   onRetryQueued,
   bot,
   conversation,
+  firstOfRun,
+  lastOfRun,
 }: {
   message: Message;
   // Whether the session is actively working on THIS turn — drives the thinking
@@ -17621,6 +17627,10 @@ function MessageBubble({
   onRetryQueued?: (message: Message) => void;
   bot?: PersistentBot;
   conversation?: ProductConversation | null;
+  // Same-speaker run edges from ChatStream. Only OtherHumanMessageBubble
+  // reads these; own-turn and bot replies ignore them.
+  firstOfRun?: boolean;
+  lastOfRun?: boolean;
 }) {
   const openArtifact = useContext(ArtifactViewerContext);
   const viewerParticipantId = useContext(ViewerIdentityContext);
@@ -17795,6 +17805,8 @@ function MessageBubble({
         attachments={userContent.attachments}
         participant={otherHumanSender}
         entering={entering}
+        firstOfRun={firstOfRun}
+        lastOfRun={lastOfRun}
       />
     );
   }
@@ -17980,6 +17992,14 @@ function HumanParticipantAvatar({
  * the viewer's own turns — this is still plain user prose, just not the
  * viewer's) with an `otherAuthor` tint so the two remain visually distinct at
  * a glance even though they share a shape.
+ *
+ * Consecutive beats from the same verified person share one caption: the
+ * name on the first of the run, the face on the last (items-end, so a
+ * multi-line run still pins the avatar to the bottom bubble). A single
+ * message is both edges and still shows both. The aria-label keeps the
+ * sender name on every bubble, including the ones that hide the visible
+ * caption. Defaults keep both chrome when the caller has no siblings
+ * (queued rows).
  */
 function OtherHumanMessageBubble({
   message,
@@ -17987,12 +18007,16 @@ function OtherHumanMessageBubble({
   attachments,
   participant,
   entering,
+  firstOfRun = true,
+  lastOfRun = true,
 }: {
   message: Message;
   html: string;
   attachments: MessageAttachment[];
   participant: ConversationParticipant;
   entering?: boolean;
+  firstOfRun?: boolean;
+  lastOfRun?: boolean;
 }) {
   const name = conversationParticipantDisplayName(participant);
   return (
@@ -18003,9 +18027,15 @@ function OtherHumanMessageBubble({
       aria-label={`Message from ${name}`}
     >
       <div className="flex w-full min-w-0 items-end gap-2">
-        <HumanParticipantAvatar participant={participant} size={22} className="mb-0.5" />
+        {lastOfRun ? (
+          <HumanParticipantAvatar participant={participant} size={22} className="mb-0.5" />
+        ) : (
+          <span aria-hidden="true" className="mb-0.5 size-[22px] shrink-0" />
+        )}
         <div className="flex min-w-0 max-w-[calc(100%-1.75rem)] flex-col items-start gap-1">
-          <span className="px-0.5 text-[11px] font-medium leading-none text-muted-foreground">{name}</span>
+          {firstOfRun ? (
+            <span className="px-0.5 text-[11px] font-medium leading-none text-muted-foreground">{name}</span>
+          ) : null}
           {attachments.length > 0 ? <UserAttachments attachments={attachments} /> : null}
           {html ? (
             <MessageActions text={message.text || ""} isUser={false}>

--- a/web/src/bootstrap.ts
+++ b/web/src/bootstrap.ts
@@ -1,7 +1,12 @@
 import { omgFetch } from "./lib/omg-client";
 
-export async function fetchBootstrap<T>(): Promise<T> {
-  const res = await omgFetch("/api/bootstrap");
+export async function fetchBootstrap<T>(asUser?: string): Promise<T> {
+  // Mirrors the identity already sent to /api/bots?user= (see botUnreadIdentity
+  // in App.tsx): the local roster profile this browser is using, for the
+  // response's `viewer.participantId` on an unmanaged box. A managed caller's
+  // trusted header always wins over this on the server, regardless.
+  const query = asUser ? `?user=${encodeURIComponent(asUser)}` : "";
+  const res = await omgFetch(`/api/bootstrap${query}`);
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
     throw new Error((data as { error?: string })?.error || `${res.status}`);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -984,6 +984,19 @@ html.lfg-keyboard-open {
     color: var(--foreground);
   }
 
+  /* Another human's turn in a shared bot conversation (OtherHumanMessageBubble).
+     Same glass-bubble shape as the viewer's own turn — reusing UserBubble keeps
+     the clamp/attachments/copy affordances identical — but a muted fill instead
+     of the bright glass tint, so it reads as "someone else" at a glance even
+     though it sits on the opposite (left) side of the transcript already. */
+  .user-bubble.markdown.is-other {
+    --user-bubble-fill: color-mix(in oklab, var(--muted) 82%, transparent);
+  }
+
+  .dark .user-bubble.markdown.is-other {
+    --user-bubble-fill: color-mix(in oklab, var(--muted) 88%, transparent);
+  }
+
   /* In-flight user message: transition.dev's organic-shimmer language adapted
      to the chat bubble. The steady glass fill remains on the bubble while a
      turbulence-warped colour wash and its edge glow travel together above it.

--- a/web/src/lib/conversation-ui.test.ts
+++ b/web/src/lib/conversation-ui.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { activeConversationParticipants, isBotConversation, productBotId } from "./conversation-ui";
+import {
+  activeConversationParticipants,
+  isBotConversation,
+  productBotId,
+  renderedBotId,
+} from "./conversation-ui";
 import type { Conversation } from "../../../src/conversation-contract";
 
 function conversation(): Conversation {
@@ -67,5 +72,79 @@ describe("conversation product routing", () => {
       "Member",
       "Scout",
     ]);
+  });
+});
+
+// The reported bug: the "Engineer" bot's roster row resolved a real,
+// verified canonical sessionId (via botCanonicalSessionId / botStageSession —
+// see bot-stage-session.test.ts), but the desktop stage column then
+// re-derived identity from that session's own `conversation` snapshot via
+// productBotId, which can disagree with the verified resolution — a rotated
+// / nested / child / same-name / already-open-regular session's runtime
+// attachment shows up in this exact session's `conversation` object, and
+// productBotId, seeing no confirmed active bot on it, falls back to the
+// harness's generic chrome even though the caller already knows this is the
+// bot's own column. renderedBotId is the fix: a trusted id from navigation
+// wins outright over whatever this session's own data would derive.
+describe("renderedBotId — trusted navigation identity vs. re-derived session data", () => {
+  test("undefined trustedBotId is unchanged: falls through to productBotId (regular sessions keep existing UI)", () => {
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, undefined)).toBe("scout");
+    expect(renderedBotId({ sessionId: "legacy", botId: "scout" }, undefined)).toBe("scout");
+    const regular = conversation();
+    regular.participants = regular.participants.filter((participant) => participant.kind === "human");
+    expect(renderedBotId({ sessionId: "primary", conversation: regular, botId: "stale" }, undefined)).toBeNull();
+  });
+
+  test("a trusted id overrides a WRONG botId productBotId would have derived from this session's own data", () => {
+    // productBotId on its own would resolve "scout" (the conversation's
+    // active bot) — the caller's verified resolution (a different bot
+    // entirely) must win instead of being second-guessed.
+    expect(productBotId({ sessionId: "primary", conversation: conversation() })).toBe("scout");
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, "engineer")).toBe("engineer");
+  });
+
+  test("a NESTED/CHILD session's runtime attachment does not decide the surface once trusted", () => {
+    // Simulates the unfinished-rotation shape: the resolved canonical session
+    // ("engineer-new") is not the one the conversation's runtimeSessions
+    // still calls "primary" (a stale/rotated-out id), and — unlike the
+    // single-bot conversation() fixture — this conversation has no active
+    // bot participant at all (the case productBotId cannot see past).
+    const nested: Conversation = {
+      id: "conv-engineer",
+      participants: [
+        { id: "human:member", kind: "human", role: "owner", display: { name: "Member", fallback: "Member" }, joinedAt: 1, historyAccess: "all" },
+      ],
+      runtimeSessions: [
+        { sessionId: "engineer-old", participantId: "bot:engineer", kind: "primary", attachedAt: 1 },
+        { sessionId: "engineer-child", participantId: "bot:engineer", kind: "execution", attachedAt: 2 },
+      ],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const session = { sessionId: "engineer-new", conversation: nested, botId: "engineer" };
+    // Without a trusted id, productBotId cannot confirm this exact session
+    // against the conversation snapshot and falls back to generic chrome.
+    expect(productBotId(session)).toBeNull();
+    // The bot-stage column already knows the answer from navigation.
+    expect(renderedBotId(session, "engineer")).toBe("engineer");
+  });
+
+  test("a SAME-NAME/already-open regular session's stale botId is not trusted just because it is undefined-passed", () => {
+    // A regular session that happens to carry a stale inherited botId (e.g.
+    // reused sessionId, or a bot that later left) must still show regular
+    // UI when nothing has resolved a trusted bot for this render.
+    const left = conversation();
+    left.participants = left.participants.map((participant) =>
+      participant.kind === "bot" ? { ...participant, leftAt: 5 } : participant,
+    );
+    const session = { sessionId: "primary", conversation: left, botId: "scout" };
+    expect(renderedBotId(session, undefined)).toBeNull();
+    // But once a caller resolves and trusts an id explicitly, that decision
+    // is authoritative even over a conversation that looks "regular".
+    expect(renderedBotId(session, "scout")).toBe("scout");
+  });
+
+  test("an explicit null trustedBotId forces regular chrome even when the session's own data would resolve a bot", () => {
+    expect(renderedBotId({ sessionId: "primary", conversation: conversation() }, null)).toBeNull();
   });
 });

--- a/web/src/lib/conversation-ui.test.ts
+++ b/web/src/lib/conversation-ui.test.ts
@@ -7,6 +7,7 @@ import {
   isOtherHumanMessageAuthor,
   productBotId,
   renderedBotId,
+  speakerRunEdges,
   unknownConversationParticipant,
 } from "./conversation-ui";
 import type { Conversation, MessageAuthorRef } from "../../../src/conversation-contract";
@@ -118,6 +119,36 @@ describe("own-vs-other-human message authorship (message-level avatar split)", (
     // the viewer's own turns would grow a redundant avatar.
     expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:member"), null)).toBe(false);
     expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:member"), undefined)).toBe(false);
+  });
+});
+
+describe("speakerRunEdges — first/last-of-run vs a single-message run", () => {
+  test("a single beat is both first and last", () => {
+    expect(speakerRunEdges(["user:angel"], 0)).toEqual({ firstOfRun: true, lastOfRun: true });
+  });
+
+  test("two consecutive beats from one person split name (first) and face (last)", () => {
+    const run = ["user:angel", "user:angel"];
+    expect(speakerRunEdges(run, 0)).toEqual({ firstOfRun: true, lastOfRun: false });
+    expect(speakerRunEdges(run, 1)).toEqual({ firstOfRun: false, lastOfRun: true });
+  });
+
+  test("a middle beat of a longer run hides both name and face", () => {
+    const run = ["user:angel", "user:angel", "user:angel"];
+    expect(speakerRunEdges(run, 1)).toEqual({ firstOfRun: false, lastOfRun: false });
+  });
+
+  test("a different speaker breaks the run so each side is last/first again", () => {
+    const speakers = ["user:angel", "user:angel", "assistant", "user:angel"];
+    expect(speakerRunEdges(speakers, 1)).toEqual({ firstOfRun: false, lastOfRun: true });
+    expect(speakerRunEdges(speakers, 2)).toEqual({ firstOfRun: true, lastOfRun: true });
+    expect(speakerRunEdges(speakers, 3)).toEqual({ firstOfRun: true, lastOfRun: true });
+  });
+
+  test("two different verified humans never share a run", () => {
+    const speakers = ["user:angel", "user:ben"];
+    expect(speakerRunEdges(speakers, 0)).toEqual({ firstOfRun: true, lastOfRun: true });
+    expect(speakerRunEdges(speakers, 1)).toEqual({ firstOfRun: true, lastOfRun: true });
   });
 });
 

--- a/web/src/lib/conversation-ui.test.ts
+++ b/web/src/lib/conversation-ui.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { activeConversationParticipants, isBotConversation, productBotId } from "./conversation-ui";
-import type { Conversation } from "../../../src/conversation-contract";
+import {
+  activeConversationParticipants,
+  conversationParticipantById,
+  conversationParticipantDisplayName,
+  isBotConversation,
+  isOtherHumanMessageAuthor,
+  productBotId,
+  unknownConversationParticipant,
+} from "./conversation-ui";
+import type { Conversation, MessageAuthorRef } from "../../../src/conversation-contract";
 
 function conversation(): Conversation {
   return {
@@ -67,5 +75,81 @@ describe("conversation product routing", () => {
       "Member",
       "Scout",
     ]);
+  });
+});
+
+const VERIFIED_HUMAN = (participantId: string): MessageAuthorRef => ({
+  kind: "human",
+  participantId,
+  verified: true,
+});
+const VERIFIED_BOT = (participantId: string): MessageAuthorRef => ({
+  kind: "bot",
+  participantId,
+  verified: true,
+});
+const LEGACY_UNKNOWN: MessageAuthorRef = { kind: "legacy", participantId: "legacy:unknown", verified: false };
+
+describe("own-vs-other-human message authorship (message-level avatar split)", () => {
+  test("a verified author that matches the viewer is the viewer's own turn", () => {
+    expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:member"), "human:member")).toBe(false);
+  });
+
+  test("a verified author that differs from the viewer is someone else's turn", () => {
+    expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:angel"), "human:member")).toBe(true);
+  });
+
+  test("a bot author is never the 'other human' case, even if ids happened to collide", () => {
+    expect(isOtherHumanMessageAuthor(VERIFIED_BOT("bot:scout"), "bot:scout")).toBe(false);
+  });
+
+  test("an unresolved historical turn is never treated as someone else's", () => {
+    // The pre-feature transcript and any turn the server could not verify —
+    // rendering it as "someone else" would draw an avatar the server never
+    // actually claimed, which is worse than the existing unattributed look.
+    expect(isOtherHumanMessageAuthor(LEGACY_UNKNOWN, "human:member")).toBe(false);
+    expect(isOtherHumanMessageAuthor(undefined, "human:member")).toBe(false);
+  });
+
+  test("an unknown viewer never turns every message into 'someone else's'", () => {
+    // If bootstrap could not resolve "who am I" (viewerParticipantId is
+    // null), the safe default is "unknown", not "everyone but me" — otherwise
+    // the viewer's own turns would grow a redundant avatar.
+    expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:member"), null)).toBe(false);
+    expect(isOtherHumanMessageAuthor(VERIFIED_HUMAN("human:member"), undefined)).toBe(false);
+  });
+});
+
+describe("resolving a message sender's display info", () => {
+  test("looks the author's participant id up in the conversation roster", () => {
+    const row = conversation();
+    const found = conversationParticipantById(row, "human:member");
+    expect(found?.display.fallback).toBe("Member");
+  });
+
+  test("a participant id absent from the roster (left, or never synced) resolves to nothing", () => {
+    expect(conversationParticipantById(conversation(), "human:ghost")).toBeUndefined();
+  });
+
+  test("no conversation object resolves to nothing rather than throwing", () => {
+    expect(conversationParticipantById(null, "human:member")).toBeUndefined();
+    expect(conversationParticipantById(undefined, "human:member")).toBeUndefined();
+  });
+
+  test("prefers the profile display name, falling back to the server's explicit fallback", () => {
+    const row = conversation();
+    expect(conversationParticipantDisplayName(row.participants[0])).toBe("Member");
+    row.participants[0].display.name = "  Angel  ";
+    expect(conversationParticipantDisplayName(row.participants[0])).toBe("Angel");
+    row.participants[0].display.name = "   ";
+    expect(conversationParticipantDisplayName(row.participants[0])).toBe("Member");
+  });
+
+  test("a deleted/unreachable profile gets an honest generic fallback, not a guessed name", () => {
+    const ghost = unknownConversationParticipant("human:ghost");
+    expect(ghost.id).toBe("human:ghost");
+    expect(ghost.kind).toBe("human");
+    expect(conversationParticipantDisplayName(ghost)).toBe("Member");
+    expect(ghost.display.avatar).toBeUndefined();
   });
 });

--- a/web/src/lib/conversation-ui.ts
+++ b/web/src/lib/conversation-ui.ts
@@ -42,3 +42,31 @@ export function productBotId(session: ConversationSessionIdentity): string | nul
 export function isBotConversation(session: ConversationSessionIdentity): boolean {
   return !!productBotId(session);
 }
+
+/**
+ * The botId a render should trust for bot chrome (header avatar/settings,
+ * composer, message-send endpoint) — the single place that decides between
+ * "trust the caller" and "derive it from this session's own data."
+ *
+ * `trustedBotId` is anything other than `undefined` (including explicit
+ * `null`) when the caller already resolved and verified which bot this
+ * render belongs to — the bot-stage column, reached via the canonical,
+ * botId-verified picker (botCanonicalSessionId / botStageSession in
+ * ../../../src/bots/session.ts and ./bot-session.ts). That resolution wins
+ * outright over re-deriving identity from this session's own conversation
+ * snapshot, which can lag behind rotation, or share a runtime attachment
+ * with a nested, child, same-name, or already-open regular session —
+ * exactly the cases `productBotId` cannot tell apart from this session's
+ * data alone, because it only has this session's data to look at.
+ *
+ * Every other caller (a grid card, the generic mobile session-detail sheet
+ * opened from the plain session list) never resolved a bot from navigation
+ * and passes `undefined`, so it keeps deriving from `productBotId` exactly
+ * as before — a regular session's chrome does not change.
+ */
+export function renderedBotId(
+  session: ConversationSessionIdentity,
+  trustedBotId: string | null | undefined,
+): string | null {
+  return trustedBotId !== undefined ? trustedBotId : productBotId(session);
+}

--- a/web/src/lib/conversation-ui.ts
+++ b/web/src/lib/conversation-ui.ts
@@ -98,6 +98,22 @@ export function isOtherHumanMessageAuthor(
 }
 
 /**
+ * First/last row of a same-speaker run. Other-human name chrome uses the
+ * first; the face uses the last. A one-row run is both. Speakers must already
+ * be resolved (see chatRenderItemSpeaker) — this never guesses identity.
+ */
+export function speakerRunEdges(
+  speakers: readonly string[],
+  index: number,
+): { firstOfRun: boolean; lastOfRun: boolean } {
+  const speaker = speakers[index];
+  return {
+    firstOfRun: index === 0 || speakers[index - 1] !== speaker,
+    lastOfRun: index === speakers.length - 1 || speakers[index + 1] !== speaker,
+  };
+}
+
+/**
  * The botId a render should trust for bot chrome (header avatar/settings,
  * composer, message-send endpoint) — the single place that decides between
  * "trust the caller" and "derive it from this session's own data."

--- a/web/src/lib/conversation-ui.ts
+++ b/web/src/lib/conversation-ui.ts
@@ -1,4 +1,8 @@
-import type { Conversation, ConversationParticipant } from "../../../src/conversation-contract";
+import type {
+  Conversation,
+  ConversationParticipant,
+  MessageAuthorRef,
+} from "../../../src/conversation-contract";
 
 export type ConversationSessionIdentity = {
   sessionId?: string | null;
@@ -41,4 +45,54 @@ export function productBotId(session: ConversationSessionIdentity): string | nul
 
 export function isBotConversation(session: ConversationSessionIdentity): boolean {
   return !!productBotId(session);
+}
+
+/** Look up a message's sender by the participant id MessageAuthorRef carries. */
+export function conversationParticipantById(
+  conversation: Conversation | null | undefined,
+  participantId: string | null | undefined,
+): ConversationParticipant | undefined {
+  if (!conversation || !participantId) return undefined;
+  return conversation.participants.find((participant) => participant.id === participantId);
+}
+
+/** The name to show for a participant, honoring the server's explicit fallback. */
+export function conversationParticipantDisplayName(participant: ConversationParticipant): string {
+  return participant.display.name?.trim() || participant.display.fallback || "Member";
+}
+
+/**
+ * A stand-in for a verified author whose participant record is gone —
+ * removed from the roster, or from a Computer this browser can no longer
+ * enumerate. The id is real (it came from the server-verified MessageAuthorRef,
+ * not a guess), but there is nothing to show for it beyond "somebody else": an
+ * honest fallback, not an invented name or a dropped avatar.
+ */
+export function unknownConversationParticipant(participantId: string): ConversationParticipant {
+  return {
+    id: participantId,
+    kind: "human",
+    role: "member",
+    display: { fallback: "Member" },
+    joinedAt: 0,
+    historyAccess: "all",
+  };
+}
+
+/**
+ * Whether a verified human message author is someone OTHER than the current
+ * viewer — the signal that decides "draw their avatar beside this bubble" in
+ * a shared bot conversation.
+ *
+ * Both ids must be known. A null viewerParticipantId ("who am I" could not be
+ * resolved — see BootstrapPayload["viewer"]) must not make every message read
+ * as someone else's; it degrades to "unknown", same as an unverified author.
+ */
+export function isOtherHumanMessageAuthor(
+  author: MessageAuthorRef | null | undefined,
+  viewerParticipantId: string | null | undefined,
+): boolean {
+  if (!author || author.kind !== "human" || !author.verified) return false;
+  if (!viewerParticipantId) return false;
+  return author.participantId !== viewerParticipantId;
 }

--- a/web/src/other-human-message-avatar.test.ts
+++ b/web/src/other-human-message-avatar.test.ts
@@ -129,8 +129,10 @@ describe("OtherHumanMessageBubble: avatar, accessible name, and bot-reply separa
     expect(component).not.toContain("rounded-[18px] border border-border bg-card");
   });
 
-  test("carries an accessible sender name, both as an aria-label and as visible text", () => {
+  test("carries an accessible sender name on every bubble, even when the visible caption is hidden", () => {
     expect(component).toContain("aria-label={`Message from ${name}`}");
+    // Visible name is first-of-run only; the aria-label is unconditional.
+    expect(component).toContain("firstOfRun ? (");
     expect(component).toContain("{name}");
   });
 
@@ -162,6 +164,55 @@ describe("grouping: consecutive turns from different humans still get the speake
 
   test("every non-user-authored row still collapses to one 'assistant' bucket", () => {
     expect(fn).toContain('if (item.type !== "msg" || item.message.role !== "user") return "assistant";');
+  });
+});
+
+describe("grouping: consecutive other-human beats hide repeated name+face", () => {
+  const loop = APP.slice(APP.indexOf("{items.map((item, index) =>"), APP.indexOf("<TypingIndicator"));
+  const bubble = APP.slice(APP.indexOf("function MessageBubble("), APP.indexOf("function botVisibleUserText("));
+  const component = APP.slice(APP.indexOf("function OtherHumanMessageBubble("), APP.indexOf("function botVisibleUserText("));
+
+  test("ChatStream derives run edges from chatRenderItemSpeaker, then speakerRunEdges", () => {
+    expect(APP).toContain("const speakers = useMemo(() => items.map(chatRenderItemSpeaker), [items]);");
+    expect(loop).toContain("const { firstOfRun, lastOfRun } = speakerRunEdges(speakers, index);");
+    expect(loop).toContain("const speakerChanged = index > 0 && firstOfRun;");
+    expect(loop).toContain('speakerChanged ? "pt-2.5" : undefined');
+    expect(loop).toContain("firstOfRun={firstOfRun}");
+    expect(loop).toContain("lastOfRun={lastOfRun}");
+    expect(loop).not.toMatch(/bot\.owner|currentBot|displayName/);
+  });
+
+  test("MessageBubble forwards the edges only to OtherHumanMessageBubble", () => {
+    const otherBranch = bubble.slice(
+      bubble.indexOf("if (otherHumanSender)"),
+      bubble.indexOf('const isUser = message.role === "user";'),
+    );
+    expect(otherBranch).toContain("firstOfRun={firstOfRun}");
+    expect(otherBranch).toContain("lastOfRun={lastOfRun}");
+    const ownBranch = bubble.slice(
+      bubble.indexOf('const isUser = message.role === "user";'),
+      bubble.indexOf("// A bot's turn reads as somebody talking"),
+    );
+    expect(ownBranch).not.toContain("firstOfRun");
+    expect(ownBranch).not.toContain("lastOfRun");
+    expect(ownBranch).not.toContain("HumanParticipantAvatar");
+  });
+
+  test("name is first-of-run only; avatar is last-of-run only; a spacer keeps the column", () => {
+    expect(component).toContain("firstOfRun = true");
+    expect(component).toContain("lastOfRun = true");
+    expect(component).toContain("firstOfRun ? (");
+    expect(component).toContain("lastOfRun ? (");
+    expect(component).toContain("<HumanParticipantAvatar");
+    expect(component).toContain('className="mb-0.5 size-[22px] shrink-0"');
+    expect(component).toContain("items-end");
+  });
+
+  test("queued rows omit the edges so the defaults still show both name and face", () => {
+    const queued = APP.slice(APP.indexOf("{queuedItems.map"), APP.indexOf("</ConversationContent>"));
+    expect(queued).toContain("<MessageBubble");
+    expect(queued).not.toContain("firstOfRun");
+    expect(queued).not.toContain("lastOfRun");
   });
 });
 

--- a/web/src/other-human-message-avatar.test.ts
+++ b/web/src/other-human-message-avatar.test.ts
@@ -1,0 +1,191 @@
+// Message-level sender avatars for a shared persistent-bot conversation, and
+// the header fix that goes with them.
+//
+// The feature: in a bot conversation shared by more than one human, another
+// person's turn shows their avatar + name beside the bubble (a group chat
+// inside a bot conversation). The viewer's own turns stay exactly as they
+// were. The bot's own reply keeps its existing treatment. And — the bug this
+// was actually filed to fix — the conversation HEADER never shows a human
+// chip at all: it is the bot's identity and settings, full stop.
+//
+// App.tsx mounts the app on import in a browser context (see the note in
+// message-copy-button-layout.test.ts), so — following that file's and
+// mobile-copy-button.test.ts's precedent — this asserts against source text
+// for the JSX wiring. Pure logic (own-vs-other resolution, participant
+// lookup) has real behavioral coverage in lib/conversation-ui.test.ts.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WEB = join(import.meta.dir, "..");
+const APP = readFileSync(join(WEB, "src/App.tsx"), "utf8");
+const CSS = readFileSync(join(WEB, "src/index.css"), "utf8");
+
+function slice(start: string, end: string, from = 0): string {
+  const s = APP.indexOf(start, from);
+  expect(s, `could not find "${start}"`).toBeGreaterThanOrEqual(0);
+  const e = APP.indexOf(end, s + start.length);
+  expect(e, `could not find "${end}" after "${start}"`).toBeGreaterThan(s);
+  return APP.slice(s, e);
+}
+
+describe("no human creator/owner chip in a persistent-bot conversation header", () => {
+  test("the mobile full-screen bot chat header has no ConversationParticipantRow", () => {
+    const header = slice(
+      'aria-label="Back to bots"',
+      "<BotConversationMenu",
+      APP.indexOf("This chat is a full-screen portal above the app shell"),
+    );
+    expect(header).not.toContain("ConversationParticipantRow");
+    expect(header).toContain("<BotAvatar");
+  });
+
+  test("the desktop/tablet bot chat header has no ConversationParticipantRow", () => {
+    const header = slice(
+      'aria-label="Back to bots"',
+      "<BotConversationMenu",
+      APP.indexOf("mx-auto flex h-[calc(100dvh-6rem)]"),
+    );
+    expect(header).not.toContain("ConversationParticipantRow");
+    expect(header).toContain("<BotAvatar");
+  });
+
+  test("a bot-backed session card's header drops the participant row entirely", () => {
+    // Every OTHER (non-bot) session card keeps ConversationParticipantRow —
+    // this only gates it off specifically when the card is the authoritative
+    // bot conversation surface (headerBot truthy), which is the exact case
+    // the screenshot bug was filed against.
+    expect(APP).toContain("{headerBot ? null : <ConversationParticipantRow session={session} compact={isMobile} />}");
+  });
+
+  test("the bot chat header keeps its identity + settings — an avatar and a menu, nothing human", () => {
+    const mobileHeader = slice(
+      'aria-label="Back to bots"',
+      "</header>",
+      APP.indexOf("This chat is a full-screen portal above the app shell"),
+    );
+    expect(mobileHeader).toContain("<BotAvatar");
+    expect(mobileHeader).toContain("<BotConversationMenu");
+  });
+});
+
+describe("MessageBubble routes a verified other-human author to its own component", () => {
+  const bubble = APP.slice(APP.indexOf("function MessageBubble("), APP.indexOf("function botVisibleUserText("));
+
+  test("computes otherHumanSender from the server-verified author, never from bot/creator/display data", () => {
+    expect(bubble).toContain("isOtherHumanMessageAuthor(message.author, viewerParticipantId)");
+    // Negative check: the branch must not reach for anything that names the
+    // bot, its owner, or a client-suppliable display field as an identity
+    // source — the spec's explicit "never infer" list.
+    const otherHumanConst = bubble.slice(
+      bubble.indexOf("const otherHumanSender ="),
+      bubble.indexOf(": null;") + ": null;".length,
+    );
+    expect(otherHumanConst).not.toMatch(/bot\.owner|bot\.name|currentBot|displayName/);
+  });
+
+  test("renders OtherHumanMessageBubble before the viewer's own-turn branch, so it can't fall through", () => {
+    const otherBranch = bubble.indexOf("if (otherHumanSender)");
+    const ownBranch = bubble.indexOf('const isUser = message.role === "user";');
+    expect(otherBranch).toBeGreaterThan(-1);
+    expect(ownBranch).toBeGreaterThan(-1);
+    expect(otherBranch).toBeLessThan(ownBranch);
+  });
+
+  test("an unresolved/legacy author falls through unchanged instead of guessing", () => {
+    const comment = bubble.slice(bubble.indexOf("// A group-chat-style human turn"), bubble.indexOf("const otherHumanSender ="));
+    expect(comment).toMatch(/falls through to the unchanged "own" rendering/);
+  });
+});
+
+describe("the viewer's own messages stay visually unchanged", () => {
+  const bubble = APP.slice(APP.indexOf("function MessageBubble("), APP.indexOf("function botVisibleUserText("));
+  // Everything from the existing `isUser` branch onward, unmodified by this
+  // feature: no avatar, no name label, no new wrapper around the own-turn
+  // AiMessage.
+  const ownBranch = bubble.slice(
+    bubble.indexOf('const isUser = message.role === "user";'),
+    bubble.indexOf("// A bot's turn reads as somebody talking"),
+  );
+
+  test("draws no avatar and no sender name on the viewer's own turn", () => {
+    expect(ownBranch).not.toContain("HumanParticipantAvatar");
+    expect(ownBranch).not.toContain("conversationParticipantDisplayName");
+  });
+
+  test("still renders from=\"user\" (right-aligned), same as before the feature", () => {
+    expect(ownBranch).toContain('from="user"');
+  });
+});
+
+describe("OtherHumanMessageBubble: avatar, accessible name, and bot-reply separation", () => {
+  const component = APP.slice(APP.indexOf("function OtherHumanMessageBubble("), APP.indexOf("function botVisibleUserText("));
+
+  test("is left-aligned like an assistant turn, never the bot's own bubble style", () => {
+    expect(component).toContain('from="assistant"');
+    // Must not reuse the bot bubble's card/border treatment — that stays the
+    // bot's alone (spec: "Bot replies retain clear bot identity and existing
+    // treatment").
+    expect(component).not.toContain("rounded-[18px] border border-border bg-card");
+  });
+
+  test("carries an accessible sender name, both as an aria-label and as visible text", () => {
+    expect(component).toContain("aria-label={`Message from ${name}`}");
+    expect(component).toContain("{name}");
+  });
+
+  test("draws the sender's avatar with an honest image-failure fallback", () => {
+    expect(component).toContain("<HumanParticipantAvatar");
+    const avatar = APP.slice(APP.indexOf("function HumanParticipantAvatar("), APP.indexOf("function OtherHumanMessageBubble("));
+    // The initial-letter fallback renders underneath the <img>, and a failed
+    // load removes the <img> rather than leaving a broken-image icon or a
+    // blank circle.
+    expect(avatar).toContain("onError={(event) => event.currentTarget.remove()}");
+    expect(avatar).toMatch(/initial/);
+  });
+
+  test("reuses UserBubble (same copy/long-press/clamp affordances) with a distinguishing tint, not the viewer's own tint", () => {
+    expect(component).toContain("<UserBubble html={html} otherAuthor />");
+  });
+
+  test("passes isUser={false} to MessageActions so copy/long-press position on the correct side", () => {
+    expect(component).toContain('<MessageActions text={message.text || ""} isUser={false}>');
+  });
+});
+
+describe("grouping: consecutive turns from different humans still get the speaker-changed gap", () => {
+  const fn = APP.slice(APP.indexOf("function chatRenderItemSpeaker("), APP.indexOf("function chatRenderItemSpeaker(") + 900);
+
+  test("splits the 'user' bucket by verified participant id", () => {
+    expect(fn).toContain('author?.kind === "human" && author.verified ? `user:${author.participantId}` : "user"');
+  });
+
+  test("every non-user-authored row still collapses to one 'assistant' bucket", () => {
+    expect(fn).toContain('if (item.type !== "msg" || item.message.role !== "user") return "assistant";');
+  });
+});
+
+describe("no horizontal overflow at 390px: the other-human bubble reuses the existing width caps", () => {
+  test("MessageActions already caps non-user content at 92%-of-row minus the copy-button gutter — reused as-is", () => {
+    const actions = slice("function MessageActions(", "onPointerDown={onPointerDown}");
+    expect(actions).toContain("max-w-[min(92%,calc(100%-2.25rem))]");
+  });
+
+  test("the avatar + name column subtracts its own width before handing off to MessageActions' cap", () => {
+    const component = APP.slice(APP.indexOf("function OtherHumanMessageBubble("), APP.indexOf("function botVisibleUserText("));
+    expect(component).toContain("max-w-[calc(100%-1.75rem)]");
+    expect(component).toContain("min-w-0");
+  });
+});
+
+describe("CSS: the other-human bubble is visually distinct from the viewer's own bubble", () => {
+  test("is-other overrides the fill in both light and dark mode", () => {
+    expect(CSS).toContain(".user-bubble.markdown.is-other {");
+    expect(CSS).toContain(".dark .user-bubble.markdown.is-other {");
+  });
+
+  test("does not touch the base .user-bubble rule the viewer's own turns still use", () => {
+    const base = CSS.slice(CSS.indexOf(".user-bubble.markdown {"), CSS.indexOf(".dark .user-bubble.markdown {"));
+    expect(base).not.toContain("is-other");
+  });
+});


### PR DESCRIPTION
## Summary
- The persistent-bot conversation header was showing a human avatar/name chip (creator/owner) next to the bot's own identity. Removed it from both bot chat headers (mobile + desktop) and from a bot-backed session card's header — the header now shows only the bot's identity and settings.
- Added message-level sender avatars: in a shared bot conversation, a verified human author other than the current viewer now renders left-aligned with their avatar and an accessible name (`OtherHumanMessageBubble`), like a group chat inside the bot conversation. The viewer's own turns and the bot's replies are unchanged. Unresolved/legacy/historical authorship falls through to the existing rendering rather than guessing.
- `GET /api/bootstrap` now returns `viewer.participantId` — the trusted-header identity on a managed Computer, or the client's already-selected local roster profile on an unmanaged box — via new `viewerConversationParticipantId`, so the client can tell "my turn" from "someone else's turn" without ever inferring identity from the bot's creator/owner/current-bot/display data.
- Includes #199 (merged in): botId-driven header/renderer trust fix + back-button simplification, coordinated with that session to avoid overlapping header edits.

## Test plan
- [x] `bun run typecheck` (root) — clean
- [x] `cd web && bun run typecheck` — clean
- [x] `bun run test` — 2164 pass, 0 fail, 1 skip (pre-existing)
- [x] `cd web && bun run build` — clean production build
- [x] `bun run chat:smoke` — green
- [x] New/updated tests: `src/conversations.test.ts` (viewer participant id resolution), `web/src/lib/conversation-ui.test.ts` (own-vs-other authorship, participant lookup/fallback), `web/src/other-human-message-avatar.test.ts` (header no-chip, MessageBubble routing, accessibility, grouping, 390px width caps, CSS distinctness), `test/bootstrap-payload.test.ts` (viewer field wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)