### PR TITLE
Show actionable voice transcription failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Recent product updates and deployment notes.
 
+## Unreleased
+
+- **Voice failures now explain what to fix.** Batch dictation no longer goes
+  silent when a provider rejects a key, runs out of API credit, rate limits a
+  request, or cannot be reached. The server returns a stable safe error code,
+  and the composer shows an actionable message without exposing the provider's
+  response body. The mic also reports its starting and transcribing states to
+  assistive technology.
+
 ## August 23, 2026 - A quieter composer, and Manage sessions is gone (v0.4.0)
 
 - **New: one-shot commands over the API.** `POST /api/exec` runs a single

--- a/src/voice-providers.test.ts
+++ b/src/voice-providers.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { writeEnvValue } from "./voice-providers.ts";
+import {
+  classifySttProviderError,
+  providerErrorResponse,
+  writeEnvValue,
+} from "./voice-providers.ts";
 
 let dir = "";
 
@@ -36,5 +40,54 @@ describe("writeEnvValue", () => {
     await writeEnvValue(created, "ELEVENLABS_API_KEY", "key");
     expect(await readFile(created, "utf8")).toBe("ELEVENLABS_API_KEY=key");
     expect((await stat(created)).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("classifySttProviderError", () => {
+  test("maps authentication failures without returning provider text", () => {
+    expect(classifySttProviderError("openai", 401, "invalid_api_key")).toEqual({
+      code: "invalid_api_key",
+      provider: "openai",
+      retryable: false,
+      upstreamStatus: 401,
+      message: "OpenAI rejected the API key. Add a valid key in Voice settings.",
+    });
+  });
+
+  test("separates exhausted credit from a temporary rate limit", () => {
+    expect(classifySttProviderError("openai", 429, "credit_balance_exhausted").code).toBe(
+      "credit_balance_exhausted",
+    );
+    expect(classifySttProviderError("openai", 429, "insufficient_quota").code).toBe(
+      "credit_balance_exhausted",
+    );
+    expect(classifySttProviderError("openai", 429).code).toBe("rate_limited");
+  });
+
+  test("keeps unknown provider failures generic", () => {
+    const failure = classifySttProviderError("elevenlabs", 418, "secret-provider-detail");
+    expect(failure.code).toBe("transcription_failed");
+    expect(failure.retryable).toBe(false);
+    expect(failure.message).not.toContain("secret-provider-detail");
+  });
+
+  test("returns the stable code without leaking the upstream response", async () => {
+    const response = await providerErrorResponse(
+      "openai",
+      new Response(
+        JSON.stringify({
+          error: {
+            code: "credit_balance_exhausted",
+            message: "private upstream account detail",
+          },
+        }),
+        { status: 429 },
+      ),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(response.status).toBe(502);
+    expect(body.code).toBe("credit_balance_exhausted");
+    expect(body.provider).toBe("openai");
+    expect(JSON.stringify(body)).not.toContain("private upstream account detail");
   });
 });

--- a/src/voice-providers.ts
+++ b/src/voice-providers.ts
@@ -55,7 +55,94 @@ const jres = (obj: unknown, status = 200) =>
     status,
     headers: { "Content-Type": "application/json" },
   });
-const eres = (status: number, message: string) => jres({ error: message }, status);
+export type VoiceErrorCode =
+  | "provider_not_configured"
+  | "invalid_api_key"
+  | "credit_balance_exhausted"
+  | "rate_limited"
+  | "provider_unreachable"
+  | "transcription_failed"
+  | "realtime_only";
+
+type VoiceErrorDetails = {
+  code: VoiceErrorCode;
+  provider: string;
+  retryable: boolean;
+  upstreamStatus?: number;
+};
+
+const eres = (status: number, message: string, details?: VoiceErrorDetails) =>
+  jres({ error: message, ...details }, status);
+
+type ProviderFailure = VoiceErrorDetails & { message: string };
+
+/** Map provider failures to a stable, safe browser contract. Never return an upstream body. */
+export function classifySttProviderError(
+  provider: string,
+  status: number,
+  upstreamCode = "",
+): ProviderFailure {
+  const name = provider === "openai" ? "OpenAI" : provider === "elevenlabs" ? "ElevenLabs" : provider;
+  const code = upstreamCode.toLowerCase();
+  if (status === 401 || status === 403) {
+    return {
+      code: "invalid_api_key",
+      provider,
+      retryable: false,
+      upstreamStatus: status,
+      message: `${name} rejected the API key. Add a valid key in Voice settings.`,
+    };
+  }
+  if (
+    status === 402
+    || code === "credit_balance_exhausted"
+    || code === "insufficient_quota"
+    || code === "quota_exceeded"
+  ) {
+    return {
+      code: "credit_balance_exhausted",
+      provider,
+      retryable: false,
+      upstreamStatus: status,
+      message: `${name} API credit is empty. Add credit in the provider billing settings.`,
+    };
+  }
+  if (status === 429) {
+    return {
+      code: "rate_limited",
+      provider,
+      retryable: true,
+      upstreamStatus: status,
+      message: `${name} is rate limiting transcription. Wait and try again.`,
+    };
+  }
+  return {
+    code: "transcription_failed",
+    provider,
+    retryable: status >= 500,
+    upstreamStatus: status,
+    message: `${name} could not transcribe this recording. Try again.`,
+  };
+}
+
+async function upstreamErrorCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as {
+      error?: { code?: unknown; type?: unknown };
+      code?: unknown;
+      type?: unknown;
+    };
+    const candidate = body.error?.code ?? body.error?.type ?? body.code ?? body.type;
+    return typeof candidate === "string" ? candidate : "";
+  } catch {
+    return "";
+  }
+}
+
+export async function providerErrorResponse(provider: string, response: Response): Promise<Response> {
+  const failure = classifySttProviderError(provider, response.status, await upstreamErrorCode(response));
+  return eres(502, failure.message, failure);
+}
 
 type SttProvider = {
   id: string;
@@ -335,7 +422,11 @@ const sttOmg: SttProvider = {
     // audio URL, not bytes, so there is nothing to POST a clip to. Say so
     // plainly instead of returning an empty transcript the caller would treat
     // as silence.
-    return eres(503, "omg relay is realtime-only; batch transcription is unavailable");
+    return eres(503, "omg.dev live transcription is unavailable for this recording.", {
+      code: "realtime_only",
+      provider: "omg",
+      retryable: true,
+    });
   },
 };
 
@@ -348,7 +439,13 @@ const sttElevenLabs: SttProvider = {
   openStream: (handlers) => elevenLabsRealtimeStream(handlers),
   async transcribe(audio) {
     const key = process.env.ELEVENLABS_API_KEY;
-    if (!key) return eres(503, "elevenlabs not configured");
+    if (!key) {
+      return eres(503, "ElevenLabs is not configured. Add an API key in Voice settings.", {
+        code: "provider_not_configured",
+        provider: "elevenlabs",
+        retryable: false,
+      });
+    }
     const form = new FormData();
     form.append("file", new Blob([audio], { type: "audio/wav" }), "audio.wav");
     form.append("model_id", process.env.ELEVENLABS_STT_MODEL || "scribe_v1");
@@ -359,11 +456,15 @@ const sttElevenLabs: SttProvider = {
         body: form,
         signal: AbortSignal.timeout(TIMEOUT_MS),
       });
-      if (!r.ok) return eres(502, `elevenlabs stt ${r.status}`);
+      if (!r.ok) return providerErrorResponse("elevenlabs", r);
       const j = (await r.json().catch(() => ({}))) as { text?: string };
       return jres({ text: (j.text || "").trim() });
     } catch {
-      return eres(502, "elevenlabs unreachable");
+      return eres(502, "Could not reach ElevenLabs. Check the connection and try again.", {
+        code: "provider_unreachable",
+        provider: "elevenlabs",
+        retryable: true,
+      });
     }
   },
 };
@@ -376,7 +477,13 @@ const sttOpenAI: SttProvider = {
   available: () => !!process.env.OPENAI_API_KEY,
   async transcribe(audio) {
     const key = process.env.OPENAI_API_KEY;
-    if (!key) return eres(503, "openai not configured");
+    if (!key) {
+      return eres(503, "OpenAI is not configured. Add an API key in Voice settings.", {
+        code: "provider_not_configured",
+        provider: "openai",
+        retryable: false,
+      });
+    }
     const form = new FormData();
     form.append("file", new Blob([audio], { type: "audio/wav" }), "audio.wav");
     form.append("model", process.env.OPENAI_STT_MODEL || "gpt-4o-mini-transcribe");
@@ -387,11 +494,15 @@ const sttOpenAI: SttProvider = {
         body: form,
         signal: AbortSignal.timeout(TIMEOUT_MS),
       });
-      if (!r.ok) return eres(502, `openai stt ${r.status}`);
+      if (!r.ok) return providerErrorResponse("openai", r);
       const j = (await r.json().catch(() => ({}))) as { text?: string };
       return jres({ text: (j.text || "").trim() });
     } catch {
-      return eres(502, "openai unreachable");
+      return eres(502, "Could not reach OpenAI. Check the connection and try again.", {
+        code: "provider_unreachable",
+        provider: "openai",
+        retryable: true,
+      });
     }
   },
 };

--- a/test/omg-relay-stt.test.ts
+++ b/test/omg-relay-stt.test.ts
@@ -116,8 +116,9 @@ test("the relay reports batch transcription as unavailable rather than empty", a
   const { transcribeStt } = await import("../src/voice-providers.ts");
   const res = await transcribeStt(new ArrayBuffer(8));
   expect(res.status).toBe(503);
-  const body = (await res.json()) as { error?: string };
-  expect(body.error).toContain("realtime-only");
+  const body = (await res.json()) as { error?: string; code?: string };
+  expect(body.code).toBe("realtime_only");
+  expect(body.error).toBe("omg.dev live transcription is unavailable for this recording.");
 });
 
 test("without OMG_MEDIA_URL the relay is not offered", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -365,6 +365,7 @@ import {
   type TranscriptView,
 } from "./lib/transcript-view";
 import { isMachineryPreviewText, isRequestInterruptedMessage } from "./lib/transcript-status";
+import { voiceErrorMessage, type VoiceSttResponse } from "./lib/voice-errors";
 import {
   ensureVoiceConfigured,
   invalidateVoiceConfig,
@@ -3311,12 +3312,17 @@ function useDictation(opts: {
           headers: { "Content-Type": "application/octet-stream" },
           body: floatToWav(merged, s.rate),
         });
-        const data = (await res.json().catch(() => ({}))) as { text?: string };
+        const data = (await res.json().catch(() => ({}))) as VoiceSttResponse;
         const text = (data.text || "").trim();
         if (res.ok && text) deliver(text);
-        else if (streamed) deliver(streamed);
+        else if (!res.ok) {
+          toast.error(voiceErrorMessage(data, res.status));
+          if (streamed) deliver(streamed);
+        } else if (streamed) deliver(streamed);
+        else toast.error("No speech was detected. Check the microphone and try again.");
       } catch {
         // Batch also failed — fall back to whatever the stream gave us, if any.
+        toast.error("Could not reach speech transcription. Check the connection and try again.");
         if (streamed) deliver(streamed);
       }
       finish();
@@ -4093,6 +4099,16 @@ const MicButton = forwardRef<
   if (!supported) return null;
   const recording = state === "recording";
   const batchOnly = voiceBatchOnlyCached();
+  const busy = state === "starting" || state === "transcribing";
+  const accessibleLabel = state === "starting"
+    ? "Starting microphone"
+    : state === "transcribing"
+      ? "Transcribing audio"
+      : recording
+        ? cancelArmed
+          ? "Release to cancel dictation"
+          : "Stop dictation — tap the X above, or press Esc, to cancel"
+        : "Dictate";
   // While recording, the button reacts to the live mic level: it scales up and
   // throws a red glow ring that swells with your volume. Inline transitions keep
   // it snappy (the className `transition` would lag the per-frame updates by
@@ -4117,13 +4133,8 @@ const MicButton = forwardRef<
         onPointerCancel={onPointerCancel}
         onClick={onClick}
         onContextMenu={(e) => e.preventDefault()}
-        aria-label={
-          recording
-            ? cancelArmed
-              ? "Release to cancel dictation"
-              : "Stop dictation — tap the X above, or press Esc, to cancel"
-            : "Dictate"
-        }
+        aria-label={accessibleLabel}
+        aria-busy={busy}
         title={
           // A batch-only provider still transcribes, it just can't show words as
           // you speak. Saying so beats looking frozen until the take ends.

--- a/web/src/lib/voice-errors.test.ts
+++ b/web/src/lib/voice-errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { voiceErrorMessage } from "./voice-errors";
+
+describe("voiceErrorMessage", () => {
+  test("turns the OpenAI errors seen in production into actionable text", () => {
+    expect(voiceErrorMessage({ code: "invalid_api_key", provider: "openai" }, 502)).toBe(
+      "OpenAI rejected the API key. Replace it in Voice settings.",
+    );
+    expect(
+      voiceErrorMessage({ code: "credit_balance_exhausted", provider: "openai" }, 502),
+    ).toBe("OpenAI API credit is empty. Add credit in the provider billing settings.");
+  });
+
+  test("separates retryable failures from missing configuration", () => {
+    expect(voiceErrorMessage({ code: "rate_limited", provider: "openai" }, 502)).toContain(
+      "Wait and try again",
+    );
+    expect(voiceErrorMessage({ code: "provider_not_configured", provider: "elevenlabs" }, 503)).toBe(
+      "ElevenLabs is not configured. Add an API key in Voice settings.",
+    );
+  });
+
+  test("does not render an unknown server error body", () => {
+    const message = voiceErrorMessage(
+      { code: "unknown-provider-code", error: "secret upstream response" },
+      500,
+    );
+    expect(message).toBe("Speech transcription failed. Try again.");
+    expect(message).not.toContain("secret upstream response");
+  });
+
+  test("keeps a useful fallback for older servers", () => {
+    expect(voiceErrorMessage({}, 429)).toContain("API credit");
+    expect(voiceErrorMessage({}, 401)).toContain("API key");
+  });
+});

--- a/web/src/lib/voice-errors.ts
+++ b/web/src/lib/voice-errors.ts
@@ -1,0 +1,49 @@
+export type VoiceErrorCode =
+  | "provider_not_configured"
+  | "invalid_api_key"
+  | "credit_balance_exhausted"
+  | "rate_limited"
+  | "provider_unreachable"
+  | "transcription_failed"
+  | "realtime_only";
+
+export type VoiceSttResponse = {
+  text?: string;
+  error?: string;
+  code?: VoiceErrorCode | string;
+  provider?: string;
+  retryable?: boolean;
+};
+
+function providerName(provider: unknown): string {
+  if (provider === "openai") return "OpenAI";
+  if (provider === "elevenlabs") return "ElevenLabs";
+  if (provider === "omg") return "omg.dev";
+  return "The speech provider";
+}
+
+/** Convert the stable server code to user text. Do not display provider response bodies. */
+export function voiceErrorMessage(payload: VoiceSttResponse, status = 0): string {
+  const provider = providerName(payload.provider);
+  switch (payload.code) {
+    case "provider_not_configured":
+      return `${provider} is not configured. Add an API key in Voice settings.`;
+    case "invalid_api_key":
+      return `${provider} rejected the API key. Replace it in Voice settings.`;
+    case "credit_balance_exhausted":
+      return `${provider} API credit is empty. Add credit in the provider billing settings.`;
+    case "rate_limited":
+      return `${provider} is rate limiting transcription. Wait and try again.`;
+    case "provider_unreachable":
+      return `Could not reach ${provider}. Check the connection and try again.`;
+    case "realtime_only":
+      return "Live transcription ended before it returned text. Record the message again.";
+    case "transcription_failed":
+      return `${provider} could not transcribe this recording. Try again.`;
+    default:
+      if (status === 401 || status === 403) return "The speech API key was rejected. Check Voice settings.";
+      if (status === 429) return "Speech transcription is temporarily unavailable. Check API credit or try again later.";
+      return "Speech transcription failed. Try again.";
+  }
+}
+


### PR DESCRIPTION
## Outcome

Batch dictation now reports why transcription failed instead of silently returning to idle.

## Changes

- return stable safe codes for invalid API keys, exhausted credit, rate limits, missing configuration, provider outages, realtime-only providers, and generic transcription failures
- never forward provider response bodies to the browser
- show an actionable error toast and a no-speech message
- expose microphone startup and transcription with `aria-busy` and an accurate accessible label
- preserve the existing `{ error: string }` response field for compatibility

## Verification

- 10 focused provider and web tests pass
- relay compatibility tests pass (5/5)
- web TypeScript check passes
- root TypeScript check passes
- production web build passes
- full suite passes: 2,578 passed, 1 skipped, 0 failed (2,579 total)
- real Chromium take showed the actionable invalid-key message and returned to idle
- live OpenAI batch transcription returned HTTP 200 with non-empty text