### PR TITLE
feat(serve): one-shot command execution for remote callers

### DIFF
--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -1,4 +1,5 @@
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { hostname } from "node:os";
 import { join } from "node:path";
 import { PATHS, localServeHost } from "../config.ts";
 import {
@@ -1124,7 +1125,10 @@ async function pollSessionEvents(seen: Map<string, SeenSession>, getSocket: () =
 
 function connectSocket(
   relayUrl: string,
-  hello: ({ type: "pair"; code: string } | { type: "hello"; token: string }) & { computerUrl?: string },
+  hello: ({ type: "pair"; code: string } | { type: "hello"; token: string }) & {
+    computerUrl?: string;
+    name?: string;
+  },
 ): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(relayUrl);
@@ -1141,11 +1145,28 @@ function connectSocket(
 }
 
 /** Redeems a one-time pairing code, persists the returned token, then falls through to the persistent connect loop. */
+/**
+ * This machine's hostname, sent so a relay can offer a human-readable handle
+ * instead of a UUID.
+ *
+ * Generic on purpose: a hostname is not an omg concept, and a relay that does
+ * not want it simply ignores the field. Best-effort — a box with no resolvable
+ * hostname sends nothing and the relay falls back on its own.
+ */
+function boxName(): string | undefined {
+  try {
+    const name = hostname().trim().replace(/\.local$/i, "");
+    return name || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function pair(code: string, explicitComputerUrl?: string): Promise<void> {
   const relayUrl = requireRelayUrl();
   const computerUrl = normalizeComputerUrl(explicitComputerUrl ?? process.env.LFG_PUBLIC_URL);
   console.log(`lfg connect: redeeming pairing code against ${relayUrl} …`);
-  const ws = await connectSocket(relayUrl, { type: "pair", code, ...(computerUrl ? { computerUrl } : {}) });
+  const ws = await connectSocket(relayUrl, { type: "pair", code, name: boxName(), ...(computerUrl ? { computerUrl } : {}) });
 
   const paired = await new Promise<{ token: string; boxId: string }>((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error("timed out waiting for relay to confirm pairing")), 15_000);
@@ -1232,6 +1253,9 @@ async function runConnectLoop(explicitComputerUrl?: string): Promise<void> {
       const ws = await connectSocket(creds.relayUrl, {
         type: "hello",
         token: creds.token,
+        // Re-sent on every reconnect, not just at pairing, so a renamed
+        // machine reads correctly without re-pairing.
+        name: boxName(),
         ...(computerUrl ? { computerUrl } : {}),
       });
       currentWs = ws;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -342,6 +342,7 @@ import {
 } from "../repos-store.ts";
 import { projectName, reposRoot } from "../projects.ts";
 import { listConfiguredRepos } from "../repo-list.ts";
+import { runExecCommand, clampExecTimeout, MAX_EXEC_TIMEOUT_MS } from "../exec.ts";
 import {
   cwdIsWithin,
   repoContainingCwd,
@@ -6193,6 +6194,45 @@ a{color:#60a5fa}
           if (e instanceof FolderDeleteError) return err(e.status, e.message);
           return err(400, e instanceof Error ? e.message : String(e));
         }
+      }
+
+      // One-shot command execution. See src/exec.ts for why this exists and
+      // why it is capped; the short version is that a remote caller has no
+      // shell on this box, and spawning a whole session to read a file is
+      // absurd. Seconds here; minutes belong in a session.
+      if (path === "/api/exec" && req.method === "POST") {
+        const b = (await req.json().catch(() => null)) as {
+          command?: unknown;
+          cwd?: unknown;
+          timeoutMs?: unknown;
+        } | null;
+        const command = typeof b?.command === "string" ? b.command.trim() : "";
+        if (!command) return err(400, "expected { command }");
+
+        // cwd resolves through the same repo allowlist that POST
+        // /api/sessions/new uses, rather than accepting any absolute path.
+        // Two reasons: an agent that mistypes a path gets "unknown repo"
+        // instead of silently running in $HOME, and the box keeps ONE answer
+        // to "where may work happen" instead of a second one here.
+        const repos = await listRepos();
+        const requestedCwd = typeof b?.cwd === "string" ? b.cwd.trim() : "";
+        const repo = requestedCwd
+          ? repoForRequestedSessionCwd(repos, requestedCwd, undefined)
+          : (repos.find((r) => r.cwd === SELF_REPO) ?? repos[0]);
+        if (!repo) {
+          return err(
+            400,
+            requestedCwd
+              ? `unknown repo: ${requestedCwd}`
+              : "no repositories are configured on this computer",
+          );
+        }
+
+        const timeoutMs = clampExecTimeout(b?.timeoutMs);
+        if (typeof b?.timeoutMs === "number" && b.timeoutMs > MAX_EXEC_TIMEOUT_MS) {
+          return err(400, `timeoutMs may not exceed ${MAX_EXEC_TIMEOUT_MS}`);
+        }
+        return json(await runExecCommand({ command, cwd: repo.cwd, timeoutMs }));
       }
 
       if (path === "/api/repos") {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -49,24 +49,117 @@ export interface ExecResult {
   /** True when either stream hit MAX_EXEC_OUTPUT_BYTES. Say so; never truncate silently. */
   truncated: boolean;
   timedOut: boolean;
+  /**
+   * False when a timeout could only signal the shell, not its whole process
+   * group — no `setsid` on this box. Anything the command spawned may still be
+   * running. Reported rather than hidden: a caller that just timed out needs
+   * to know whether the work actually stopped.
+   */
+  killedGroup: boolean;
   durationMs: number;
   cwd: string;
 }
 
-function clip(buf: Uint8Array): { text: string; truncated: boolean } {
-  const decoder = new TextDecoder();
-  if (buf.byteLength <= MAX_EXEC_OUTPUT_BYTES) {
-    return { text: decoder.decode(buf), truncated: false };
-  }
-  // Keep the head AND the tail: a failing command's cause is usually at the
-  // top (the first error) and its verdict at the bottom (the summary line).
-  // Keeping only one end reliably discards the half the caller needed.
+/**
+ * Read a stream to its end while never holding more than the cap in memory.
+ *
+ * THE BUG THIS REPLACES: the first version buffered the whole stream and
+ * clipped afterwards, which caps the RESPONSE but not the READ. `yes | cat`
+ * took the server from 220 MB to 2.5 GB of RSS in about ten seconds, and the
+ * timeout could not save it because the buffering await never resolved. A
+ * one-shot command endpoint is reachable by anything that can reach this API,
+ * so unbounded accumulation here is a denial of service on the whole box.
+ *
+ * Keeps the head AND a rolling tail: a failure's cause is at the top (the
+ * first error) and its verdict at the bottom (the summary line), so keeping
+ * one end reliably discards the half the caller needed.
+ */
+async function readCapped(
+  stream: ReadableStream<Uint8Array>,
+): Promise<{ text: string; truncated: boolean }> {
   const half = Math.floor(MAX_EXEC_OUTPUT_BYTES / 2);
-  const head = decoder.decode(buf.slice(0, half));
-  const tail = decoder.decode(buf.slice(buf.byteLength - half));
-  const omitted = buf.byteLength - half * 2;
-  return { text: `${head}\n… ${omitted} bytes omitted …\n${tail}`, truncated: true };
+  const head: Uint8Array[] = [];
+  let headBytes = 0;
+  // Rolling window. Chunks fall off the front as new ones arrive, so this
+  // holds at most `half` bytes plus one chunk regardless of stream length.
+  const tail: Uint8Array[] = [];
+  let tailBytes = 0;
+  let total = 0;
+
+  const reader = stream.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+
+      if (headBytes < half) {
+        const take = Math.min(half - headBytes, value.byteLength);
+        head.push(value.subarray(0, take));
+        headBytes += take;
+        if (take === value.byteLength) continue;
+        tail.push(value.subarray(take));
+        tailBytes += value.byteLength - take;
+      } else {
+        tail.push(value);
+        tailBytes += value.byteLength;
+      }
+      // Trim to EXACTLY `half`, slicing the oldest chunk rather than only
+      // dropping whole ones. A pipe can hand over a single chunk far larger
+      // than the window, and keeping it intact was letting the tail run to
+      // ~245 KB against a 32 KB budget.
+      while (tailBytes > half) {
+        const first = tail[0]!;
+        const excess = tailBytes - half;
+        if (first.byteLength <= excess) {
+          tail.shift();
+          tailBytes -= first.byteLength;
+        } else {
+          tail[0] = first.subarray(excess);
+          tailBytes -= excess;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const decoder = new TextDecoder();
+  const join = (parts: Uint8Array[], bytes: number): string => {
+    const out = new Uint8Array(bytes);
+    let at = 0;
+    for (const part of parts) {
+      out.set(part, at);
+      at += part.byteLength;
+    }
+    return decoder.decode(out);
+  };
+
+  if (total <= MAX_EXEC_OUTPUT_BYTES) {
+    return { text: join([...head, ...tail], headBytes + tailBytes), truncated: false };
+  }
+  const omitted = total - headBytes - tailBytes;
+  return {
+    text: `${join(head, headBytes)}\n… ${omitted} bytes omitted …\n${join(tail, tailBytes)}`,
+    truncated: true,
+  };
 }
+
+/**
+ * `setsid` puts the command in its own process group so the whole tree can be
+ * signalled at once.
+ *
+ * Without it, killing the shell orphans everything it started: `yes | cat`
+ * left both halves running after the timeout fired, burning a core until
+ * someone noticed. Measured — group kill leaves 0 survivors, killing the
+ * shell alone leaves 1.
+ *
+ * Resolved once at load. macOS has no setsid binary, so a box without it
+ * degrades to killing the shell only rather than failing to run commands at
+ * all; the orphan risk is named in ExecResult.killedGroup.
+ */
+const SETSID = Bun.which("setsid");
 
 export function clampExecTimeout(raw: unknown): number {
   const value = typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_EXEC_TIMEOUT_MS;
@@ -88,7 +181,7 @@ export async function runExecCommand(
   const timeoutMs = clampExecTimeout(request.timeoutMs);
   const started = performance.now();
 
-  const child = spawn(["bash", "-lc", request.command], {
+  const child = spawn([...(SETSID ? [SETSID] : []), "bash", "-lc", request.command], {
     cwd,
     stdin: "ignore",
     stdout: "pipe",
@@ -97,10 +190,23 @@ export async function runExecCommand(
   });
 
   let timedOut = false;
+  let killedGroup = false;
   const timer = setTimeout(() => {
     timedOut = true;
     // SIGKILL, not SIGTERM. This is already past a deadline the caller is
     // blocked on, and a process that ignores TERM would hold them past it.
+    //
+    // Negative pid = the whole process group. A pipeline is several processes,
+    // and signalling only the shell leaves the rest running with the pipe
+    // still open, which also keeps the reads above from ever finishing.
+    if (SETSID) {
+      try {
+        process.kill(-child.pid, 9);
+        killedGroup = true;
+      } catch {
+        // Group already gone.
+      }
+    }
     try {
       child.kill(9);
     } catch {
@@ -109,13 +215,11 @@ export async function runExecCommand(
   }, timeoutMs);
 
   try {
-    const [stdoutBuf, stderrBuf, exitCode] = await Promise.all([
-      new Response(child.stdout).bytes(),
-      new Response(child.stderr).bytes(),
+    const [out, err, exitCode] = await Promise.all([
+      readCapped(child.stdout as ReadableStream<Uint8Array>),
+      readCapped(child.stderr as ReadableStream<Uint8Array>),
       child.exited,
     ]);
-    const out = clip(stdoutBuf);
-    const err = clip(stderrBuf);
     return {
       exitCode: timedOut ? null : exitCode,
       stdout: out.text,
@@ -124,6 +228,7 @@ export async function runExecCommand(
         : err.text,
       truncated: out.truncated || err.truncated,
       timedOut,
+      killedGroup: timedOut ? killedGroup : true,
       durationMs: Math.round(performance.now() - started),
       cwd,
     };

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,133 @@
+// One-shot command execution on this box.
+//
+// WHY THIS EXISTS AT ALL. An agent running ON this machine already has a
+// shell; it does not need an HTTP endpoint to run `git status`. A REMOTE
+// caller reaching this box through a relay has nothing, and without this its
+// only way to look at a file is to spawn a whole coding-agent session — which
+// costs a tmux pane, a model, and thirty seconds, to answer a question that
+// takes ten milliseconds.
+//
+// ON THE SECURITY BOUNDARY. This does not widen it. `POST /api/sessions/new`
+// already starts a coding agent with full shell on this box, so anything that
+// can reach this API can already run arbitrary code. What changes is
+// auditability, in the right direction: one recorded command with an exit code
+// is far easier to reason about than an agent turn. The perimeter is, as ever,
+// the loopback bind or whatever put this server behind a relay — see
+// docs/remote-access.md.
+//
+// SHORT AND SYNCHRONOUS, ON PURPOSE. The whole point of a remote box is that
+// work leaves the caller's process. A build that blocks the caller for four
+// minutes defeats that, so this caps hard and tells the caller to delegate
+// instead. Seconds here; minutes belong in a session.
+
+import { resolve } from "node:path";
+
+/** Long enough for a test file or a git command; short enough to never look hung. */
+export const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
+export const MAX_EXEC_TIMEOUT_MS = 120_000;
+
+/**
+ * Per stream.
+ *
+ * Not a nicety. A relay frame caps at 16 MiB and base64 inflates it by 4/3, so
+ * a full build log does not merely bloat a response — it exceeds the frame the
+ * relay will accept and closes the box's socket with a 1009, taking the machine
+ * offline. Truncation is a liveness requirement.
+ */
+export const MAX_EXEC_OUTPUT_BYTES = 64 * 1024;
+
+export interface ExecRequest {
+  command: string;
+  cwd: string;
+  timeoutMs?: number;
+}
+
+export interface ExecResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  /** True when either stream hit MAX_EXEC_OUTPUT_BYTES. Say so; never truncate silently. */
+  truncated: boolean;
+  timedOut: boolean;
+  durationMs: number;
+  cwd: string;
+}
+
+function clip(buf: Uint8Array): { text: string; truncated: boolean } {
+  const decoder = new TextDecoder();
+  if (buf.byteLength <= MAX_EXEC_OUTPUT_BYTES) {
+    return { text: decoder.decode(buf), truncated: false };
+  }
+  // Keep the head AND the tail: a failing command's cause is usually at the
+  // top (the first error) and its verdict at the bottom (the summary line).
+  // Keeping only one end reliably discards the half the caller needed.
+  const half = Math.floor(MAX_EXEC_OUTPUT_BYTES / 2);
+  const head = decoder.decode(buf.slice(0, half));
+  const tail = decoder.decode(buf.slice(buf.byteLength - half));
+  const omitted = buf.byteLength - half * 2;
+  return { text: `${head}\n… ${omitted} bytes omitted …\n${tail}`, truncated: true };
+}
+
+export function clampExecTimeout(raw: unknown): number {
+  const value = typeof raw === "number" && Number.isFinite(raw) ? raw : DEFAULT_EXEC_TIMEOUT_MS;
+  return Math.max(1_000, Math.min(MAX_EXEC_TIMEOUT_MS, Math.round(value)));
+}
+
+/**
+ * Run `command` through a login shell and return everything about it.
+ *
+ * A login shell (`bash -lc`) rather than a bare exec: the caller's mental model
+ * is a terminal on this machine, and the tools they expect — mise, nvm, a
+ * PATH set in a profile — only exist in one.
+ */
+export async function runExecCommand(
+  request: ExecRequest,
+  spawn: typeof Bun.spawn = Bun.spawn,
+): Promise<ExecResult> {
+  const cwd = resolve(request.cwd);
+  const timeoutMs = clampExecTimeout(request.timeoutMs);
+  const started = performance.now();
+
+  const child = spawn(["bash", "-lc", request.command], {
+    cwd,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: process.env,
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    // SIGKILL, not SIGTERM. This is already past a deadline the caller is
+    // blocked on, and a process that ignores TERM would hold them past it.
+    try {
+      child.kill(9);
+    } catch {
+      // Already gone.
+    }
+  }, timeoutMs);
+
+  try {
+    const [stdoutBuf, stderrBuf, exitCode] = await Promise.all([
+      new Response(child.stdout).bytes(),
+      new Response(child.stderr).bytes(),
+      child.exited,
+    ]);
+    const out = clip(stdoutBuf);
+    const err = clip(stderrBuf);
+    return {
+      exitCode: timedOut ? null : exitCode,
+      stdout: out.text,
+      stderr: timedOut
+        ? `${err.text}${err.text ? "\n" : ""}Command exceeded ${timeoutMs}ms and was killed. Long work belongs in a session, not a one-shot command.`
+        : err.text,
+      truncated: out.truncated || err.truncated,
+      timedOut,
+      durationMs: Math.round(performance.now() - started),
+      cwd,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -96,3 +96,55 @@ describe("runExecCommand", () => {
     expect(r.durationMs).toBeLessThan(15_000);
   });
 });
+
+// Regressions found by an independent verifier against a running server.
+// Both were denial-of-service class, not cosmetic.
+describe("runExecCommand under hostile output", () => {
+  // THE BUG: the first version buffered whole streams and clipped afterwards,
+  // which caps the RESPONSE but not the READ. `yes | cat` drove the server
+  // from 220 MB to 2.5 GB of RSS in ten seconds, and the timeout could not
+  // save it because the buffering await never resolved.
+  //
+  // Deliberately NOT asserted by measuring heapUsed. That is process-wide, so
+  // in a full-suite run it moves with every other test's garbage and the
+  // assertion fails for reasons unrelated to this code — which it did.
+  //
+  // What actually regressed is observable without it: a buffering
+  // implementation cannot return promptly OR keep the response at the cap
+  // while `truncated` proves the stream produced vastly more. Three seconds of
+  // `yes` is hundreds of megabytes; if that is ever accumulated again, this
+  // test stops finishing rather than merely failing an inequality.
+  test("returns promptly and bounded against an infinite stream", async () => {
+    const started = performance.now();
+
+    const r = await runExecCommand({ command: "yes STREAM | cat", cwd, timeoutMs: 3_000 });
+
+    expect(r.timedOut).toBe(true);
+    expect(performance.now() - started).toBeLessThan(20_000);
+    expect(r.stdout.length).toBeLessThan(MAX_EXEC_OUTPUT_BYTES + 512);
+    expect(r.truncated).toBe(true);
+  }, 30_000);
+
+  // THE OTHER BUG: killing the shell orphaned everything it started. Both
+  // halves of a pipeline stayed alive after the timeout, burning a core.
+  test("kills the whole process group, not just the shell", async () => {
+    const marker = `EXECMARK${Date.now()}`;
+    const r = await runExecCommand({
+      command: `exec -a ${marker} yes X | cat > /dev/null`,
+      cwd,
+      timeoutMs: 1_000,
+    });
+
+    expect(r.timedOut).toBe(true);
+    await Bun.sleep(500);
+    const survivors = Bun.spawnSync(["pgrep", "-f", marker])
+      .stdout.toString().trim().split("\n").filter(Boolean).length;
+    // Only meaningful where the group could actually be signalled.
+    if (r.killedGroup) expect(survivors).toBe(0);
+    Bun.spawnSync(["pkill", "-9", "-f", marker]);
+  }, 30_000);
+
+  test("a command that exits normally is never reported as an orphan risk", async () => {
+    expect((await runExecCommand({ command: "echo ok", cwd })).killedGroup).toBe(true);
+  });
+});

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  runExecCommand,
+  clampExecTimeout,
+  DEFAULT_EXEC_TIMEOUT_MS,
+  MAX_EXEC_TIMEOUT_MS,
+  MAX_EXEC_OUTPUT_BYTES,
+} from "../src/exec.ts";
+
+const cwd = mkdtempSync(`${tmpdir()}/omg-exec-`);
+
+describe("clampExecTimeout", () => {
+  test("defaults, floors, and ceilings", () => {
+    expect(clampExecTimeout(undefined)).toBe(DEFAULT_EXEC_TIMEOUT_MS);
+    expect(clampExecTimeout("nonsense")).toBe(DEFAULT_EXEC_TIMEOUT_MS);
+    expect(clampExecTimeout(Number.NaN)).toBe(DEFAULT_EXEC_TIMEOUT_MS);
+    expect(clampExecTimeout(5)).toBe(1_000);
+    expect(clampExecTimeout(10 * 60_000)).toBe(MAX_EXEC_TIMEOUT_MS);
+    expect(clampExecTimeout(5_000)).toBe(5_000);
+  });
+});
+
+describe("runExecCommand", () => {
+  test("returns stdout, stderr and the exit code separately", async () => {
+    const r = await runExecCommand({ command: "echo out; echo err >&2; exit 3", cwd });
+
+    expect(r.exitCode).toBe(3);
+    expect(r.stdout.trim()).toBe("out");
+    expect(r.stderr.trim()).toBe("err");
+    expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
+  });
+
+  test("runs in the directory it was given", async () => {
+    const r = await runExecCommand({ command: "pwd", cwd });
+    expect(r.stdout.trim()).toBe(r.cwd);
+  });
+
+  // A login shell, so the tools a user expects on their own machine — a PATH
+  // set in a profile, mise, nvm — are actually present.
+  test("runs through a login shell", async () => {
+    const r = await runExecCommand({ command: "shopt -q login_shell && echo login", cwd });
+    expect(r.stdout.trim()).toBe("login");
+  });
+
+  // The regression this pins is not cosmetic. A relay frame caps at 16 MiB and
+  // base64 inflates 4/3, so an unbounded build log closes the box's socket with
+  // a 1009 and takes the machine offline.
+  test("truncates oversized output and says so", async () => {
+    const r = await runExecCommand({
+      command: `head -c ${MAX_EXEC_OUTPUT_BYTES * 3} /dev/zero | tr '\\0' 'x'`,
+      cwd,
+    });
+
+    expect(r.truncated).toBe(true);
+    expect(r.stdout.length).toBeLessThan(MAX_EXEC_OUTPUT_BYTES + 512);
+    expect(r.stdout).toContain("bytes omitted");
+  });
+
+  // Head AND tail: a failing command's cause is usually at the top and its
+  // verdict at the bottom, so keeping one end discards the half that mattered.
+  test("keeps both ends of truncated output", async () => {
+    const r = await runExecCommand({
+      command: `echo FIRSTLINE; head -c ${MAX_EXEC_OUTPUT_BYTES * 2} /dev/zero | tr '\\0' 'x'; echo LASTLINE`,
+      cwd,
+    });
+
+    expect(r.truncated).toBe(true);
+    expect(r.stdout).toContain("FIRSTLINE");
+    expect(r.stdout).toContain("LASTLINE");
+  });
+
+  test("kills a command that overruns and points at delegation", async () => {
+    const r = await runExecCommand({ command: "sleep 30", cwd, timeoutMs: 1_000 });
+
+    expect(r.timedOut).toBe(true);
+    // null, not 0. A killed command must never look like it succeeded.
+    expect(r.exitCode).toBeNull();
+    expect(r.stderr).toContain("exceeded");
+    expect(r.stderr).toContain("session");
+    expect(r.durationMs).toBeLessThan(15_000);
+  });
+
+  // SIGKILL rather than SIGTERM: the caller is already past a deadline they
+  // are blocked on, so a process that traps TERM must not hold them longer.
+  test("kills a command that ignores SIGTERM", async () => {
+    const r = await runExecCommand({
+      command: "trap '' TERM; sleep 30",
+      cwd,
+      timeoutMs: 1_000,
+    });
+
+    expect(r.timedOut).toBe(true);
+    expect(r.durationMs).toBeLessThan(15_000);
+  });
+});


### PR DESCRIPTION
Part of the MCP pivot. `omg_bash` on the hosted MCP needs a way to run a single command on a box and get its output back; today the only route to a shell is `POST /api/sessions/new`, which spends a tmux pane, a model and thirty seconds answering a ten-millisecond question.

## What landed

**`POST /api/exec`** — `{ command, cwd?, timeoutMs? }` → `{ exitCode, stdout, stderr, truncated, timedOut, killedGroup, durationMs, cwd }`.

**`connect.ts`** now advertises this machine's hostname in the relay pair and hello frames, so a relay can offer a human-readable handle instead of a UUID. Generic — a hostname is not an omg concept, and a relay that does not want the field ignores it.

## This does not widen the security boundary

`POST /api/sessions/new` already starts a coding agent with full shell here, so anything that can reach this API can already run arbitrary code. What changes is auditability, in the right direction: one recorded command with an exit code is easier to reason about than an agent turn.

## Three limits, all load-bearing

- **64 KiB per stream, head and tail.** A relay frame caps at 16 MiB and base64 inflates it 4/3, so an unbounded log exceeds the frame the relay accepts and closes the box's socket with a 1009. Keeping only one end reliably discards the half that mattered — a failure's cause is at the top, its verdict at the bottom.
- **60s default, 120s ceiling, SIGKILL on the process group.** The caller is blocked on a deadline. A killed command returns `exitCode: null`, never 0.
- **`cwd` resolves through the repo allowlist** that `POST /api/sessions/new` already uses, so a mistyped path gets `unknown repo` instead of silently running in `$HOME`.

## Two defects found after the first commit, by an independent verifier

Both were denial-of-service class and both are fixed in `a35df60`. My original 8 tests passed against the broken code — they covered truncation of *finite* output and timeout of a *quiet* process, neither of which is the adversarial case.

1. **The read was never bounded.** `new Response(child.stdout).bytes()` buffers the whole stream and clipped after, so the cap governed the response and not memory. `yes STREAM | cat` took the server from 220 MB to 2.5 GB RSS in ten seconds, and the timeout could not save it because the buffering await never resolved.
2. **The kill only reached the shell.** `child.kill(9)` orphaned everything `bash -lc` had started. Measured: group kill leaves 0 survivors, killing the shell alone leaves 1.

## Verification

`bun test test/` — 830 pass, 0 fail (819 baseline + 11 new). Three of the new tests spawn real processes and check for real orphans.

The infinite-stream test deliberately does not assert on `heapUsed`: that is process-wide, moves with other tests' garbage, and failed in a full-suite run for reasons unrelated to this code. Prompt return plus a capped response with `truncated: true` proves the same thing deterministically. Ran three times to confirm no flake.

The repo's typecheck failure on `web/src/lib/omg-client.ts` reproduces on a clean tree — `@omg-dev/client` is unbuilt in this worktree, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)