### PR TITLE
fix(mobile): consent defects found by adversarial review

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,6 +1,6 @@
 import { DarkTheme, DefaultTheme, router, Stack, ThemeProvider } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import Reanimated, {
   Easing,
@@ -137,8 +137,8 @@ function LaunchGate() {
 }
 
 function RootNavigator() {
-  const { authStatus, signOut } = useOmg();
-  const consent = useAiDataConsent();
+  const { authStatus, signOut, user } = useOmg();
+  const consent = useAiDataConsent(user?.id ?? null);
   /**
    * A tapped notification goes to the thing it is about.
    *
@@ -150,7 +150,14 @@ function RootNavigator() {
    * is consumed, so gating waits rather than pushing into a tree that does not
    * exist yet.
    */
-  useNotificationTapRouting(authStatus === "signed-in");
+  /*
+   * Gated on consent as well as auth. While the consent gate is showing there
+   * is NO navigator mounted -- the gate returns a plain View, not a Stack -- so
+   * a notification tap routed here would push into a tree that does not exist.
+   * `useLastNotificationResponse` holds the response until it is consumed, so
+   * waiting costs nothing and the tap still lands after the gate clears.
+   */
+  useNotificationTapRouting(authStatus === "signed-in" && consent.state === "granted");
   /**
    * Land on sign-in the moment ANY path sets authStatus to "signed-out" —
    * an explicit Sign out, a session that expired underneath the app, a
@@ -187,6 +194,18 @@ function RootNavigator() {
   // Shares the splash with auth, rather than flashing an icon-less bar for a
   // frame: the font resolves from a bundled asset, so this is never a wait
   // the user can perceive on a warm start.
+  /*
+   * Declining signs out. `signOut` can REJECT -- it throws SignOutFailedError
+   * when the server did not confirm the session was revoked -- and an unhandled
+   * rejection here would leave the person staring at the consent screen with no
+   * feedback and no way forward. So the local state is cleared either way: the
+   * gate must never become a dead end, and a session that outlives the device's
+   * belief about it is the ordinary signed-out recovery path anyway.
+   */
+  const handleDecline = useCallback(() => {
+    void signOut().catch(() => {});
+  }, [signOut]);
+
   const glyphsReady = useLucideFont();
 
   if (authStatus === "loading" || !glyphsReady || consent.state === "loading") {
@@ -209,7 +228,7 @@ function RootNavigator() {
     return (
       <>
         <StatusBar style={isDark ? "light" : "dark"} />
-        <AiConsentScreen onAccept={consent.accept} onDecline={() => void signOut()} />
+        <AiConsentScreen onAccept={consent.accept} onDecline={handleDecline} />
       </>
     );
   }
@@ -247,9 +266,29 @@ function RootNavigator() {
           <Stack.Protected guard>
             <Stack.Screen name="sign-in" options={{ headerShown: false }} />
           </Stack.Protected>
+          {/*
+           * EVERY non-sign-in route, not just these two.
+           *
+           * expo-router 57 auto-registers any file route that is not explicitly
+           * protected, so listing a subset left `computers`, `settings`,
+           * `plan`, `notifications` and the whole `bots` tree reachable by deep
+           * link while signed out. `bots/[id]` reuses the composer, dictation
+           * and attachments. The old comment claiming sign-in was this Stack's
+           * only screen was simply wrong.
+           *
+           * Adding a file under app/ therefore means adding it HERE too.
+           */}
           <Stack.Protected guard={false}>
             <Stack.Screen name="index" options={{ title: "Sessions" }} />
             <Stack.Screen name="session/[id]" options={{ title: "Session" }} />
+            <Stack.Screen name="computers" />
+            <Stack.Screen name="settings" />
+            <Stack.Screen name="notifications" />
+            <Stack.Screen name="plan" />
+            <Stack.Screen name="bots/index" />
+            <Stack.Screen name="bots/new" />
+            <Stack.Screen name="bots/[id]/index" />
+            <Stack.Screen name="bots/[id]/edit" />
           </Stack.Protected>
         </Stack>
       </>

--- a/mobile/scripts/check-ios-purpose-strings.sh
+++ b/mobile/scripts/check-ios-purpose-strings.sh
@@ -27,11 +27,27 @@ ln -s "$here/node_modules" "$tmp/node_modules"
 
 ( cd "$tmp" && npx --yes expo prebuild --platform ios --no-install >/dev/null 2>&1 )
 
-plist=$(find "$tmp/ios" -name Info.plist -not -path '*/Pods/*' | head -1)
-if [ -z "$plist" ]; then
+# `head -1` over an unordered `find` was picking AN Info.plist, not THE one.
+# A prebuild emits several (Pods, test targets, expo-dev-client), so asserting on
+# an arbitrary match could pass while the app target shipped something else --
+# the exact class of bug this script exists to catch. Demand exactly one
+# candidate and fail loudly otherwise.
+mapfile -t plists < <(find "$tmp/ios" -name Info.plist \
+  -not -path '*/Pods/*' \
+  -not -path '*Tests*' \
+  -not -path '*/build/*' | sort)
+
+if [ "${#plists[@]}" -eq 0 ]; then
   echo "::error::prebuild produced no Info.plist" >&2
   exit 1
 fi
+if [ "${#plists[@]}" -gt 1 ]; then
+  echo "::error::expected exactly one app Info.plist, found ${#plists[@]}:" >&2
+  printf '::error::  %s\n' "${plists[@]}" >&2
+  exit 1
+fi
+plist="${plists[0]}"
+echo "asserting on ${plist#"$tmp/"}"
 
 fail=0
 for key in "${KEYS[@]}"; do

--- a/mobile/src/omg/ai-consent.tsx
+++ b/mobile/src/omg/ai-consent.tsx
@@ -40,9 +40,18 @@ import { Text } from "./text";
 import { useTheme } from "./theme";
 
 /** Bump whenever DISCLOSURES changes. See the header. */
-export const CONSENT_VERSION = 1;
+export const CONSENT_VERSION = 2;
 
-const STORAGE_KEY = "omg:mobile:ai-data-consent";
+/**
+ * Consent is PER ACCOUNT, not per install.
+ *
+ * The first version of this stored one flag for the whole device. Sign out,
+ * sign in as someone else, and their messages went to the model providers
+ * having never been asked — the previous person's tap answered for them. That
+ * is not consent in any sense Apple or a user would recognise, so the account
+ * id is part of the key.
+ */
+const storageKeyFor = (userId: string) => `omg:mobile:ai-data-consent:${userId}`;
 
 type Disclosure = {
   icon: { ios: SFSymbol; android: AndroidSymbol };
@@ -76,11 +85,31 @@ export const DISCLOSURES: Disclosure[] = [
     who: "The same AI provider as your messages",
     when: "When you send them.",
   },
+  {
+    icon: { ios: "chevron.left.forwardslash.chevron.right", android: "code" },
+    what: "Code and files from the repository you are working in",
+    who: "The same AI provider as your messages",
+    when: "When an agent reads or edits files to carry out your request.",
+  },
 ];
 
 type ConsentState = "loading" | "needed" | "granted";
 
-export function useAiDataConsent(): {
+/**
+ * Only a plain run of digits counts.
+ *
+ * `Number()` was the original test and it is far too permissive: `Number("0x10")`
+ * is 16 and `Number("Infinity")` is Infinity, so a corrupted value read as a
+ * GRANT. The file header claimed a read failure falls back to asking again;
+ * that claim was false for every non-decimal string AsyncStorage could hold.
+ */
+function grantedVersion(raw: string | null): number {
+  if (!raw || !/^\d+$/.test(raw)) return 0;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : 0;
+}
+
+export function useAiDataConsent(userId: string | null): {
   state: ConsentState;
   accept: () => void;
 } {
@@ -88,10 +117,18 @@ export function useAiDataConsent(): {
 
   useEffect(() => {
     let cancelled = false;
-    AsyncStorage.getItem(STORAGE_KEY)
+    // No account yet means nothing to consent FOR. The gate is only consulted
+    // once signed in, so this simply parks in "loading" rather than inventing
+    // an answer for an unknown person.
+    if (!userId) {
+      setState("loading");
+      return;
+    }
+    setState("loading");
+    AsyncStorage.getItem(storageKeyFor(userId))
       .then((raw) => {
         if (cancelled) return;
-        setState(raw && Number(raw) >= CONSENT_VERSION ? "granted" : "needed");
+        setState(grantedVersion(raw) >= CONSENT_VERSION ? "granted" : "needed");
       })
       .catch(() => {
         // A read failure must not silently imply consent. Ask again; the cost
@@ -101,21 +138,22 @@ export function useAiDataConsent(): {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [userId]);
 
   const accept = useCallback(() => {
+    if (!userId) return;
     // Flip the UI first. Persisting is best-effort: a storage failure should
     // re-ask on next launch, not block someone who just tapped Agree.
     setState("granted");
-    void AsyncStorage.setItem(STORAGE_KEY, String(CONSENT_VERSION)).catch(() => {});
-  }, []);
+    void AsyncStorage.setItem(storageKeyFor(userId), String(CONSENT_VERSION)).catch(() => {});
+  }, [userId]);
 
   return { state, accept };
 }
 
-/** Test/support hook: forget the grant so the screen shows again. */
-export async function resetAiDataConsent(): Promise<void> {
-  await AsyncStorage.removeItem(STORAGE_KEY);
+/** Test/support hook: forget one account's grant so the screen shows again. */
+export async function resetAiDataConsent(userId: string): Promise<void> {
+  await AsyncStorage.removeItem(storageKeyFor(userId));
 }
 
 export function AiConsentScreen({


### PR DESCRIPTION
Codex reviewed #230 and refuted four of my five claims. This fixes what it found.

## Defects

| # | Defect | Why it matters |
|---|---|---|
| 1 | Grant was per **install**, not per account | Sign out, sign in as someone else, their data flows with no consent ever taken. Undermines the guideline we are answering |
| 2 | `Number("0x10")` is 16, so corrupt values read as a **grant** | The file header claimed the opposite. That comment was a lie in the codebase |
| 3 | expo-router 57 auto-registers unprotected routes | `computers`, `settings`, `plan`, `notifications`, all `bots` reachable by deep link while signed out. `bots/[id]` reuses composer, dictation, attachments |
| 4 | Notification routing ran with no navigator mounted | The gate returns a plain `View`, not a `Stack` |
| 5 | `signOut()` rejection unhandled | Declining could strand the user on the gate |
| 6 | Disclosure omitted repository and code content | The largest category an agent actually sends |
| 7 | Guard picked a plist via `head -1` over unordered `find` | Could assert on the wrong target and pass while the app shipped something else |

`CONSENT_VERSION` bumped to 2, so everyone is re-asked.

## Verification

- `bunx tsc --noEmit` clean
- Guard passes and now prints its target: `asserting on ios/omg/Info.plist`, matching the IPA's `Payload/omg.app/Info.plist`
- Seen on iPhone 17 Pro. Four disclosures, no scrolling. It re-prompted an already-consented account, confirming the version bump

## Not fixed here

`omg.dev/privacy` omits audio, ElevenLabs and xAI. Apple requires the policy to identify every third party, so **5.1.1(i) still fails without this**. It is an `apps/landing` change in `vibes`, which this repo does not own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)