### PR TITLE
fix(agents): an OpenCode key alone unlocks OpenCode's paid models

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -5,8 +5,10 @@ import {
   curateOpenCodeModels,
   defaultModelForAgent,
   discoveredModelsOrFallback,
+  hasConnectedModelAccount,
   listModelCatalog,
   MODEL_OPTIONS,
+  modelsForAgent,
   OPENCODE_MODELS,
 } from "./agent-catalog.ts";
 
@@ -146,6 +148,26 @@ describe("OpenCode catalog default", () => {
   // whose `opencode` had never been signed into offered openai/* and
   // opencode-go/* — models that fail the moment they launch — and hid the free
   // Zen models it could actually run.
+  // The bug this pins: an OpenCode Go subscriber with no Claude or Codex
+  // account got the free Zen tier forever. Their key was connected and the
+  // catalog held every paid model; this gate still reported the box as
+  // anonymous, because `opencode` was missing from ACCOUNT_OWNED_AGENT_KEYS.
+  //
+  // It only reproduced on a box running OpenCode ALONE. Anywhere Claude or
+  // Codex was also signed in the gate passed for the wrong reason, which is
+  // why it survived so long.
+  //
+  // Asserted on the gate itself, NOT through listModelCatalog: that path reads
+  // the running box's discovery cache, so on a box holding only free models
+  // the assertion passes with or without the fix and pins nothing.
+  test("an OpenCode credential alone counts as a connected account", () => {
+    expect(hasConnectedModelAccount([codingAgent("opencode", true)])).toBe(true);
+  });
+
+  test("an unconnected OpenCode box is still anonymous", () => {
+    expect(hasConnectedModelAccount([codingAgent("opencode", false)])).toBe(false);
+  });
+
   test("does not let another agent's account unlock OpenCode's paid providers", () => {
     expect(accessibleModelsForAgent("opencode", DISCOVERED, true, [], false)).toEqual([
       "opencode/deepseek-v4-flash-free",

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -527,17 +527,38 @@ export function thinkingLevelsForAgent(agent: string): readonly string[] | null 
   return null;
 }
 
+/**
+ * Agents whose "connected" state means A PERSON SIGNED THIS BOX IN, which is
+ * what the hosted-visitor guard is really asking about.
+ *
+ * `opencode` belongs here, and leaving it out was a real bug. Someone who pays
+ * for OpenCode Go and uses nothing else connected their key, saw
+ * `opencode-go: connected`, and still got the free Zen tier forever — because
+ * this set decided the box was anonymous. The paid models they were being
+ * billed for never appeared. It looked like a stale catalog and was not: the
+ * catalog had all 23, and this gate dropped them.
+ *
+ * It hid behind the fact that most boxes have Claude or Codex signed in too,
+ * so the gate passed for the wrong reason and the bug only showed on a box
+ * with OpenCode alone.
+ *
+ * This does NOT weaken the second gate. `openCodeConnectedFrom` still decides
+ * whether OpenCode itself can reach a paid provider, so a Claude account
+ * cannot unlock opencode-go/* on a box OpenCode was never signed into — see
+ * the test that pins exactly that.
+ */
 const ACCOUNT_OWNED_AGENT_KEYS = new Set<CodingAgentKind>([
   "claude",
   "aisdk",
   "codex",
   "codex-aisdk",
+  "opencode",
 ]);
 
 /** Prefixes that gate a pi model behind a sign-in, from pi-auth's provider list. */
 const PI_GATED_PROVIDER_IDS = new Set<string>(PI_AUTH_PROVIDER_IDS);
 
-function hasConnectedModelAccount(codingAgents: CodingAgentInfo[]): boolean {
+export function hasConnectedModelAccount(codingAgents: CodingAgentInfo[]): boolean {
   return codingAgents.some(
     (agent) =>
       ACCOUNT_OWNED_AGENT_KEYS.has(agent.key) &&


### PR DESCRIPTION
## Symptom

An OpenCode Go subscriber with no Claude or Codex account gets the **free Zen tier forever**, while being billed for models the picker hides. Found on a real box: key connected, `opencode models` discovered 23 `opencode-go/*` models, picker showed six `-free` ones.

## Cause

`accessibleModelsForAgent` needs both gates:

```ts
if (accountConnected && openCodeConnected) return models
```

`openCodeConnected` was `true`. `accountConnected` was not, because:

```ts
const ACCOUNT_OWNED_AGENT_KEYS = new Set([ "claude", "aisdk", "codex", "codex-aisdk" ]);
```

`opencode` is missing, so a box running OpenCode alone reads as anonymous.

**Why it survived:** almost every box also has Claude or Codex signed in, so the gate passed for the wrong reason. It only reproduces with OpenCode alone.

## Not a weakening of the other gate

`openCodeConnectedFrom` still decides whether OpenCode can reach a paid provider, so a Claude account cannot unlock `opencode-go/*` on a box OpenCode was never signed into. That test still passes.

## About the test

It asserts `hasConnectedModelAccount` **directly**, not through `listModelCatalog`. That path reads the running box's discovery cache, so on a box holding only free models it passes with or without the fix and pins nothing — my first attempt did exactly that.

Verified by reverting the one-line change: the new test fails, then passes again with it.

## Verification

- `bun test src/agent-catalog.test.ts` — 25 pass
- `bun run typecheck` — clean
- `bun run test` — 2802 pass, 1 fail: `test/bots-roster-ux.test.ts`, which fails identically on a clean tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)