### PR TITLE
fix(mobile): sign-out no longer hangs on the splash

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -208,29 +208,8 @@ function RootNavigator() {
 
   const glyphsReady = useLucideFont();
 
-  if (authStatus === "loading" || !glyphsReady || consent.state === "loading") {
+  if (authStatus === "loading" || !glyphsReady) {
     return <Splash />;
-  }
-
-  /*
-   * Guidelines 5.1.1(i) and 5.1.2(i) rejected 1.0 (34): the app shared personal
-   * data with third-party AI services without disclosing it in the app and
-   * asking first. So the gate sits HERE, in front of the entire signed-in
-   * tree — above the composer, dictation and attachments alike — rather than
-   * on any one send path. One screen that cannot be routed around beats three
-   * checks that can each be forgotten.
-   *
-   * It is deliberately BELOW the signed-out branch. Someone who is not signed
-   * in cannot transmit anything, so asking them first would be a consent
-   * prompt with nothing behind it.
-   */
-  if (authStatus === "signed-in" && consent.state === "needed") {
-    return (
-      <>
-        <StatusBar style={isDark ? "light" : "dark"} />
-        <AiConsentScreen onAccept={consent.accept} onDecline={handleDecline} />
-      </>
-    );
   }
 
   if (authStatus === "signed-out") {
@@ -294,6 +273,44 @@ function RootNavigator() {
       </>
     );
   }
+
+  /*
+   * Guidelines 5.1.1(i) and 5.1.2(i) rejected 1.0 (34): the app shared personal
+   * data with third-party AI services without disclosing it in the app and
+   * asking first. So the gate sits HERE, in front of the entire signed-in
+   * tree — above the composer, dictation and attachments alike — rather than
+   * on any one send path. One screen that cannot be routed around beats three
+   * checks that can each be forgotten.
+   *
+   * It is deliberately BELOW the signed-out branch. Someone who is not signed
+   * in cannot transmit anything, so asking them first would be a consent
+   * prompt with nothing behind it.
+   *
+   * THE `loading` CHECK MUST ALSO SIT BELOW IT, and that is not a style
+   * preference. It used to be folded into the first Splash condition, above
+   * the signed-out branch:
+   *
+   *     if (authStatus === "loading" || !glyphsReady || consent.state === "loading")
+   *
+   * Consent is keyed by account id, so signing out returns the hook to
+   * `loading` and it stays there — there is no account to read a grant for.
+   * That made the splash condition permanently true and the signed-out branch
+   * unreachable: sign out, and the app hung on the splash until it was
+   * reinstalled. Keep every consent check below the signed-out branch.
+   */
+  if (consent.state === "loading") {
+    return <Splash />;
+  }
+
+  if (consent.state === "needed") {
+    return (
+      <>
+        <StatusBar style={isDark ? "light" : "dark"} />
+        <AiConsentScreen onAccept={consent.accept} onDecline={handleDecline} />
+      </>
+    );
+  }
+
 
   return (
     <>


### PR DESCRIPTION
**Live bug.** Signing out leaves the app stuck on the splash until reinstall. Reported from TestFlight on a real device, reproduced in the code.

## Cause — mine, from #232

Consent became keyed by account id, and the hook parks at `loading` when there is no account:

```ts
if (!userId) { setState("loading"); return }
```

But the splash condition still read:

```jsx
if (authStatus === "loading" || !glyphsReady || consent.state === "loading")
```

Sign out sets `user` to null → `consent.state` goes back to `loading` and never leaves → splash condition permanently true → the signed-out branch below is unreachable.

## The comment was half right

It claimed the gate sat "deliberately BELOW the signed-out branch". The `needed` check did. The `loading` check did not, folded into the splash line above. That was the entire bug, and it is the second time this session a comment asserted a property the code did not have.

New order: `loading/fonts` → **`signed-out`** → `consent loading` → `consent needed`. The comment now explains why hoisting them back breaks sign-out.

## Reach

This is already live on the `production` channel via OTA group `147bd274`, so it affects build 34, build 36 and TestFlight. Shipping the fix the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)