### PR TITLE
Add Scheduled to the Chat/Bots surface switcher

### DIFF
--- a/test/desktop-rail-switch-bar.test.ts
+++ b/test/desktop-rail-switch-bar.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 const APP = readFileSync(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+const CSS = readFileSync(new URL("../web/src/index.css", import.meta.url), "utf8");
 
 /**
  * Regression coverage for a desktop-only bug: commit 1b3ca7d added a
@@ -38,7 +39,18 @@ describe("the desktop rail keeps its Chat/Bots switch bar", () => {
   test("RailStage always mounts a SurfaceToggle wired to railSurface", () => {
     const body = railStageBody();
     expect(body).toContain(
-      "<SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />",
+      "<SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} onOpenAuto={onOpenAuto} />",
     );
+  });
+
+  test("the shared toggle exposes Scheduled as its third destination", () => {
+    const toggle = APP.slice(APP.indexOf("function SurfaceToggle("), APP.indexOf("function MobileSurfaceDock("));
+    expect(toggle).toContain('["auto", "Scheduled", onOpenAuto]');
+    expect(toggle).toContain("<CalendarClock");
+  });
+
+  test("the compact dock keeps touch-sized targets and a visible focus ring", () => {
+    expect(CSS).toMatch(/\.lfg-surface-toggle--dock \.t-tab,[\s\S]*?height: 44px;/);
+    expect(CSS).toMatch(/\.t-tab:focus-visible \{[\s\S]*?outline: 2px solid var\(--ring\);/);
   });
 });

--- a/test/pages-nav.test.ts
+++ b/test/pages-nav.test.ts
@@ -21,11 +21,12 @@ describe("page navigation reachability", () => {
     for (const page of ["notifications", "artifacts", "settings"]) {
       expect(body, `PagesMenu is missing ${page}`).toContain(`value="${page}"`);
     }
-    // Live and Bots are deliberately absent: the Chat/Bots switch bar is the
+    // Live, Bots, and Scheduled are deliberately absent: the shared switch bar is the
     // control for that choice and sits directly under this menu wherever it
-    // renders, so listing the pair here made one decision reachable two ways.
+    // renders, so listing them here would make one decision reachable two ways.
     expect(body).not.toContain('value="live"');
     expect(body).not.toContain('value="bots"');
+    expect(body).not.toContain('value="auto"');
   });
 
   // ...but "not in the menu" must not become "not reachable", which is the
@@ -38,7 +39,7 @@ describe("page navigation reachability", () => {
     );
     // And the switch bar reaches Bots from there.
     expect(app).toContain(
-      "<SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />",
+      "<SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} onOpenAuto={onOpenAuto} />",
     );
     expect(app).toContain("shouldShowMobileSurfaceToggle(isMobile, tab, selectedBotId)");
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7946,7 +7946,7 @@ export function App() {
   // not also become blank layout space.
   const mainBottomPadding = mobileComposerVisible
     ? "pb-[calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+var(--lfg-mobile-surface-dock-height))] [scroll-padding-bottom:calc(var(--lfg-inline-composer-height,var(--lfg-composer-clear))+var(--lfg-mobile-surface-dock-height))]"
-    : isMobile && tab === "bots"
+    : isMobile && (tab === "bots" || tab === "auto")
       ? "pb-[calc(var(--lfg-mobile-surface-dock-height)+var(--lfg-device-safe-bottom))] [scroll-padding-bottom:calc(var(--lfg-mobile-surface-dock-height)+var(--lfg-device-safe-bottom))]"
     : tab === "live"
       ? keyboardOpen
@@ -8358,6 +8358,7 @@ export function App() {
               onOpenAsk={() => setTab("notifications")}
               onOpenBots={() => setTab("bots")}
               onOpenSessions={() => setTab("live")}
+              onOpenAuto={() => setTab("auto")}
               railSurface={tab === "bots" ? "chat" : "sessions"}
               bots={bots}
               selectedBotId={selectedBotId}
@@ -8445,6 +8446,7 @@ export function App() {
             onOpen={openBot}
             onBack={closeBot}
             onOpenSessions={() => setTab("live")}
+            onOpenAuto={() => setTab("auto")}
             onNew={() => openBotEditor("new")}
             onEdit={(bot) => openBotEditor(bot)}
             onRefreshBots={refreshBots}
@@ -8608,6 +8610,7 @@ export function App() {
           aboveComposer={mobileComposerVisible}
           onOpenSessions={() => setTab("live")}
           onOpenBots={() => setTab("bots")}
+          onOpenAuto={() => setTab("auto")}
         />
       ) : null}
 
@@ -9420,9 +9423,9 @@ function PagesMenu({
           }}
         >
           <DropdownMenuLabel>Pages</DropdownMenuLabel>
-          {/* Live and Bots are not listed. The Chat/Bots switch bar sits right
+          {/* Live, Bots, and Scheduled are not listed. The shared switch bar sits right
               under this menu on every surface that renders it, and it is the
-              control for that choice — repeating the pair here made one
+              control for that choice — repeating the destinations here made one
               decision reachable two ways, with the menu's version giving no
               hint that the faster one was inches below it. */}
           <DropdownMenuRadioItem value="notifications">
@@ -10608,6 +10611,7 @@ function LiveView({
   onOpenAsk,
   onOpenBots,
   onOpenSessions,
+  onOpenAuto,
   railSurface = "sessions",
   bots = [],
   selectedBotId = null,
@@ -10639,6 +10643,7 @@ function LiveView({
   onOpenAsk?: () => void;
   onOpenBots: () => void;
   onOpenSessions?: () => void;
+  onOpenAuto: () => void;
   /** Which list the rail is showing. Bots ride the same rail as sessions. */
   railSurface?: "sessions" | "chat";
   bots?: PersistentBot[];
@@ -11008,6 +11013,7 @@ function LiveView({
         onOpenAsk={onOpenAsk}
         onOpenBots={onOpenBots}
         onOpenSessions={onOpenSessions}
+        onOpenAuto={onOpenAuto}
         railSurface={railSurface}
         bots={bots}
         selectedBotId={selectedBotId}
@@ -11189,6 +11195,7 @@ function RailStage({
   onOpenAsk,
   onOpenBots,
   onOpenSessions = () => {},
+  onOpenAuto,
   railSurface = "sessions",
   bots = [],
   selectedBotId = null,
@@ -11217,6 +11224,7 @@ function RailStage({
   onOpenAsk?: () => void;
   onOpenBots: () => void;
   onOpenSessions?: () => void;
+  onOpenAuto: () => void;
   railSurface?: "sessions" | "chat";
   bots?: PersistentBot[];
   selectedBotId?: string | null;
@@ -12352,7 +12360,7 @@ function RailStage({
                 once a bot is selected (`selectedBotId`, mirroring the mobile
                 guard added in 1b3ca7d) stranded desktop users on the Bots
                 surface with no way back to Chat. Always render it here. */}
-            <SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} />
+            <SurfaceToggle active={railSurface} onOpenSessions={onOpenSessions} onOpenBots={onOpenBots} onOpenAuto={onOpenAuto} />
           </div>
         )}
         <div className="session-list-scroll min-h-0 flex-1 overflow-y-auto px-1.5 py-2">
@@ -26148,16 +26156,18 @@ function SurfaceToggle({
   active,
   onOpenSessions,
   onOpenBots,
+  onOpenAuto,
   compact = false,
 }: {
-  active: "sessions" | "chat";
+  active: "sessions" | "chat" | "auto";
   onOpenSessions: () => void;
   onOpenBots: () => void;
+  onOpenAuto: () => void;
   compact?: boolean;
 }) {
   const { any: botsUnread } = useContext(BotUnreadContext);
   // This is the one segmented-toggle component both the desktop rail header
-  // (RailStage, isWide-only) and the mobile Chat/Bots header render — one
+  // (RailStage, isWide-only) and the mobile primary-surface dock render — one
   // navigation idiom, two mount points, instead of a second control. It used
   // to hard-hide at mobile widths (docs/design/bot-mode/spec.md §2.1 predates
   // the mobile primary-nav toggle); callers now decide where it mounts.
@@ -26212,7 +26222,7 @@ function SurfaceToggle({
       className={cn(
         "t-tabs lfg-surface-toggle",
         compact
-          ? "lfg-surface-toggle--dock w-[13rem] max-w-[calc(100vw-2rem)]"
+          ? "lfg-surface-toggle--dock w-[20rem] max-w-[calc(100vw-2rem)]"
           : "w-full",
       )}
       role="tablist"
@@ -26222,6 +26232,7 @@ function SurfaceToggle({
       {([
         ["sessions", "Chat", onOpenSessions],
         ["chat", "Bots", onOpenBots],
+        ["auto", "Scheduled", onOpenAuto],
       ] as const).map(([value, label, onClick]) => (
         <button
           key={value}
@@ -26232,7 +26243,13 @@ function SurfaceToggle({
           className="t-tab flex flex-1 items-center justify-center gap-1.5 text-xs font-semibold"
         >
           {compact ? (
-            value === "sessions" ? <MessageSquare className="size-3.5" /> : <Bot className="size-3.5" />
+            value === "sessions" ? (
+              <MessageSquare className="size-3.5" aria-hidden="true" />
+            ) : value === "chat" ? (
+              <Bot className="size-3.5" aria-hidden="true" />
+            ) : (
+              <CalendarClock className="size-3.5" aria-hidden="true" />
+            )
           ) : null}
           <span>{label}</span>
           {value === "chat" && botsUnread ? (
@@ -26251,11 +26268,13 @@ function MobileSurfaceDock({
   aboveComposer,
   onOpenSessions,
   onOpenBots,
+  onOpenAuto,
 }: {
-  active: "sessions" | "chat";
+  active: "sessions" | "chat" | "auto";
   aboveComposer: boolean;
   onOpenSessions: () => void;
   onOpenBots: () => void;
+  onOpenAuto: () => void;
 }) {
   return (
     <div
@@ -26267,6 +26286,7 @@ function MobileSurfaceDock({
         active={active}
         onOpenSessions={onOpenSessions}
         onOpenBots={onOpenBots}
+        onOpenAuto={onOpenAuto}
       />
     </div>
   );
@@ -26637,6 +26657,7 @@ function BotsView({
   onOpen,
   onBack,
   onOpenSessions,
+  onOpenAuto,
   onNew,
   onEdit,
   onRefreshBots,
@@ -26651,6 +26672,7 @@ function BotsView({
   onOpen: (id: string, conversationId?: string | null) => void;
   onBack: () => void;
   onOpenSessions: () => void;
+  onOpenAuto: () => void;
   onNew: () => void;
   onEdit: (bot: PersistentBot) => void;
   onRefreshBots: () => Promise<void>;
@@ -26814,10 +26836,10 @@ function BotsView({
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-2" data-lfg-page-column>
       {/* Tablet band only (no persistent header toggle there yet) — real
-          mobile gets the pinned Chat/Bot toggle in the app shell's mobile
+          mobile gets the pinned Chat/Bots/Scheduled toggle in the app shell's mobile
           chrome instead, so it isn't doubled here. */}
       {shouldShowInlineBotsSurfaceToggle(isMobile) ? (
-        <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} />
+        <SurfaceToggle active="chat" onOpenSessions={onOpenSessions} onOpenBots={() => {}} onOpenAuto={onOpenAuto} />
       ) : null}
       {/* No page title: the switch bar directly above already says Bots, and a
           32px heading under it said it twice while pushing the first row off

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -124,6 +124,11 @@
   color: var(--tabs-text-active);
 }
 
+.t-tab:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
 .t-tabs-pill {
   position: absolute;
   top: 3px;
@@ -157,6 +162,11 @@
   border: 1px solid var(--border);
   box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
   backdrop-filter: blur(18px);
+}
+
+.lfg-surface-toggle--dock .t-tab,
+.lfg-surface-toggle--dock .t-tabs-pill {
+  height: 44px;
 }
 
 /* Framed inside omg Computer (`?embed=1` / iframe): cancel the device

--- a/web/src/lib/mobile-bots-nav.test.ts
+++ b/web/src/lib/mobile-bots-nav.test.ts
@@ -31,6 +31,10 @@ describe("shouldShowMobileSurfaceToggle", () => {
     expect(shouldShowMobileSurfaceToggle(true, "bots")).toBe(true);
   });
 
+  test("shows on the Scheduled tab at mobile widths", () => {
+    expect(shouldShowMobileSurfaceToggle(true, "auto")).toBe(true);
+  });
+
   test("stays off an open bot conversation", () => {
     expect(shouldShowMobileSurfaceToggle(true, "bots", "bot_scout")).toBe(false);
   });
@@ -54,6 +58,10 @@ describe("shouldShowMobileSurfaceToggle", () => {
 describe("mobileSurfaceToggleActive", () => {
   test("bots tab maps to the chat segment", () => {
     expect(mobileSurfaceToggleActive("bots")).toBe("chat");
+  });
+
+  test("auto tab maps to the scheduled segment", () => {
+    expect(mobileSurfaceToggleActive("auto")).toBe("auto");
   });
 
   test("live and any other tab map to the sessions segment", () => {

--- a/web/src/lib/mobile-bots-nav.ts
+++ b/web/src/lib/mobile-bots-nav.ts
@@ -1,5 +1,5 @@
 /**
- * Pure decision logic for the mobile "Chat | Bot" surface toggle.
+ * Pure decision logic for the mobile Chat/Bots/Scheduled surface toggle.
  *
  * Desktop reaches the bots surface through `SurfaceToggle` in the rail
  * header (`RailStage`), which only mounts at `isWide` widths. Mobile uses one
@@ -11,11 +11,11 @@
  * drift apart.
  */
 
-/** The two tabs the mobile surface toggle switches between. */
-export type PrimaryMobileTab = "live" | "bots";
+/** The three primary destinations in the mobile surface toggle. */
+export type PrimaryMobileTab = "live" | "bots" | "auto";
 
 /** `SurfaceToggle`'s own active-segment vocabulary (desktop rail history). */
-export type SurfaceToggleActive = "sessions" | "chat";
+export type SurfaceToggleActive = "sessions" | "chat" | "auto";
 
 /**
  * Flat roster treatment for a bot roster, on every width.
@@ -37,7 +37,7 @@ export const BOT_ROSTER_ROW_CLASS =
 
 /**
  * The persistent mobile bottom toggle shows only at real mobile widths, and
- * only on the two tabs it switches between. Other
+ * only on the three tabs it switches between. Other
  * pages (Notifications, Artifacts, Settings, extension tabs) stay reachable
  * through the existing `PagesMenu` overflow — this keeps exactly one
  * additional navigation affordance, not a competing tab-bar model.
@@ -47,12 +47,14 @@ export function shouldShowMobileSurfaceToggle(
   tab: string,
   selectedBotId: string | null = null,
 ): tab is PrimaryMobileTab {
-  return isMobile && (tab === "live" || (tab === "bots" && !selectedBotId));
+  return isMobile && (tab === "live" || tab === "auto" || (tab === "bots" && !selectedBotId));
 }
 
 /** Maps the current tab to `SurfaceToggle`'s active-segment value. */
 export function mobileSurfaceToggleActive(tab: string): SurfaceToggleActive {
-  return tab === "bots" ? "chat" : "sessions";
+  if (tab === "bots") return "chat";
+  if (tab === "auto") return "auto";
+  return "sessions";
 }
 
 /**


### PR DESCRIPTION
## Summary

- add Scheduled as the third destination in the shared Chat/Bots surface switcher
- keep the mobile dock visible on `/auto` and reserve its bottom space
- preserve the open bot-conversation exception and Bots unread state
- give compact controls 44px touch targets and a visible focus ring

## Verification

- `bun run test`: 2,574 passed, 1 skipped, 0 failed
- web TypeScript check passed
- Chromium at 500x844: 320x52 dock, 44px targets, no horizontal overflow, `/auto` stays selected
- Chromium at 1440x900: all labels fit, no horizontal overflow, Scheduled opens `/auto`
- no console warnings or errors

Closes #224