### PR TITLE
fix(exec): repair UTF-8 at every cut, and stop overclaiming the kill

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -50,14 +50,56 @@ export interface ExecResult {
   truncated: boolean;
   timedOut: boolean;
   /**
-   * False when a timeout could only signal the shell, not its whole process
-   * group — no `setsid` on this box. Anything the command spawned may still be
-   * running. Reported rather than hidden: a caller that just timed out needs
-   * to know whether the work actually stopped.
+   * Whether the timeout could signal the whole process GROUP rather than only
+   * the shell. False when this box has no `setsid` (macOS), where anything the
+   * command spawned may still be running.
+   *
+   * TRUE IS NOT A GUARANTEE THAT NOTHING SURVIVED. A command that starts its
+   * own new session — `setsid foo &`, a daemon that double-forks — leaves the
+   * group we signal, and measurably survives. `nohup ... &` and `disown` do
+   * NOT escape, because neither creates a session. Containing a deliberate
+   * escape needs a PID namespace or a cgroup, which is a box-provisioning
+   * decision rather than something this endpoint can do; and a caller that can
+   * reach this API can already start a coding agent that daemonizes anything
+   * it likes. Reported so a caller knows which guarantee it has, not as proof
+   * the work stopped.
    */
   killedGroup: boolean;
   durationMs: number;
   cwd: string;
+}
+
+/**
+ * Drop an incomplete UTF-8 sequence from the END of a buffer.
+ *
+ * Head and tail are cut at byte offsets, which lands mid-codepoint on any
+ * multibyte output. Decoding the halves separately then renders each severed
+ * sequence as U+FFFD — a stream of `€` came back with replacement characters
+ * at both seams. Trimming the partial bytes loses at most three bytes that
+ * were already inside a truncation marker, and keeps the text valid.
+ */
+function trimPartialSequenceAtEnd(buf: Uint8Array): Uint8Array {
+  // A sequence is at most 4 bytes, so a lead byte further back than 3 is
+  // necessarily complete.
+  for (let back = 1; back <= Math.min(4, buf.byteLength); back++) {
+    const byte = buf[buf.byteLength - back]!;
+    if ((byte & 0b1100_0000) === 0b1000_0000) continue; // continuation
+    const needed =
+      (byte & 0b1000_0000) === 0 ? 1 :
+      (byte & 0b1110_0000) === 0b1100_0000 ? 2 :
+      (byte & 0b1111_0000) === 0b1110_0000 ? 3 :
+      (byte & 0b1111_1000) === 0b1111_0000 ? 4 : 1;
+    // Complete: the whole sequence fits before the end. Otherwise cut it off.
+    return needed <= back ? buf : buf.subarray(0, buf.byteLength - back);
+  }
+  return buf;
+}
+
+/** Drop orphaned continuation bytes from the START of a buffer. */
+function trimPartialSequenceAtStart(buf: Uint8Array): Uint8Array {
+  let at = 0;
+  while (at < buf.byteLength && at < 3 && (buf[at]! & 0b1100_0000) === 0b1000_0000) at++;
+  return at === 0 ? buf : buf.subarray(at);
 }
 
 /**
@@ -126,22 +168,32 @@ async function readCapped(
   }
 
   const decoder = new TextDecoder();
-  const join = (parts: Uint8Array[], bytes: number): string => {
+  const joinBytes = (parts: Uint8Array[], bytes: number): Uint8Array => {
     const out = new Uint8Array(bytes);
     let at = 0;
     for (const part of parts) {
       out.set(part, at);
       at += part.byteLength;
     }
-    return decoder.decode(out);
+    return out;
   };
 
+  // THREE cut points can land mid-codepoint, not two. The seams are obvious;
+  // the third is the end of the stream itself, because SIGKILL stops the
+  // producer wherever it happens to be — including halfway through writing a
+  // character. That one bites the untruncated case too, so it is repaired on
+  // every path rather than only when a seam exists.
   if (total <= MAX_EXEC_OUTPUT_BYTES) {
-    return { text: join([...head, ...tail], headBytes + tailBytes), truncated: false };
+    const whole = trimPartialSequenceAtEnd(joinBytes([...head, ...tail], headBytes + tailBytes));
+    return { text: decoder.decode(whole), truncated: false };
   }
-  const omitted = total - headBytes - tailBytes;
+  const headBytesTrimmed = trimPartialSequenceAtEnd(joinBytes(head, headBytes));
+  const tailBytesTrimmed = trimPartialSequenceAtEnd(
+    trimPartialSequenceAtStart(joinBytes(tail, tailBytes)),
+  );
+  const omitted = total - headBytesTrimmed.byteLength - tailBytesTrimmed.byteLength;
   return {
-    text: `${join(head, headBytes)}\n… ${omitted} bytes omitted …\n${join(tail, tailBytes)}`,
+    text: `${decoder.decode(headBytesTrimmed)}\n… ${omitted} bytes omitted …\n${decoder.decode(tailBytesTrimmed)}`,
     truncated: true,
   };
 }
@@ -224,7 +276,7 @@ export async function runExecCommand(
       exitCode: timedOut ? null : exitCode,
       stdout: out.text,
       stderr: timedOut
-        ? `${err.text}${err.text ? "\n" : ""}Command exceeded ${timeoutMs}ms and was killed. Long work belongs in a session, not a one-shot command.`
+        ? `${err.text}${err.text ? "\n" : ""}Command exceeded ${timeoutMs}ms and was killed${killedGroup ? " (process group signalled)" : " (shell only — spawned processes may still be running)"}. Long work belongs in a session, not a one-shot command.`
         : err.text,
       truncated: out.truncated || err.truncated,
       timedOut,

--- a/test/exec.test.ts
+++ b/test/exec.test.ts
@@ -148,3 +148,57 @@ describe("runExecCommand under hostile output", () => {
     expect((await runExecCommand({ command: "echo ok", cwd })).killedGroup).toBe(true);
   });
 });
+
+// Both found by an independent verifier probing the running endpoint, after
+// the first round of fixes had already landed.
+describe("runExecCommand truncation seams and kill scope", () => {
+  // A byte-offset cut lands mid-codepoint on any multibyte output, and
+  // decoding the halves separately rendered each severed sequence as U+FFFD.
+  test("does not corrupt multibyte output at the truncation seams", async () => {
+    const r = await runExecCommand({
+      command: `yes '€' | tr -d '\\n'`,
+      cwd,
+      timeoutMs: 2_000,
+    });
+
+    expect(r.truncated).toBe(true);
+    expect(r.stdout).toContain("bytes omitted");
+    // No replacement characters anywhere — not at the head cut, not at the
+    // tail cut, not from the rolling-window slice that produced the tail.
+    expect(r.stdout).not.toContain("�");
+    // And the payload really is the multibyte character, not stripped ASCII.
+    expect(r.stdout).toContain("€");
+  }, 30_000);
+
+  test("survives a 4-byte codepoint at the seams too", async () => {
+    const r = await runExecCommand({
+      command: `yes '🙂' | tr -d '\\n'`,
+      cwd,
+      timeoutMs: 2_000,
+    });
+
+    expect(r.truncated).toBe(true);
+    expect(r.stdout).not.toContain("�");
+    expect(r.stdout).toContain("🙂");
+  }, 30_000);
+
+  // nohup and disown do NOT create a session, so they stay in the group and
+  // die with it. This pins the half of the boundary that actually holds.
+  test("nohup and disown do not escape the process group", async () => {
+    const marker = `NOHUPMARK${Date.now()}`;
+    const r = await runExecCommand({
+      command: `nohup bash -c "exec -a ${marker} sleep 30" >/dev/null 2>&1 & disown; sleep 30`,
+      cwd,
+      timeoutMs: 1_000,
+    });
+
+    expect(r.timedOut).toBe(true);
+    await Bun.sleep(500);
+    if (r.killedGroup) {
+      const survivors = Bun.spawnSync(["pgrep", "-f", marker])
+        .stdout.toString().trim().split("\n").filter(Boolean).length;
+      expect(survivors).toBe(0);
+    }
+    Bun.spawnSync(["pkill", "-9", "-f", marker]);
+  }, 30_000);
+});


### PR DESCRIPTION
Follow-up to #219. Both defects found by an independent verifier probing the running endpoint — after the previous round of fixes had landed and passed their tests.

## Multibyte output was corrupted

Head and tail are cut at byte offsets, which lands mid-codepoint on any non-ASCII stream. Decoding the halves separately rendered each severed sequence as `U+FFFD` — a stream of `€` came back with replacement characters at the seams.

**There are three such cuts, not two.** The seams are the obvious pair. The third is the end of the stream itself: SIGKILL stops the producer wherever it happens to be, including halfway through writing a character, so the final bytes can be a partial sequence *even when nothing was truncated*.

I fixed the seams first, and the emoji test still failed — with the replacement character at the very end rather than at a seam. Partial sequences are now trimmed on every path. Cost is at most three bytes, already adjacent to a truncation marker.

## `killedGroup` overclaimed

It read as "the work stopped". A command that starts its own session — `setsid foo &`, a daemon that double-forks — leaves the group we signal and measurably survives.

`nohup ... &` and `disown` do **not** escape, because neither creates a session; that half is now pinned by a test.

Containing a deliberate escape needs a PID namespace or a cgroup — a box-provisioning decision, not something this endpoint can do. Anything that can reach this API can already start a coding agent that daemonizes whatever it likes. So the field is documented for what it actually promises, and the timeout message now states which guarantee the caller got.

## Not fixed here, and not mine

**Request bodies are uncapped.** A 20 MiB JSON body is accepted and costs ~22 MB of RSS. This is serve-wide — 58 POST routes call `req.json()` and nothing limits body size anywhere in `serve.ts` — so it predates this endpoint. Filing rather than folding it into this PR.

## Verifier's confirmation of the previous round

The original hostile probe now returns in 1.16s: `timedOut: true`, `exitCode: null`, `truncated: true`, `killedGroup: true`, stdout 65,569 bytes, RSS 269,728 → 298,344 KB, **zero survivors**. Six simultaneous two-stream floods all returned in ~1.10s with RSS peaking at 277,624 KB and settling to 243,468 KB, zero survivors — so the cap holds in aggregate, not just per request.

## Verification

`bun test test/` — 833 pass, 0 fail, 3 new. The multibyte tests run real killed processes. Ran three times to confirm no flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)