### PR TITLE
Restore create / deploy / login on the public omg 0.5.1 binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Recent product updates and deployment notes.
 
+## August 21, 2026 - One `omg` for computer setup and create / deploy
+
+- **`@omg-dev/cli` 0.5.1 keeps one public `omg` binary.** `0.5.0` rejected
+  `create` / `deploy` / `login` after it replaced the vibes 0.4.42 line.
+  `@omg-dev/apps` was never published, so a fresh `npm i -g @omg-dev/cli`
+  lost those verbs. This version starts the hosted app flow again on the
+  same command.
+- **`omg computer setup` is still the local control plane.** It still
+  installs this repository's runtime and still opens
+  http://localhost:8766. You still bring your own agent accounts. omg.dev
+  does not resell tokens.
+- **`omg create`, `omg deploy`, and `omg login` start the last published
+  hosted app CLI (`@omg-dev/cli@0.4.42`).** The user does not type a second
+  command. A maintainer can point `OMG_APPS_BIN` at another runner, or put
+  `omg-apps` on PATH after `@omg-dev/apps` is published.
+
 ## August 20, 2026 - Coding agent toggles follow readiness
 
 - **A coding agent is on only when it can run.** The Settings list used to

--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ curl -fsSL https://raw.githubusercontent.com/BennyKok/omg.dev/main/scripts/setup
 
 Then open **http://localhost:8766**.
 
-Do not install the npm package `@omg-dev/cli` at 0.4.x. That line is the
-retired prompt-to-app CLI published from `BennyKok/vibes` (`create` / `deploy`
-to `*.omgs.app`). This repository publishes the control-plane bootstrapper as
-`@omg-dev/cli` 0.5.0+. After that version is on npm, this is the same install:
+`@omg-dev/cli` 0.5.1+ is one `omg` binary. `omg computer setup` installs the
+local control plane. `omg create` / `omg deploy` / `omg login` still start the
+hosted app flow. After that version is on npm, this is the same install:
 
 ```bash
 bun install --global @omg-dev/cli && omg computer setup
@@ -422,9 +421,9 @@ locally the old way.
 
 Every release publishes `@omg-dev/cli`, `@omg-dev/protocol`, `@omg-dev/client`,
 `@omg-dev/react`, and `@omg-dev/app` to npm — the last being the exact full
-application the standalone web UI runs. `@omg-dev/cli` 0.5.0+ is the
-control-plane bootstrapper. Do not install 0.4.x. React hosts mount it with their own transport and asset
-origin:
+application the standalone web UI runs. `@omg-dev/cli` 0.5.1+ is the
+control-plane bootstrapper. The same `omg` also starts create / deploy / login.
+React hosts mount `@omg-dev/app` with their own transport and asset origin:
 
 ```bash
 npm install @omg-dev/app @omg-dev/client
@@ -437,7 +436,7 @@ See **[docs/embedding.md](./docs/embedding.md)**.
 ```text
 src/                 CLI, server, sessions, tmux, agents, MCP, integrations
 web/                 React/Vite PWA
-packages/cli         @omg-dev/cli 0.5.0+ control-plane bootstrapper
+packages/cli         @omg-dev/cli 0.5.1+ control-plane bootstrapper + hosted app verbs
 agents/              Example markdown-defined insight agents
 scripts/setup.sh     Installer / provisioning (documented first-run)
 scripts/             Release, fleet, and smoke helpers

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -51,10 +51,10 @@ saved OMG binding. Use `omg connect --new` only when you intentionally want a
 fresh binding, or `--no-install` to require an existing OMG install.
 
 The hosted `omg login && omg connect` convenience wrapper is owned by
-`BennyKok/vibes`. Do not install `@omg-dev/cli` 0.4.x for that path — that
-package is the retired prompt-to-app CLI. This repository's `@omg-dev/cli`
-0.5.0+ installs the local control plane only. The `omg connect <code>` command
-and the wire protocol below remain provider-agnostic.
+`BennyKok/vibes`. `@omg-dev/cli` 0.5.1+ is one `omg`: `computer setup` still
+installs the local control plane, and `login` / `create` / `deploy` start the
+hosted app flow. The `omg connect <code>` command and the wire protocol below
+remain provider-agnostic.
 
 ### Custom relay
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,12 +3,12 @@
 Install and manage the local omg.dev agent control plane.
 
 This package is the control-plane bootstrapper published from
-[BennyKok/omg.dev](https://github.com/BennyKok/omg.dev). It is not the retired
-prompt-to-app CLI that deployed apps to `*.omgs.app`.
+[BennyKok/omg.dev](https://github.com/BennyKok/omg.dev). The same `omg`
+binary also starts the hosted create / deploy flow.
 
 Versions `0.4.x` on this name were published from `BennyKok/vibes`. This line
 starts at `0.5.0` so `npm install --global @omg-dev/cli` resolves to the current
-product.
+product. `0.5.1+` restores `create` / `deploy` / `login` on this binary.
 
 ## Install
 
@@ -37,10 +37,14 @@ You bring your own agent accounts. omg.dev does not resell tokens.
 | `omg computer uninstall [--purge --yes]` | Remove the install. Keeps data unless purged. |
 | `omg computer status` | Show this machine's install. |
 | `omg serve` | After setup, run the web UI (forwarded to the install). |
+| `omg create <name>` | Create an app (hosted `*.omgs.app`). |
+| `omg deploy` | Publish the current directory. |
+| `omg login` | Sign in for create / deploy. |
 
 Any other verb the install owns (`mcp`, `doctor`, `agents`, …) is forwarded to
-it. `create`, `deploy`, and other retired prompt-to-app commands are rejected
-here on purpose.
+it. `create` / `deploy` / `login` start the last published hosted app CLI
+(`@omg-dev/cli@0.4.42`) under this same `omg`. They do not install a second
+command.
 
 ## Versioning
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omg-dev/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Install and manage the local omg.dev agent control plane.",
   "license": "MIT",
   "homepage": "https://github.com/BennyKok/omg.dev",

--- a/packages/cli/src/apps.test.ts
+++ b/packages/cli/src/apps.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import {
+  APP_COMMANDS,
+  APPS_CLI_ENTRY,
+  APPS_CLI_SPEC,
+  APPS_CLI_TARBALL,
+  APPS_CLI_VERSION,
+  appsEntryPath,
+  ensureAppsCli,
+  resolveAppRunner,
+  runAppCommand,
+} from "./apps.ts";
+
+describe("hosted app verbs stay on this omg binary", () => {
+  test("create, deploy, and login are in the forwarded set", () => {
+    expect(APP_COMMANDS.has("create")).toBe(true);
+    expect(APP_COMMANDS.has("deploy")).toBe(true);
+    expect(APP_COMMANDS.has("login")).toBe(true);
+    expect(APP_COMMANDS.has("computer")).toBe(false);
+    expect(APP_COMMANDS.has("serve")).toBe(false);
+  });
+
+  test("the pin is the last published create/deploy CLI, not a stub", () => {
+    expect(APPS_CLI_SPEC).toBe("@omg-dev/cli@0.4.42");
+    expect(APPS_CLI_VERSION).toBe("0.4.42");
+    expect(APPS_CLI_TARBALL).toContain("cli-0.4.42.tgz");
+    expect(APPS_CLI_ENTRY).toBe("dist/omg-bun.mjs");
+  });
+});
+
+describe("resolveAppRunner", () => {
+  test("OMG_APPS_BIN wins so tests and local checkouts can inject a runner", async () => {
+    const resolved = await resolveAppRunner({
+      env: { OMG_APPS_BIN: "/opt/custom-apps" },
+      which: () => "/usr/bin/omg-apps",
+    });
+    expect(resolved).toEqual({ command: ["/opt/custom-apps"], source: "override" });
+  });
+
+  test("uses omg-apps on PATH when present, without asking the user to type it", async () => {
+    const resolved = await resolveAppRunner({
+      env: {},
+      which: (name) => (name === "omg-apps" ? "/usr/bin/omg-apps" : null),
+    });
+    expect(resolved).toEqual({ command: ["/usr/bin/omg-apps"], source: "omg-apps" });
+  });
+
+  test("falls back to the cached 0.4.42 entry run with Bun", async () => {
+    const home = "/tmp/apps-home";
+    const entry = appsEntryPath(home);
+    const resolved = await resolveAppRunner({
+      env: {},
+      which: () => null,
+      homedir: () => home,
+      exists: (path) => path === entry,
+      execPath: "/opt/bun/bin/bun",
+    });
+    expect(resolved.source).toBe("pinned-0.4.42");
+    expect(resolved.command).toEqual(["/opt/bun/bin/bun", entry]);
+  });
+});
+
+describe("ensureAppsCli", () => {
+  test("downloads the pinned tarball once when the cache is empty", async () => {
+    const home = "/tmp/empty-apps-home";
+    const fetched: string[] = [];
+    const extracted: string[][] = [];
+    const made: string[] = [];
+    const written: string[] = [];
+    const entry = appsEntryPath(home);
+    let extractedNow = false;
+    const path = await ensureAppsCli({
+      homedir: () => home,
+      exists: (candidate) => extractedNow && candidate === entry,
+      mkdir: (directory) => {
+        made.push(directory);
+      },
+      fetchBuffer: async (url) => {
+        fetched.push(url);
+        return new Uint8Array([1, 2, 3]);
+      },
+      writeFile: (file) => {
+        written.push(file);
+      },
+      extract: async (tarball, dest) => {
+        extracted.push([tarball, dest]);
+        extractedNow = true;
+        return 0;
+      },
+    });
+    expect(path).toBe(entry);
+    expect(fetched).toEqual([APPS_CLI_TARBALL]);
+    expect(made).toEqual([`${home}/.omg/apps-cli/0.4.42`]);
+    expect(extracted).toHaveLength(1);
+    expect(extracted[0]?.[1]).toBe(`${home}/.omg/apps-cli/0.4.42`);
+    expect(written).toHaveLength(1);
+  });
+
+  test("reuses the cache and does not download again", async () => {
+    let fetched = 0;
+    const path = await ensureAppsCli({
+      homedir: () => "/tmp/cached-apps-home",
+      exists: () => true,
+      fetchBuffer: async () => {
+        fetched += 1;
+        return new Uint8Array();
+      },
+    });
+    expect(path).toBe(appsEntryPath("/tmp/cached-apps-home"));
+    expect(fetched).toBe(0);
+  });
+});
+
+describe("runAppCommand", () => {
+  test("spawns the resolved runner with the original argv", async () => {
+    const spawned: string[][] = [];
+    const code = await runAppCommand(["create", "my-app", "--no-install"], {
+      env: { OMG_APPS_BIN: "/tmp/apps" },
+      spawn: async (argv) => {
+        spawned.push(argv);
+        return 7;
+      },
+    });
+    expect(code).toBe(7);
+    expect(spawned).toEqual([["/tmp/apps", "create", "my-app", "--no-install"]]);
+  });
+
+  test("reports a clear error when the runner cannot start", async () => {
+    const lines: string[] = [];
+    const code = await runAppCommand(["login"], {
+      env: {},
+      which: () => null,
+      homedir: () => "/tmp/missing-apps",
+      exists: () => false,
+      fetchBuffer: async () => {
+        throw new Error("registry unavailable");
+      },
+      error: (line) => {
+        lines.push(line);
+      },
+    });
+    expect(code).toBe(1);
+    expect(lines.join("\n")).toContain("could not start login");
+    expect(lines.join("\n")).toContain("registry unavailable");
+  });
+});

--- a/packages/cli/src/apps.ts
+++ b/packages/cli/src/apps.ts
@@ -1,0 +1,148 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { type ForwardDependencies } from "./forward.ts";
+
+/**
+ * Hosted create / deploy verbs that 0.4.42 owned. This package keeps the
+ * public `omg` name and starts that flow; it does not teach a second command.
+ */
+export const APP_COMMANDS = new Set([
+  "create",
+  "deploy",
+  "dev",
+  "apps",
+  "link",
+  "visibility",
+  "login",
+  "logout",
+  "whoami",
+]);
+
+/** Last published create/deploy implementation. `@omg-dev/apps` is still 404. */
+export const APPS_CLI_SPEC = "@omg-dev/cli@0.4.42";
+export const APPS_CLI_VERSION = "0.4.42";
+export const APPS_CLI_TARBALL = "https://registry.npmjs.org/@omg-dev/cli/-/cli-0.4.42.tgz";
+export const APPS_CLI_ENTRY = "dist/omg-bun.mjs";
+
+export type AppCommandDependencies = ForwardDependencies & {
+  env?: NodeJS.ProcessEnv;
+  fetchBuffer?: (url: string) => Promise<Uint8Array>;
+  extract?: (tarball: string, dest: string) => Promise<number>;
+  mkdir?: (path: string) => void;
+  writeFile?: (path: string, data: Uint8Array) => void;
+  execPath?: string;
+  error?: (line: string) => void;
+};
+
+export function appsCacheDir(home: string): string {
+  return join(home, ".omg", "apps-cli", APPS_CLI_VERSION);
+}
+
+export function appsEntryPath(home: string): string {
+  return join(appsCacheDir(home), APPS_CLI_ENTRY);
+}
+
+async function defaultFetchBuffer(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`could not download ${APPS_CLI_SPEC} from ${url} (${response.status})`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function defaultExtract(tarball: string, dest: string): Promise<number> {
+  const child = Bun.spawn(["tar", "-xzf", tarball, "-C", dest, "--strip-components=1"], {
+    stdin: "ignore",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  return await child.exited;
+}
+
+function resolveBun(dependencies: AppCommandDependencies): string | null {
+  if (dependencies.execPath) return dependencies.execPath;
+  if (typeof Bun !== "undefined" && process.execPath) return process.execPath;
+  const which = dependencies.which ?? ((name: string) => Bun.which(name));
+  return which("bun");
+}
+
+/**
+ * Download the pinned 0.4.42 CLI once so `omg create` does not recurse into
+ * this 0.5.x `omg` binary. The published 0.4.42 bin is also named `omg`.
+ */
+export async function ensureAppsCli(dependencies: AppCommandDependencies = {}): Promise<string> {
+  const home = (dependencies.homedir ?? homedir)();
+  const exists = dependencies.exists ?? ((path: string) => existsSync(path));
+  const entry = appsEntryPath(home);
+  if (exists(entry)) return entry;
+
+  const cache = appsCacheDir(home);
+  const mkdir = dependencies.mkdir ?? ((path: string) => mkdirSync(path, { recursive: true }));
+  mkdir(cache);
+
+  const fetchBuffer = dependencies.fetchBuffer ?? defaultFetchBuffer;
+  const bytes = await fetchBuffer(APPS_CLI_TARBALL);
+  const directory = mkdtempSync(join(tmpdir(), "omg-apps-cli-"));
+  const tarball = join(directory, "cli.tgz");
+  const writeFile = dependencies.writeFile ?? ((path: string, data: Uint8Array) => writeFileSync(path, data));
+  writeFile(tarball, bytes);
+
+  const extract = dependencies.extract ?? defaultExtract;
+  const code = await extract(tarball, cache);
+  if (code !== 0) {
+    throw new Error(`could not extract ${APPS_CLI_SPEC} (tar exit ${code})`);
+  }
+  if (!exists(entry)) {
+    throw new Error(`extracted ${APPS_CLI_SPEC} but ${APPS_CLI_ENTRY} was missing`);
+  }
+  return entry;
+}
+
+/**
+ * Resolve the hosted create/deploy runner without a second user-facing command.
+ *
+ * Preference:
+ * 1. `OMG_APPS_BIN` — explicit binary or script
+ * 2. `omg-apps` on PATH — published `@omg-dev/apps`, if a maintainer installed it
+ * 3. cached `@omg-dev/cli@0.4.42` entry, run with Bun
+ */
+export async function resolveAppRunner(
+  dependencies: AppCommandDependencies = {},
+): Promise<{ command: string[]; source: "override" | "omg-apps" | "pinned-0.4.42" }> {
+  const env = dependencies.env ?? process.env;
+  const override = env.OMG_APPS_BIN?.trim();
+  if (override) return { command: [override], source: "override" };
+
+  const which = dependencies.which ?? ((name: string) => Bun.which(name));
+  const apps = which("omg-apps");
+  if (apps) return { command: [apps], source: "omg-apps" };
+
+  const entry = await ensureAppsCli(dependencies);
+  const bun = resolveBun(dependencies);
+  if (!bun) {
+    throw new Error("Bun is required to run create / deploy / login. Install it from https://bun.sh");
+  }
+  return { command: [bun, entry], source: "pinned-0.4.42" };
+}
+
+export async function runAppCommand(
+  argv: string[],
+  dependencies: AppCommandDependencies = {},
+): Promise<number> {
+  try {
+    const { command } = await resolveAppRunner(dependencies);
+    const spawn =
+      dependencies.spawn ??
+      (async (commandLine: string[]) => {
+        const child = Bun.spawn(commandLine, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+        return await child.exited;
+      });
+    return await spawn([...command, ...argv]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    (dependencies.error ?? console.error)(`omg: could not start ${argv[0] ?? "the hosted app command"}.`);
+    (dependencies.error ?? console.error)(message);
+    return 1;
+  }
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -9,42 +9,18 @@ Usage:
   omg computer update                  Update an existing install
   omg computer uninstall [--purge --yes]
   omg serve                            Run the web UI (after setup)
+  omg create <name>                    Create an app (hosted *.omgs.app)
+  omg deploy                           Publish the current directory
+  omg login                            Sign in for create / deploy
   omg help
 
-This command installs the local omg.dev agent control plane. It does not
-create or deploy apps to *.omgs.app.
+This command installs the local omg.dev agent control plane. After setup,
+open http://localhost:8766.
 
 You bring your own agent accounts. omg.dev does not resell tokens.
 
 After setup, unknown commands are forwarded to the install. \`lfg\` remains
 a compatibility alias for that install.
 
-Then open http://localhost:8766.
+create / deploy / login still start the hosted app flow on this same \`omg\`.
 `;
-
-/** Retired prompt-to-app verbs that must not silently fall through. */
-export const RETIRED_APP_COMMANDS = new Set([
-  "create",
-  "deploy",
-  "dev",
-  "apps",
-  "link",
-  "visibility",
-  "login",
-  "logout",
-  "whoami",
-]);
-
-export function retiredAppMessage(command: string): string {
-  return `omg: \`${command}\` is not part of the current omg.dev product.
-
-The current product is the local agent control plane. Install it with:
-
-  omg computer setup
-
-Then open http://localhost:8766.
-
-create / deploy to *.omgs.app was the retired prompt-to-app CLI, published
-as @omg-dev/cli 0.4.x from BennyKok/vibes. That line is not this package.
-`;
-}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { HELP_BANNER, RETIRED_APP_COMMANDS } from "./help.ts";
+import { APP_COMMANDS } from "./apps.ts";
+import { HELP_BANNER } from "./help.ts";
 import { runCli } from "./index.ts";
 import manifest from "../package.json" with { type: "json" };
 
@@ -18,21 +19,23 @@ function capture() {
 }
 
 describe("published version can replace the retired 0.4.x line", () => {
-  test("this package is 0.5.0 or newer so npm latest is not 0.4.42", () => {
-    const [major, minor] = String(manifest.version).split(".").map(Number);
-    expect(major * 100 + minor).toBeGreaterThanOrEqual(5);
+  test("this package is 0.5.1 or newer so npm latest is not 0.4.42 or 0.5.0", () => {
+    const [major, minor, patch] = String(manifest.version).split(".").map(Number);
+    expect(major * 10000 + minor * 100 + patch).toBeGreaterThanOrEqual(501);
   });
 });
 
-describe("omg help is the control plane, not the retired app CLI", () => {
+describe("omg help names the control plane and the hosted app verbs", () => {
   test("help prints the probe phrase setup.sh greps for", async () => {
     const log = capture();
     expect(await runCli(["help"], log)).toBe(0);
     expect(log.text()).toContain(HELP_BANNER);
     expect(log.text()).toContain("computer setup");
     expect(log.text()).toContain("localhost:8766");
-    expect(log.text()).not.toContain("omg create");
-    expect(log.text()).not.toContain("omg deploy");
+    expect(log.text()).toContain("omg create");
+    expect(log.text()).toContain("omg deploy");
+    expect(log.text()).toContain("omg login");
+    expect(log.text()).not.toContain("omg-apps");
   });
 
   test("the forward probe is the same help, so setup.sh can surrender omg", async () => {
@@ -41,21 +44,22 @@ describe("omg help is the control plane, not the retired app CLI", () => {
     expect(log.text()).toContain("run and manage your AI coding agents");
   });
 
-  test("retired prompt-to-app verbs are rejected, not forwarded", async () => {
-    for (const command of RETIRED_APP_COMMANDS) {
+  test("hosted app verbs start the old app flow on this same omg", async () => {
+    for (const command of APP_COMMANDS) {
       const log = capture();
       const spawned: string[][] = [];
-      const code = await runCli([command], {
+      const code = await runCli([command, "arg"], {
         ...log,
+        env: { OMG_APPS_BIN: "/tmp/apps-cli" },
         which: () => "/tmp/lfg",
         spawn: async (argv) => {
           spawned.push(argv);
           return 0;
         },
       });
-      expect(code, command).toBe(1);
-      expect(log.text(), command).toContain("not part of the current omg.dev product");
-      expect(spawned, command).toEqual([]);
+      expect(code, command).toBe(0);
+      expect(spawned, command).toEqual([["/tmp/apps-cli", command, "arg"]]);
+      expect(log.text(), command).not.toContain("not part of the current omg.dev product");
     }
   });
 });
@@ -96,6 +100,23 @@ describe("omg computer", () => {
     expect(code).toBe(0);
     expect(fetched).toBe(false);
     expect(log.text()).toContain("already set up");
+  });
+
+  test("computer setup does not start the hosted app CLI", async () => {
+    const spawned: string[][] = [];
+    const log = capture();
+    await runCli(["computer", "setup"], {
+      ...log,
+      env: { OMG_APPS_BIN: "/tmp/apps-cli" },
+      which: () => "/tmp/lfg",
+      spawn: async (argv) => {
+        spawned.push(argv);
+        return 0;
+      },
+    });
+    expect(spawned).toEqual([]);
+    expect(log.text()).toContain("already set up");
+    expect(log.text()).toContain("localhost:8766");
   });
 
   test("update and uninstall go to the install, not to setup.sh", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,13 @@
-import { HELP, HELP_BANNER, RETIRED_APP_COMMANDS, retiredAppMessage } from "./help.ts";
+import { APP_COMMANDS, runAppCommand, type AppCommandDependencies } from "./apps.ts";
+import { HELP, HELP_BANNER } from "./help.ts";
 import { forwardToInstall, type ForwardDependencies } from "./forward.ts";
 import { runComputerForward, runComputerSetup, type InstallDependencies } from "./install.ts";
 
 export { HELP, HELP_BANNER };
 
 export type CliDependencies = InstallDependencies &
-  ForwardDependencies & {
+  ForwardDependencies &
+  AppCommandDependencies & {
     output?: (line: string) => void;
     error?: (line: string) => void;
   };
@@ -28,13 +30,12 @@ export async function runCli(argv: string[], dependencies: CliDependencies = {})
 
   if (cmd === "version" || cmd === "--version" || cmd === "-v") {
     const manifest = await Bun.file(new URL("../package.json", import.meta.url)).json();
-    out(typeof manifest.version === "string" ? manifest.version : "0.5.0");
+    out(typeof manifest.version === "string" ? manifest.version : "0.5.1");
     return 0;
   }
 
-  if (RETIRED_APP_COMMANDS.has(cmd)) {
-    err(retiredAppMessage(cmd));
-    return 1;
+  if (APP_COMMANDS.has(cmd)) {
+    return await runAppCommand(argv, { ...dependencies, error: err });
   }
 
   if (cmd === "computer") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Conclusion

`@omg-dev/cli@0.5.0` is npm `latest` and rejects `create` / `deploy` / `login` (`RETIRED_APP_COMMANDS`). `@omg-dev/apps` is still 404. A fresh `npm i -g @omg-dev/cli@latest` therefore loses those verbs.

I picked the smaller path that keeps **one public `omg`**:

- This package still owns `omg computer setup` → local control plane / http://localhost:8766
- The same `omg` starts the hosted app flow for `create` / `deploy` / `login` (and the other 0.4.42 app verbs)
- The implementation is the last published create/deploy CLI, `@omg-dev/cli@0.4.42`, cached under `~/.omg/apps-cli/0.4.42` and run with Bun
- The user never types `omg-apps`
- BYO-agent / no-resold-tokens copy for the control plane is unchanged

I did not copy the vibes auth/deploy stack into this repo. I did not invent a second product name.

## What I verified before the change

| Fact | Source |
| --- | --- |
| npm latest is `@omg-dev/cli@0.5.0` from this repo | `npm view @omg-dev/cli` |
| `@omg-dev/apps` is 404 | `npm view @omg-dev/apps` |
| vibes `packages/cli/package.json` is `@omg-dev/apps` 0.4.42, `"private": true`, bin `omg-apps` | BennyKok/vibes main after #1509 |
| 0.4.42 `omg create` / `omg deploy` / `omg login` still work | published tarball `dist/omg-bun.mjs` |
| This agent has no npm auth | `npm whoami` → `ENEEDAUTH` |

## Changed behavior

- `omg create` / `omg deploy` / `omg login` start the old hosted app flow on this binary
- `omg computer setup` is still this repo's installer and still prints http://localhost:8766
- Help names both surfaces. The `setup.sh` forward-probe banner is unchanged
- Optional: `OMG_APPS_BIN` or `omg-apps` on PATH can replace the 0.4.42 pin after `@omg-dev/apps` is published

## BennyKok/vibes follow-up (not this PR)

No vibes code change is required for these verbs to work today. 0.4.42 is already on npm.

A maintainer with npm auth should still publish `@omg-dev/apps` so this CLI can stop pinning a retired version of its own name:

| File | Action |
| --- | --- |
| `packages/cli/package.json` | Already named `@omg-dev/apps`, bin `omg-apps`, `"private": true`. Leave `private` in git. |
| `packages/cli/scripts/release.sh` | Already strips `private` and publishes `@omg-dev/apps`. Run this with npm auth. |
| `packages/cli/src/index.ts` | Already implements create / deploy / login. No export change required. This CLI invokes the published bin, not a JS API. |

Exact vibes command:

```bash
# in BennyKok/vibes, with npm auth
packages/cli/scripts/release.sh            # publishes @omg-dev/apps
# or
packages/cli/scripts/release.sh --dry-run
```

Do **not** unpublish `@omg-dev/cli@0.4.42`. This 0.5.1 pin downloads that tarball. Deprecating `<0.5.0` is still fine.

After `@omg-dev/apps` exists, a later omg.dev change can switch `APPS_CLI_SPEC` in `packages/cli/src/apps.ts` from `@omg-dev/cli@0.4.42` to `@omg-dev/apps`. Until then, `omg-apps` on PATH is already preferred.

## npm publish (not done here)

`npm whoami` failed with `ENEEDAUTH`. This PR does **not** publish.

After merge, a maintainer with npm auth should publish **only** the CLI so `latest` gets the verbs (no runtime tag required):

```bash
# from a clean checkout of main after this merges
cd packages/cli && bun run build && cd ../..
bash scripts/pack-packages.sh
npm publish ./dist/omg-dev-cli-0.5.1.tgz --access public
npm view @omg-dev/cli version   # expect 0.5.1
```

The next `scripts/tag-release.sh` runtime release will also publish this 0.5.1 tarball if it is already on main. That is a second path, not a requirement for npm `latest`.

## Test plan

- [x] Focused tests: `bun test packages/cli test/setup-command-name.test.ts test/cli-computer-namespace.test.ts`
- [x] Live pin: downloaded `@omg-dev/cli@0.4.42`, then `omg create` printed `Usage: omg create <name> [--no-install]` and `omg deploy` printed `Not signed in. Run \`omg login\``
- [x] `omg computer setup` with an existing install still printed `Open http://localhost:8766`
- [ ] **Fresh machine:** `npm i -g @omg-dev/cli@0.5.1` (or this packed tarball)
  1. `omg computer setup` still means the local control plane / http://localhost:8766
  2. `omg create` starts the old app flow (`Usage: omg create <name>` or the generator)
  3. `omg deploy` starts the old app flow (login prompt or deploy)
  4. `omg login` starts the old app flow (browser OAuth or `--token`)
  5. `command -v omg` is one program. Do not ask the user to learn `omg-apps`
- [ ] After publish: `npm view @omg-dev/cli version` is `0.5.1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa54d1ec-0d6b-4884-b065-448c33be4929?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa54d1ec-0d6b-4884-b065-448c33be4929&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

