### PR TITLE
fix(mobile): purpose strings that satisfy guideline 5.1.1(ii)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -11,8 +11,8 @@
       "bundleIdentifier": "dev.omg.computer",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSCameraUsageDescription": "Take a photo to attach to a message.",
-        "NSMicrophoneUsageDescription": "Dictate a message instead of typing it."
+        "NSCameraUsageDescription": "omg.dev uses the camera only when you choose to attach a photo to a message. The photo is uploaded to your own omg.dev cloud computer, and the coding agent you are messaging can then open that file. For example, photograph an error on your screen and send it so the agent can debug it.",
+        "NSMicrophoneUsageDescription": "omg.dev records audio only while dictation is on. You tap the microphone button to start and tap it again to stop. The recording is sent to ElevenLabs, our speech-to-text provider, to convert it into text. For example, say \"fix the login bug on the settings page\" and those words appear as a typed message to your coding agent. The audio is not used for any other purpose."
       },
       "runtimeVersion": {
         "policy": "appVersion"

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -12,7 +12,7 @@
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSCameraUsageDescription": "omg.dev uses the camera only when you choose to attach a photo to a message. The photo is uploaded to your own omg.dev cloud computer, and the coding agent you are messaging can then open that file. For example, photograph an error on your screen and send it so the agent can debug it.",
-        "NSMicrophoneUsageDescription": "omg.dev records audio only while dictation is on. You tap the microphone button to start and tap it again to stop. The recording is sent to ElevenLabs, our speech-to-text provider, to convert it into text. For example, say \"fix the login bug on the settings page\" and those words appear as a typed message to your coding agent. The audio is not used for any other purpose."
+        "NSMicrophoneUsageDescription": "omg.dev records audio only while dictation is on. You tap the microphone button to start and tap it again to stop. The recording is sent to ElevenLabs, our speech-to-text provider, to convert it into text. For example, say \"fix the login bug on the settings page\" and those words appear as a typed message to your coding agent. omg.dev does not use the audio for any other purpose."
       },
       "runtimeVersion": {
         "policy": "appVersion"


### PR DESCRIPTION
App review rejected iOS 1.0 (29) on two guidelines. Both trace to one fact: dictation audio leaves the phone and is transcribed by a third party, and neither purpose string said so.

## Guideline 5.1.1(ii)

`NSMicrophoneUsageDescription` was `"Dictate a message instead of typing it."` That names the feature but not what happens to the recording. Apple asked for the use plus a concrete example.

The new string states when recording happens, that the audio goes to ElevenLabs for speech-to-text, and gives an example utterance.

`NSCameraUsageDescription` was not cited but had the same defect, so it is fixed in the same pass.

## Claims verified against the code, not assumed

- Dictation is **tap-on / tap-off**, not hold-to-talk — `onPress={dictation.toggle}` in `src/components.tsx`. An earlier draft said "hold".
- Attached photos are **not** sent to a third-party model. Per `src/omg/attachments.ts`, bytes upload to the user's own computer, which returns a path the agent opens. The string says that instead.
- The mic string says "**omg.dev** does not use the audio for any other purpose", scoped deliberately. ElevenLabs defaults to `enable_logging=true`, Zero Retention Mode is enterprise-only, and their privacy policy reserves the right to use Voice Data to improve their models — so a blanket purpose-limitation claim would not be true.

## Note

`infoPlist` is baked at build time, so this needs a new binary. Metadata-only resubmission will not clear 5.1.1.

Guideline 2.1 ("Information Needed") is a separate written reply in App Store Connect and is not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)