### PR TITLE
fix(web): shrink the mobile Bots avatar so the roster reads as a list

### DIFF
--- a/test/bots-roster-ux.test.ts
+++ b/test/bots-roster-ux.test.ts
@@ -59,13 +59,17 @@ describe("bots page roster chrome", () => {
 
   test("the page roster is larger than the compact rail", () => {
     expect(ROSTER).toContain("text-[32px] font-bold");
-    expect(ROSTER).toContain("size={56}");
+    // 44px, not the rail's 24/28px — still a page roster, not the compact
+    // rail — but not 56px either: that size (paired with the mockup's
+    // padding) made the row pitch 84px, which read as a settings list on a
+    // phone rather than a scannable roster. See mobile-bots-nav.ts.
+    expect(ROSTER).toContain("size={44}");
     expect(ROSTER).toContain("text-base font-semibold");
     expect(ROSTER).toContain("text-sm");
     expect(ROSTER).toContain("text-xs tabular-nums");
     expect(ROSTER).toContain("isCodingAgentStoppedText(rawPreview)");
     expect(ROSTER).toContain("text-destructive");
-    expect(ROSTER).not.toContain("size={44}");
+    expect(ROSTER).not.toContain("size={56}");
     expect(ROSTER).not.toContain("text-[13px]");
     expect(BOT_RAIL).toContain("size={railCollapsed ? 24 : 28}");
     expect(BOT_RAIL).not.toContain("size={56}");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25684,7 +25684,7 @@ function BotsView({
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
         <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
       ) : null}
-      <div className="flex items-center gap-3 px-2 pb-2 pt-4">
+      <div className="flex items-center gap-3 px-2 pb-2 pt-3">
         <h1 className="min-w-0 flex-1 text-[32px] font-bold leading-tight tracking-tight">Bots</h1>
         <button
           type="button"
@@ -25711,11 +25711,11 @@ function BotsView({
             aria-label={`${item.name}${row.unread ? ", unread conversation" : ""}`}
             className={MOBILE_BOT_ROSTER_ROW_CLASS}
           >
-            <BotAvatar bot={item} working={working} size={56} />
+            <BotAvatar bot={item} working={working} size={44} />
             <span className="flex min-w-0 flex-1 flex-col">
-              <span className={cn("truncate text-base font-semibold", !item.enabled && "text-muted-foreground")}>{item.name}</span>
+              <span className={cn("truncate text-base font-semibold leading-tight", !item.enabled && "text-muted-foreground")}>{item.name}</span>
               {preview ? (
-                <span className={cn("truncate text-sm", stopped ? "text-destructive" : "text-muted-foreground")}>{preview}</span>
+                <span className={cn("truncate text-sm leading-tight", stopped ? "text-destructive" : "text-muted-foreground")}>{preview}</span>
               ) : null}
             </span>
             {row.unread ? (

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -12,10 +12,13 @@ test("the mobile bot roster uses a flat rail-style row", () => {
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("hover:bg-muted");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("border-border");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("bg-card");
-  // Density is the mockup's `.roster-row`: 10px vertical padding, 12px gap.
-  // py-4 made the row pitch 100px against a 56px avatar.
-  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-2.5");
+  // 8px vertical padding paired with the 44px avatar in App.tsx (down from
+  // 56px) puts the row pitch at 68px. The mockup's own 10px/12px density
+  // (py-2.5, PR #208) still measured 84px because that density assumed the
+  // large avatar; shrinking the avatar is what makes the row scannable.
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("py-2");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).toContain("gap-3");
+  expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("py-2.5");
   expect(MOBILE_BOT_ROSTER_ROW_CLASS).not.toContain("py-4");
 });
 

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -19,13 +19,17 @@ export type SurfaceToggleActive = "sessions" | "chat";
 
 /**
  * Flat roster treatment on the Bots page — larger than the compact rail, but
- * not airier. The row keeps its 56px avatar; the padding and gap come from the
- * bot-mode mockup (docs/design/bot-mode/mockup.html `.roster-row`: 10px
- * vertical padding, 12px gap). `py-4` here put the row pitch at 100px, which
- * read as a settings list with four items rather than a roster you scan.
+ * not airier. PR #208 ported the bot-mode mockup's `.roster-row` density
+ * (10px vertical padding, 12px gap) verbatim and only got the row pitch from
+ * 100px to 84px, because the mockup's own airiness assumes the same large
+ * avatar this page renders (`size={56}` in App.tsx) — padding was never the
+ * dominant term. `py-2` (8px vertical padding) here pairs with the smaller
+ * 44px avatar in App.tsx to bring the row pitch to 68px, in the range of a
+ * scannable native list (iOS Messages runs roughly a 52px avatar in a ~76px
+ * row) rather than a settings screen.
  */
 export const MOBILE_BOT_ROSTER_ROW_CLASS =
-  "flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors hover:bg-muted";
+  "flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted";
 
 /**
  * The persistent mobile bottom toggle shows only at real mobile widths, and


### PR DESCRIPTION
## Summary

PR #208 tightened the mobile Bots roster row's padding/gap to the bot-mode mockup's `.roster-row` spec exactly (10px vertical padding, 12px gap) and it did not visibly fix the density Benny reported. The reason: the row pitch is dominated by `<BotAvatar size={56} />`, not the padding.

**Before (current main):** `56 (avatar) + 20 (py-2.5) + 8 (container gap-2) = 84px`
**After (this PR):** `44 (avatar) + 16 (py-2) + 8 (container gap-2) = 68px`

Shaving padding alone could never fix this — conforming to the mockup was chasing the wrong spec, since the mockup itself is airy because it assumes the same large avatar. This PR shrinks the avatar (56px → 44px) and pairs it with 8px vertical padding (`py-2.5` → `py-2`), which is the change that actually moves the needle Benny can see on a phone.

For reference, iOS Messages runs roughly a 52px avatar in a ~76px row. 68px goes tighter than that, per the ask ("tighter than what he has").

- `web/src/App.tsx`: `BotAvatar` size `56` → `44`; add `leading-tight` to the name and preview lines so the two-line text block (now ~37.5px: 20px title + 17.5px preview) stays comfortably under the 44px avatar with no clipping; heading top padding `pt-4` → `pt-3` (secondary, the rows were the priority).
- `web/src/lib/mobile-bots-nav.ts`: `MOBILE_BOT_ROSTER_ROW_CLASS` `py-2.5` → `py-2`. Horizontal `gap-3` between avatar/text/etc. is unchanged.
- Did **not** touch the separate, denser rail roster (`BOT_RAIL` / `botRailList` in `App.tsx`) — confirmed via `test/bots-roster-ux.test.ts`, which explicitly pins the rail at `size={railCollapsed ? 24 : 28}`.
- Checked `BotAvatar` (`web/src/components/BotAvatar.tsx`): `width`/`height` are the raw `size` prop, no card, no ring, no hardcoded minimum — it honors a smaller size cleanly.

## Test plan

- [x] `bun install --frozen-lockfile` at repo root and in `web/` (no symlinked `node_modules`)
- [x] Updated `web/src/lib/mobile-bots-nav.test.ts` (row class pins) and `test/bots-roster-ux.test.ts` (avatar size pin) to the new values, keeping the real invariants: `hover:bg-muted` present, `border-border`/`bg-card` absent, page roster still larger than the compact rail.
- [x] `test/bot-conversation-surface-toggle.test.ts` — unaffected (anchors on the page-column shell, not spacing utilities); passes.
- [x] Focused: `bun test web/src/lib/mobile-bots-nav.test.ts test/bots-roster-ux.test.ts test/bot-conversation-surface-toggle.test.ts` → 27 pass, 0 fail
- [x] Full suite, run sequentially: `bun run test` → **2342 pass, 1 skip, 1 fail** (matches the stated baseline exactly; the 1 failure is the pre-existing `scripts/audit.test.ts` lockfile-coverage issue, unrelated to this change and already being fixed elsewhere). Confirmed stable across two consecutive runs.
- [x] `bun run typecheck` → 0 errors (matches baseline)

Not merging — this is a visual judgement call and Benny asked to look at it himself before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)