### PR TITLE
Polish Bots roster: less copy, larger rows

### DIFF
--- a/src/bots/transcript.ts
+++ b/src/bots/transcript.ts
@@ -97,6 +97,35 @@ export function isSubagentUpdateText(text: string): boolean {
   return BACKGROUND_ATTRIBUTION.test(text) || SUBAGENT_UPDATE.test(text);
 }
 
+/** Last-line prefixes the coding agent writes when it dies mid-session. */
+const CODING_AGENT_STOPPED_UNEXPECTEDLY = "The coding agent stopped unexpectedly";
+const CODING_AGENT_STOPPED_BEFORE_START = "The coding agent stopped before it could start";
+
+export function isCodingAgentStoppedText(text: string): boolean {
+  const trimmed = text.trim();
+  return (
+    trimmed.startsWith(CODING_AGENT_STOPPED_UNEXPECTEDLY) ||
+    trimmed.startsWith(CODING_AGENT_STOPPED_BEFORE_START)
+  );
+}
+
+/**
+ * One-line preview for a bot roster or rail row.
+ *
+ * Empty means the row shows the name only. Crash text collapses to
+ * "Stopped" instead of the raw exception. A background-task report stays
+ * the existing "Background task reported in" line. Busy wins over the
+ * last-message text and is always "Working".
+ */
+export function botRosterPreview(rawPreview: string | undefined, busy = false): string {
+  if (busy) return "Working";
+  const raw = (rawPreview ?? "").trim();
+  if (!raw) return "";
+  if (isCodingAgentStoppedText(raw)) return "Stopped";
+  if (isSubagentUpdateText(raw)) return "Background task reported in";
+  return botVisibleUserText(raw);
+}
+
 /**
  * Transcript kinds a bot chat does not show.
  *

--- a/src/bots/transcript.ts
+++ b/src/bots/transcript.ts
@@ -112,15 +112,15 @@ export function isCodingAgentStoppedText(text: string): boolean {
 /**
  * One-line preview for a bot roster or rail row.
  *
- * Empty means the row shows the name only. Crash text collapses to
- * "Stopped" instead of the raw exception. A background-task report stays
- * the existing "Background task reported in" line. Busy wins over the
+ * An empty last-message is "Say hi". Crash text collapses to "Stopped"
+ * instead of the raw exception. A background-task report stays the
+ * existing "Background task reported in" line. Busy wins over the
  * last-message text and is always "Working".
  */
 export function botRosterPreview(rawPreview: string | undefined, busy = false): string {
   if (busy) return "Working";
   const raw = (rawPreview ?? "").trim();
-  if (!raw) return "";
+  if (!raw) return "Say hi";
   if (isCodingAgentStoppedText(raw)) return "Stopped";
   if (isSubagentUpdateText(raw)) return "Background task reported in";
   return botVisibleUserText(raw);

--- a/test/bot-conversation-surface-toggle.test.ts
+++ b/test/bot-conversation-surface-toggle.test.ts
@@ -29,7 +29,7 @@ function openBotConversationBranch(): string {
   const start = APP.indexOf("\n  if (bot) {", view);
   expect(start).toBeGreaterThan(-1);
   // The branch ends where the roster (non-selected) render begins.
-  const end = APP.indexOf('\n    <div className="mx-auto flex max-w-3xl flex-col gap-2" data-lfg-page-column>', start);
+  const end = APP.indexOf('\n    <div className="mx-auto flex max-w-3xl flex-col gap-3" data-lfg-page-column>', start);
   expect(end).toBeGreaterThan(start);
   return APP.slice(start, end);
 }

--- a/test/bot-transcript.test.ts
+++ b/test/bot-transcript.test.ts
@@ -98,10 +98,10 @@ describe("bot roster preview line", () => {
     expect(isCodingAgentStoppedText("The coding agent stopped unexpectedly: timeout")).toBe(true);
   });
 
-  test("an empty last-message has no second line", () => {
-    expect(botRosterPreview("")).toBe("");
-    expect(botRosterPreview(undefined)).toBe("");
-    expect(botRosterPreview("   ")).toBe("");
+  test("an empty last-message is Say hi", () => {
+    expect(botRosterPreview("")).toBe("Say hi");
+    expect(botRosterPreview(undefined)).toBe("Say hi");
+    expect(botRosterPreview("   ")).toBe("Say hi");
   });
 
   test("a background-task report keeps the existing roster line", () => {

--- a/test/bot-transcript.test.ts
+++ b/test/bot-transcript.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  botRosterPreview,
   botVisibleUserText,
   isBotHiddenLogKind,
   isBotLaunchOnlyText,
+  isCodingAgentStoppedText,
   isSubagentUpdateText,
   stripBotLaunchEnvelope,
 } from "../web/src/lib/bot-transcript";
@@ -84,6 +86,42 @@ describe("background task updates in a bot chat", () => {
 // A bot chat is a conversation, not a log. The full log still exists — the
 // bot's session opens as an ordinary session — but the chat view does not
 // narrate the mechanics of being answered.
+describe("bot roster preview line", () => {
+  test("a crash last-message collapses to Stopped", () => {
+    expect(
+      botRosterPreview("The coding agent stopped unexpectedly: datab…"),
+    ).toBe("Stopped");
+    expect(
+      botRosterPreview("The coding agent stopped unexpectedly after the session had started."),
+    ).toBe("Stopped");
+    expect(botRosterPreview("The coding agent stopped before it could start.")).toBe("Stopped");
+    expect(isCodingAgentStoppedText("The coding agent stopped unexpectedly: timeout")).toBe(true);
+  });
+
+  test("an empty last-message has no second line", () => {
+    expect(botRosterPreview("")).toBe("");
+    expect(botRosterPreview(undefined)).toBe("");
+    expect(botRosterPreview("   ")).toBe("");
+  });
+
+  test("a background-task report keeps the existing roster line", () => {
+    expect(botRosterPreview("[subagent complete] rebased onto main")).toBe(
+      "Background task reported in",
+    );
+  });
+
+  test("ordinary last-message text stays readable", () => {
+    expect(botRosterPreview("[Message from benny@example.com to bot Scout]\n\nping")).toBe("ping");
+    expect(botRosterPreview("still there?")).toBe("still there?");
+  });
+
+  test("busy wins and is always Working", () => {
+    expect(botRosterPreview("still there?", true)).toBe("Working");
+    expect(botRosterPreview("", true)).toBe("Working");
+    expect(botRosterPreview("The coding agent stopped unexpectedly: datab…", true)).toBe("Working");
+  });
+});
+
 describe("what a bot chat hides", () => {
   test("tool calls, their results, and reasoning are machinery", () => {
     expect(isBotHiddenLogKind("tool_use")).toBe(true);

--- a/test/bots-roster-ux.test.ts
+++ b/test/bots-roster-ux.test.ts
@@ -7,10 +7,9 @@ const BOTS_VIEW = APP.slice(
   APP.indexOf("function BotsView("),
   APP.indexOf("function BotEditorPage("),
 );
-const BOT_RAIL = APP.slice(
-  APP.indexOf("const botRailList = ("),
-  APP.indexOf("return (", APP.indexOf("const botRailList = (")),
-);
+const railStart = APP.indexOf("const botRailList = (");
+const railEnd = APP.indexOf("    </div>\n  );\n\n  return (\n    <div ref={workspaceRef}", railStart);
+const BOT_RAIL = APP.slice(railStart, railEnd);
 const PLACEHOLDER = APP.slice(
   APP.indexOf("function BotStagePlaceholder("),
   APP.indexOf("function BotsView("),
@@ -63,7 +62,7 @@ describe("bots page roster chrome", () => {
     expect(ROSTER).toContain("text-sm text-muted-foreground");
     expect(ROSTER).toContain("size-9");
     expect(ROSTER).toContain("text-[15px]");
-    expect(BOT_RAIL).toContain("size={28}");
+    expect(BOT_RAIL).toContain("size={railCollapsed ? 24 : 28}");
     expect(BOT_RAIL).not.toContain("size={56}");
     expect(BOT_RAIL).not.toContain("text-3xl");
   });

--- a/test/bots-roster-ux.test.ts
+++ b/test/bots-roster-ux.test.ts
@@ -56,15 +56,17 @@ describe("bots page roster chrome", () => {
   });
 
   test("the page roster is larger than the compact rail", () => {
-    expect(ROSTER).toContain("text-3xl font-semibold");
+    expect(ROSTER).toContain("text-[32px] font-bold");
     expect(ROSTER).toContain("size={56}");
     expect(ROSTER).toContain("text-base font-semibold");
-    expect(ROSTER).toContain("text-sm text-muted-foreground");
+    expect(ROSTER).toContain("text-sm");
     expect(ROSTER).toContain("size-9");
     expect(ROSTER).toContain("text-[15px]");
+    expect(ROSTER).toContain("isCodingAgentStoppedText(rawPreview)");
+    expect(ROSTER).toContain("text-destructive");
     expect(BOT_RAIL).toContain("size={railCollapsed ? 24 : 28}");
     expect(BOT_RAIL).not.toContain("size={56}");
-    expect(BOT_RAIL).not.toContain("text-3xl");
+    expect(BOT_RAIL).not.toContain("text-[32px]");
   });
 
   test("New bot stays a quiet dashed row", () => {

--- a/test/bots-roster-ux.test.ts
+++ b/test/bots-roster-ux.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+
+const BOTS_VIEW = APP.slice(
+  APP.indexOf("function BotsView("),
+  APP.indexOf("function BotEditorPage("),
+);
+const BOT_RAIL = APP.slice(
+  APP.indexOf("const botRailList = ("),
+  APP.indexOf("return (", APP.indexOf("const botRailList = (")),
+);
+const PLACEHOLDER = APP.slice(
+  APP.indexOf("function BotStagePlaceholder("),
+  APP.indexOf("function BotsView("),
+);
+const ROSTER = BOTS_VIEW.slice(BOTS_VIEW.indexOf("return (\n    <div className=\"mx-auto"));
+
+describe("bots roster copy", () => {
+  test("drops the manifesto everywhere on the Bots surfaces", () => {
+    expect(APP).not.toContain("persistent agent you talk to");
+    expect(APP).not.toContain("Persistent agents you talk to");
+    expect(APP).not.toContain("Give a persona a name");
+    expect(APP).not.toContain("Say hi to get started.");
+  });
+
+  test("keeps one short empty-state line on each surface", () => {
+    expect(ROSTER).toContain("No bots yet.");
+    expect(ROSTER).not.toContain("Give a persona");
+    expect(BOT_RAIL).toContain("No bots yet.");
+    expect(BOT_RAIL).not.toContain("A bot is a persistent");
+    expect(PLACEHOLDER).toContain("Pick one from the rail.");
+    expect(PLACEHOLDER).not.toContain("A bot is a persistent");
+  });
+
+  test("the page header is the word Bots only", () => {
+    expect(ROSTER).toContain(">Bots</h1>");
+    expect(ROSTER).not.toContain("<p className=\"text-sm text-muted-foreground\">");
+  });
+});
+
+describe("bots roster preview wiring", () => {
+  test("rail and page roster share the preview helper", () => {
+    expect(BOT_RAIL).toContain("botRosterPreview(rawPreview, busy)");
+    expect(ROSTER).toContain("botRosterPreview(rawPreview, working)");
+    expect(BOT_RAIL).not.toContain("Say hi to get started.");
+    expect(ROSTER).not.toContain("Say hi to get started.");
+    expect(BOT_RAIL).not.toContain("Working…");
+    expect(ROSTER).not.toContain("Working — ");
+  });
+});
+
+describe("bots page roster chrome", () => {
+  test("the mobile roster row has no trailing chevron", () => {
+    expect(ROSTER).not.toContain("<ChevronRight");
+  });
+
+  test("the page roster is larger than the compact rail", () => {
+    expect(ROSTER).toContain("text-3xl font-semibold");
+    expect(ROSTER).toContain("size={56}");
+    expect(ROSTER).toContain("text-base font-semibold");
+    expect(ROSTER).toContain("text-sm text-muted-foreground");
+    expect(ROSTER).toContain("size-9");
+    expect(ROSTER).toContain("text-[15px]");
+    expect(BOT_RAIL).toContain("size={28}");
+    expect(BOT_RAIL).not.toContain("size={56}");
+    expect(BOT_RAIL).not.toContain("text-3xl");
+  });
+
+  test("New bot stays a quiet dashed row", () => {
+    expect(ROSTER).toContain("border-dashed");
+    expect(ROSTER).toContain("New bot");
+    expect(ROSTER).not.toContain("lfg-gborder--brand");
+  });
+});

--- a/test/bots-roster-ux.test.ts
+++ b/test/bots-roster-ux.test.ts
@@ -33,8 +33,10 @@ describe("bots roster copy", () => {
     expect(PLACEHOLDER).not.toContain("A bot is a persistent");
   });
 
-  test("the page header is the word Bots only", () => {
+  test("the page header is Bots plus a New control", () => {
     expect(ROSTER).toContain(">Bots</h1>");
+    expect(ROSTER).toContain('aria-label="New bot"');
+    expect(ROSTER).toContain("\n          New\n");
     expect(ROSTER).not.toContain("<p className=\"text-sm text-muted-foreground\">");
   });
 });
@@ -60,18 +62,20 @@ describe("bots page roster chrome", () => {
     expect(ROSTER).toContain("size={56}");
     expect(ROSTER).toContain("text-base font-semibold");
     expect(ROSTER).toContain("text-sm");
-    expect(ROSTER).toContain("size-9");
-    expect(ROSTER).toContain("text-[15px]");
+    expect(ROSTER).toContain("text-xs tabular-nums");
     expect(ROSTER).toContain("isCodingAgentStoppedText(rawPreview)");
     expect(ROSTER).toContain("text-destructive");
+    expect(ROSTER).not.toContain("size={44}");
+    expect(ROSTER).not.toContain("text-[13px]");
     expect(BOT_RAIL).toContain("size={railCollapsed ? 24 : 28}");
     expect(BOT_RAIL).not.toContain("size={56}");
     expect(BOT_RAIL).not.toContain("text-[32px]");
   });
 
-  test("New bot stays a quiet dashed row", () => {
-    expect(ROSTER).toContain("border-dashed");
-    expect(ROSTER).toContain("New bot");
+  test("create is a header New control, not a dashed row", () => {
+    expect(ROSTER).toContain('aria-label="New bot"');
+    expect(ROSTER).not.toContain("border-dashed");
+    expect(ROSTER).not.toContain(">New bot<");
     expect(ROSTER).not.toContain("lfg-gborder--brand");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,6 +94,7 @@ import {
   type PersistentBotQuota,
 } from "./lib/bot-quota";
 import {
+  botRosterPreview,
   botVisibleUserText as botVisibleUserTextFor,
   isBotHiddenLogKind,
   isBotLaunchOnlyText,
@@ -12533,11 +12534,7 @@ function RailStage({
         // A background task's report is machinery, not conversation: it is
         // hidden inside the chat, so it must not surface as the roster preview
         // either — the row would read `[subagent complete] …`.
-        const line = !rawPreview
-          ? "Say hi to get started."
-          : isSubagentUpdateText(rawPreview)
-            ? "Background task reported in"
-            : plainPreviewText(botVisibleUserText(rawPreview, bot));
+        const preview = plainPreviewText(botRosterPreview(rawPreview, busy));
         return (
           <button
             key={row.key}
@@ -12564,9 +12561,11 @@ function RailStage({
                 >
                   {bot.name}
                 </span>
-                <span className="truncate text-[11px] leading-tight text-muted-foreground">
-                  {busy ? "Working…" : line}
-                </span>
+                {preview ? (
+                  <span className="truncate text-[11px] leading-tight text-muted-foreground">
+                    {preview}
+                  </span>
+                ) : null}
               </span>
             ) : null}
             {row.unread ? (
@@ -12584,7 +12583,7 @@ function RailStage({
       })}
       {!bots.length && !railCollapsed ? (
         <div className="px-2 py-6 text-center text-xs text-muted-foreground">
-          No bots yet. A bot is a persistent agent you talk to, not a task you launch.
+          No bots yet.
         </div>
       ) : null}
     </div>
@@ -25040,7 +25039,7 @@ function BotStagePlaceholder({
           <div className="mt-1 text-sm text-muted-foreground">
             {bot
               ? "Re-enable it in its settings to keep talking to it."
-              : "Pick one from the rail. A bot is a persistent agent you talk to, not a task you launch."}
+              : "Pick one from the rail."}
           </div>
         </div>
         {!bot && onNewBot ? (
@@ -25736,29 +25735,27 @@ function BotsView({
   }
 
   return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-2" data-lfg-page-column>
+    <div className="mx-auto flex max-w-3xl flex-col gap-3" data-lfg-page-column>
       {/* Tablet band only (no persistent header toggle there yet) — real
           mobile gets the pinned Chat/Bot toggle in the app shell's mobile
           chrome instead, so it isn't doubled here. */}
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
         <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
       ) : null}
-      <div className="flex items-start gap-3 px-1 pb-1 pt-2">
+      <div className="flex items-start gap-3 px-2 pb-2 pt-4">
         <div className="min-w-0 flex-1">
-          <h1 className="text-lg font-semibold leading-tight">Bots</h1>
-          <p className="text-sm text-muted-foreground">Persistent agents you talk to, not tasks you launch.</p>
+          <h1 className="text-3xl font-semibold leading-tight tracking-tight">Bots</h1>
         </div>
       </div>
-      {/* Flat "New bot" item, same shell as the desktop rail's botRailList —
-          the page's information hierarchy matches the rail: a flat New bot
-          row above a flat list of bots, no card-grid CTA. */}
+      {/* Quiet dashed "New bot" row — same control as the rail, sized for
+          this page roster rather than the compact sidebar. */}
       <button
         type="button"
         onClick={onNew}
-        className="mb-1 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[13px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        className="mb-1 flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left text-[15px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       >
-        <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-dashed border-border">
-          <Plus className="size-3.5" />
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-dashed border-border">
+          <Plus className="size-4" />
         </span>
         <span className="truncate">New bot</span>
       </button>
@@ -25768,11 +25765,7 @@ function BotsView({
         const working = !!(session?.sessionId && busyBySid[session.sessionId]);
         const rawPreview = session?.last?.text || session?.lastUserText || row.lastMessagePreview || item.lastMessagePreview || "";
         // See the rail roster: a `[subagent …]` report is not preview material.
-        const preview = !rawPreview
-          ? "Say hi to get started."
-          : isSubagentUpdateText(rawPreview)
-            ? "Background task reported in"
-            : plainPreviewText(botVisibleUserText(rawPreview, item));
+        const preview = plainPreviewText(botRosterPreview(rawPreview, working));
         return (
           <button
             key={row.key}
@@ -25781,10 +25774,12 @@ function BotsView({
             aria-label={`${item.name}${row.unread ? ", unread conversation" : ""}`}
             className={MOBILE_BOT_ROSTER_ROW_CLASS}
           >
-            <BotAvatar bot={item} working={working} size={44} />
+            <BotAvatar bot={item} working={working} size={56} />
             <span className="flex min-w-0 flex-1 flex-col">
-              <span className={cn("truncate text-[13px] font-semibold", !item.enabled && "text-muted-foreground")}>{item.name}</span>
-              <span className="truncate text-xs text-muted-foreground">{working ? `Working — ${preview}` : preview}</span>
+              <span className={cn("truncate text-base font-semibold", !item.enabled && "text-muted-foreground")}>{item.name}</span>
+              {preview ? (
+                <span className="truncate text-sm text-muted-foreground">{preview}</span>
+              ) : null}
             </span>
             {row.unread ? (
               <span role="status" aria-label={`Unread conversation with ${item.name}`}>
@@ -25792,29 +25787,27 @@ function BotsView({
               </span>
             ) : null}
             {row.lastMessageTs || item.lastMessageAt ? (
-              <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/70">{relTime(row.lastMessageTs || item.lastMessageAt!)}</span>
+              <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{relTime(row.lastMessageTs || item.lastMessageAt!)}</span>
             ) : null}
             {!item.enabled ? <Badge variant="secondary">Disabled</Badge> : null}
-            <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
           </button>
         );
       }) : (
         // The flat "New bot" row above is already the create affordance here
         // (matches the rail: one create control, not a header button plus a
         // second dashed row repeating it) — the empty state is just the
-        // explanation card.
-        <div className="flex flex-col items-center rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+        // heading card.
+        <div className="flex flex-col items-center rounded-xl border border-border bg-card p-10 text-center">
           {/* One creature, asleep, waiting to be woken by the first bot. */}
           <BotMascot
             shape="circle"
             colorway="warm"
             size={72}
             state="sleeping"
-            className="mb-3"
+            className="mb-4"
             title="No bots yet"
           />
-          <span className="block font-medium text-foreground">No bots yet.</span>
-          <span>Give a persona a name and a memory — it will be there next time you open this.</span>
+          <span className="block text-base font-medium text-foreground">No bots yet.</span>
         </div>
       )}
     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -98,6 +98,7 @@ import {
   botVisibleUserText as botVisibleUserTextFor,
   isBotHiddenLogKind,
   isBotLaunchOnlyText,
+  isCodingAgentStoppedText,
   isSubagentUpdateText,
 } from "./lib/bot-transcript";
 import { sessionMatchesUserFilter } from "./lib/user-filter";
@@ -25742,9 +25743,9 @@ function BotsView({
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
         <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
       ) : null}
-      <div className="flex items-start gap-3 px-2 pb-2 pt-4">
+      <div className="flex items-start gap-3 px-2 pb-3 pt-5">
         <div className="min-w-0 flex-1">
-          <h1 className="text-3xl font-semibold leading-tight tracking-tight">Bots</h1>
+          <h1 className="text-[32px] font-bold leading-tight tracking-tight">Bots</h1>
         </div>
       </div>
       {/* Quiet dashed "New bot" row — same control as the rail, sized for
@@ -25766,6 +25767,7 @@ function BotsView({
         const rawPreview = session?.last?.text || session?.lastUserText || row.lastMessagePreview || item.lastMessagePreview || "";
         // See the rail roster: a `[subagent …]` report is not preview material.
         const preview = plainPreviewText(botRosterPreview(rawPreview, working));
+        const stopped = !working && isCodingAgentStoppedText(rawPreview);
         return (
           <button
             key={row.key}
@@ -25778,7 +25780,7 @@ function BotsView({
             <span className="flex min-w-0 flex-1 flex-col">
               <span className={cn("truncate text-base font-semibold", !item.enabled && "text-muted-foreground")}>{item.name}</span>
               {preview ? (
-                <span className="truncate text-sm text-muted-foreground">{preview}</span>
+                <span className={cn("truncate text-sm", stopped ? "text-destructive" : "text-muted-foreground")}>{preview}</span>
               ) : null}
             </span>
             {row.unread ? (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25743,23 +25743,17 @@ function BotsView({
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
         <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
       ) : null}
-      <div className="flex items-start gap-3 px-2 pb-3 pt-5">
-        <div className="min-w-0 flex-1">
-          <h1 className="text-[32px] font-bold leading-tight tracking-tight">Bots</h1>
-        </div>
+      <div className="flex items-center gap-3 px-2 pb-3 pt-5">
+        <h1 className="min-w-0 flex-1 text-[32px] font-bold leading-tight tracking-tight">Bots</h1>
+        <button
+          type="button"
+          onClick={onNew}
+          aria-label="New bot"
+          className="shrink-0 px-1 text-base font-medium text-primary transition-colors hover:text-primary/80"
+        >
+          New
+        </button>
       </div>
-      {/* Quiet dashed "New bot" row — same control as the rail, sized for
-          this page roster rather than the compact sidebar. */}
-      <button
-        type="button"
-        onClick={onNew}
-        className="mb-1 flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left text-[15px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-full border border-dashed border-border">
-          <Plus className="size-4" />
-        </span>
-        <span className="truncate">New bot</span>
-      </button>
       {bots.length ? botConversationRows(bots, sessions, conversations).map((row) => {
         const item = row.bot;
         const session = row.session;
@@ -25795,10 +25789,8 @@ function BotsView({
           </button>
         );
       }) : (
-        // The flat "New bot" row above is already the create affordance here
-        // (matches the rail: one create control, not a header button plus a
-        // second dashed row repeating it) — the empty state is just the
-        // heading card.
+        // Create lives in the header "New" control so the empty card is
+        // only the heading.
         <div className="flex flex-col items-center rounded-xl border border-border bg-card p-10 text-center">
           {/* One creature, asleep, waiting to be woken by the first bot. */}
           <BotMascot

--- a/web/src/lib/bot-transcript.ts
+++ b/web/src/lib/bot-transcript.ts
@@ -9,10 +9,12 @@
 //
 // So the rules live in src/bots/transcript.ts and both sides use them.
 export {
+  botRosterPreview,
   botVisibleUserText,
   isBotHiddenLogKind,
   isBotLaunchOnlyText,
   isBotRotationNoticeText,
+  isCodingAgentStoppedText,
   isSubagentUpdateText,
   stripBotLaunchEnvelope,
 } from "../../../src/bots/transcript.ts";

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -12,7 +12,7 @@ test("the mobile bot roster uses a flat rail-style row", () => {
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("hover:bg-muted");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("border-border");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("bg-card");
-  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-3.5");
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-4");
 });
 
 describe("shouldShowMobileSurfaceToggle", () => {

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -12,6 +12,7 @@ test("the mobile bot roster uses a flat rail-style row", () => {
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("hover:bg-muted");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("border-border");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("bg-card");
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-3.5");
 });
 
 describe("shouldShowMobileSurfaceToggle", () => {

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -17,9 +17,9 @@ export type PrimaryMobileTab = "live" | "bots";
 /** `SurfaceToggle`'s own active-segment vocabulary (desktop rail history). */
 export type SurfaceToggleActive = "sessions" | "chat";
 
-/** Flat roster treatment shared with the rail instead of the former card shell. */
+/** Flat roster treatment on the Bots page — airier than the compact rail. */
 export const MOBILE_BOT_ROSTER_ROW_CLASS =
-  "flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted";
+  "flex w-full items-center gap-3.5 rounded-lg px-2 py-3.5 text-left transition-colors hover:bg-muted";
 
 /**
  * The persistent mobile bottom toggle shows only at real mobile widths, and

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -19,7 +19,7 @@ export type SurfaceToggleActive = "sessions" | "chat";
 
 /** Flat roster treatment on the Bots page — airier than the compact rail. */
 export const MOBILE_BOT_ROSTER_ROW_CLASS =
-  "flex w-full items-center gap-3.5 rounded-lg px-2 py-3.5 text-left transition-colors hover:bg-muted";
+  "flex w-full items-center gap-3.5 rounded-lg px-2 py-4 text-left transition-colors hover:bg-muted";
 
 /**
  * The persistent mobile bottom toggle shows only at real mobile widths, and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Bots page repeated a manifesto and showed raw crash text as the last-message preview.

**Copy**
- Drop the manifesto from the page subtitle, rail empty state, desktop empty card, and mobile empty card.
- Empty states are one short line each. The sleeping mascot stays.
- Create on the Bots page is a header `New` control (`aria-label="New bot"`), not a dashed row.

**Preview**
- One shared `botRosterPreview` helper for the rail and the page roster.
- Crash last-messages render as `Stopped`. On the mobile roster that line uses the destructive color.
- No messages: `Say hi`.
- Busy: `Working`.
- Subagent reports stay `Background task reported in`.

**Rows**
- The whole mobile roster row is the hit target. The trailing chevron is gone.
- The Bots page roster is the larger scale: 32px bold title, 56px avatar, 16/14/12 type, Messages-like row padding.
- The 280px desktop rail stays compact, including its dashed New bot row.

**Tests**
- Unit coverage for crash, empty (`Say hi`), subagent, normal, and busy previews.
- Source pins for the new copy, header New control, and page-vs-rail sizes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7b1c6b-522d-4364-8e07-6bc7faeda0ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7b1c6b-522d-4364-8e07-6bc7faeda0ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

