### PR TITLE
fix(web): center the Bots empty state on mobile instead of leaving it stranded

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26129,7 +26129,24 @@ function BotsView({
       }) : (
         // Create lives in the header "New" control so the empty card is
         // only the heading.
-        <div className="flex flex-col items-center rounded-xl border border-border bg-card p-10 text-center">
+        //
+        // This list has no height management of its own — it sizes to its
+        // content inside <main>'s scroll box — so on a mobile phone a lone
+        // card left the bottom half of the screen dead below it (reported:
+        // "Fix the position of the bot/chat button position", Angel,
+        // 2026-08-23). LiveView's mobile empty state (10853 above) already
+        // solves the same shape of problem by giving itself a min-h-[50dvh]
+        // floor and centering inside it; mirror that value and pattern here
+        // rather than inventing a new one. Mobile only — the desktop rail's
+        // narrower column reads fine top-aligned and must not grow a half
+        // -screen card. `bots.length` gates this whole branch, so a
+        // populated roster (1, 3, 10 bots — whatever) never sees this floor.
+        <div
+          className={cn(
+            "flex flex-col items-center rounded-xl border border-border bg-card p-10 text-center",
+            isMobile && "min-h-[50dvh] justify-center",
+          )}
+        >
           {/* One creature, asleep, waiting to be woken by the first bot. */}
           <BotMascot
             shape="circle"


### PR DESCRIPTION
## Summary

Bug report: on a phone, the Bots list ("Welcome, X" / "New bot" / "No bots yet.") renders its content in the top ~40% of the screen and leaves the bottom ~60% empty, with the empty-state card floating high (Angel, real iPhone, app.omg.dev, screenshot circled the dead bottom third).

**Correction mid-investigation**: this screen runs embedded inside the omg.dev host (app.omg.dev), not standalone — so before touching layout I had to establish who owns the viewport height in that configuration, since a host/guest disagreement about height would need a different fix (possibly in the vibes repo) than a plain CSS bug.

**Finding: lfg owns the height, correctly, and vibes never disputes it.**
- `--lfg-app-height` / `--lfg-visual-height` are set exclusively by lfg's own `visualViewport`-driven effect in `App.tsx` — real DOM measurements, not anything derived from the host.
- `grep -rn "lfg-app-height" /home/dev/repos/vibes` → zero hits, anywhere. Vibes only contributes `--lfg-host-bottom-inset` / `--lfg-host-top-inset` (padding for its own floating chrome), a separate variable namespace from height entirely.
- The DOM chain vibes hands to lfg's mount point (`computer-home-screen.tsx`) is `fixed inset-0` → `relative flex-1` → `absolute inset-0` → lfg's own `h-full` root — a genuine viewport-anchored box, not a fragile `height: 100%` percentage chain that could silently collapse.
- `<main>` already receives a correctly sized, correctly scrolling box from this either way.

So the dead space is **not** a host/embed height-ownership bug. It's one level down: `BotsView`'s list container (`<div className="mx-auto flex max-w-3xl flex-col gap-2" data-lfg-page-column>`) has no height management of its own at all — no `min-height`, no `flex-1`, nothing. A short roster (or the "No bots yet" card) just sizes to its own content inside `<main>`'s otherwise-correctly-sized scroll box, leaving whatever's left of the screen blank underneath.

**Fix**: mirror the pattern this app already uses for exactly this shape of problem. LiveView's mobile empty state ("No running sessions") already solves it with `min-h-[50dvh] flex flex-col items-center justify-center` — I gave the Bots empty-state card the same `min-h-[50dvh]` floor and vertical centering, mobile-only, rather than inventing a new pattern. Populated states (1, 3, 10 bots — checked all three) are untouched: the change only applies inside the existing `bots.length ? … : (empty state)` branch.

**"New bot" position**: considered making it a bottom-anchored, thumb-reachable FAB instead, per the task's prompt. Decided against it — the code already deliberately puts bot creation as the *first* row ("the thing you add to is the thing you add from," matching how the desktop rail does it), and no other list screen in this app uses a bottom FAB for creation. Moving it would be inventing a new interaction pattern the task explicitly asked me to avoid, for a screen where the actual reported complaint was dead space, not reach.

I did not touch anything in the vibes repo — no companion PR there. Confirmed nothing needs to change on that side.

## Test plan

- [x] `cd web && bun x tsc --noEmit` — clean (root `bun run typecheck` also clean)
- [x] `bun test test/bots-roster-ux.test.ts test/bot-conversation-surface-toggle.test.ts test/bot-restart-wiring.test.ts test/bot-rotation-wiring.test.ts test/bot-transcript.test.ts test/bot-unread-wiring.test.ts web/src/mobile-bot-chat-navigation.test.ts` — 49/49 pass
- [x] Visual repro at 390×844, light + dark: empty state before (dead space below a top-aligned card) vs. after (card fills ~50dvh, centered) — screenshots attached in the task report
- [x] Same repro at 1, 3, and 10 bots — populated list renders unchanged in all three counts
- (No lint script exists for this repo/web app per `AGENTS.md`'s verification profiles — typecheck + focused tests only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)