### PR TITLE
fix(web): stop assistant headings rendering smaller than their own text

### DIFF
--- a/web/src/assistant-heading-scale.test.ts
+++ b/web/src/assistant-heading-scale.test.ts
@@ -1,0 +1,73 @@
+// Regression coverage for assistant headings rendering SMALLER than the body
+// text they introduce.
+//
+// `msg-text` sits on the assistant's markdown as well as the user's bubble, so
+// a `.msg-text.markdown h2` rule written for the bubble (flat, 14px, no rule
+// line) outranked `.markdown h2` and applied to every answer. All three heading
+// levels came out at 14px against a 17px body: identical to each other, and
+// smaller than the paragraphs under them.
+//
+// index.css is not cheap to render and the bug lives entirely in the cascade,
+// so — following mobile-copy-button.test.ts — this asserts against the source.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Comments are stripped first: a selector is everything since the previous
+// brace, so a doc comment above a rule would otherwise be read as part of it.
+const CSS = readFileSync(join(import.meta.dir, "index.css"), "utf8").replace(
+  /\/\*[\s\S]*?\*\//g,
+  "",
+);
+
+/** Every rule in the sheet, as [selector list, declaration block]. */
+const RULES: Array<[string[], string]> = [
+  ...CSS.matchAll(/([^{}]+)\{([^{}]*)\}/g),
+].map((m) => [m[1].split(",").map((s) => s.trim()).filter(Boolean), m[2]]);
+
+/**
+ * The font-size `selector` ends up with, as the cascade would resolve it among
+ * rules of equal specificity: the last one that names it wins.
+ *
+ * Matching the selector anywhere in a rule's list — not just as the whole list
+ * — is what makes this test fail loudly on the ORIGINAL bug rather than erroring
+ * out. Back then the only rule naming `.msg-text.markdown h1` was the shared
+ * three-selector one, and the failure should read "expected 14 to be greater
+ * than 17", not "no rule found".
+ */
+function fontSize(selector: string): number {
+  let size: number | null = null;
+  for (const [sel, body] of RULES) {
+    if (!sel.includes(selector)) continue;
+    const px = /font-size:\s*([\d.]+)px/.exec(body);
+    if (px) size = Number(px[1]);
+  }
+  if (size === null) throw new Error(`no font-size resolved for: ${selector}`);
+  return size;
+}
+
+describe("assistant heading scale", () => {
+  const body = fontSize(".msg-text.markdown");
+  const h1 = fontSize(".msg-text.markdown h1");
+  const h2 = fontSize(".msg-text.markdown h2");
+  const h3 = fontSize(".msg-text.markdown h3");
+
+  test("every heading level is larger than the body text it introduces", () => {
+    // Deliberately a relation, not fixed numbers, so restyling the transcript
+    // cannot silently reintroduce headings that read as fine print.
+    expect(h1).toBeGreaterThan(body);
+    expect(h2).toBeGreaterThan(body);
+    expect(h3).toBeGreaterThan(body);
+  });
+
+  test("the three levels stay distinguishable from each other", () => {
+    expect(h1).toBeGreaterThan(h2);
+    expect(h2).toBeGreaterThan(h3);
+  });
+
+  test("flat 14px headings are scoped to the user's own bubble", () => {
+    expect(fontSize(".msg-text.markdown.user-bubble h1")).toBe(14);
+    expect(fontSize(".msg-text.markdown.user-bubble h3")).toBe(14);
+  });
+});

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -710,13 +710,42 @@ html.lfg-keyboard-open {
     line-height: 1.55;
   }
 
-  .msg-text.markdown h1,
-  .msg-text.markdown h2,
-  .msg-text.markdown h3 {
+  /* Small, flat headings belong to YOUR bubble: it is short, it is already
+     visually bounded, and a 21px h1 inside it would shout.
+
+     This used to apply to every message. `msg-text` is on the assistant's
+     markdown too, and `.msg-text.markdown h2` outranks `.markdown h2`, so an
+     answer rendered all three heading levels at 14px -- three pixels SMALLER
+     than the 17px body they introduce, and identical to one another. Structure
+     in a reply came out weaker than the prose around it, and the base
+     `.markdown` heading scale below was reachable only from the changelog. */
+  .msg-text.markdown.user-bubble h1,
+  .msg-text.markdown.user-bubble h2,
+  .msg-text.markdown.user-bubble h3 {
     margin: 0.5em 0 0.3em;
     border: none;
     padding: 0;
     font-size: 14px;
+  }
+
+  /* The assistant's headings, sized off the 17px chat body rather than the
+     16px the base scale was drawn against: there a 15px h3 still reads as a
+     heading, here it would sit below its own paragraph. Only size and rhythm
+     are set, so h2 keeps the base scale's hairline -- that line is what
+     separates sections in a long answer. */
+  .msg-text.markdown h1 {
+    font-size: 21px;
+    margin: 1.1em 0 0.4em;
+  }
+
+  .msg-text.markdown h2 {
+    font-size: 19px;
+    margin: 1.15em 0 0.4em;
+  }
+
+  .msg-text.markdown h3 {
+    font-size: 17.5px;
+    margin: 1em 0 0.3em;
   }
 
   .msg-text.markdown p {


### PR DESCRIPTION
## The bug

`msg-text` sits on the assistant's markdown as well as on the user's bubble. So the flat heading rule written for the bubble

```css
.msg-text.markdown h1,
.msg-text.markdown h2,
.msg-text.markdown h3 { font-size: 14px; border: none; }
```

outranks `.markdown h1/h2/h3` and applies to **every** message.

Measured in the running app, inside an assistant answer:

| | rendered |
|---|---|
| body text | 17px |
| H1 | 14px |
| H2 | 14px |
| H3 | 14px |

Headings come out three pixels *smaller* than the paragraphs they introduce, and all three levels are identical to each other. Structure in a reply reads weaker than the prose around it, and the carefully built `.markdown` scale below (19 / 16.5 / 15px, hairline under H2) is reachable only from the changelog — never from a chat transcript.

## The fix

- Scope the flat 14px rule to `.user-bubble`, where small headings are right: that bubble is short and already visually bounded, and a 21px H1 inside it would shout.
- Give the transcript its own scale, sized off the 17px chat body rather than the 16px the base scale was drawn against — there a 15px H3 still reads as a heading, here it would sit below its own paragraph.

Only size and rhythm are set, so H2 keeps the base scale's hairline: that line is what separates sections in a long answer.

## Verification

- `web/src/assistant-heading-scale.test.ts` asserts **relations**, not fixed numbers (every level > body, h1 > h2 > h3), so a future restyle of the transcript cannot silently reintroduce fine-print headings. Reverting `index.css` fails it with `Expected: > 17, Received: 14` — a reviewer sees exactly what broke.
- `bun test web/src/` → 520 pass, 0 fail.
- `tsc --noEmit -p web/tsconfig.json` clean.
- Checked in the built stylesheet, not just the source: assistant `h1/h2/h3` compile to 21 / 19 / 17.5px against a 17px body, and `.msg-text.markdown.user-bubble h1/h2/h3` keeps 14px.