### PR TITLE
Audit App Store frame renderer dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,11 @@ risk and delivery scope.
 - Dependency audit: `bun run audit`
 - Chat ingestion smoke test: `bun run chat:smoke`
 
+Run full tests and typecheck sequentially. Package-build tests can temporarily
+replace workspace artifacts and cause false module-resolution errors.
+Use a real install in each worktree. Do not share or symlink `node_modules`
+between checkouts because stale dependencies cause false test and type errors.
+
 Do not run the full suite after every small edit. Run it before delivery when
 the change crosses subsystems or affects a release. If a check cannot run,
 report the exact reason and the unverified risk.

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -80,6 +80,11 @@ export const LOCKFILE_BY_TOOL: Record<AuditTool, string> = {
 export const AUDIT_ROOTS: { dir: string; why: string; tool: AuditTool }[] = [
   { dir: ".", why: "the workspace graph — the CLI, agent backends, packages/* and web/", tool: "bun" },
   { dir: "mobile", why: "the Expo mobile app — its own npm graph, outside the root workspaces list", tool: "npm" },
+  {
+    dir: "mobile/docs/appstore-frames",
+    why: "the standalone App Store frame renderer — its own npm graph executes Playwright during asset production",
+    tool: "npm",
+  },
 ];
 
 /** The lockfile a configured root audits, relative to the repo root. */


### PR DESCRIPTION
## Summary

- Add `mobile/docs/appstore-frames/package-lock.json` to `AUDIT_ROOTS` as a distinct npm graph.
- Keep the one-off renderer under supply-chain review because it installs and executes Playwright to produce App Store release assets.
- Record the test-harness lesson in `AGENTS.md`: use real per-worktree installs and run full tests and typecheck sequentially.

## Supply-chain decision

I chose `AUDIT_ROOTS`, not `EXCLUDED_LOCKFILES`. The renderer is executable code. Its install can execute package lifecycle code. Its runtime launches Chromium, reads local inputs, and writes release-preparation assets. A vulnerable dependency can therefore affect the developer or asset-production environment even though the tool lives under `docs/`. Its current npm graph has zero advisories.

## Verification

Untouched `a3d94c4` baseline, after real root and `web/` installs and a stable sequential run:

- `bun test`: 2342 pass, 1 skip, 1 fail, 291 files.
- `bun x tsc -p tsconfig.json --noEmit`: 0 errors.
- The only stable failure was `audit coverage > every lockfile in the repo is either audited or excluded with a reason`.

After this change, run sequentially:

- `bun test scripts/audit.test.ts`: 20 pass, 0 fail.
- `bun run audit -- --offline`: 3 lockfiles audited; no unaccepted high or critical advisories.
- `bun test`: 2343 pass, 1 skip, 0 fail, 291 files.
- `bun x tsc -p tsconfig.json --noEmit`: 0 errors.

## Process note

These checks need a real install in each worktree. Symlinked `node_modules` can create phantom test and type failures. Run the full test suite and typecheck sequentially because package-build activity can create phantom `@omg-dev/client` resolution errors when checks overlap.

The `built embed resolves host externals and mounts` test is timing-sensitive under parallel load. It passed here and was not changed. Do not chase or increase its timeout when it only fails on a busy box.
