### PR TITLE
fix(test): prepare package builds before discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "setup": "bun run src/cli.ts setup",
     "uninstall": "bun run src/cli.ts uninstall",
     "icons": "bun run scripts/generate-icons.ts",
-    "test": "bun test",
+    "test": "bun run scripts/prepare-test-builds.ts && bun test",
     "audit": "bun run scripts/audit.ts",
     "audit:exceptions": "bun run scripts/audit.ts --update-exceptions",
     "bench:agent-transport": "bun run scripts/benchmark-agent-transport.ts",

--- a/scripts/prepare-test-builds.ts
+++ b/scripts/prepare-test-builds.ts
@@ -1,0 +1,20 @@
+import { join } from "node:path";
+import { testBuildPrerequisiteError, unreadyTestBuilds } from "./test-builds";
+
+const root = join(import.meta.dir, "..");
+const before = unreadyTestBuilds(root);
+
+if (before.length > 0) {
+  console.log("Building test prerequisites before test discovery...");
+  const result = Bun.spawnSync([process.execPath, "run", "build:packages"], {
+    cwd: root,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`Test prerequisite build failed with exit code ${result.exitCode}.`);
+  }
+}
+
+const after = unreadyTestBuilds(root);
+if (after.length > 0) throw testBuildPrerequisiteError(after);

--- a/scripts/test-builds.ts
+++ b/scripts/test-builds.ts
@@ -1,0 +1,85 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export const TEST_BUILDS = [
+  {
+    output: "packages/protocol/dist/index.js",
+    inputs: [
+      "packages/protocol/src",
+      "packages/protocol/package.json",
+      "packages/protocol/tsconfig.build.json",
+    ],
+  },
+  {
+    output: "packages/client/dist/index.js",
+    inputs: [
+      "packages/client/src/index.ts",
+      "packages/client/package.json",
+      "packages/client/tsconfig.build.json",
+      "packages/protocol/dist/index.js",
+    ],
+  },
+  {
+    output: "packages/react/dist/index.js",
+    inputs: [
+      "packages/react/src",
+      "packages/react/package.json",
+      "packages/react/tsconfig.build.json",
+      "packages/client/dist/index.js",
+      "packages/protocol/dist/index.js",
+    ],
+  },
+  {
+    output: "packages/react/dist/styles.css",
+    inputs: ["packages/react/src/styles.css"],
+  },
+  {
+    output: "web/dist-lib/index.js",
+    inputs: [
+      "package.json",
+      "web/src",
+      "web/package.json",
+      "web/tsconfig.json",
+      "web/vite.lib.config.ts",
+      "packages/client/dist/index.js",
+    ],
+  },
+] as const;
+
+function newestMtime(path: string): number {
+  const stat = statSync(path);
+  if (!stat.isDirectory()) return stat.mtimeMs;
+  return readdirSync(path, { withFileTypes: true }).reduce(
+    (latest, entry) =>
+      /\.test\.[^.]+$/.test(entry.name)
+        ? latest
+        : Math.max(latest, newestMtime(join(path, entry.name))),
+    0,
+  );
+}
+
+export function unreadyTestBuilds(root: string): string[] {
+  return TEST_BUILDS.filter(({ output, inputs }) => {
+    const outputPath = join(root, output);
+    if (!existsSync(outputPath)) return true;
+    const outputMtime = statSync(outputPath).mtimeMs;
+    return inputs.some((input) => newestMtime(join(root, input)) > outputMtime);
+  }).map(({ output }) => output);
+}
+
+export function testBuildPrerequisiteError(unready: readonly string[]): Error {
+  return new Error(
+    [
+      "Test build prerequisites are missing or stale:",
+      ...unready.map((path) => `- ${path}`),
+      "Run `bun run test` from the repository root.",
+      "It builds package entrypoints before Bun starts loading test files.",
+      "Do not run package builds concurrently with `bun test`; they replace these dist entrypoints.",
+    ].join("\n"),
+  );
+}
+
+export function assertTestBuilds(root: string): void {
+  const unready = unreadyTestBuilds(root);
+  if (unready.length > 0) throw testBuildPrerequisiteError(unready);
+}

--- a/web/src/embedded-lib-smoke.test.ts
+++ b/web/src/embedded-lib-smoke.test.ts
@@ -5,21 +5,23 @@
 // that OmgAppSurface still mounts a real router tree — not just that vite
 // printed "built in Ns".
 //
-// The mount tests are not optional. If dist-lib/index.js is missing they
-// build it; if the build fails they fail the suite. A silent skip reports
-// green while proving nothing.
+// The mount tests are not optional. `bun run test` builds dist-lib before Bun
+// discovers tests. A direct run of this file fails before registration with
+// one actionable prerequisite error when the output is absent. A silent skip
+// would report green while proving nothing.
 
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Window } from "happy-dom";
+import { assertTestBuilds } from "../../scripts/test-builds";
 
 const WEB = join(import.meta.dir, "..");
 const REPO = join(WEB, "..");
 const DIST = join(WEB, "dist-lib");
-const INDEX = join(DIST, "index.js");
 const MANIFEST = join(WEB, "package.json");
+
+assertTestBuilds(REPO);
 
 const EXPECTED_PEERS = {
   "@base-ui/react": "^1.6.0",
@@ -30,28 +32,6 @@ const EXPECTED_PEERS = {
   "react-dom": "^19.2.4",
   vaul: "^1.1.2",
 } as const;
-
-function ensureLibBuild(): void {
-  if (existsSync(INDEX)) return;
-  const result = spawnSync("bun", ["run", "--cwd", "web", "build:lib"], {
-    cwd: REPO,
-    encoding: "utf8",
-    timeout: 180_000,
-  });
-  if (result.status !== 0 || !existsSync(INDEX)) {
-    throw new Error(
-      [
-        "embed smoke test requires web/dist-lib/index.js and will not skip.",
-        "bun run --cwd web build:lib failed:",
-        result.stdout ?? "",
-        result.stderr ?? "",
-        result.error ? String(result.error) : "",
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-}
 
 const win = new Window({ url: "https://app.omg.dev/" });
 beforeAll(() => {
@@ -159,8 +139,6 @@ describe("vite.lib.config host-shared externals", () => {
 });
 
 describe("built embed resolves host externals and mounts", () => {
-  beforeAll(ensureLibBuild);
-
   let host: HTMLElement | null = null;
   let reactRoot: { unmount: () => void } | null = null;
 

--- a/web/src/first-run-e2e.test.ts
+++ b/web/src/first-run-e2e.test.ts
@@ -9,47 +9,18 @@
 // asked whether the STATE was right. None mounted the app and looked.
 //
 // Mounted from source rather than from web/dist-lib, deliberately. The embed
-// smoke test builds dist-lib only when it is missing, so a stale bundle would
-// let this file certify code that is no longer in the tree — precisely the
-// "green while proving nothing" failure its own header warns about.
+// smoke test exercises the built artifact, but this file must certify the code
+// in the current tree — precisely the "green while proving nothing" failure
+// its own header warns about.
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Window } from "happy-dom";
+import { assertTestBuilds } from "../../scripts/test-builds";
 
 const REPO = join(import.meta.dir, "..", "..");
 
-// web/src/embedded.tsx imports @omg-dev/client, a workspace package that is
-// only resolvable once its dist/ exists. A clean checkout has node_modules but
-// no built packages, so without this the test dies on "Cannot find module
-// '@omg-dev/client'" — a failure about the checkout, not about the product.
-//
-// Building is the right move rather than skipping. This file is the only guard
-// that mounts the real surface, so a skip on a fresh clone or a CI runner would
-// silently retire the exact coverage the blank-home bug proved we needed. Same
-// reasoning, and same shape, as ensureLibBuild() in embedded-lib-smoke.test.ts.
-function ensureWorkspacePackages(): void {
-  if (existsSync(join(REPO, "packages", "client", "dist", "index.js"))) return;
-  const result = spawnSync("bash", ["scripts/pack-packages.sh", "--build-only"], {
-    cwd: REPO,
-    encoding: "utf8",
-    timeout: 300_000,
-  });
-  if (!existsSync(join(REPO, "packages", "client", "dist", "index.js"))) {
-    throw new Error(
-      [
-        "first-run app-surface test requires the workspace packages and will not skip.",
-        "bun run build:packages failed:",
-        result.stdout ?? "",
-        result.stderr ?? "",
-        result.error ? String(result.error) : "",
-      ]
-        .filter(Boolean)
-        .join("\n"),
-    );
-  }
-}
+assertTestBuilds(REPO);
 
 const win = new Window({ url: "https://app.omg.dev/" });
 
@@ -180,10 +151,6 @@ afterEach(async () => {
 
 describe("a fresh hosted account is shown its onboarding steps", () => {
   test("the real app surface renders the getting-started panel on an empty home", async () => {
-    // Inside the test, not in beforeAll: a cold build takes longer than bun's
-    // 5s hook timeout, and a hook that times out reports as an anonymous
-    // failure with no clue which check broke.
-    ensureWorkspacePackages();
     const React = await import("react");
     const { createRoot } = await import("react-dom/client");
     const { act } = await import("react");


### PR DESCRIPTION
## Problem

The suite had two build owners inside test execution. `first-run-e2e.test.ts` ran `scripts/pack-packages.sh --build-only`, while `embedded-lib-smoke.test.ts` could run `web build:lib`. The workspace packages export generated `dist/index.js` files, and every package build starts by deleting `dist`.

I reproduced the race from absent outputs with two Bun workers. The embed build was terminated at the five-second hook timeout while the other worker rebuilt packages. The result was 4 pass / 1 fail after 306.02 seconds. With only `packages/client/dist` moved aside, an importer failed in 301 ms with:

```
error: Cannot find module '@omg-dev/client' from 'web/src/embedded.tsx'
```

## Fix

- `bun run test` now prepares missing or stale package and embed outputs before Bun discovers test files.
- Package-consuming tests stop before registration with one actionable prerequisite error when direct `bun test` bypasses preparation.
- The two test files no longer build shared outputs during test execution.
- Freshness follows package sources, configs, upstream package outputs, and production files in `web/src`.
- Unrelated focused tests do not require public package builds.

This keeps generated package entrypoints as the tested public boundary. Importing package source would bypass that boundary. Merely isolating one build test would leave the second builder and clean-checkout failures. Making all package builds atomic or adding a cross-process build/test lock would be a larger build-system change. It remains a useful follow-up if external package builds must run concurrently with tests.

## Verification

- Forced cold two-worker reproducer after the fix: 6 pass / 0 fail in 37.88 seconds, including prerequisite build.
- Direct missing output: one clear prerequisite error in 62 ms.
- Direct stale output: one clear prerequisite error in 52 ms.
- Full suite: 2343 pass / 1 skip / 0 fail.
- Typecheck: 0 errors.
- Standalone IndexNow CI command: 17 pass / 0 fail.
- Warm runtime: 58.05 seconds before and 59.03 seconds after on the first comparable run. The readiness scan itself takes 0.04-0.05 seconds.
- Cold supported runtime: 91.37-92.36 seconds, including the prerequisite package and embed build that the old suite attempted during test execution.

The box also showed load-induced SIGTERM and timeout failures during reproduction. This change makes the package-build case explicit. General resource-starvation timeouts remain a separate runner-capacity signal.
