### PR TITLE
fix(web): tighten the Bots roster density to match the bot-mode mockup

### DIFF
--- a/test/bot-conversation-surface-toggle.test.ts
+++ b/test/bot-conversation-surface-toggle.test.ts
@@ -28,8 +28,11 @@ function openBotConversationBranch(): string {
   expect(view).toBeGreaterThan(-1);
   const start = APP.indexOf("\n  if (bot) {", view);
   expect(start).toBeGreaterThan(-1);
-  // The branch ends where the roster (non-selected) render begins.
-  const end = APP.indexOf('\n    <div className="mx-auto flex max-w-3xl flex-col gap-3" data-lfg-page-column>', start);
+  // The branch ends where the roster (non-selected) render begins. Anchor on
+  // the page-column shell only, not on its spacing utilities: the roster's gap
+  // is a design value that moves, and pinning it here made a padding tweak
+  // look like a SurfaceToggle regression.
+  const end = APP.indexOf('\n    <div className="mx-auto flex max-w-3xl', start);
   expect(end).toBeGreaterThan(start);
   return APP.slice(start, end);
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25677,14 +25677,14 @@ function BotsView({
   }
 
   return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-3" data-lfg-page-column>
+    <div className="mx-auto flex max-w-3xl flex-col gap-2" data-lfg-page-column>
       {/* Tablet band only (no persistent header toggle there yet) — real
           mobile gets the pinned Chat/Bot toggle in the app shell's mobile
           chrome instead, so it isn't doubled here. */}
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
         <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
       ) : null}
-      <div className="flex items-center gap-3 px-2 pb-3 pt-5">
+      <div className="flex items-center gap-3 px-2 pb-2 pt-4">
         <h1 className="min-w-0 flex-1 text-[32px] font-bold leading-tight tracking-tight">Bots</h1>
         <button
           type="button"

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -12,7 +12,11 @@ test("the mobile bot roster uses a flat rail-style row", () => {
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("hover:bg-muted");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("border-border");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("bg-card");
-  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-4");
+  // Density is the mockup's `.roster-row`: 10px vertical padding, 12px gap.
+  // py-4 made the row pitch 100px against a 56px avatar.
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-2.5");
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("gap-3");
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("py-4");
 });
 
 describe("shouldShowMobileSurfaceToggle", () => {

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -17,9 +17,15 @@ export type PrimaryMobileTab = "live" | "bots";
 /** `SurfaceToggle`'s own active-segment vocabulary (desktop rail history). */
 export type SurfaceToggleActive = "sessions" | "chat";
 
-/** Flat roster treatment on the Bots page — airier than the compact rail. */
+/**
+ * Flat roster treatment on the Bots page — larger than the compact rail, but
+ * not airier. The row keeps its 56px avatar; the padding and gap come from the
+ * bot-mode mockup (docs/design/bot-mode/mockup.html `.roster-row`: 10px
+ * vertical padding, 12px gap). `py-4` here put the row pitch at 100px, which
+ * read as a settings list with four items rather than a roster you scan.
+ */
 export const MOBILE_BOT_ROSTER_ROW_CLASS =
-  "flex w-full items-center gap-3.5 rounded-lg px-2 py-4 text-left transition-colors hover:bg-muted";
+  "flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted";
 
 /**
  * The persistent mobile bottom toggle shows only at real mobile widths, and


### PR DESCRIPTION
Follow-up to #206, which changed the design surfaces only. This one changes the app.

## The problem

The Bots page row pitch was 100px: a 56px avatar + `py-4` (32px) + the column's `gap-3` (12px). Four bots filled the viewport.

## The change

Density comes from the mockup landed in #206, `docs/design/bot-mode/mockup.html` `.roster-row`.

| | before | after | mockup |
|---|---|---|---|
| row vertical padding | `py-4` (32px) | `py-2.5` (20px) | 20px |
| row gap | `gap-3.5` (14px) | `gap-3` (12px) | 12px |
| column gap between rows | `gap-3` (12px) | `gap-2` (8px) | 8px |
| heading block | `pt-5 pb-3` | `pt-4 pb-2` | — |
| **row pitch** | **100px** | **84px** | 72px (44px avatar) |

Most of it lands in `web/src/lib/mobile-bots-nav.ts`, as asked. `web/src/App.tsx` takes 2 lines: the column gap and the heading block padding. Both are spacing utilities on existing elements, so the conflict surface for #207 is small.

## What did not change

The 56px avatar, the flat row treatment, and the header **New** control all stay. This is spacing only. That leaves two known divergences from the mockup, both deliberate and both open for @BennyKok:

1. **Heading size.** App is `text-[32px]`, mockup is 22px. Benny called 28px too large in the mockup, so the app heading is likely too large too. One-line change if he wants it.
2. **Create placement.** The mockup puts a dashed **New bot** row at the bottom. The app keeps the header **New** control, which `test/bots-roster-ux.test.ts` locks deliberately (#203). Moving it reverses that decision, so I left it.

## Test slice fix

`test/bot-conversation-surface-toggle.test.ts` sliced `App.tsx` on the roster container's exact class string, `gap-3` included, so a spacing tweak surfaced as three false SurfaceToggle failures. The slice now anchors on the page-column shell and ignores spacing utilities.

## Verification

- `bun test web/src/lib/mobile-bots-nav.test.ts test/bots-roster-ux.test.ts test/bot-conversation-surface-toggle.test.ts` — 27 pass, 0 fail.
- `bun run test` — **42 fail, 39 errors**, against a baseline of **43 fail, 39 errors** measured on `35abb4f` in this same worktree. No new named failure; the one delta is the flaky `worktree sweeper > keeps the worktree of a session that was active recently`, which passed this run.
- Note: the stated bar of "18 fail and 15 errors" does not reproduce here. Clean `main` in this worktree is 43/39, so I compared against my own measured baseline.
- `bun run typecheck` fails with `TS2688: Cannot find type definition file for 'bun'` on clean `main` too. That is a missing dependency install in this worktree, not this change. Unverified risk: no type check ran over these edits, though they only touch string literals in class names.
- No screenshot of the live app. This worktree cannot serve the UI with real bot data. The numbers above are arithmetic from the class values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)