### PR TITLE
fix(mobile): purpose string that survives prebuild, and AI data consent

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Metro export smoke test
         run: bunx expo export --platform ios
 
+      # Build 34 shipped "Allow $(PRODUCT_NAME) to access your microphone" and
+      # was rejected under guideline 5.1.1(ii) TWICE, while app.json held the
+      # correct long string the whole time. A config plugin overwrote it. Only
+      # the prebuild output can tell you what Apple will actually see, so
+      # assert on that -- before anything bills.
+      - name: Check iOS purpose strings in the generated Info.plist
+        run: ./scripts/check-ios-purpose-strings.sh
+
       - name: Build on EAS
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -11,8 +11,7 @@
       "bundleIdentifier": "dev.omg.computer",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSCameraUsageDescription": "omg.dev uses the camera only when you choose to attach a photo to a message. The photo is uploaded to your own omg.dev cloud computer, and the coding agent you are messaging can then open that file. For example, photograph an error on your screen and send it so the agent can debug it.",
-        "NSMicrophoneUsageDescription": "omg.dev records audio only while dictation is on. You tap the microphone button to start and tap it again to stop. The recording is sent to ElevenLabs, our speech-to-text provider, to convert it into text. For example, say \"fix the login bug on the settings page\" and those words appear as a typed message to your coding agent. omg.dev does not use the audio for any other purpose."
+        "NSCameraUsageDescription": "omg.dev uses the camera only when you choose to attach a photo to a message. The photo is uploaded to your own omg.dev cloud computer, and the coding agent you are messaging can then open that file. For example, photograph an error on your screen and send it so the agent can debug it."
       },
       "runtimeVersion": {
         "policy": "appVersion"
@@ -35,7 +34,14 @@
       "expo-router",
       "expo-font",
       "expo-asset",
-      "@siteed/audio-studio",
+      [
+        "@siteed/audio-studio",
+        {
+          "iosConfig": {
+            "microphoneUsageDescription": "omg.dev records audio only while dictation is on. You tap the microphone button to start and tap it again to stop. The recording is sent to ElevenLabs, our speech-to-text provider, to convert it into text. For example, say \"fix the login bug on the settings page\" and those words appear as a typed message to your coding agent. omg.dev does not use the audio for any other purpose."
+          }
+        }
+      ],
       [
         "expo-notifications",
         {

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -10,6 +10,7 @@ import Reanimated, {
   withTiming,
 } from "react-native-reanimated";
 
+import { AiConsentScreen, useAiDataConsent } from "../src/omg/ai-consent";
 import { BrandMark } from "../src/omg/brand-mark";
 import { LaunchScreen } from "../src/omg/launch";
 import { useLucideFont } from "../src/omg/lucide";
@@ -136,7 +137,8 @@ function LaunchGate() {
 }
 
 function RootNavigator() {
-  const { authStatus } = useOmg();
+  const { authStatus, signOut } = useOmg();
+  const consent = useAiDataConsent();
   /**
    * A tapped notification goes to the thing it is about.
    *
@@ -187,8 +189,29 @@ function RootNavigator() {
   // the user can perceive on a warm start.
   const glyphsReady = useLucideFont();
 
-  if (authStatus === "loading" || !glyphsReady) {
+  if (authStatus === "loading" || !glyphsReady || consent.state === "loading") {
     return <Splash />;
+  }
+
+  /*
+   * Guidelines 5.1.1(i) and 5.1.2(i) rejected 1.0 (34): the app shared personal
+   * data with third-party AI services without disclosing it in the app and
+   * asking first. So the gate sits HERE, in front of the entire signed-in
+   * tree — above the composer, dictation and attachments alike — rather than
+   * on any one send path. One screen that cannot be routed around beats three
+   * checks that can each be forgotten.
+   *
+   * It is deliberately BELOW the signed-out branch. Someone who is not signed
+   * in cannot transmit anything, so asking them first would be a consent
+   * prompt with nothing behind it.
+   */
+  if (authStatus === "signed-in" && consent.state === "needed") {
+    return (
+      <>
+        <StatusBar style={isDark ? "light" : "dark"} />
+        <AiConsentScreen onAccept={consent.accept} onDecline={() => void signOut()} />
+      </>
+    );
   }
 
   if (authStatus === "signed-out") {

--- a/mobile/scripts/check-ios-purpose-strings.sh
+++ b/mobile/scripts/check-ios-purpose-strings.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Assert the GENERATED Info.plist, not app.json.
+#
+# WHY THIS EXISTS. Build 34 shipped
+# "Allow $(PRODUCT_NAME) to access your microphone" and was rejected under
+# guideline 5.1.1(ii) -- twice. app.json held a long, specific string the
+# whole time. The @siteed/audio-studio config plugin overwrites
+# NSMicrophoneUsageDescription with its own default, because the value from
+# `ios.infoPlist` is not yet in modResults when that plugin's mod runs. Reading
+# app.json therefore proves nothing. Only the prebuild output does.
+#
+# Runs prebuild in a THROWAWAY COPY. A leftover `ios/` directory in the real
+# tree would flip EAS to the bare workflow and ignore app.json entirely.
+set -euo pipefail
+
+MIN_LEN=${MIN_LEN:-80}
+KEYS=(NSMicrophoneUsageDescription NSCameraUsageDescription)
+
+here=$(cd "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# node_modules is needed for the config plugins to resolve, and copying it is
+# far slower than linking it.
+tar -c --exclude=node_modules --exclude=ios --exclude=android --exclude=.git -C "$here" . | tar -x -C "$tmp"
+ln -s "$here/node_modules" "$tmp/node_modules"
+
+( cd "$tmp" && npx --yes expo prebuild --platform ios --no-install >/dev/null 2>&1 )
+
+plist=$(find "$tmp/ios" -name Info.plist -not -path '*/Pods/*' | head -1)
+if [ -z "$plist" ]; then
+  echo "::error::prebuild produced no Info.plist" >&2
+  exit 1
+fi
+
+fail=0
+for key in "${KEYS[@]}"; do
+  value=$(/usr/bin/env python3 - "$plist" "$key" <<'PY'
+import plistlib, sys
+with open(sys.argv[1], 'rb') as fh:
+    print(plistlib.load(fh).get(sys.argv[2], ''))
+PY
+)
+  if [ -z "$value" ]; then
+    echo "::error::$key is missing from the generated Info.plist" >&2
+    fail=1
+    continue
+  fi
+  # The two known-bad shapes: a config plugin's generic default, and anything
+  # too short to name the data, the recipient and an example.
+  if [[ "$value" == *'$(PRODUCT_NAME)'* ]] || [[ "$value" == Allow\ * ]]; then
+    echo "::error::$key is a config plugin default, not ours: $value" >&2
+    fail=1
+    continue
+  fi
+  if [ "${#value}" -lt "$MIN_LEN" ]; then
+    echo "::error::$key is only ${#value} chars, under $MIN_LEN: $value" >&2
+    fail=1
+    continue
+  fi
+  echo "ok  $key  (${#value} chars)"
+done
+
+exit $fail

--- a/mobile/src/omg/ai-consent.tsx
+++ b/mobile/src/omg/ai-consent.tsx
@@ -60,21 +60,21 @@ type Disclosure = {
 export const DISCLOSURES: Disclosure[] = [
   {
     icon: { ios: "mic.fill", android: "mic" },
-    what: "Voice recordings, and the text they become",
-    who: "ElevenLabs (Scribe speech-to-text)",
-    when: "Only while dictation is on. You start and stop it with the microphone button.",
+    what: "Voice recordings",
+    who: "ElevenLabs, for speech to text",
+    when: "Only while dictation is on.",
   },
   {
     icon: { ios: "text.bubble.fill", android: "chat_bubble" },
-    what: "The messages you type",
-    who: "The AI model provider behind the coding agent you pick, such as Anthropic, OpenAI or xAI",
-    when: "When you send a message to an agent.",
+    what: "Messages you type",
+    who: "Your agent's AI provider: Anthropic, OpenAI or xAI",
+    when: "When you send a message.",
   },
   {
     icon: { ios: "paperclip", android: "attach_file" },
     what: "Files and photos you attach",
-    who: "The same AI model provider as your messages",
-    when: "When you attach a file and send it.",
+    who: "The same AI provider as your messages",
+    when: "When you send them.",
   },
 ];
 
@@ -141,9 +141,8 @@ export function AiConsentScreen({
           Your data and AI providers
         </Text>
         <Text style={{ ...type.body, color: colors.textMuted }}>
-          omg.dev runs coding agents for you. To do that it sends some of what you
-          type, attach and say to AI companies outside omg.dev. Here is exactly
-          what goes out, and to whom.
+          To run coding agents, omg.dev sends some of your data to AI companies
+          outside omg.dev.
         </Text>
 
         <View
@@ -171,9 +170,8 @@ export function AiConsentScreen({
         </View>
 
         <Text style={{ ...type.footnote, color: colors.textMuted }}>
-          omg.dev does not send your contacts, your location, your health data or
-          your device identifiers to any AI provider. You can read the full
-          detail in the privacy policy at omg.dev/privacy.
+          Never sent: contacts, location, health data, device identifiers. Full
+          detail at omg.dev/privacy.
         </Text>
       </ScrollView>
 

--- a/mobile/src/omg/ai-consent.tsx
+++ b/mobile/src/omg/ai-consent.tsx
@@ -1,0 +1,194 @@
+/**
+ * Consent for sending personal data to third-party AI services.
+ *
+ * WHY THIS EXISTS. App Review rejected 1.0 (34) under guidelines 5.1.1(i) and
+ * 5.1.2(i): the app shares personal data with a third-party AI service without
+ * disclosing what is sent, naming who it is sent to, or asking first. Apple was
+ * explicit that a privacy policy alone does not satisfy this -- the disclosure
+ * has to be IN THE APP and the permission has to be an affirmative act.
+ *
+ * So this gate stands in front of the whole signed-in tree. Nothing that can
+ * transmit a message, an attachment or audio is reachable until `accept()` has
+ * run. That placement is the point: a consent screen the user can route around
+ * is not consent.
+ *
+ * ── Why the stored value carries a version ────────────────────────────────
+ *
+ * The recipients ARE the disclosure. Adding a fourth provider, or sending a
+ * new category of data, makes a previously granted consent describe something
+ * the user never agreed to. Bumping `CONSENT_VERSION` re-asks everyone, which
+ * is the honest behaviour and also the one Apple expects. Do not reuse a
+ * version after changing `DISCLOSURES`.
+ *
+ * ── Why refusing signs out ────────────────────────────────────────────────
+ *
+ * omg.dev is a client for AI coding agents. There is no meaningful offline
+ * mode to fall back to, so "Not now" cannot leave someone parked on an empty
+ * shell wondering what is broken. It returns them to sign-in, which is a state
+ * the app already handles completely.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { ScrollView, View } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import type { AndroidSymbol, SFSymbol } from "expo-symbols";
+
+import { Icon, PrimaryButton, Separator } from "../components";
+import { Text } from "./text";
+import { useTheme } from "./theme";
+
+/** Bump whenever DISCLOSURES changes. See the header. */
+export const CONSENT_VERSION = 1;
+
+const STORAGE_KEY = "omg:mobile:ai-data-consent";
+
+type Disclosure = {
+  icon: { ios: SFSymbol; android: AndroidSymbol };
+  what: string;
+  who: string;
+  when: string;
+};
+
+/**
+ * The literal text App Review will read. Each entry answers Apple's three
+ * questions in order: what data, who receives it, and what triggers the send.
+ * Keep them specific. A generic line here is the 5.1.1(ii) mistake again, in a
+ * different place.
+ */
+export const DISCLOSURES: Disclosure[] = [
+  {
+    icon: { ios: "mic.fill", android: "mic" },
+    what: "Voice recordings, and the text they become",
+    who: "ElevenLabs (Scribe speech-to-text)",
+    when: "Only while dictation is on. You start and stop it with the microphone button.",
+  },
+  {
+    icon: { ios: "text.bubble.fill", android: "chat_bubble" },
+    what: "The messages you type",
+    who: "The AI model provider behind the coding agent you pick, such as Anthropic, OpenAI or xAI",
+    when: "When you send a message to an agent.",
+  },
+  {
+    icon: { ios: "paperclip", android: "attach_file" },
+    what: "Files and photos you attach",
+    who: "The same AI model provider as your messages",
+    when: "When you attach a file and send it.",
+  },
+];
+
+type ConsentState = "loading" | "needed" | "granted";
+
+export function useAiDataConsent(): {
+  state: ConsentState;
+  accept: () => void;
+} {
+  const [state, setState] = useState<ConsentState>("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (cancelled) return;
+        setState(raw && Number(raw) >= CONSENT_VERSION ? "granted" : "needed");
+      })
+      .catch(() => {
+        // A read failure must not silently imply consent. Ask again; the cost
+        // of one extra screen is far lower than transmitting without approval.
+        if (!cancelled) setState("needed");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const accept = useCallback(() => {
+    // Flip the UI first. Persisting is best-effort: a storage failure should
+    // re-ask on next launch, not block someone who just tapped Agree.
+    setState("granted");
+    void AsyncStorage.setItem(STORAGE_KEY, String(CONSENT_VERSION)).catch(() => {});
+  }, []);
+
+  return { state, accept };
+}
+
+/** Test/support hook: forget the grant so the screen shows again. */
+export async function resetAiDataConsent(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}
+
+export function AiConsentScreen({
+  onAccept,
+  onDecline,
+}: {
+  onAccept: () => void;
+  onDecline: () => void;
+}) {
+  const { colors, space, type, radius } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={{ flex: 1, backgroundColor: colors.bg }}>
+      <ScrollView
+        contentContainerStyle={{
+          padding: space.lg,
+          paddingTop: insets.top + space.xl,
+          gap: space.lg,
+        }}
+      >
+        <Text style={{ ...type.largeTitle, color: colors.text }}>
+          Your data and AI providers
+        </Text>
+        <Text style={{ ...type.body, color: colors.textMuted }}>
+          omg.dev runs coding agents for you. To do that it sends some of what you
+          type, attach and say to AI companies outside omg.dev. Here is exactly
+          what goes out, and to whom.
+        </Text>
+
+        <View
+          style={{
+            backgroundColor: colors.card,
+            borderRadius: radius.lg,
+            paddingVertical: space.xs,
+          }}
+        >
+          {DISCLOSURES.map((item, index) => (
+            <View key={item.what}>
+              {index > 0 ? <Separator inset="text" /> : null}
+              <View style={{ flexDirection: "row", gap: space.md, padding: space.md }}>
+                <Icon ios={item.icon.ios} android={item.icon.android} size={20} color={colors.textMuted} />
+                <View style={{ flex: 1, gap: space.xs }}>
+                  <Text style={{ ...type.headline, color: colors.text }}>{item.what}</Text>
+                  <Text style={{ ...type.footnote, color: colors.textMuted }}>
+                    Sent to: {item.who}
+                  </Text>
+                  <Text style={{ ...type.footnote, color: colors.textMuted }}>{item.when}</Text>
+                </View>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        <Text style={{ ...type.footnote, color: colors.textMuted }}>
+          omg.dev does not send your contacts, your location, your health data or
+          your device identifiers to any AI provider. You can read the full
+          detail in the privacy policy at omg.dev/privacy.
+        </Text>
+      </ScrollView>
+
+      <View
+        style={{
+          padding: space.lg,
+          paddingBottom: insets.bottom + space.lg,
+          gap: space.sm,
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+        }}
+      >
+        <PrimaryButton label="Agree and continue" onPress={onAccept} />
+        <PrimaryButton label="Not now" tone="quiet" onPress={onDecline} />
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
Addresses the three items in the 1.0 (34) App Review rejection.

## 5.1.1(ii) microphone purpose string

`app.json` has held the correct long string since `fb4e5d54`. Build 34 still shipped `Allow $(PRODUCT_NAME) to access your microphone`, so Apple rejected it a second time.

Cause: the `@siteed/audio-studio` config plugin overwrites `NSMicrophoneUsageDescription`. Its fallback only preserves a value already in `modResults`, and the static `ios.infoPlist` value is not there yet when that mod runs.

Fix: pass the string as the plugin's own `iosConfig.microphoneUsageDescription`, which takes priority.

## A guard so this cannot repeat silently

`mobile/scripts/check-ios-purpose-strings.sh` prebuilds a throwaway copy and asserts on the **generated** `Info.plist`. Reading `app.json` is what hid this twice.

Verified both directions:

- passes on this branch (microphone 381 chars, camera 285 chars)
- fails on the build-34 config with `NSMicrophoneUsageDescription is a config plugin default, not ours: Allow $(PRODUCT_NAME) to access your microphone`

It runs in `mobile-release` before the EAS build, so it costs nothing when it fails.

## 5.1.1(i) and 5.1.2(i) consent

New gate in front of the entire signed-in tree, above the composer, dictation and attachments. Names each data type, its recipient and its trigger. Apple stated a privacy policy alone is not sufficient.

Declining signs out, because there is no useful offline mode to strand someone in.

`CONSENT_VERSION` re-asks everyone if the disclosure list changes.

## Verification

- `bunx tsc --noEmit` clean
- `bunx expo export --platform ios` clean
- Rendered on an iPhone 17 Pro simulator, on an already signed-in device

## Not addressed here

Guideline 2.1(b), "we cannot locate the In-App Purchases". Cause still unconfirmed. It needs an observation of the plan screen while signed in as `appreview@omg.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)