### PR TITLE
design(bots): drop the roster subtitle, enlarge the heading, move create to the bottom

### DIFF
--- a/docs/design/bot-mode/mockup.html
+++ b/docs/design/bot-mode/mockup.html
@@ -333,9 +333,8 @@
 
   /* ── Bots roster page (§3) ────────────────────────────────────────── */
   .page-col { padding: 16px 14px 24px; overflow-y: auto; flex: 1; }
-  .page-head { padding: 2px 2px 14px; display: flex; align-items: flex-start; gap: 10px; }
-  .page-head h1 { margin: 0; font-size: 18px; font-weight: 700; line-height: 1.25; }
-  .page-head p { margin: 2px 0 0; font-size: 13px; color: var(--muted-foreground); }
+  .page-head { padding: 2px 2px 8px; display: flex; align-items: center; gap: 10px; }
+  .page-head h1 { margin: 0; font-size: 22px; font-weight: 700; line-height: 1.2; letter-spacing: -0.02em; }
   .btn {
     appearance: none;
     border: 1px solid transparent;
@@ -776,14 +775,7 @@
 
               <div class="page-col">
                 <div class="page-head">
-                  <div style="flex:1">
-                    <h1>Bots</h1>
-                    <p>Persistent agents you talk to, not tasks you launch.</p>
-                  </div>
-                  <button class="btn btn-sm btn-brand" type="button">
-                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
-                    New bot
-                  </button>
+                  <h1 style="flex:1">Bots</h1>
                 </div>
 
                 <!-- read row -->
@@ -862,6 +854,13 @@
                     </span>
                   </span>
                 </button>
+
+                <!-- create lives after the roster, never above it: the bots you
+                     already have are the point of the page. -->
+                <div class="dashed-row">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+                  New bot
+                </div>
               </div>
             </div>
           </div>
@@ -886,10 +885,7 @@
               </div>
               <div class="page-col">
                 <div class="page-head">
-                  <div style="flex:1">
-                    <h1>Bots</h1>
-                    <p>Persistent agents you talk to, not tasks you launch.</p>
-                  </div>
+                  <h1 style="flex:1">Bots</h1>
                 </div>
                 <div class="empty-card">
                   <strong>No bots yet.</strong>

--- a/docs/design/bot-mode/spec.md
+++ b/docs/design/bot-mode/spec.md
@@ -96,11 +96,10 @@ Page shell matches `AutoManageView`: `mx-auto flex max-w-3xl flex-col gap-2` wit
 
 ```
 Bots
-Persistent agents you talk to, not tasks you launch.
 ```
-- `h1`: `text-lg font-semibold leading-tight`
-- subtitle: `text-sm text-muted-foreground`
-- Place a flat **New bot** row directly below the heading. It uses the same compact rail-list rhythm as the bot rows: a dashed circular icon shell, the `Plus` icon, and a text label. Do not add a separate card-style or header CTA.
+- `h1`: `text-[22px] font-bold leading-tight tracking-tight` — the page name carries the header alone.
+- No subtitle. The roster explains itself.
+- Place a flat **New bot** row at the **bottom** of the roster, after the last bot. It uses the same compact rail-list rhythm as the bot rows: a dashed circular icon shell, the `Plus` icon, and a text label. Do not add a separate card-style or header CTA.
 
 ### 3.2 Roster row (populated, default state)
 


### PR DESCRIPTION
Bots roster design surfaces only: `docs/design/bot-mode/mockup.html` and `docs/design/bot-mode/spec.md` §3.1.

## Changed

- Removed the subtitle "Persistent agents you talk to, not tasks you launch." from both roster frames.
- Heading 18px -> 22px, tighter tracking, smaller gap below it. A first pass at 28px was too large.
- The dashed **New bot** row now sits after the last bot. The brand button in the page header is gone. The empty roster already had this row at the bottom.

## Verification

Rendered the mockup in headless Chromium and checked both frames. `bun test test/bots-roster-ux.test.ts` passes, 7 tests.

## Why this is a draft

`web/src/App.tsx` is untouched and now disagrees with this mockup:

- The app dropped the subtitle already in 90c0e96.
- The app heading is 32px. The mockup is now 22px.
- The app keeps create as a header "New" control, and `test/bots-roster-ux.test.ts` locks that placement.

Open question for @BennyKok: should the app follow this mockup and move create to the bottom, and which heading size wins? If yes, the app change and the test update belong in this branch before review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)