### PR TITLE
feat(onboarding): add-to-home-screen as the optional last first-run step

### DIFF
--- a/web/src/components/embedded-connect-gate.tsx
+++ b/web/src/components/embedded-connect-gate.tsx
@@ -26,12 +26,14 @@ import {
   CalendarClock,
   Check,
   Clock,
+  Download,
   Github,
   Laptop,
   Layers,
   Palette,
   Repeat,
   Rocket,
+  Share,
   Shuffle,
   Smartphone,
   Sparkles,
@@ -39,6 +41,8 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { BrandIcon } from "../lib/brand-icons";
+import { InstallInstructions } from "./pwa-install";
+import { usePwaInstall } from "../lib/pwa-install";
 import type { ConnectOption, ToolConnectOption } from "../lib/embedded-connect";
 import { LFG_SMALL_ICON_PATH } from "../lib/icon-assets";
 import { agentIconAlt, agentIconSrc } from "../lib/session-ui";
@@ -199,6 +203,9 @@ export function EmbeddedConnectGate({
   const [page, setPage] = useState<GatePage>("survey-identity");
   const [surveyAnswers, setSurveyAnswers] = useState<SurveyAnswers>(EMPTY_SURVEY_ANSWERS);
   const hasConnectedAgent = options.some((option) => option.configured);
+  const pwa = usePwaInstall();
+  const [installBusy, setInstallBusy] = useState(false);
+  const [installHelpOpen, setInstallHelpOpen] = useState(false);
 
   // Skip the tools page when nothing on it can actually be connected.
   //
@@ -210,8 +217,13 @@ export function EmbeddedConnectGate({
   // means still loading, which is NOT the same as unavailable — that case
   // keeps the page and shows its skeleton.
   const toolsUsable = toolConnections === undefined || toolConnections.some((t) => t.installed);
-  const connectPages: ConnectPageId[] = toolsUsable ? ["agents", "tools", "value"] : ["agents", "value"];
-  const flow = buildGateFlow(toolsUsable);
+  // `page === "install"` keeps the page in the flow once the user is ON it —
+  // a successful install flips `pwa.installed`, and that must not delete the
+  // page out from under them (same stays-mounted rule as the agent login).
+  const installable = (!pwa.installed && pwa.mode !== "none") || page === "install";
+  const flow = buildGateFlow(toolsUsable, installable);
+  const connectPages = flow.filter((p): p is ConnectPageId => !isSurveyPage(p));
+  const installIsLastPage = flow[flow.length - 1] === "install";
   const goNext = () => setPage(stepAfter(flow, page));
   const goBack = () => setPage(stepBefore(flow, page));
 
@@ -489,9 +501,9 @@ export function EmbeddedConnectGate({
               Back
             </button>
           </>
-        ) : (
+        ) : page === "value" ? (
           <>
-            {/* The closing beat, and the only screen here that sells rather
+            {/* The selling beat, and the only screen here that sells rather
                 than asks. Two things, because two is what someone remembers
                 from a first run: this Computer runs the agent account you
                 already pay for, and it can run work while you are not looking.
@@ -550,7 +562,69 @@ export function EmbeddedConnectGate({
               </div>
             </div>
 
-            <Button variant="brand" className="mt-4 w-full" onClick={onDone}>
+            <Button
+              variant="brand"
+              className="mt-4 w-full"
+              onClick={installIsLastPage ? goNext : onDone}
+            >
+              {installIsLastPage ? "Continue" : "Open my Computer"}
+            </Button>
+            <button
+              type="button"
+              onClick={goBack}
+              className="mt-4 w-full text-center text-xs text-muted-foreground underline-offset-2 hover:underline"
+            >
+              Back
+            </button>
+          </>
+        ) : (
+          <>
+            {/* Last step, and optional by construction: "Open my Computer"
+                is always right below the install action, so this page can
+                never gate the product. Install lived inside a signup wizard
+                once and walled iOS users with no skip control — the ask only
+                works AFTER the product, over a machine that is already set
+                up. See buildGateFlow for why it is last. */}
+            <h1 className="text-xl font-semibold">Add omg to your home screen</h1>
+            <p className="mb-5 mt-1 text-sm text-muted-foreground">
+              One tap back to your Computer — its own icon and window, no
+              browser tabs in the way.
+            </p>
+            {pwa.installed ? (
+              <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5 text-sm font-medium">
+                <span className="flex size-8 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-500">
+                  <Check className="size-4" />
+                </span>
+                Added
+              </div>
+            ) : (
+              <Button
+                variant="brand"
+                className="w-full"
+                disabled={installBusy}
+                onClick={() => {
+                  if (pwa.mode !== "native") {
+                    setInstallHelpOpen(true);
+                    return;
+                  }
+                  if (installBusy) return;
+                  setInstallBusy(true);
+                  void pwa.install().finally(() => setInstallBusy(false));
+                }}
+              >
+                {pwa.mode === "ios" ? (
+                  <Share className="size-4" />
+                ) : (
+                  <Download className="size-4" />
+                )}
+                {pwa.mode === "native" ? "Install omg" : "Add to Home Screen"}
+              </Button>
+            )}
+            <Button
+              variant={pwa.installed ? "brand" : "outline"}
+              className="mt-3 w-full"
+              onClick={onDone}
+            >
               Open my Computer
             </Button>
             <button
@@ -560,6 +634,11 @@ export function EmbeddedConnectGate({
             >
               Back
             </button>
+            <InstallInstructions
+              mode={pwa.mode}
+              open={installHelpOpen}
+              onOpenChange={setInstallHelpOpen}
+            />
           </>
         )}
       </div>

--- a/web/src/components/pwa-install.tsx
+++ b/web/src/components/pwa-install.tsx
@@ -24,7 +24,7 @@ function initiallyDismissed() {
   }
 }
 
-function InstallInstructions({ mode, open, onOpenChange }: {
+export function InstallInstructions({ mode, open, onOpenChange }: {
   mode: PwaInstallMode;
   open: boolean;
   onOpenChange: (open: boolean) => void;

--- a/web/src/lib/onboarding-survey.test.ts
+++ b/web/src/lib/onboarding-survey.test.ts
@@ -38,6 +38,37 @@ describe("buildGateFlow", () => {
       "value",
     ]);
   });
+
+  test("install is the last page when the browser can install", () => {
+    expect(buildGateFlow(true, true)).toEqual([
+      "survey-identity",
+      "survey-pain",
+      "survey-tools",
+      "survey-ai",
+      "agents",
+      "tools",
+      "value",
+      "install",
+    ]);
+    expect(buildGateFlow(false, true)).toEqual([
+      "survey-identity",
+      "survey-pain",
+      "survey-tools",
+      "survey-ai",
+      "agents",
+      "value",
+      "install",
+    ]);
+  });
+
+  test("install never precedes agent connection or the value pitch", () => {
+    for (const toolsUsable of [true, false]) {
+      const flow = buildGateFlow(toolsUsable, true);
+      expect(flow.indexOf("install")).toBe(flow.length - 1);
+      expect(flow.indexOf("install")).toBeGreaterThan(flow.indexOf("agents"));
+      expect(flow.indexOf("install")).toBeGreaterThan(flow.indexOf("value"));
+    }
+  });
 });
 
 describe("isSurveyPage", () => {

--- a/web/src/lib/onboarding-survey.ts
+++ b/web/src/lib/onboarding-survey.ts
@@ -89,7 +89,7 @@ export const AI_TOOL_OPTIONS: readonly SurveyOption<SurveyAiTool>[] = SHOWCASE_A
 }));
 
 export type SurveyPageId = "survey-identity" | "survey-pain" | "survey-tools" | "survey-ai";
-export type ConnectPageId = "agents" | "tools" | "value";
+export type ConnectPageId = "agents" | "tools" | "value" | "install";
 export type GatePage = SurveyPageId | ConnectPageId;
 
 export const SURVEY_PAGES: readonly SurveyPageId[] = [
@@ -107,8 +107,16 @@ export function isSurveyPage(page: GatePage): page is SurveyPageId {
 // pages. `toolsUsable` is the same "skip the tools page when nothing on it
 // can be connected" check the gate already does — see its own comment in
 // embedded-connect-gate.tsx for why that page can disappear from the flow.
-export function buildGateFlow(toolsUsable: boolean): GatePage[] {
+//
+// `installable` appends the add-to-home-screen page, deliberately LAST: the
+// install ask comes after agent connection and the value pitch, never in
+// front of them (install-as-a-gate was the highest-drop-off screen the old
+// signup wizard had). It only exists where the browser has a real install
+// path — a captured native prompt, iOS, or Mac Safari instructions — because
+// a dead step in a first run is worse than no step.
+export function buildGateFlow(toolsUsable: boolean, installable = false): GatePage[] {
   const connect: ConnectPageId[] = toolsUsable ? ["agents", "tools", "value"] : ["agents", "value"];
+  if (installable) connect.push("install");
   return [...SURVEY_PAGES, ...connect];
 }
 


### PR DESCRIPTION
## Summary

- New last page in the embedded first-run gate: **Add omg to your home screen**
- Joins the flow only when the browser has a real install path (captured native prompt, iOS, or Mac Safari); otherwise the flow is unchanged
- Native mode fires the real install prompt; iOS / Mac Safari open the existing InstallInstructions dialog
- "Open my Computer" sits directly below the install action on the page itself — it can never gate the product
- The page stays in the flow once entered, so a successful install cannot delete it mid-step
- The value page's CTA becomes "Continue" only when the install page follows it

## Why last

Install-as-a-gate was the old signup wizard's highest-drop-off screen (iOS rendered it with no skip control). The ask runs after agent connection and the value pitch, over a machine that is already set up. `buildGateFlow` tests pin that install can never precede agents or value.

## Verification

- `bun test web/src/lib/onboarding-survey.test.ts test/embedded-connect-gate.test.ts` — 57 pass
- `bun run build` in `web/` — typecheck + production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)