### PR TITLE
fix(computer): refuse a port another process already holds

### DIFF
--- a/src/computer/desktop-port-conflict.test.ts
+++ b/src/computer/desktop-port-conflict.test.ts
@@ -1,0 +1,86 @@
+// The Computer's ports used to be compile-time constants, and a start on a box
+// that already had something on one of them reported success anyway: Chrome
+// could not bind its debugging port, `waitForPort` saw the OTHER process
+// listening, and agents silently drove that browser instead of the one on the
+// screen. These cover both halves of the fix -- refuse a taken port, and give
+// an environment knob to move out of the way.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { busyPort, DEFAULT_DESKTOP, envPort } from "./desktop.ts";
+
+const ENV_KEY = "OMG_COMPUTER_TEST_PORT";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+/** A listening server plus the ephemeral port it landed on. */
+function listen(): { server: ReturnType<typeof Bun.serve>; port: number } {
+  const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+  const port = server.port;
+  if (!port) throw new Error("Bun.serve gave no port to test against");
+  return { server, port };
+}
+
+/**
+ * A port nothing is listening on: bind an ephemeral one, then release it.
+ *
+ * Never leave a port in a config to its default here. The machine running
+ * these tests may well be running a Computer, and then 5900 is genuinely busy
+ * and every assertion below drifts onto it.
+ */
+function freePort(): number {
+  const { server, port } = listen();
+  server.stop(true);
+  return port;
+}
+
+describe("envPort", () => {
+  test("falls back when the variable is unset", () => {
+    expect(envPort(ENV_KEY, 9222)).toBe(9222);
+  });
+
+  test("uses a valid port from the environment", () => {
+    process.env[ENV_KEY] = "9280";
+    expect(envPort(ENV_KEY, 9222)).toBe(9280);
+  });
+
+  test("falls back rather than throwing on unusable values", () => {
+    // A typo in a systemd drop-in must not take the whole server down, and a
+    // port of 0 or 70000 would fail far away from its cause.
+    for (const bad of ["", "nope", "0", "-1", "70000", "9222.5"]) {
+      process.env[ENV_KEY] = bad;
+      expect(envPort(ENV_KEY, 9222)).toBe(9222);
+    }
+  });
+});
+
+describe("busyPort", () => {
+  test("reports a port another process is already holding", async () => {
+    const { server, port } = listen();
+    try {
+      expect(await busyPort({ ...DEFAULT_DESKTOP, rfbPort: freePort(), cdpPort: port })).toBe(port);
+      expect(await busyPort({ ...DEFAULT_DESKTOP, rfbPort: port, cdpPort: freePort() })).toBe(port);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("reports the rfb port first, so the error names the one hit first", async () => {
+    const a = listen();
+    const b = listen();
+    try {
+      const config = { ...DEFAULT_DESKTOP, rfbPort: a.port, cdpPort: b.port };
+      expect(await busyPort(config)).toBe(a.port);
+    } finally {
+      a.server.stop(true);
+      b.server.stop(true);
+    }
+  });
+
+  test("returns null when both ports are free", async () => {
+    expect(
+      await busyPort({ ...DEFAULT_DESKTOP, rfbPort: freePort(), cdpPort: freePort() }),
+    ).toBeNull();
+  });
+});

--- a/src/computer/desktop.ts
+++ b/src/computer/desktop.ts
@@ -50,12 +50,26 @@ export interface DesktopConfig {
   proxy?: string;
 }
 
+/**
+ * A port from the environment, or the default when unset or unparseable.
+ *
+ * The defaults are fine on a box that runs nothing else, but 9222 is the
+ * conventional Chrome debugging port, so it is exactly the one a box is most
+ * likely to have already spoken for.
+ */
+export function envPort(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 && n < 65536 ? n : fallback;
+}
+
 export const DEFAULT_DESKTOP: DesktopConfig = {
-  display: 99,
+  display: envPort("OMG_COMPUTER_DISPLAY", 99),
   width: 1280,
   height: 800,
-  rfbPort: 5900,
-  cdpPort: 9222,
+  rfbPort: envPort("OMG_COMPUTER_RFB_PORT", 5900),
+  cdpPort: envPort("OMG_COMPUTER_CDP_PORT", 9222),
   profileDir: `${process.env.HOME ?? "/tmp"}/.omg/computer/chrome-profile`,
 };
 
@@ -330,6 +344,25 @@ function waitForPort(port: number, timeoutMs: number): Promise<boolean> {
 }
 
 /**
+ * The first configured port already answering, or null when both are free.
+ *
+ * `waitForPort` only proves that *something* accepted a connection; it cannot
+ * tell our own Chrome from a stranger's. So a box that already has a browser on
+ * 9222 used to get a start that reported success: Chrome failed to bind its
+ * debugging port and exited, `waitForPort` saw the other process listening and
+ * called it healthy, and every agent then drove that browser instead of the one
+ * on the screen being watched -- with an empty desktop as the only symptom.
+ *
+ * Checking before we spawn anything turns that into an error you can act on.
+ */
+export async function busyPort(config: DesktopConfig): Promise<number | null> {
+  for (const port of [config.rfbPort, config.cdpPort]) {
+    if (await waitForPort(port, 0)) return port;
+  }
+  return null;
+}
+
+/**
  * Reattach to a desktop left by a previous server process, if there is one.
  *
  * `desktopStatus()` is synchronous and adoption needs to probe a port, so the
@@ -358,6 +391,18 @@ export async function startDesktop(partial: Partial<DesktopConfig> = {}): Promis
   if (!deps.ok) throw new Error(deps.hint);
 
   const config: DesktopConfig = { ...DEFAULT_DESKTOP, ...partial };
+
+  // Anything already holding these ports is not ours: adoption ran above, and
+  // it either reattached or reaped. Refuse now rather than starting a stack
+  // that cannot work and cannot report that it does not work.
+  const busy = await busyPort(config);
+  if (busy !== null) {
+    const knob = busy === config.cdpPort ? "OMG_COMPUTER_CDP_PORT" : "OMG_COMPUTER_RFB_PORT";
+    throw new Error(
+      `port ${busy} is already in use by another process, so the Computer cannot claim it. ` +
+        `Stop whatever holds it, or set ${knob} to a free port and restart the server.`,
+    );
+  }
   const display = `:${config.display}`;
   const env = { ...process.env, DISPLAY: display };
   const next: DesktopState = { config };


### PR DESCRIPTION
## The problem

`waitForPort` only proves that *something* accepted a connection on the port. It cannot tell our own Chrome from a stranger's.

So on a box that already has a browser on 9222, `startDesktop` reports success while it has plainly failed:

1. Chrome cannot bind `--remote-debugging-port=9222` and exits.
2. `waitForPort(config.cdpPort, 20_000)` connects to the *other* process and resolves `true`.
3. `/api/computer/status` returns `running: true` with a `cdpPort` that belongs to somebody else's browser.

The symptom is hard to notice, because it isn't a blank failure. Xvfb and x11vnc do come up, so there is a screen to watch — it just stays empty. Meanwhile every Computer Use MCP call is answered by that other browser.

I hit this on a host where 9222 belongs to a persistent, signed-in Chromium that automated jobs use. Agents would have been driving a logged-in session while the desktop they were supposedly working on showed nothing at all. Live capture at the time:

```
$ curl -s localhost:8766/api/computer/status
{"running":true,"display":":99","rfbPort":5900,"cdpPort":9222,...}

$ ps -ef | grep 'DISPLAY=:99'      # Xvfb and x11vnc, and no Chrome anywhere

$ curl -s localhost:9222/json/version   # answers — it's the *other* browser
```

## The fix

Check the ports before spawning anything. By that point `adoptOrReap()` has already run and has either reattached to our own desktop or reaped it, so anything still holding these ports is not ours and never will be. The error names the port and the way out.

That way out is new as well: `display`, `rfbPort` and `cdpPort` now read from `OMG_COMPUTER_DISPLAY` / `OMG_COMPUTER_RFB_PORT` / `OMG_COMPUTER_CDP_PORT`. 9222 is *the* conventional Chrome debugging port, which makes it precisely the one a box is most likely to have already spoken for, and until now there was no way to move the Computer off it short of editing the source. An unparseable value falls back to the default rather than throwing — a typo in a systemd drop-in shouldn't take the server down.

I kept adoption untouched: a healthy desktop of ours is still reattached, and a restart stays invisible.

## Tests

`src/computer/desktop-port-conflict.test.ts` — covers `envPort` (fallback, valid value, and each unusable form) and `busyPort` (a held port, which of the two is reported, and both free). Ports come from binding an ephemeral one and releasing it, never from a default, so the suite still passes on a machine that is itself running a Computer. That detail is not hypothetical: the first version of this test failed on mine because 5900 was genuinely busy.

```
bun test src/computer/ src/bot-shared-computer-access.test.ts
 20 pass, 0 fail
bun x tsc -p tsconfig.json --noEmit
 no new errors (the pre-existing web/src `@omg-dev/client` one is unrelated)
```

## Note

While tracking this down I also noticed that `stopDesktop()` leaves session processes behind — Xvfb survived, the next start adopted it, and a polkit dialog from the very first launch outlived three stop/start cycles. Different bug, not touched here; happy to open a separate issue if useful.