### PR TITLE
fix(bots): restart a bot runtime immediately instead of queueing it

### DIFF
--- a/src/bots/rotation.test.ts
+++ b/src/bots/rotation.test.ts
@@ -135,12 +135,25 @@ describe("manual restart lifecycle", () => {
     expect(botRotationAdmission("bot_one", undefined, [])).toEqual({ ready: true });
   });
 
-  test("queues instead of interrupting busy work or promoting a child", () => {
-    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: true }, []))
+  test("runs immediately even when the primary is busy or a child is live", () => {
+    // A human reaches for Restart precisely when the busy signal has stopped
+    // meaning progress, so waiting on it parks the escape hatch behind the
+    // wedged turn it exists to clear.
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: true }, [], "restart"))
+      .toEqual({ ready: true });
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: false }, [
+      { sessionId: "child-live", botId: "bot_one", parentSessionId: "runtime-live", pid: 11 },
+    ], "restart")).toEqual({ ready: true });
+  });
+
+  test("still defers a rotation the machine decided to run", () => {
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: true }, [], "config"))
+      .toEqual({ ready: false, blocked: "primary-busy", children: [] });
+    expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: true }, [], "compaction"))
       .toEqual({ ready: false, blocked: "primary-busy", children: [] });
     expect(botRotationAdmission("bot_one", { sessionId: "runtime-live", busy: false }, [
       { sessionId: "child-live", botId: "bot_one", parentSessionId: "runtime-live", pid: 11 },
-    ])).toEqual({ ready: false, blocked: "children-active", children: ["child-live"] });
+    ], "compaction")).toEqual({ ready: false, blocked: "children-active", children: ["child-live"] });
   });
 });
 

--- a/src/bots/rotation.ts
+++ b/src/bots/rotation.ts
@@ -274,16 +274,33 @@ export function activeBotChildren<T extends BotRotationSession>(
 /**
  * Whether rotation may proceed, and if not, why.
  *
- * Default is to wait, never to kill. A bot mid-turn is producing an answer
- * somebody is waiting for; a bot with live children has delegated work that
- * will try to report home. Rotating through either loses real work silently,
- * which is the one outcome worse than a stale persona.
+ * For a rotation the machine decided to run, the default is to wait, never to
+ * kill. A bot mid-turn is producing an answer somebody is waiting for; a bot
+ * with live children has delegated work that will try to report home. Rotating
+ * through either loses real work silently, which is the one outcome worse than
+ * a stale persona.
+ *
+ * A human `restart` is the exception, and it is not a special case so much as
+ * the whole point of the action. Waiting is only safe while the busy signal
+ * still means progress. The reason a person reaches for Restart is that it
+ * does not: a wedged turn, a provider error the harness never returned from, a
+ * runtime whose session id no longer resolves. Those states report `busy`
+ * forever, so an admission gate turns the one escape hatch into another thing
+ * that is stuck. Deferring here produced exactly that bug — a restart parked
+ * as "queued" behind a turn that could never end.
+ *
+ * So a restart is admitted unconditionally, and the work that admission used
+ * to protect is carried instead of guarded: `rotateBotSession` moves the
+ * undelivered send queue onto the replacement, and a late child report finds
+ * the bot through its archived session ids.
  */
 export function botRotationAdmission(
   botId: string,
   primary: BotRotationSession | undefined,
   sessions: readonly BotRotationSession[],
+  reason: BotRotationReason = "config",
 ): BotRotationAdmission {
+  if (reason === "restart") return { ready: true };
   if (primary?.busy) {
     return {
       ready: false,
@@ -298,7 +315,13 @@ export function botRotationAdmission(
   return { ready: true };
 }
 
-/** A queued turn must keep its original ordering and finish before rotation. */
+/**
+ * A queued turn must keep its original ordering and finish before rotation.
+ *
+ * Applies to automatic rotations only. A restart carries the queue forward
+ * instead of waiting for it, because a queue that cannot drain is the symptom
+ * the human is restarting to clear.
+ */
 export function queueBlocksBotRotation(
   messages: readonly { status: string }[],
 ): boolean {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -674,6 +674,7 @@ import {
   getMessage,
   recordCommandFileMessage,
   resumePersistedQueues,
+  takeUndeliveredQueue,
 } from "../sendq.ts";
 import { startFleetWatcher } from "../voice-bus.ts";
 import { startSessionPushBridge } from "../session-push.ts";
@@ -2801,7 +2802,7 @@ async function rotateBotSession(
 
     const sessions = await listSessions();
     const primary = findBotMainSession(bot, sessions);
-    const admission = botRotationAdmission(bot.id, primary, sessions);
+    const admission = botRotationAdmission(bot.id, primary, sessions, opts.reason);
     if (!admission.ready) {
       mutateBot(bot.id, (current) => ({
         ...current,
@@ -2820,8 +2821,12 @@ async function rotateBotSession(
       return { ok: false, deferred: true, blocked: admission.blocked, children: admission.children };
     }
 
+    // An automatic rotation waits for the queue to drain so ordering survives.
+    // A restart cannot: the queue it would wait on is stuck behind the same
+    // wedged turn the human is restarting to clear. It carries those sends onto
+    // the replacement after the swap instead (see `carried` below).
     const queueSessionId = primary?.sessionId ?? botCanonicalSessionId(bot, sessions);
-    if (queueSessionId) {
+    if (queueSessionId && opts.reason !== "restart") {
       await reconcileQueued(queueSessionId).catch(() => false);
       const queueBusy = queueBlocksBotRotation(listQueue(queueSessionId));
       if (queueBusy) {
@@ -2988,6 +2993,36 @@ async function rotateBotSession(
         }));
         await stopReplacement("bot_rotation_close_rollback");
         return fail(outcome.status, outcome.reason);
+      }
+    }
+
+    // Undelivered sends belong to the conversation, not to the process that
+    // happened to be running when they arrived. Only a restart can reach here
+    // with a non-empty queue, and dropping it would make "restart now" cost the
+    // user the messages they were waiting on. Reconcile first so anything the
+    // old runtime did read is not sent twice, then re-address the rest in their
+    // original order through the one owner of session delivery.
+    if (previousSessionId && previousSessionId !== newSessionId) {
+      await reconcileQueued(previousSessionId).catch(() => false);
+      const carried = takeUndeliveredQueue(previousSessionId);
+      for (const message of carried) {
+        const sent = sendPromptToLiveSession(launched.session, message.text, { mode: "queue" });
+        if (!sent.ok) {
+          evlog("bot_rotation_queue_carry_failed", {
+            botId,
+            sessionId: newSessionId,
+            error: sent.error,
+          });
+          break;
+        }
+      }
+      if (carried.length) {
+        evlog("bot_rotation_queue_carried", {
+          botId,
+          from: previousSessionId,
+          to: newSessionId,
+          count: carried.length,
+        });
       }
     }
 
@@ -3229,12 +3264,22 @@ async function deliverBotMessage(
  *
  * Only for agent-authored sends (the caller passes `fromSessionId`): a human
  * posting to a dead session id should still get the 404 that tells them so.
+ *
+ * Archived ids count as the bot. A child is told its parent's session id once,
+ * at spawn, and a rotation replaces that id underneath it — so after a restart
+ * or a compaction the child reports to an id the record no longer names as
+ * current. Matching the archive is what lets the report land in the
+ * conversation it was always meant for, and it is why a restart no longer has
+ * to wait for delegated children before it can run.
  */
 async function reviveBotSessionForReport(
   targetSessionId: string,
   text: string,
 ): Promise<{ session: Session; delivered: boolean } | null> {
-  const bot = (await listBots()).find((candidate) => candidate.sessionId === targetSessionId);
+  const bot = (await listBots()).find((candidate) =>
+    candidate.sessionId === targetSessionId ||
+    !!candidate.archivedSessionIds?.includes(targetSessionId)
+  );
   if (!bot?.enabled) return null;
   const ensured = await ensureBotSession(bot, text);
   if (ensured instanceof Response) return null;
@@ -5173,14 +5218,11 @@ a{color:#60a5fa}
             });
           }
           if (outcome.deferred) {
-            return json({
-              ok: true,
-              state: "queued",
-              conversationId,
-              runtimeSessionId: after.sessionId ?? expectedRuntimeSessionId,
-              blocked: outcome.blocked,
-              activeChildren: outcome.children.length,
-            }, { status: 202 });
+            // Not reachable: `botRotationAdmission` admits a restart
+            // unconditionally, which is the point of the action. Handled so the
+            // shared rotation outcome stays exhaustive, and reported as a
+            // failure rather than as a "queued" restart that nothing will drain.
+            return err(503, "the restart could not start; retry in a moment", "bot_restart_failed");
           }
           return err(outcome.status, outcome.error, "bot_restart_failed");
         }

--- a/src/sendq.test.ts
+++ b/src/sendq.test.ts
@@ -15,6 +15,7 @@ import {
   resetSendQueueForTests,
   resumePersistedQueues,
   retryMessage,
+  takeUndeliveredQueue,
   type QueuedMsg,
 } from "./sendq.ts";
 import { writeStoredQueueMessage } from "./sendq-store.ts";
@@ -172,6 +173,42 @@ describe("command-file queue state", () => {
         error: expect.stringContaining("server restart"),
       }),
     ]);
+  });
+
+  test("hands undelivered rows to a replacement session and keeps the rest", () => {
+    const sessionId = crypto.randomUUID();
+    const now = Date.now();
+    for (const [index, status] of (["delivered", "sending", "failed"] as const).entries()) {
+      writeStoredQueueMessage(sessionId, {
+        id: `${status}-row`,
+        text: status,
+        status,
+        attempts: 1,
+        createdAt: now + index,
+        updatedAt: now + index,
+      });
+    }
+    resetSendQueueForTests();
+    const first = recordCommandFileMessage(sessionId, "routine one", true);
+    const second = recordCommandFileMessage(sessionId, "routine two", true);
+
+    // Only rows that never reached the agent move, and they keep their order.
+    const carried = takeUndeliveredQueue(sessionId);
+    expect(carried.map((m) => m.id)).toEqual([first.id, second.id]);
+    // A `sending` row still belongs to its delivery worker, and terminal rows
+    // stay as the history of the retired session.
+    expect(listQueue(sessionId).map((m) => m.status).sort())
+      .toEqual(["delivered", "failed", "sending"]);
+
+    // Removed from the store too: a carried message must not be live in the
+    // old queue and the new one at the same time.
+    resetSendQueueForTests();
+    expect(listQueue(sessionId).some((m) => m.id === first.id || m.id === second.id)).toBe(false);
+  });
+
+  test("takes nothing from a queue with no undelivered rows", () => {
+    const sessionId = crypto.randomUUID();
+    expect(takeUndeliveredQueue(sessionId)).toEqual([]);
   });
 
   test("prunes delivered rows in memory and in SQLite", () => {

--- a/src/sendq.ts
+++ b/src/sendq.ts
@@ -179,6 +179,34 @@ export function clearResolved(sessionId: string): number {
   return before - s.msgs.length;
 }
 
+/**
+ * Remove and return the sends that never reached the agent, so a caller can
+ * re-address them at a replacement session.
+ *
+ * A bot restart retires the runtime a queue was addressed to. `pending` and
+ * `queued` rows are undelivered by definition — one never entered the
+ * composer, the other sits in the harness's own queue behind a turn that is
+ * about to be destroyed with it — so leaving them here strands them in a
+ * session no UI watches again. They are removed rather than copied: the caller
+ * re-enqueues them on the new session, and one message must not be live in two
+ * queues at once.
+ *
+ * A `sending` row is deliberately left behind. It may already have been
+ * submitted, and its delivery worker still owns it; taking it would risk a
+ * duplicate user turn, which is the same tradeoff `resumePersistedQueues`
+ * makes for an interrupted send.
+ */
+export function takeUndeliveredQueue(sessionId: string): QueuedMsg[] {
+  const s = q(sessionId);
+  const taken = s.msgs.filter((m) => m.status === "pending" || m.status === "queued");
+  if (!taken.length) return [];
+  const ids = new Set(taken.map((m) => m.id));
+  s.msgs = s.msgs.filter((m) => !ids.has(m.id));
+  deleteStoredQueueMessages(sessionId, [...ids]);
+  traceLog("sendq_taken_for_handoff", { sessionId, count: taken.length });
+  return taken;
+}
+
 // Bounded retention applies only to truly resolved rows. A `queued` row is
 // still waiting to be reconciled against the transcript, and a `failed` row is
 // still waiting for the user to retry or clear it — pruning either would

--- a/test/bot-restart-wiring.test.ts
+++ b/test/bot-restart-wiring.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 const SERVE = readFileSync(new URL("../src/commands/serve.ts", import.meta.url), "utf8");
 const STORE = readFileSync(new URL("../src/bots/store.ts", import.meta.url), "utf8");
 const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+const ROTATION = readFileSync(new URL("../src/bots/rotation.ts", import.meta.url), "utf8");
 
 const restartRoute = SERVE.slice(
   SERVE.indexOf("Explicit runtime lifecycle action for a persistent bot conversation"),
@@ -33,11 +34,33 @@ describe("persistent bot manual restart wiring", () => {
     expect(restartRoute).toContain('"bot_restart_forbidden"');
   });
 
-  test("returns typed success, queued and failure states", () => {
+  test("returns typed success and failure states, and never a queued restart", () => {
     expect(restartRoute).toContain('state: outcome.rotated ? "restarted" : "already-restarted"');
-    expect(restartRoute).toContain('state: "queued"');
     expect(restartRoute).toContain('"bot_restart_failed"');
-    expect(restartRoute).toContain("activeChildren: outcome.children.length");
+    // A restart that cannot run is a failure the caller can retry, not a
+    // pending state parked behind the wedged turn it exists to clear.
+    expect(restartRoute).not.toContain('state: "queued"');
+    expect(restartRoute).not.toContain("activeChildren");
+    expect(APP).not.toContain("Restart queued");
+  });
+
+  test("admits a restart unconditionally and carries its undelivered queue", () => {
+    const rotation = SERVE.slice(
+      SERVE.indexOf("async function rotateBotSession"),
+      SERVE.indexOf("async function applyPendingBotRotation"),
+    );
+    expect(ROTATION).toContain('if (reason === "restart") return { ready: true };');
+    expect(rotation).toContain("botRotationAdmission(bot.id, primary, sessions, opts.reason)");
+    // The queue gate is for automatic rotations only.
+    expect(rotation).toContain('if (queueSessionId && opts.reason !== "restart")');
+    // Undelivered sends move onto the replacement instead of being stranded in
+    // the retired session's queue, and only after the old primary is closed.
+    expect(rotation).toContain("takeUndeliveredQueue(previousSessionId)");
+    expect(rotation.indexOf("takeUndeliveredQueue(previousSessionId)")).toBeGreaterThan(
+      rotation.indexOf('source: `bot_rotation_${opts.reason}`'),
+    );
+    // A child told the old parent id at spawn still finds the bot afterwards.
+    expect(SERVE).toContain("candidate.archivedSessionIds?.includes(targetSessionId)");
   });
 
   test("persists enough state to resume a queued restart after reload", () => {
@@ -62,7 +85,8 @@ describe("persistent bot manual restart wiring", () => {
   test("exposes the accessible action only in the bot conversation menu", () => {
     expect(botMenu).toContain('label="Restart session"');
     expect(botMenu).toContain('aria-label="Restart session"');
-    expect(botMenu).toContain("Queue restart after current work");
+    expect(botMenu).toContain('confirmLabel="Confirm restart"');
+    expect(botMenu).not.toContain("Queue restart after current work");
     expect(regularSessionMenu).not.toContain("Restart session");
     expect(SERVE).not.toContain("/api/sessions/:id/restart");
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25364,12 +25364,10 @@ function reportBotChatError(message: string | null) {
 
 type BotRestartResponse = {
   ok: true;
-  state: "restarted" | "queued" | "already-restarted";
+  state: "restarted" | "already-restarted";
   conversationId: string | null;
   runtimeSessionId: string | null;
   previousRuntimeSessionId?: string | null;
-  blocked?: "primary-busy" | "children-active";
-  activeChildren?: number;
 };
 
 /** The bot-chat-only lifecycle menu, shared by desktop and mobile headers. */
@@ -25402,12 +25400,7 @@ function BotConversationMenu({
       // failure must not turn a completed restart into a false failure toast;
       // the normal poll/live stream will reconcile the view.
       await onRefresh().catch(() => {});
-      if (result.state === "queued") {
-        const detail = result.blocked === "children-active"
-          ? ` after ${result.activeChildren || 1} active child task${result.activeChildren === 1 ? "" : "s"} finish`
-          : " after the current work and queued messages finish";
-        toast.success(`Restart queued${detail}.`, { id: toastId });
-      } else if (result.state === "already-restarted") {
+      if (result.state === "already-restarted") {
         toast.success("The runtime was already restarted.", { id: toastId });
       } else {
         toast.success("Runtime restarted. Conversation and history were preserved.", { id: toastId });
@@ -25423,28 +25416,26 @@ function BotConversationMenu({
     : !bot.conversationId && !bot.sessionId
       ? "Restart unavailable — start the conversation first"
       : null;
-  const persistedRestartState = bot.rotationReason === "restart" ? bot.rotationState : null;
+  // Only an in-flight rotation disables the action. A restart never parks in
+  // `queued` any more, and a stale queued record from an older build must not
+  // grey out the one control that clears it.
+  const restartInFlight = bot.rotationReason === "restart" && bot.rotationState === "rotating";
   const restartItem = unavailable ? (
     <DropdownMenuItem disabled aria-label={unavailable}>
       <RotateCcw className="size-4" />
       {unavailable}
     </DropdownMenuItem>
-  ) : restarting || persistedRestartState === "rotating" ? (
+  ) : restarting || restartInFlight ? (
     <DropdownMenuItem disabled aria-label="Restarting session">
       <Loader2 className="size-4 animate-spin" />
       Restarting…
-    </DropdownMenuItem>
-  ) : persistedRestartState === "queued" ? (
-    <DropdownMenuItem disabled aria-label="Restart queued">
-      <Clock3 className="size-4" />
-      Restart queued
     </DropdownMenuItem>
   ) : runtimeHealthy ? (
     <DoubleConfirmAction
       resetKey={`${bot.id}:${bot.sessionId ?? "none"}:${busy ? "busy" : "idle"}`}
       label="Restart session"
-      confirmLabel={busy ? "Queue restart after current work" : "Confirm restart"}
-      pendingLabel={busy ? "Queuing restart…" : "Restarting…"}
+      confirmLabel="Confirm restart"
+      pendingLabel="Restarting…"
       icon={<RotateCcw className="size-4" />}
       confirmIcon={<RotateCcw className="size-4" />}
       render={<DropdownMenuItem />}


### PR DESCRIPTION
## The bug

A manual restart went through the same admission gate as an automatic rotation: defer while the primary is `busy`, has live delegated children, or still has undelivered sends.

That is correct for a rotation the machine decided to run, and exactly backwards for one a human asked for. Waiting on `busy` is only safe while `busy` still means progress. The reason somebody reaches for Restart is that it does not — a wedged turn, a provider error the harness never returned from, a runtime whose session id no longer resolves. Those states report busy forever, so the gate parked the restart as "queued" behind a turn that could never end, and the one escape hatch became another thing that was stuck.

Reported with a bot sitting on `Build paused — provider error` / `No conversation found with session ID`, its menu showing a disabled **Restart queued**, two scheduled-routine prompts waiting behind the dead turn.

## The change

`botRotationAdmission` now takes the rotation reason and admits `restart` unconditionally. `config` and `compaction` still wait for a safe moment, and the send-queue gate in `rotateBotSession` applies to automatic rotations only.

The work admission used to protect is carried rather than guarded:

- **Undelivered sends** (`pending` and `queued`) move onto the replacement runtime after the old primary retires, in their original order, through `sendPromptToLiveSession`. They land behind the handoff checkpoint, so the bot reads its context first. A `sending` row stays with its delivery worker, which may already have submitted it — the same tradeoff `resumePersistedQueues` makes for an interrupted send.
- **Late child reports.** `reviveBotSessionForReport` now matches archived session ids. A child is told its parent's session id once at spawn and a rotation moves that id underneath it, so matching the archive is what lets a report still land in the conversation it was meant for. This is what makes bypassing the children gate safe.

The restart route no longer returns a `queued` state, and the menu no longer offers to queue one or greys itself out on a stale queued record from an older build.

## Verification

- `bun run typecheck` clean
- `bun run test` clean — 2347 pass, 1 skip
- New coverage: restart admission under a busy primary and a live child, continued deferral for `config`/`compaction`, and the queue handoff (order preserved, `sending` and terminal rows left behind, carried rows removed from the old store)

## Risk

A message the old runtime accepted and read in the millisecond between `reconcileQueued` and the swap would be carried and delivered twice. That is chosen over the certain cost of dropping it. The now-unreachable `deferred` branch in the restart route returns 503 rather than a `queued` state, so a reverted policy fails loudly instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)