### PR TITLE
fix(mobile): name the paywall for the reviewer, not for us

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -457,7 +457,7 @@ function RootNavigator() {
               Settings — the two places someone learns they need to pay. It is
               a normal pushed screen rather than a modal so the back gesture
               behaves the same as everywhere else. */}
-          <Stack.Screen name="plan" options={{ title: "Plan", headerLargeTitle: true }} />
+          <Stack.Screen name="plan" options={{ title: "Subscription", headerLargeTitle: true }} />
         </Stack.Protected>
       </Stack>
     </>

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -328,8 +328,8 @@ export default function PlanScreen() {
               lineHeight: 18,
             }}
           >
-            Your cloud computer runs on a monthly plan. Pick the size you need — you can change
-            or cancel it any time in the App Store.
+            Your cloud computer runs on an auto-renewable monthly subscription. Pick the
+            size you need — you can change or cancel it any time in the App Store.
           </Text>
 
           {loadError ? (
@@ -348,7 +348,7 @@ export default function PlanScreen() {
 
           {products.length > 0 ? (
             <>
-              <SectionLabel>Computer plans</SectionLabel>
+              <SectionLabel>Monthly subscriptions</SectionLabel>
               {products.map((product) => (
                 <TierCard
                   key={product.productId}

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -62,10 +62,18 @@ import {
  * stated as a fact in the app and followed up by email, which is allowed in
  * every storefront.
  *
- * STOREKIT HAS NOW LANDED, and the honest fix arrived as predicted: the "Plan"
- * row in the Computer card pushes app/plan.tsx, an in-app purchase. The web
- * link did NOT come back and must not — an in-app paywall that also offers an
- * external checkout is the same 3.1.1(a) violation with an extra step.
+ * STOREKIT HAS NOW LANDED, and the honest fix arrived as predicted: the
+ * "Subscription and plan" row in the Computer card pushes app/plan.tsx, an
+ * in-app purchase. The web link did NOT come back and must not — an in-app
+ * paywall that also offers an external checkout is the same 3.1.1(a) violation
+ * with an extra step.
+ *
+ * THE ROW IS NAMED FOR THE REVIEWER, NOT FOR US. It read "Plan", under a
+ * heading reading "Computer", and App Review rejected 1.0 (34) under guideline
+ * 2.1(b) saying they "cannot locate the In-App Purchases within the app".
+ * Nothing on the path to the paywall contained the word subscription. Someone
+ * hunting for in-app purchases had no reason to open a row called Plan. Do not
+ * rename this back to something shorter.
  */
 /**
  * Legal documents, on omg.dev rather than app.omg.dev.
@@ -301,7 +309,9 @@ export default function SettingsScreen() {
             with an extra step. */}
         <Separator inset="text" />
         <Row onPress={() => router.push("/plan")}>
-          <Text style={{ ...type.callout, color: colors.text, flex: 1 }}>Plan</Text>
+          <Text style={{ ...type.callout, color: colors.text, flex: 1 }}>
+            Subscription and plan
+          </Text>
           <Icon
             ios="chevron.right"
             android="chevron_right"


### PR DESCRIPTION
Guideline 2.1(b): *"we cannot locate the In-App Purchases within the app at this time."*

Every mechanical cause is ruled out — sign-in works, `canPurchase` is true, all four tiers publish, the Paid Apps Agreement is active, and Benny confirms the purchase itself worked when he tested it.

What was left is the naming. The path to the paywall was:

`Settings` → row **Plan** → under heading **Computer** → screen titled **Plan** → section **Computer plans**

The word *subscription* appeared nowhere. A reviewer hunting for in-app purchases had no reason to open a row called Plan.

| Where | Before | After |
|---|---|---|
| Settings row | Plan | Subscription and plan |
| Screen title | Plan | Subscription |
| Section label | Computer plans | Monthly subscriptions |
| Intro copy | "monthly plan" | "auto-renewable monthly subscription" |

## Pipeline

JS only. No `app.json` change, no native surface, so this ships **over the air** per `docs/TESTFLIGHT.md`, reaching build 36 without another Apple review.

## Verification

`bunx tsc --noEmit` clean. I have **not** re-rendered these screens on the simulator — the only risk is the longer row label wrapping, which I judged low against a ~40 character row. Say the word if you want it seen before it goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)