### PR TITLE
HOLD: compact paywall with edge-flush hero

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -392,10 +392,11 @@ function RootNavigator() {
           <Stack.Screen name="bots/new" options={{ headerShown: false, gestureEnabled: false }} />
           <Stack.Screen name="bots/[id]/edit" options={{ headerShown: false }} />
           {/* In-app purchase. Pushed from the blocked cloud computer and from
-              Settings — the two places someone learns they need to pay. It is
-              a normal pushed screen rather than a modal so the back gesture
-              behaves the same as everywhere else. */}
-          <Stack.Screen name="plan" options={{ title: "Plan", headerLargeTitle: true }} />
+              Settings — the two places someone learns they need to pay. Header
+              is hidden so the launch still can sit flush to the screen edges.
+              It stays a pushed screen rather than a modal so the back gesture
+              (and Skip for now) behave the same as everywhere else. */}
+          <Stack.Screen name="plan" options={{ headerShown: false }} />
         </Stack.Protected>
       </Stack>
     </>

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -35,7 +35,9 @@
  *
  * Edge-flush hero, one compact list, one Continue button. Tapping a row
  * selects it. Continue buys the selected paid rung, or leaves on Free / Skip.
- * Always On is not a row. StoreKit product ids do not change.
+ * Always On and the old $5 Starter (`computer_s20`) are not rows. StoreKit
+ * product ids do not change. The compact paid rungs are `computer_s40`,
+ * `computer_5`, and `computer_10`.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -636,7 +636,7 @@ function PaywallHero({ fadeTo }: { fadeTo: string }) {
   );
 }
 
-function FeedLine({ width }: { width: string }) {
+function FeedLine({ width }: { width: `${number}%` }) {
   return (
     <View
       style={{

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -1,5 +1,5 @@
 /**
- * The paywall. The way out of `upgrade_required`.
+ * The paywall. The way out of `upgrade_required`, and the onboarding plan step.
  *
  * "Included computer time is used up" was a dead end BY DESIGN. app/computers.tsx
  * states that fact and offers nothing, because the only thing it could have
@@ -30,16 +30,47 @@
  * Hence the `activating` state. The transaction is also deliberately NOT
  * finished in that case, so StoreKit replays it on next launch and it gets
  * recorded then.
+ *
+ * ── This layout ────────────────────────────────────────────────────────────
+ *
+ * Edge-flush hero, one compact list, one Continue button. Tapping a row
+ * selects it. Continue buys the selected paid rung, or leaves on Free / Skip.
+ * Always On is not a row. StoreKit product ids do not change.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { ActivityIndicator, Linking, ScrollView, View } from "react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  ScrollView,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import * as Haptics from "expo-haptics";
-import { useLocalSearchParams } from "expo-router";
+import { LinearGradient } from "expo-linear-gradient";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { EmptyState, Icon, PrimaryButton, SectionLabel, Separator } from "../src/components";
+import { EmptyState, PrimaryButton } from "../src/components";
+import { BrandMark } from "../src/omg/brand-mark";
 import { PressableScale } from "../src/omg/motion";
+import {
+  COMPACT_PAID_PLANS,
+  continueCtaLabel,
+  defaultSelectedPlan,
+  emphasizeParallel,
+  formatAllowanceLine,
+  FREE_PLAN_KEY,
+  FREE_ROW,
+  isPopularPlan,
+  PAYWALL_HEADLINE,
+  PAYWALL_SUBHEAD,
+  PERSONAL_PLAN_KEY,
+  sellOnPaywall,
+  taglineForPlan,
+} from "../src/omg/plan-copy";
+import { FALLBACK_TIERS, labelForPlan } from "../src/omg/plan-specs";
 import { Text } from "../src/omg/text";
 import { useTheme } from "../src/omg/theme";
 import { useToast } from "../src/omg/toast";
@@ -52,15 +83,6 @@ import {
   type Entitlement,
   type PurchaseAccount,
 } from "../src/omg/billing";
-import {
-  FALLBACK_TIERS,
-  formatComputeHours,
-  formatMachine,
-  formatParallelAgents,
-  labelForPlan,
-  sleepsBetweenTasks,
-  type TierSpecs,
-} from "../src/omg/plan-specs";
 import {
   connectStore,
   fetchTiers,
@@ -94,16 +116,21 @@ type Phase =
   | { kind: "activating"; plan: string }
   | { kind: "done"; entitlement: Entitlement };
 
+const SELECTED_FILL = "rgba(255, 85, 48, 0.08)";
+
 export default function PlanScreen() {
   const insets = useSafeAreaInsets();
-  const { colors, type, space } = useTheme();
+  const router = useRouter();
+  const { colors, type, space, radius, isDark } = useTheme();
   const toast = useToast();
   const { refreshMachines } = useOmg();
+  const pageBg = isDark ? colors.bg : "#ffffff";
 
   const [phase, setPhase] = useState<Phase>({ kind: "loading" });
   const [account, setAccount] = useState<PurchaseAccount | null>(null);
   const [products, setProducts] = useState<StoreProduct[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState(PERSONAL_PLAN_KEY);
 
   /**
    * MOCK-ONLY: pick a scenario, and optionally run the flow, from the deep link
@@ -165,7 +192,7 @@ export default function PlanScreen() {
       setAccount(purchaseAccount);
       // A control plane that published no catalog leaves `tiers` null, and the
       // bundled ids stand in so the screen can still sell something. They carry
-      // no specs, so the cards degrade to a name and Apple's price rather than
+      // no specs, so the rows degrade to a name and Apple's price rather than
       // to numbers this build remembers — the whole reason the facts moved to
       // the server. Null and [] are different answers: [] means omg genuinely
       // sells nothing right now, and is passed through as an empty list.
@@ -279,14 +306,34 @@ export default function PlanScreen() {
     }
   }, [account, record, refreshMachines, toast]);
 
+  const skip = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/");
+  }, [router]);
+
   // MOCK-ONLY. See the note on `params` above.
   useEffect(() => {
     if (!isMockStore || !params.auto || autoRan.current === scenarioKey) return;
     if (phase.kind !== "ready" || products.length === 0) return;
     autoRan.current = scenarioKey;
     if (params.auto === "restore") void restore();
-    else void buy(products.find((p) => p.plan === "computer_5") ?? products[0]);
+    else void buy(products.find((p) => p.plan === PERSONAL_PLAN_KEY) ?? products[0]);
   }, [buy, params.auto, phase.kind, products, restore, scenarioKey]);
+
+  const paidRows = useMemo(
+    () =>
+      COMPACT_PAID_PLANS.flatMap((plan) => {
+        const product = products.find((entry) => entry.plan === plan);
+        if (!product || !sellOnPaywall(product.plan, product.specs)) return [];
+        return [product];
+      }),
+    [products],
+  );
+
+  useEffect(() => {
+    if (paidRows.length === 0) return;
+    setSelected(defaultSelectedPlan([FREE_PLAN_KEY, ...paidRows.map((row) => row.plan)]));
+  }, [paidRows]);
 
   const busy = phase.kind === "purchasing" || phase.kind === "restoring";
   const currentPlan = phase.kind === "done" ? phase.entitlement.plan : account?.plan ?? null;
@@ -297,135 +344,424 @@ export default function PlanScreen() {
    * and still needs a name in "You're all set" and in the Stripe notice.
    */
   const catalog = account?.tiers ?? FALLBACK_TIERS;
+  const selectedProduct = paidRows.find((row) => row.plan === selected);
+  const choosing = phase.kind === "ready" || phase.kind === "purchasing" || phase.kind === "restoring";
+  const ctaLabel = continueCtaLabel(
+    selected === FREE_PLAN_KEY ? null : (selectedProduct?.displayPrice ?? null),
+  );
+
+  const continuePress = () => {
+    if (selected === FREE_PLAN_KEY || selected === currentPlan) {
+      skip();
+      return;
+    }
+    if (selectedProduct) void buy(selectedProduct);
+  };
 
   return (
-    <ScrollView
-      style={{ flex: 1 }}
-      contentContainerStyle={{ paddingBottom: insets.bottom + space.xxl }}
-      contentInsetAdjustmentBehavior="automatic"
-    >
+    <View style={{ flex: 1, backgroundColor: pageBg }}>
+      <StatusBar style={isDark ? "light" : "dark"} />
       {isMockStore ? <MockBanner /> : null}
 
-      {phase.kind === "loading" ? (
-        <View style={{ paddingVertical: space.xxl * 2, alignItems: "center", gap: space.md }}>
-          <ActivityIndicator color={colors.textMuted} />
-          <Text style={{ ...type.footnote, color: colors.textMuted }}>Loading plans…</Text>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: space.lg }}
+        showsVerticalScrollIndicator={false}
+      >
+        <PaywallHero fadeTo={pageBg} />
+
+        <View style={{ alignItems: "center", marginTop: -36 }}>
+          <BrandMark size={56} holeColor={pageBg} />
         </View>
-      ) : phase.kind === "unavailable" ? (
-        <EmptyState title="Not available on this build" detail={phase.message} />
-      ) : phase.kind === "done" ? (
-        <Subscribed entitlement={phase.entitlement} catalog={catalog} />
-      ) : phase.kind === "activating" ? (
-        <Activating plan={phase.plan} catalog={catalog} />
-      ) : (
-        <>
-          <Text
+
+        <Text
+          style={{
+            ...type.title,
+            color: colors.text,
+            textAlign: "center",
+            paddingHorizontal: space.xl,
+            marginTop: space.md,
+          }}
+        >
+          {PAYWALL_HEADLINE}
+        </Text>
+        <Text
+          style={{
+            ...type.callout,
+            color: colors.textMuted,
+            textAlign: "center",
+            paddingHorizontal: space.xl,
+            marginTop: space.xs,
+            marginBottom: space.lg,
+          }}
+        >
+          {PAYWALL_SUBHEAD}
+        </Text>
+
+        {phase.kind === "loading" ? (
+          <View style={{ paddingVertical: space.xxl, alignItems: "center", gap: space.md }}>
+            <ActivityIndicator color={colors.textMuted} />
+            <Text style={{ ...type.footnote, color: colors.textMuted }}>Loading plans…</Text>
+          </View>
+        ) : phase.kind === "unavailable" ? (
+          <EmptyState title="Not available on this build" detail={phase.message} />
+        ) : phase.kind === "done" ? (
+          <Subscribed entitlement={phase.entitlement} catalog={catalog} />
+        ) : phase.kind === "activating" ? (
+          <Activating plan={phase.plan} catalog={catalog} />
+        ) : (
+          <>
+            {loadError ? (
+              <View style={{ paddingHorizontal: space.lg, paddingBottom: space.md, gap: space.md }}>
+                <Text style={{ ...type.footnote, color: colors.danger }}>{loadError}</Text>
+                <PrimaryButton label="Try again" tone="quiet" onPress={() => void load()} />
+              </View>
+            ) : null}
+
+            {/* canPurchase:false is a NORMAL state for an existing web customer,
+                not an edge case — so it gets an explanation rather than a
+                disabled button someone has to guess the meaning of. */}
+            {account && !account.canPurchase ? (
+              <AlreadySubscribed plan={account.plan} reason={account.reason} catalog={catalog} />
+            ) : null}
+
+            {paidRows.length > 0 || !loadError ? (
+              <View
+                style={{
+                  marginHorizontal: space.lg,
+                  borderRadius: 16,
+                  borderWidth: 1,
+                  borderColor: colors.borderSoft,
+                  backgroundColor: isDark ? colors.card : "#ffffff",
+                  overflow: "hidden",
+                }}
+              >
+                <PlanRow
+                  selected={selected === FREE_PLAN_KEY}
+                  onPress={() => {
+                    void Haptics.selectionAsync();
+                    setSelected(FREE_PLAN_KEY);
+                  }}
+                  label={FREE_ROW.label}
+                  tagline={FREE_ROW.tagline}
+                  computeHours={FREE_ROW.computeHours}
+                  parallelAgents={FREE_ROW.parallelAgents}
+                  price={FREE_ROW.priceLabel}
+                  last={paidRows.length === 0}
+                />
+                {paidRows.map((product, index) => (
+                  <PlanRow
+                    key={product.productId}
+                    selected={selected === product.plan}
+                    onPress={() => {
+                      void Haptics.selectionAsync();
+                      setSelected(product.plan);
+                    }}
+                    label={product.label}
+                    tagline={taglineForPlan(product.plan)}
+                    computeHours={product.specs?.computeHours}
+                    parallelAgents={product.specs?.parallelAgents}
+                    price={product.displayPrice}
+                    popular={isPopularPlan(product.plan)}
+                    current={currentPlan === product.plan}
+                    last={index === paidRows.length - 1}
+                  />
+                ))}
+              </View>
+            ) : (
+              <EmptyState
+                title="No plans available"
+                detail="The App Store didn't return any products. Try again in a moment."
+              />
+            )}
+
+            <View style={{ paddingHorizontal: space.lg, paddingTop: space.lg, gap: space.sm }}>
+              <PressableScale onPress={() => void restore()} disabled={busy} hitSlop={8}>
+                <Text
+                  style={{
+                    ...type.caption,
+                    color: colors.textMuted,
+                    textAlign: "center",
+                    textDecorationLine: "underline",
+                  }}
+                >
+                  {phase.kind === "restoring" ? "Restoring…" : "Restore purchases"}
+                </Text>
+              </PressableScale>
+              <Text
+                style={{
+                  ...type.caption,
+                  color: colors.textMuted,
+                  textAlign: "center",
+                  lineHeight: 16,
+                }}
+              >
+                Payment is charged to your Apple ID. Subscriptions renew monthly until cancelled in
+                the App Store.
+              </Text>
+              <LegalLinks />
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      {choosing ? (
+        <View
+          style={{
+            paddingHorizontal: space.lg,
+            paddingTop: space.sm,
+            paddingBottom: Math.max(insets.bottom, space.md),
+            backgroundColor: pageBg,
+            gap: space.sm,
+          }}
+        >
+          <PressableScale
+            onPress={continuePress}
+            disabled={
+              busy ||
+              (selected !== FREE_PLAN_KEY &&
+                (!selectedProduct || !account?.canPurchase || selected === currentPlan))
+            }
+            accessibilityRole="button"
+            accessibilityLabel={ctaLabel}
+            scale={0.98}
             style={{
-              ...type.footnote,
-              color: colors.textMuted,
-              paddingHorizontal: space.lg,
-              paddingTop: space.md,
-              lineHeight: 18,
+              height: 52,
+              borderRadius: radius.lg,
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: colors.brand,
+              opacity:
+                busy ||
+                (selected !== FREE_PLAN_KEY &&
+                  (!selectedProduct || !account?.canPurchase || selected === currentPlan))
+                  ? 0.4
+                  : 1,
             }}
           >
-            Your cloud computer runs on a monthly plan. Pick the size you need — you can change
-            or cancel it any time in the App Store.
-          </Text>
+            {phase.kind === "purchasing" ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={{ ...type.headline, color: "#ffffff" }}>{ctaLabel}</Text>
+            )}
+          </PressableScale>
+          <PressableScale onPress={skip} disabled={busy} hitSlop={10}>
+            <Text style={{ ...type.callout, color: colors.textMuted, textAlign: "center" }}>
+              Skip for now
+            </Text>
+          </PressableScale>
+        </View>
+      ) : null}
+    </View>
+  );
+}
 
-          {loadError ? (
-            <View style={{ padding: space.lg, gap: space.md }}>
-              <Text style={{ ...type.footnote, color: colors.danger }}>{loadError}</Text>
-              <PrimaryButton label="Try again" tone="quiet" onPress={() => void load()} />
-            </View>
-          ) : null}
+/**
+ * Edge-flush launch still. Square-ish, zoomed on the phone, fading into the
+ * page.
+ *
+ * There is no clip asset in this repo or in the onboarding flow — no mp4, no
+ * existing host URL. This is a still crop of the same frame the mock shows,
+ * not a YouTube player and not a new video host.
+ */
+function PaywallHero({ fadeTo }: { fadeTo: string }) {
+  const { width } = useWindowDimensions();
+  const height = Math.round(width * 0.92);
 
-          {/* canPurchase:false is a NORMAL state for an existing web customer,
-              not an edge case — so it gets an explanation rather than a
-              disabled button someone has to guess the meaning of. */}
-          {account && !account.canPurchase ? (
-            <AlreadySubscribed plan={account.plan} reason={account.reason} catalog={catalog} />
-          ) : null}
-
-          {products.length > 0 ? (
-            <>
-              <SectionLabel>Computer plans</SectionLabel>
-              {products.map((product) => (
-                <TierCard
-                  key={product.productId}
-                  product={product}
-                  current={currentPlan === product.plan}
-                  purchasing={phase.kind === "purchasing" && phase.productId === product.productId}
-                  disabled={busy || !account?.canPurchase || currentPlan === product.plan}
-                  onPress={() => void buy(product)}
-                />
-              ))}
-              {/* ── REMOVED: an idle-billing claim that is not currently true ──
-                  This said, directly above a Buy button:
-
-                    "Every plan pauses while idle, so time you are not using
-                     does not come out of your hours. A paused Computer keeps
-                     its files and picks up where it left off."
-
-                  Session d3f4e3e8 measured a cloud Computer with no sessions
-                  and nothing connected, twice, five minutes each:
-
-                    2083 micros / 302s -> 24,830 micros/hour
-
-                  Full running rate is 25,000 and hibernated is 0, so an idle
-                  Computer bills at 99.3% of full rate. The second measurement
-                  was taken AFTER an explicit pause through the lifecycle
-                  endpoint and was identical to the byte. Idle time comes out
-                  of your hours almost entirely.
-
-                  That makes this the most consequential sentence on the
-                  screen, because it is what tells someone how to read every
-                  "N hours" above it — 20 hours of USAGE and 20 hours of
-                  CALENDAR are different products at the same price. Stating it
-                  wrongly next to a purchase is worse than not explaining the
-                  hours at all, which is the same rule this file already
-                  follows for spec numbers: degrade to silence, never to a
-                  number we cannot stand behind.
-
-                  RESTORE THIS, unchanged, once idle Computers actually stop
-                  billing — the sentence is good and it is where it belongs.
-                  Do not reword it to describe the current behaviour instead:
-                  "your hours are consumed whether or not you are working" is
-                  accurate today, but it is a platform decision in flight
-                  (raised with Benny, outside this release), and a paywall is
-                  the wrong place to litigate it. Silence is honest in both
-                  states. */}
-            </>
-          ) : !loadError ? (
-            <EmptyState
-              title="No plans available"
-              detail="The App Store didn't return any products. Try again in a moment."
+  return (
+    <View style={{ width, height, overflow: "hidden", backgroundColor: "#c8b7aa" }}>
+      <View
+        pointerEvents="none"
+        style={{
+          position: "absolute",
+          top: -height * 0.08,
+          left: -width * 0.12,
+          width: width * 1.24,
+          height: height * 1.2,
+        }}
+      >
+        <LinearGradient
+          colors={["#d9c7b8", "#c3b0a2", "#b19788"]}
+          start={{ x: 0.15, y: 0 }}
+          end={{ x: 0.9, y: 1 }}
+          style={{ position: "absolute", top: 0, right: 0, bottom: 0, left: 0 }}
+        />
+        <View
+          style={{
+            position: "absolute",
+            width: width * 0.86,
+            height: height * 1.05,
+            left: width * 0.19,
+            top: height * 0.1,
+            borderRadius: 36,
+            backgroundColor: "#111111",
+            padding: 8,
+            transform: [{ rotate: "-8deg" }],
+          }}
+        >
+          <View
+            style={{
+              flex: 1,
+              borderRadius: 28,
+              backgroundColor: "#f4f4f5",
+              overflow: "hidden",
+              paddingTop: 18,
+              paddingHorizontal: 12,
+              gap: 8,
+            }}
+          >
+            <View
+              style={{
+                alignSelf: "center",
+                width: 48,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: "#111",
+                marginBottom: 8,
+              }}
             />
-          ) : null}
+            <FeedLine width="78%" />
+            <FeedLine width="64%" />
+            <FeedLine width="86%" />
+            <FeedLine width="52%" />
+          </View>
+        </View>
+      </View>
+      <LinearGradient
+        colors={["rgba(255,255,255,0)", fadeTo]}
+        locations={[0.2, 1]}
+        style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: height * 0.46 }}
+      />
+    </View>
+  );
+}
 
-          <View style={{ paddingHorizontal: space.lg, paddingTop: space.xl, gap: space.md }}>
-            <PrimaryButton
-              label="Restore purchases"
-              tone="quiet"
-              loading={phase.kind === "restoring"}
-              disabled={busy}
-              onPress={() => void restore()}
-            />
+function FeedLine({ width }: { width: string }) {
+  return (
+    <View
+      style={{
+        height: 34,
+        width,
+        borderRadius: 10,
+        backgroundColor: "#ffffff",
+        borderWidth: 1,
+        borderColor: "rgba(0,0,0,0.06)",
+      }}
+    />
+  );
+}
+
+function PlanRow({
+  selected,
+  onPress,
+  label,
+  tagline,
+  computeHours,
+  parallelAgents,
+  price,
+  popular = false,
+  current = false,
+  last = false,
+}: {
+  selected: boolean;
+  onPress: () => void;
+  label: string;
+  tagline?: string;
+  computeHours?: number;
+  parallelAgents?: number;
+  price: string;
+  popular?: boolean;
+  current?: boolean;
+  last?: boolean;
+}) {
+  const { colors, type, space } = useTheme();
+  const allowance =
+    computeHours != null && parallelAgents != null
+      ? formatAllowanceLine(computeHours, parallelAgents)
+      : null;
+  const emphasize = parallelAgents != null && emphasizeParallel(parallelAgents);
+
+  return (
+    <PressableScale
+      onPress={onPress}
+      accessibilityRole="radio"
+      accessibilityState={{ selected }}
+      accessibilityLabel={[
+        label,
+        popular ? "most popular" : "",
+        current ? "current plan" : "",
+        tagline ?? "",
+        allowance
+          ? `${allowance.hours} · ${allowance.parallelCount} ${allowance.parallelSuffix}`
+          : "",
+        price,
+      ]
+        .filter(Boolean)
+        .join(". ")}
+      scale={1}
+      style={{
+        backgroundColor: selected ? SELECTED_FILL : "transparent",
+        paddingHorizontal: space.md,
+        paddingVertical: 12,
+        borderBottomWidth: last ? 0 : 1,
+        borderBottomColor: colors.borderSoft,
+        flexDirection: "row",
+        alignItems: "center",
+        gap: space.md,
+      }}
+    >
+      <Radio selected={selected} />
+      <View style={{ flex: 1, gap: 2 }}>
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <Text style={{ ...type.headline, color: colors.text }}>{label}</Text>
+          {popular ? (
+            <Text style={{ ...type.overline, color: colors.brand, fontSize: 10 }}>MOST POPULAR</Text>
+          ) : null}
+        </View>
+        {tagline ? (
+          <Text style={{ ...type.footnote, color: colors.textMuted }}>{tagline}</Text>
+        ) : null}
+        {allowance ? (
+          <Text style={{ ...type.footnote, color: colors.textSecondary }}>
+            {allowance.hours}
+            {" · "}
             <Text
               style={{
-                ...type.caption,
-                color: colors.textMuted,
-                textAlign: "center",
-                lineHeight: 16,
+                color: emphasize ? colors.brand : colors.textSecondary,
+                fontWeight: emphasize ? "700" : "400",
               }}
             >
-              Payment is charged to your Apple ID. Subscriptions renew monthly until cancelled in
-              the App Store.
+              {allowance.parallelCount}
             </Text>
-            <LegalLinks />
-          </View>
-        </>
-      )}
-    </ScrollView>
+            {" "}
+            {allowance.parallelSuffix}
+          </Text>
+        ) : null}
+      </View>
+      <Text style={{ ...type.headline, color: colors.text }}>{price}</Text>
+    </PressableScale>
+  );
+}
+
+function Radio({ selected }: { selected: boolean }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        width: 22,
+        height: 22,
+        borderRadius: 11,
+        borderWidth: selected ? 0 : 1.5,
+        borderColor: colors.borderStrong,
+        backgroundColor: selected ? colors.brand : "transparent",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {selected ? (
+        <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: "#ffffff" }} />
+      ) : null}
+    </View>
   );
 }
 
@@ -476,202 +812,6 @@ function LegalLinks() {
 }
 
 /**
- * One fact about a tier: an icon, what it is, and the number.
- *
- * Every row is exactly one line by construction. The value never wraps and
- * never shrinks; the label yields first, because a wrapped value would make one
- * card taller than its neighbours and break the column of numbers that makes
- * five tiers comparable at a glance.
- */
-function SpecRow({
-  label,
-  value,
-  emphasis = false,
-  ...glyph
-}: {
-  label: string;
-  value: string;
-  /** The number this tier is really sold on. */
-  emphasis?: boolean;
-} & ({ ios: "clock"; android: "schedule" } | { ios: "cpu"; android: "memory" } | { ios: "internaldrive"; android: "storage" } | { ios: "bolt.fill"; android: "bolt" })) {
-  const { colors, type, space } = useTheme();
-  return (
-    <View style={{ flexDirection: "row", alignItems: "center", gap: space.md, paddingVertical: 5 }}>
-      <Icon
-        {...glyph}
-        size={15}
-        weight={emphasis ? "semibold" : "regular"}
-        color={emphasis ? colors.text : colors.textMuted}
-      />
-      <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted, flexShrink: 1 }}>
-        {label}
-      </Text>
-      <Text
-        style={{
-          ...type.footnote,
-          color: colors.text,
-          fontWeight: emphasis ? "600" : "500",
-          marginLeft: "auto",
-          flexShrink: 0,
-        }}
-      >
-        {value}
-      </Text>
-    </View>
-  );
-}
-
-/**
- * One tier, as something you can read rather than only price-compare.
- *
- * ── Why a list of cards and not the dashboard's slider ──────────────────────
- *
- * The dashboard shows ONE rung at a time and makes moving between them the
- * whole interaction: a slider, ticks, a spring onto each detent. That works
- * because a mouse is bad at direct selection and good at scrubbing, and because
- * the overlay owns the entire viewport.
- *
- * Neither holds here. The equivalent of "move between the rungs" that a thumb
- * already does perfectly is SCROLL — the vertical scroll IS this screen's
- * slider, and it costs nothing to learn. Reproducing a drag control would also
- * have meant five tiers hidden behind a gesture nobody was told about, on the
- * one screen where hiding what someone is buying is the actual complaint.
- *
- * So: same vocabulary as the web ("Compute time", "Machine", "Disk", "agents in
- * parallel", the same formatters), same facts, different control. All five are
- * visible and comparable without touching anything, which a slider cannot do.
- *
- * ── The card makes no claim it was not handed ──────────────────────────────
- *
- * `specs` is null whenever the server did not describe this tier, and then the
- * card is deliberately just a name and Apple's price. That is the honest
- * degradation and it is the reason the numbers left the bundle: a stale spec
- * would still render beautifully.
- */
-function TierCard({
-  product,
-  current,
-  purchasing,
-  disabled,
-  onPress,
-}: {
-  product: StoreProduct;
-  current: boolean;
-  purchasing: boolean;
-  disabled: boolean;
-  onPress: () => void;
-}) {
-  const { colors, radius, type, space } = useTheme();
-  const specs: TierSpecs | null = product.specs;
-  const sleeps = specs ? sleepsBetweenTasks(specs) : null;
-
-  return (
-    <PressableScale
-      onPress={onPress}
-      disabled={disabled}
-      accessibilityRole="button"
-      // One label for the whole card. VoiceOver reading eight separate nodes
-      // per tier, five times over, is how a screen becomes unusable while
-      // technically being accessible.
-      accessibilityLabel={[
-        product.label,
-        current ? "current plan" : product.displayPrice + " per month",
-        specs
-          ? `${formatParallelAgents(specs.parallelAgents)}, ${formatComputeHours(specs.computeHours)} of compute time, ${formatMachine(specs)}, ${specs.diskGb} GB disk${sleeps ? ", always on, never sleeps" : ""}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join(". ")}
-      scale={0.98}
-      style={({ pressed }) => ({
-        backgroundColor: pressed && !disabled ? colors.cardPressed : colors.card,
-        borderRadius: radius.lg,
-        marginHorizontal: space.lg,
-        marginBottom: space.md,
-        padding: space.lg,
-        gap: specs ? space.md : 0,
-        // The current plan is outlined rather than dimmed. Dimming it would
-        // hide the specs of the machine someone actually has, which is the one
-        // tier they have the most reason to re-read.
-        borderWidth: current ? 1.5 : 0,
-        borderColor: current ? colors.primary : "transparent",
-        // Only a card you cannot buy fades, and the current plan is not one of
-        // those — it is disabled because it is already yours.
-        opacity: disabled && !current ? 0.5 : 1,
-      })}
-    >
-      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: space.md }}>
-        <View style={{ flex: 1, gap: 2 }}>
-          <Text style={{ ...type.headline, color: colors.text }}>{product.label}</Text>
-          {specs ? (
-            /* The dashboard's hero number, demoted to a subtitle. It is still
-               the headline fact — the thing the ladder is really sold on — but
-               five 40pt numbers down a scroll is five heroes and therefore
-               none. */
-            <Text style={{ ...type.subhead, color: colors.textSecondary }}>
-              {formatParallelAgents(specs.parallelAgents)}
-            </Text>
-          ) : null}
-        </View>
-        <View style={{ alignItems: "flex-end", gap: 1 }}>
-          {purchasing ? (
-            <ActivityIndicator color={colors.textMuted} />
-          ) : (
-            <>
-              {/* Apple's string, verbatim. Never composed here — it is a
-                  different currency in every storefront. */}
-              <Text style={{ ...type.headline, color: colors.text }}>{product.displayPrice}</Text>
-              {current ? (
-                <View style={{ flexDirection: "row", alignItems: "center", gap: 3 }}>
-                  <Icon ios="checkmark" android="check" size={11} weight="semibold" color={colors.primary} />
-                  <Text style={{ ...type.caption, color: colors.primary }}>Current plan</Text>
-                </View>
-              ) : (
-                <Text style={{ ...type.caption, color: colors.textMuted }}>per month</Text>
-              )}
-            </>
-          )}
-        </View>
-      </View>
-
-      {specs ? (
-        <>
-          <Separator />
-          <View>
-            {/* Compute time carries the emphasis, matching the dashboard: it is
-                the allowance that actually runs out, and the one people are
-                surprised by. */}
-            <SpecRow
-              ios="clock"
-              android="schedule"
-              label="Compute time"
-              value={formatComputeHours(specs.computeHours)}
-              emphasis
-            />
-            <SpecRow ios="cpu" android="memory" label="Machine" value={formatMachine(specs)} />
-            <SpecRow
-              ios="internaldrive"
-              android="storage"
-              label="Disk"
-              value={`${specs.diskGb} GB`}
-            />
-            {sleeps ? (
-              <SpecRow
-                ios="bolt.fill"
-                android="bolt"
-                label="Sleeps between tasks"
-                value={sleeps}
-                emphasis
-              />
-            ) : null}
-          </View>
-        </>
-      ) : null}
-    </PressableScale>
-  );
-}
-
-/**
  * Apple has the money, omg has not confirmed yet.
  *
  * Deliberately reassuring and deliberately not an error. The transaction is
@@ -682,7 +822,7 @@ function Activating({ plan, catalog }: { plan: string; catalog: readonly Tier[] 
   const { colors, type, space } = useTheme();
   const label = labelForPlan(plan, catalog);
   return (
-    <View style={{ paddingTop: space.xxl }}>
+    <View style={{ paddingTop: space.lg }}>
       <EmptyState
         title="Purchase complete"
         detail={`Your ${label ?? "new"} plan is being activated. This usually takes a few seconds — you can close this screen, it will finish on its own.`}
@@ -709,7 +849,7 @@ function Subscribed({
   // label would be neither.
   const label = labelForPlan(entitlement.plan, catalog) ?? entitlement.plan;
   return (
-    <View style={{ paddingTop: space.xxl }}>
+    <View style={{ paddingTop: space.lg }}>
       <EmptyState
         title={entitlement.replayed ? "Purchases restored" : "You're all set"}
         detail={`Your cloud computer is on ${label}. It may take a moment to come back online.`}
@@ -736,7 +876,7 @@ function Subscribed({
  * Do not add a link to this component.
  *
  * The second sentence stays because the first alone does not explain why the
- * cards below cannot be tapped, and an unexplained dead control is what #115
+ * rows below cannot be bought, and an unexplained dead control is what #115
  * set out to avoid. It describes this screen's own behaviour, not somewhere
  * else's.
  */
@@ -753,10 +893,10 @@ function AlreadySubscribed({
   const label = labelForPlan(plan, catalog);
   const stripe = reason === "stripe_subscription_active";
   return (
-    <View style={{ paddingHorizontal: space.lg, paddingTop: space.lg }}>
+    <View style={{ paddingHorizontal: space.lg, paddingBottom: space.md }}>
       <View
         style={{
-          backgroundColor: colors.accentSoft,
+          backgroundColor: SELECTED_FILL,
           borderRadius: 12,
           padding: space.lg,
           gap: space.xs,

--- a/mobile/src/omg/billing.ts
+++ b/mobile/src/omg/billing.ts
@@ -160,7 +160,7 @@ const MOCK_CATALOG: unknown = [
   {
     productId: "dev.omg.computer.computer_s40.monthly.v1",
     plan: "computer_s40",
-    label: "Starter Plus",
+    label: "Starter",
     specs: { parallelAgents: 3, vcpus: 2, memoryMb: 4096, diskGb: 16, computeHours: 40, alwaysOn: false },
   },
   {

--- a/mobile/src/omg/plan-copy.ts
+++ b/mobile/src/omg/plan-copy.ts
@@ -1,0 +1,121 @@
+/**
+ * Paywall merchandising copy. Not hardware facts.
+ *
+ * plan-specs.ts owns the rule that the phone never invents vCPU, hours, or
+ * parallel-agent numbers for a paid rung: those arrive from the catalog, or
+ * the row stays quiet. This file is the other half of the screen — the
+ * headline, the taglines, and the Free row the mock locked.
+ *
+ * Free is not an App Store product. Its hours and parallel count are display
+ * copy for a $0 try-out, not a StoreKit SKU and not a catalog spec. Paid
+ * prices still come from Apple's displayPrice. Paid hours still come from
+ * specs, or they do not appear.
+ */
+
+import { formatComputeHours, type TierSpecs } from "./plan-specs";
+
+export const PAYWALL_HEADLINE = "A space for all your coding agents.";
+export const PAYWALL_SUBHEAD = "Always at your fingertips.";
+
+export const FREE_PLAN_KEY = "free";
+export const PERSONAL_PLAN_KEY = "computer_5";
+export const ALWAYS_ON_PLAN_KEY = "computer_20";
+
+/** Locked Free row. Not in FALLBACK_TIERS and not sold through StoreKit. */
+export const FREE_ROW = {
+  plan: FREE_PLAN_KEY,
+  label: "Free",
+  tagline: "A computer to try",
+  computeHours: 3,
+  parallelAgents: 3,
+  priceLabel: "$0",
+} as const;
+
+/**
+ * One-line pitch per plan key. Words only.
+ *
+ * Starter Plus keeps a line so a catalog that still sends that SKU does not
+ * fall back to a blank subtitle. It is not in the compact mock list; the
+ * merchandising filter decides whether the row appears.
+ */
+const TAGLINES: Record<string, string> = {
+  [FREE_PLAN_KEY]: FREE_ROW.tagline,
+  computer_s20: "A capable computer",
+  computer_s40: "A capable computer",
+  computer_5: "A bigger, faster computer",
+  computer_10: "The most powerful computer",
+};
+
+export function taglineForPlan(plan: string): string | undefined {
+  return TAGLINES[plan];
+}
+
+export function isPopularPlan(plan: string): boolean {
+  return plan === PERSONAL_PLAN_KEY;
+}
+
+/**
+ * Always On stays off this screen. The SKU list in FALLBACK_TIERS already
+ * omits it; this is the display-side belt so a catalog that still publishes
+ * the rung cannot put it back on the compact list.
+ */
+export function sellOnPaywall(
+  plan: string,
+  specs?: Pick<TierSpecs, "alwaysOn"> | null,
+): boolean {
+  if (plan === ALWAYS_ON_PLAN_KEY) return false;
+  if (specs?.alwaysOn) return false;
+  return true;
+}
+
+/**
+ * The mock's compact ladder: Free, then Starter / Personal / Pro.
+ *
+ * Starter Plus (`computer_s40`) stays in FALLBACK_TIERS so the product id
+ * does not change. It is not a row on this list.
+ */
+export const COMPACT_PAID_PLANS = ["computer_s20", "computer_5", "computer_10"] as const;
+
+export function isCompactPaidPlan(plan: string): boolean {
+  return (COMPACT_PAID_PLANS as readonly string[]).includes(plan);
+}
+
+/** Personal, unless that SKU is not on sale in this storefront. */
+export function defaultSelectedPlan(plans: readonly string[]): string {
+  if (plans.includes(PERSONAL_PLAN_KEY)) return PERSONAL_PLAN_KEY;
+  const paid = plans.find((plan) => plan !== FREE_PLAN_KEY);
+  return paid ?? FREE_PLAN_KEY;
+}
+
+/**
+ * "Continue · $38/mo" — Apple's string, then the period.
+ *
+ * `displayPrice` is already localised. This does not parse it, strip cents,
+ * or invent a currency. Null means Free (or no price yet): just Continue.
+ */
+export function continueCtaLabel(displayPrice: string | null): string {
+  return displayPrice ? `Continue · ${displayPrice}/mo` : "Continue";
+}
+
+/**
+ * The compact allowance line: "150 hours · 5 in parallel".
+ *
+ * Hours use the dashboard formatter. The parallel figure is a bare number
+ * plus "in parallel" so the mock can paint 5 and 16 in brand orange.
+ */
+export function formatAllowanceLine(computeHours: number, parallelAgents: number): {
+  hours: string;
+  parallelCount: string;
+  parallelSuffix: string;
+} {
+  return {
+    hours: formatComputeHours(computeHours),
+    parallelCount: String(parallelAgents),
+    parallelSuffix: "in parallel",
+  };
+}
+
+/** The mock emphasises Personal's 5 and Pro's 16, not the shared 3. */
+export function emphasizeParallel(parallelAgents: number): boolean {
+  return parallelAgents >= 5;
+}

--- a/mobile/src/omg/plan-copy.ts
+++ b/mobile/src/omg/plan-copy.ts
@@ -19,6 +19,8 @@ export const PAYWALL_SUBHEAD = "Always at your fingertips.";
 
 export const FREE_PLAN_KEY = "free";
 export const PERSONAL_PLAN_KEY = "computer_5";
+/** Old $5 / 20-hour Starter. Kept mappable; not a row on this screen. */
+export const LEGACY_STARTER_PLAN_KEY = "computer_s20";
 export const ALWAYS_ON_PLAN_KEY = "computer_20";
 
 /** Locked Free row. Not in FALLBACK_TIERS and not sold through StoreKit. */
@@ -34,9 +36,9 @@ export const FREE_ROW = {
 /**
  * One-line pitch per plan key. Words only.
  *
- * Starter Plus keeps a line so a catalog that still sends that SKU does not
- * fall back to a blank subtitle. It is not in the compact mock list; the
- * merchandising filter decides whether the row appears.
+ * `computer_s40` is Starter on the locked web ladder. Its tagline stays
+ * "A capable computer". `computer_s20` keeps the same words so a leftover
+ * catalog entry is not blank if something still names it.
  */
 const TAGLINES: Record<string, string> = {
   [FREE_PLAN_KEY]: FREE_ROW.tagline,
@@ -55,26 +57,29 @@ export function isPopularPlan(plan: string): boolean {
 }
 
 /**
- * Always On stays off this screen. The SKU list in FALLBACK_TIERS already
- * omits it; this is the display-side belt so a catalog that still publishes
- * the rung cannot put it back on the compact list.
+ * Always On and the old $5 Starter stay off this screen.
+ *
+ * Both product ids remain in FALLBACK_TIERS (or stay mappable) so a purchase
+ * can still be named. They are not compact rows. A catalog that still
+ * publishes either rung cannot put it back on this list.
  */
 export function sellOnPaywall(
   plan: string,
   specs?: Pick<TierSpecs, "alwaysOn"> | null,
 ): boolean {
-  if (plan === ALWAYS_ON_PLAN_KEY) return false;
+  if (plan === ALWAYS_ON_PLAN_KEY || plan === LEGACY_STARTER_PLAN_KEY) return false;
   if (specs?.alwaysOn) return false;
   return true;
 }
 
 /**
- * The mock's compact ladder: Free, then Starter / Personal / Pro.
+ * The locked web ladder: Starter $19 / Personal $38 / Pro $98.
  *
- * Starter Plus (`computer_s40`) stays in FALLBACK_TIERS so the product id
- * does not change. It is not a row on this list.
+ * That is `computer_s40` / `computer_5` / `computer_10`. The old Starter
+ * (`computer_s20`) stays in FALLBACK_TIERS so the product id stays mappable.
+ * It is not a row on this list.
  */
-export const COMPACT_PAID_PLANS = ["computer_s20", "computer_5", "computer_10"] as const;
+export const COMPACT_PAID_PLANS = ["computer_s40", "computer_5", "computer_10"] as const;
 
 export function isCompactPaidPlan(plan: string): boolean {
   return (COMPACT_PAID_PLANS as readonly string[]).includes(plan);

--- a/mobile/src/omg/plan-specs.ts
+++ b/mobile/src/omg/plan-specs.ts
@@ -184,7 +184,7 @@ export const FALLBACK_TIERS: readonly CatalogTier[] = [
   {
     productId: "dev.omg.computer.computer_s40.monthly.v1",
     plan: "computer_s40",
-    label: "Starter Plus",
+    label: "Starter",
     specs: null,
   },
   {

--- a/mobile/src/omg/store.ts
+++ b/mobile/src/omg/store.ts
@@ -64,7 +64,7 @@ export type Tier = CatalogTier;
 /** A tier joined with what Apple actually charges for it in this storefront. */
 export type StoreProduct = Tier & {
   /**
-   * APPLE'S OWN LOCALISED PRICE STRING — "$5.99", "HK$47.00", "¥900".
+   * APPLE'S OWN LOCALISED PRICE STRING — "$19.99", "HK$47.00", "¥900".
    *
    * Rendered verbatim and never reformatted, never parsed, never compared. The
    * App Store shows a different number in a different currency in every

--- a/mobile/storekit/omg.storekit
+++ b/mobile/storekit/omg.storekit
@@ -101,7 +101,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "11.99",
+          "displayPrice" : "19.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "31000002",
@@ -126,7 +126,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "57.99",
+          "displayPrice" : "37.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "31000003",
@@ -151,7 +151,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "179.99",
+          "displayPrice" : "97.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "31000004",

--- a/test/mobile-plan-copy.test.ts
+++ b/test/mobile-plan-copy.test.ts
@@ -7,6 +7,8 @@
  * selection, CTA, and "Always On stays off the compact list".
  */
 
+import { readFileSync } from "node:fs";
+
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -44,7 +46,7 @@ describe("the locked onboarding copy", () => {
   });
 
   test("paid taglines match the mock", () => {
-    expect(taglineForPlan("computer_s20")).toBe("A capable computer");
+    expect(taglineForPlan("computer_s40")).toBe("A capable computer");
     expect(taglineForPlan("computer_5")).toBe("A bigger, faster computer");
     expect(taglineForPlan("computer_10")).toBe("The most powerful computer");
   });
@@ -52,28 +54,30 @@ describe("the locked onboarding copy", () => {
   test("Personal is the popular default", () => {
     expect(isPopularPlan(PERSONAL_PLAN_KEY)).toBe(true);
     expect(isPopularPlan("computer_10")).toBe(false);
-    expect(defaultSelectedPlan(["free", "computer_s20", "computer_5", "computer_10"])).toBe(
+    expect(defaultSelectedPlan(["free", "computer_s40", "computer_5", "computer_10"])).toBe(
       PERSONAL_PLAN_KEY,
     );
   });
 
   test("a storefront without Personal still picks a paid rung", () => {
-    expect(defaultSelectedPlan(["free", "computer_s20"])).toBe("computer_s20");
+    expect(defaultSelectedPlan(["free", "computer_s40"])).toBe("computer_s40");
     expect(defaultSelectedPlan([FREE_PLAN_KEY])).toBe(FREE_PLAN_KEY);
   });
 });
 
 describe("the compact merchandising list", () => {
   test("the paid rows are Starter, Personal, Pro", () => {
-    expect(COMPACT_PAID_PLANS).toEqual(["computer_s20", "computer_5", "computer_10"]);
-    expect(isCompactPaidPlan("computer_s20")).toBe(true);
-    expect(isCompactPaidPlan("computer_s40")).toBe(false);
+    expect(COMPACT_PAID_PLANS).toEqual(["computer_s40", "computer_5", "computer_10"]);
+    expect(isCompactPaidPlan("computer_s40")).toBe(true);
+    expect(isCompactPaidPlan("computer_s20")).toBe(false);
     expect(isCompactPaidPlan("computer_20")).toBe(false);
   });
 
-  test("Always On is not sold on this list", () => {
+  test("Always On and the old $5 Starter are not sold on this list", () => {
     expect(sellOnPaywall("computer_20")).toBe(false);
+    expect(sellOnPaywall("computer_s20")).toBe(false);
     expect(sellOnPaywall("computer_10", { alwaysOn: true })).toBe(false);
+    expect(sellOnPaywall("computer_s40")).toBe(true);
     expect(sellOnPaywall("computer_5")).toBe(true);
   });
 
@@ -84,6 +88,19 @@ describe("the compact merchandising list", () => {
       "dev.omg.computer.computer_5.monthly.v1",
       "dev.omg.computer.computer_10.monthly.v1",
     ]);
+  });
+
+  test("the local StoreKit config mocks the locked ladder prices", () => {
+    // The file already used .99 amounts. Live App Store Connect is not edited
+    // from this repo — these strings only change what the simulator shows.
+    const storekit = readFileSync("mobile/storekit/omg.storekit", "utf8");
+    expect(storekit).toContain('"productID" : "dev.omg.computer.computer_s40.monthly.v1"');
+    expect(storekit).toContain('"displayPrice" : "19.99"');
+    expect(storekit).toContain('"displayPrice" : "37.99"');
+    expect(storekit).toContain('"displayPrice" : "97.99"');
+    expect(storekit).not.toContain('"displayPrice" : "11.99"');
+    expect(storekit).not.toContain('"displayPrice" : "57.99"');
+    expect(storekit).not.toContain('"displayPrice" : "179.99"');
   });
 });
 

--- a/test/mobile-plan-copy.test.ts
+++ b/test/mobile-plan-copy.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Paywall merchandising copy, as tests.
+ *
+ * The companion file (test/mobile-plan-specs.test.ts) pins the safety rule:
+ * the phone never invents paid-tier hardware numbers. This file pins the
+ * locked mock copy and the merchandising filter — headline, Free row, default
+ * selection, CTA, and "Always On stays off the compact list".
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  COMPACT_PAID_PLANS,
+  continueCtaLabel,
+  defaultSelectedPlan,
+  emphasizeParallel,
+  formatAllowanceLine,
+  FREE_PLAN_KEY,
+  FREE_ROW,
+  isCompactPaidPlan,
+  isPopularPlan,
+  PAYWALL_HEADLINE,
+  PAYWALL_SUBHEAD,
+  PERSONAL_PLAN_KEY,
+  sellOnPaywall,
+  taglineForPlan,
+} from "../mobile/src/omg/plan-copy";
+import { FALLBACK_TIERS } from "../mobile/src/omg/plan-specs";
+
+describe("the locked onboarding copy", () => {
+  test("headline and sub match the mock", () => {
+    expect(PAYWALL_HEADLINE).toBe("A space for all your coding agents.");
+    expect(PAYWALL_SUBHEAD).toBe("Always at your fingertips.");
+  });
+
+  test("Free is display copy, not a StoreKit product", () => {
+    expect(FREE_ROW.label).toBe("Free");
+    expect(FREE_ROW.tagline).toBe("A computer to try");
+    expect(FREE_ROW.computeHours).toBe(3);
+    expect(FREE_ROW.parallelAgents).toBe(3);
+    expect(FREE_ROW.priceLabel).toBe("$0");
+    expect(FALLBACK_TIERS.some((tier) => tier.plan === FREE_PLAN_KEY)).toBe(false);
+    expect(FALLBACK_TIERS.some((tier) => tier.productId.includes("free"))).toBe(false);
+  });
+
+  test("paid taglines match the mock", () => {
+    expect(taglineForPlan("computer_s20")).toBe("A capable computer");
+    expect(taglineForPlan("computer_5")).toBe("A bigger, faster computer");
+    expect(taglineForPlan("computer_10")).toBe("The most powerful computer");
+  });
+
+  test("Personal is the popular default", () => {
+    expect(isPopularPlan(PERSONAL_PLAN_KEY)).toBe(true);
+    expect(isPopularPlan("computer_10")).toBe(false);
+    expect(defaultSelectedPlan(["free", "computer_s20", "computer_5", "computer_10"])).toBe(
+      PERSONAL_PLAN_KEY,
+    );
+  });
+
+  test("a storefront without Personal still picks a paid rung", () => {
+    expect(defaultSelectedPlan(["free", "computer_s20"])).toBe("computer_s20");
+    expect(defaultSelectedPlan([FREE_PLAN_KEY])).toBe(FREE_PLAN_KEY);
+  });
+});
+
+describe("the compact merchandising list", () => {
+  test("the paid rows are Starter, Personal, Pro", () => {
+    expect(COMPACT_PAID_PLANS).toEqual(["computer_s20", "computer_5", "computer_10"]);
+    expect(isCompactPaidPlan("computer_s20")).toBe(true);
+    expect(isCompactPaidPlan("computer_s40")).toBe(false);
+    expect(isCompactPaidPlan("computer_20")).toBe(false);
+  });
+
+  test("Always On is not sold on this list", () => {
+    expect(sellOnPaywall("computer_20")).toBe(false);
+    expect(sellOnPaywall("computer_10", { alwaysOn: true })).toBe(false);
+    expect(sellOnPaywall("computer_5")).toBe(true);
+  });
+
+  test("product ids in the fallback list do not change", () => {
+    expect(FALLBACK_TIERS.map((tier) => tier.productId)).toEqual([
+      "dev.omg.computer.computer_s20.monthly.v1",
+      "dev.omg.computer.computer_s40.monthly.v1",
+      "dev.omg.computer.computer_5.monthly.v1",
+      "dev.omg.computer.computer_10.monthly.v1",
+    ]);
+  });
+});
+
+describe("the continue button", () => {
+  test("paid uses Apple's price string, Free does not invent one", () => {
+    expect(continueCtaLabel("$38.00")).toBe("Continue · $38.00/mo");
+    expect(continueCtaLabel("HK$47.00")).toBe("Continue · HK$47.00/mo");
+    expect(continueCtaLabel(null)).toBe("Continue");
+  });
+
+  test("allowance copy matches the compact line", () => {
+    expect(formatAllowanceLine(150, 5)).toEqual({
+      hours: "150 hours",
+      parallelCount: "5",
+      parallelSuffix: "in parallel",
+    });
+    expect(formatAllowanceLine(3, 3)).toEqual({
+      hours: "3 hours",
+      parallelCount: "3",
+      parallelSuffix: "in parallel",
+    });
+  });
+
+  test("only the bigger parallel counts are emphasised", () => {
+    expect(emphasizeParallel(3)).toBe(false);
+    expect(emphasizeParallel(5)).toBe(true);
+    expect(emphasizeParallel(16)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HOLD / DO NOT MERGE

The iOS app is pending Apple review. This is a parked design PR only.

Do not merge this PR.
Do not mark it ready for review.
Do not retarget `main`.
Do not OTA.
Do not bump a build.
Do not submit to App Store Connect.
Do not change the binary that is in review.

---

The iOS onboarding/upgrade paywall now follows the locked mock.

**Changed behavior**
- The launch still sits flush to the top of the screen. It is a square-ish crop zoomed on the phone, fading into the page. It is not a YouTube player. This repo has no clip asset to reuse.
- Headline: “A space for all your coding agents.”
- Sub: “Always at your fingertips.”
- Compact paid rows follow the locked web ladder: Starter (`computer_s40`), Personal (`computer_5`, MOST POPULAR, selected by default), Pro (`computer_10`). Free $0 stays as a display row.
- The old $5 / 20-hour Starter (`computer_s20`) stays mappable, like Always On. It is not a row.
- Paid prices still come from StoreKit `displayPrice`. Paid hours and parallel counts still come from the catalog specs, or the row stays quiet.
- Bottom CTA: `Continue · {displayPrice}/mo`. Free and Skip for now leave without a purchase.
- StoreKit product IDs in `FALLBACK_TIERS` are unchanged. No new SKUs.

**App Store Connect**
- This change does not edit App Store Connect.
- Local `omg.storekit` mock amounts are now 19.99 / 37.99 / 97.99 for the three compact products.
- Live iOS amounts stay on the old ASC prices until those three existing products are edited in App Store Connect.

**Verification**
- `bun test test/mobile-plan-copy.test.ts test/mobile-plan-specs.test.ts` — 31 pass
- `bun run typecheck` in `mobile/` — pass

**Base**
`feat/mobile-omg-foundation` — that branch owns the current iOS app. `main` still has the todo scaffold.

**Remaining risk**
- There is no launch clip in the repo or onboarding flow. The hero is a still crop, not a bundled video.
- I did not run the iOS simulator or a device build. A web preview is not proof that the native path works.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9c010f0-fcbe-4f3d-8daf-7508a96230d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9c010f0-fcbe-4f3d-8daf-7508a96230d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

