### PR TITLE
fix: sync session pins through server

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -11,6 +11,11 @@ import {
   computerAgentAdmissionContext,
 } from "../agent-admission.ts";
 import { PATHS, appVersion, installInfo } from "../config.ts";
+import {
+  importSessionPins,
+  pruneSessionPins,
+  setSessionPinned,
+} from "../session-pins.ts";
 import { createConnectManager } from "../connect-manager.ts";
 import { claudeOauthToken as sharedClaudeOauthToken } from "../claude-creds.ts";
 import {
@@ -4512,6 +4517,49 @@ a{color:#60a5fa}
       if (path === "/api/server/session-usage" && req.method === "GET") {
         return json({ usage: await sessionUsage() });
       }
+      if (path === "/api/session-pins" && req.method === "GET") {
+        return json({ sessionIds: pruneSessionPins(await liveSessionIdsCached()) });
+      }
+      if (path === "/api/session-pins/import" && req.method === "POST") {
+        const body = (await req.json().catch(() => null)) as { sessionIds?: unknown } | null;
+        if (!Array.isArray(body?.sessionIds) || body.sessionIds.length > 500) {
+          return err(400, "sessionIds must be an array with at most 500 entries");
+        }
+        const liveIds = await liveSessionIdsCached();
+        const sessionIds = [
+          ...new Set(
+            body.sessionIds.filter(
+              (value): value is string =>
+                typeof value === "string" &&
+                value.length > 0 &&
+                value.length <= 200 &&
+                liveIds.has(value),
+            ),
+          ),
+        ];
+        importSessionPins(sessionIds);
+        return json({ sessionIds: pruneSessionPins(liveIds) });
+      }
+      {
+        const match = path.match(/^\/api\/session-pins\/([^/]+)$/);
+        if (match && req.method === "PUT") {
+          let sessionId = "";
+          try {
+            sessionId = decodeURIComponent(match[1]!);
+          } catch {
+            return err(400, "invalid session id");
+          }
+          if (!sessionId || sessionId.length > 200) return err(400, "invalid session id");
+          const body = (await req.json().catch(() => null)) as { pinned?: unknown } | null;
+          if (typeof body?.pinned !== "boolean") {
+            return err(400, "pinned must be a boolean");
+          }
+          const liveIds = await liveSessionIdsCached();
+          if (body.pinned && !liveIds.has(sessionId)) return err(404, "live session not found");
+          setSessionPinned(sessionId, body.pinned);
+          return json({ sessionIds: pruneSessionPins(liveIds) });
+        }
+      }
       if (path === "/api/settings") {
         if (req.method === "GET") {
           const settings = await getGlobalSettings();
@@ -4623,12 +4671,16 @@ a{color:#60a5fa}
         const reposTask = listRepos();
         const codingAgentsTask = listCodingAgentsCached();
         const settingsTask = getGlobalSettings();
+        const sessionPinsTask = sessionsTask.then((sessions) =>
+          pruneSessionPins(liveSessionIds(sessions)),
+        );
         const tasks = {
           agents: listAgentSummaries(),
           codingAgents: codingAgentsTask,
           models: codingAgentsTask.then((agents) => listModelCatalog(agents)),
           settings: settingsTask,
           sessions: sessionsTask,
+          sessionPins: sessionPinsTask,
           conversations: conversationsTask,
           users: Promise.resolve(userRoster()),
           repos: reposTask,
@@ -4649,6 +4701,7 @@ a{color:#60a5fa}
           models?: ReturnType<typeof listModelCatalog> | null;
           settings?: GlobalSettings | null;
           sessions?: Awaited<ReturnType<typeof listSessionsCached>> | null;
+          sessionPins?: string[] | null;
           conversations?: Awaited<typeof conversationsTask> | null;
           users?: ReturnType<typeof userRoster> | null;
           repos?: Awaited<ReturnType<typeof listRepos>> | null;
@@ -4663,6 +4716,7 @@ a{color:#60a5fa}
             models: boot.models ?? null,
             settings: boot.settings ?? null,
             sessions: boot.sessions ? boot.sessions.map(sessionListRow) : null,
+            sessionPins: boot.sessionPins ?? null,
             conversations: boot.conversations ?? null,
             // Not an authorization signal — never gates what the UI is allowed
             // to show. It only tells the transcript renderer which already-

--- a/src/session-pins.test.ts
+++ b/src/session-pins.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import {
+  importSessionPins,
+  listSessionPins,
+  pruneSessionPins,
+  resetSessionPinsDbConnectionForTests,
+  setSessionPinned,
+} from "./session-pins.ts";
+
+const originalData = PATHS.data;
+let testData = "";
+
+beforeAll(async () => {
+  testData = await mkdtemp(join(tmpdir(), "omg-session-pins-"));
+  PATHS.data = testData;
+  resetSessionPinsDbConnectionForTests();
+});
+
+afterAll(async () => {
+  resetSessionPinsDbConnectionForTests();
+  PATHS.data = originalData;
+  await rm(testData, { recursive: true, force: true });
+});
+
+describe("server-owned session pins", () => {
+  test("keeps insertion order and makes repeated mutations idempotent", () => {
+    setSessionPinned("alpha", true);
+    setSessionPinned("alpha", true);
+    setSessionPinned("beta", true);
+    expect(listSessionPins()).toEqual(["alpha", "beta"]);
+
+    setSessionPinned("alpha", false);
+    setSessionPinned("alpha", false);
+    expect(listSessionPins()).toEqual(["beta"]);
+  });
+
+  test("merges legacy device state without replacing pins from another device", () => {
+    importSessionPins(["phone", "shared", "phone"]);
+    importSessionPins(["laptop", "shared"]);
+    expect(listSessionPins()).toEqual(["beta", "phone", "shared", "laptop"]);
+  });
+
+  test("prunes ended sessions against the authoritative live roster", () => {
+    expect(pruneSessionPins(new Set(["phone", "laptop"]))).toEqual(["phone", "laptop"]);
+    expect(listSessionPins()).toEqual(["phone", "laptop"]);
+  });
+
+  test("survives a database reconnect", () => {
+    resetSessionPinsDbConnectionForTests();
+    expect(listSessionPins()).toEqual(["phone", "laptop"]);
+  });
+});

--- a/src/session-pins.ts
+++ b/src/session-pins.ts
@@ -1,0 +1,90 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { PATHS } from "./config.ts";
+
+const pinsDbPath = () => join(PATHS.data, "lfg.sqlite");
+let db: Database | null = null;
+
+function pinsDb(): Database {
+  if (db) return db;
+  mkdirSync(PATHS.data, { recursive: true });
+  const opened = new Database(pinsDbPath(), { create: true });
+  opened.exec("PRAGMA journal_mode = WAL");
+  opened.exec("PRAGMA busy_timeout = 5000");
+  opened.exec(`
+    CREATE TABLE IF NOT EXISTS session_pins (
+      session_id TEXT PRIMARY KEY,
+      position INTEGER NOT NULL,
+      pinned_at INTEGER NOT NULL
+    )
+  `);
+  db = opened;
+  return opened;
+}
+
+export function resetSessionPinsDbConnectionForTests(): void {
+  db?.close();
+  db = null;
+}
+
+export function listSessionPins(): string[] {
+  return pinsDb()
+    .query<{ session_id: string }, []>(
+      "SELECT session_id FROM session_pins ORDER BY position ASC, pinned_at ASC, session_id ASC",
+    )
+    .all()
+    .map((row) => row.session_id);
+}
+
+export function setSessionPinned(sessionId: string, pinned: boolean): string[] {
+  const database = pinsDb();
+  if (!pinned) {
+    database.query("DELETE FROM session_pins WHERE session_id = ?").run(sessionId);
+    return listSessionPins();
+  }
+  database.transaction(() => {
+    const next = database
+      .query<{ position: number }, []>(
+        "SELECT COALESCE(MAX(position), -1) + 1 AS position FROM session_pins",
+      )
+      .get()?.position ?? 0;
+    database
+      .query(
+        "INSERT OR IGNORE INTO session_pins (session_id, position, pinned_at) VALUES (?, ?, ?)",
+      )
+      .run(sessionId, next, Date.now());
+  })();
+  return listSessionPins();
+}
+
+export function importSessionPins(sessionIds: readonly string[]): string[] {
+  const database = pinsDb();
+  database.transaction(() => {
+    const insert = database.query(
+      "INSERT OR IGNORE INTO session_pins (session_id, position, pinned_at) VALUES (?, ?, ?)",
+    );
+    let next = database
+      .query<{ position: number }, []>(
+        "SELECT COALESCE(MAX(position), -1) + 1 AS position FROM session_pins",
+      )
+      .get()?.position ?? 0;
+    const now = Date.now();
+    for (const sessionId of new Set(sessionIds)) {
+      const result = insert.run(sessionId, next, now + next);
+      if (result.changes) next += 1;
+    }
+  })();
+  return listSessionPins();
+}
+
+export function pruneSessionPins(liveSessionIds: ReadonlySet<string>): string[] {
+  const database = pinsDb();
+  database.transaction(() => {
+    const remove = database.query("DELETE FROM session_pins WHERE session_id = ?");
+    for (const sessionId of listSessionPins()) {
+      if (!liveSessionIds.has(sessionId)) remove.run(sessionId);
+    }
+  })();
+  return listSessionPins();
+}

--- a/test/session-pins-wiring.test.ts
+++ b/test/session-pins-wiring.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const app = readFileSync(join(root, "web", "src", "App.tsx"), "utf8");
+const server = readFileSync(join(root, "src", "commands", "serve.ts"), "utf8");
+
+describe("cross-device session pin wiring", () => {
+  test("bootstrap carries the server-owned ordered pin list", () => {
+    expect(server).toContain("sessionPins: sessionPinsTask");
+    expect(server).toContain("sessionPins: boot.sessionPins ?? null");
+    expect(app).toContain("setTopPinned(payload.sessionPins ?? [])");
+  });
+
+  test("user toggles mutate one session instead of replacing another device's list", () => {
+    expect(app).toContain(
+      "`/api/session-pins/${encodeURIComponent(sessionId)}`",
+    );
+    expect(server).toContain('path.match(/^\\/api\\/session-pins\\/([^/]+)$/)');
+    expect(server).toContain("setSessionPinned(sessionId, body.pinned)");
+  });
+
+  test("the old browser-local reconciliation owner is gone", () => {
+    expect(app).not.toContain("retainLivePinnedSessions");
+    expect(app).not.toContain('const PINNED_SESSIONS_KEY = "lfg_pinned_sessions"');
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -244,7 +244,11 @@ import {
 } from "./lib/folder-browser-recovery";
 import { setThemePreference, THEME_CHANGE_EVENT } from "./lib/theme";
 import { startsInBottomSystemGestureZone } from "./lib/touch-gestures";
-import { retainLivePinnedSessions } from "./lib/pinned-sessions";
+import {
+  clearLegacyPinnedSessions,
+  readLegacyPinnedSessions,
+  togglePinnedSession,
+} from "./lib/session-pins";
 import { pendingLiveFocusRequest } from "./lib/live-focus";
 import { ConnectionStatusToasts } from "./ConnectionStatus";
 import type {
@@ -1111,6 +1115,7 @@ type BootstrapPayload = {
   models?: ModelCatalogItem[] | null;
   settings?: GlobalSettings | null;
   sessions?: Session[] | null;
+  sessionPins?: string[] | null;
   conversations?: ProductConversation[] | null;
   /** Which conversation participant, if any, "I" am — see fetchBootstrap. */
   viewer?: { managed: boolean; participantId: string | null } | null;
@@ -5491,6 +5496,12 @@ export function App() {
   );
   const [setupChecks, setSetupChecks] = useState<SetupCheckGroup[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [topPinned, setTopPinned] = useState<string[]>([]);
+  const topPinnedRef = useRef(topPinned);
+  topPinnedRef.current = topPinned;
+  const pinMutationRevisionRef = useRef(0);
+  const pinMutationQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const pinMutationsPendingRef = useRef(0);
   // Rename is optimistic: the visible title changes before the request starts.
   // Polls that began before persistence completed must not flash the old title
   // back into the UI, so pending titles mask fetched rows until a fetch that
@@ -6079,6 +6090,22 @@ export function App() {
     // call `.filter()` unconditionally on render, so a malformed/empty payload
     // must degrade to an empty live view rather than crash.
     setSessions(payload.sessions ?? []);
+    setTopPinned(payload.sessionPins ?? []);
+    try {
+      const legacyPins = readLegacyPinnedSessions();
+      if (legacyPins.length) {
+        const migrated = await api<{ sessionIds: string[] }>("/api/session-pins/import", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionIds: legacyPins }),
+        });
+        setTopPinned(migrated.sessionIds ?? []);
+        clearLegacyPinnedSessions();
+      }
+    } catch {
+      // Keep legacy state for the next load. An older server can still serve
+      // the upgraded web app briefly during a rolling restart.
+    }
     setViewerParticipantId(payload.viewer?.participantId ?? null);
     setUsers(payload.users ?? []);
     setRepos(payload.repos ?? []);
@@ -6268,6 +6295,54 @@ export function App() {
     });
   }, []);
 
+  const refreshSessionPins = useCallback(async () => {
+    if (pinMutationsPendingRef.current > 0) return;
+    const payload = await api<{ sessionIds: string[] }>("/api/session-pins", {
+      cache: "no-store",
+    });
+    const next = payload.sessionIds ?? [];
+    topPinnedRef.current = next;
+    setTopPinned(next);
+  }, []);
+
+  const toggleTopPin = useCallback((sessionId: string) => {
+    const pinned = topPinnedRef.current.includes(sessionId);
+    const optimistic = togglePinnedSession(topPinnedRef.current, sessionId);
+    topPinnedRef.current = optimistic;
+    setTopPinned(optimistic);
+    haptic("selection");
+    toast.success(pinned ? "Session unpinned" : "Session pinned to top");
+
+    const revision = ++pinMutationRevisionRef.current;
+    pinMutationsPendingRef.current += 1;
+    const operation = pinMutationQueueRef.current.catch(() => {}).then(async () => {
+      const payload = await api<{ sessionIds: string[] }>(
+        `/api/session-pins/${encodeURIComponent(sessionId)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ pinned: !pinned }),
+        },
+      );
+      if (pinMutationRevisionRef.current !== revision) return;
+      const canonical = payload.sessionIds ?? [];
+      topPinnedRef.current = canonical;
+      setTopPinned(canonical);
+    });
+    pinMutationQueueRef.current = operation;
+    operation
+      .catch(() => {
+        if (pinMutationRevisionRef.current !== revision) return;
+        toast.error("Could not sync session pin");
+      })
+      .finally(() => {
+        pinMutationsPendingRef.current -= 1;
+        if (pinMutationRevisionRef.current === revision) {
+          void refreshSessionPins().catch(() => {});
+        }
+      });
+  }, [refreshSessionPins]);
+
   const renameSession = useCallback<RenameSession>(
     async (sid, nextTitle) => {
       const title = nextTitle.trim().slice(0, 200);
@@ -6370,6 +6445,7 @@ export function App() {
     let id: number | null = null;
     const tick = () => {
       refreshSessions().catch(() => {});
+      refreshSessionPins().catch(() => {});
       refreshAuto().catch(() => {});
       refreshBots().catch(() => {});
     };
@@ -6396,7 +6472,7 @@ export function App() {
       stop();
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [refreshSessions, refreshAuto, refreshBots]);
+  }, [refreshSessions, refreshSessionPins, refreshAuto, refreshBots]);
 
   // Refresh the user roster when the tab regains focus. The roster rarely
   // changes, so it isn't worth the 5s poll above — but avatars carry a
@@ -8414,6 +8490,8 @@ export function App() {
               sessions={liveSessions}
               shippedReview={shippedReview}
               liveSessionIds={liveStatusIds}
+              topPinned={topPinned}
+              onToggleTopPin={toggleTopPin}
               users={users}
               userFilter={userFilter}
               projectFilter={projectFilter}
@@ -10592,24 +10670,6 @@ function sessionStableId(session: Session): string {
   return session.sessionId || session.nativeSessionId || session.tmuxName || "";
 }
 
-const PINNED_SESSIONS_KEY = "lfg_pinned_sessions";
-const LEGACY_MOBILE_PINNED_SESSIONS_KEY = "lfg_mobile_pinned_sessions";
-
-function readPinnedSessions(): string[] {
-  try {
-    const parsed = JSON.parse(
-      localStorage.getItem(PINNED_SESSIONS_KEY) ??
-        localStorage.getItem(LEGACY_MOBILE_PINNED_SESSIONS_KEY) ??
-        "[]",
-    );
-    return Array.isArray(parsed)
-      ? parsed.filter((item): item is string => typeof item === "string")
-      : [];
-  } catch {
-    return [];
-  }
-}
-
 function buildSessionTree(
   sessions: Session[],
   busyOrFresh: (session: Session) => boolean,
@@ -10676,6 +10736,8 @@ function LiveView({
   sessions = [],
   shippedReview,
   liveSessionIds,
+  topPinned,
+  onToggleTopPin,
   users,
   userFilter,
   projectFilter,
@@ -10722,6 +10784,8 @@ function LiveView({
   onOpenSessionPage?: (sid: string) => void;
   onCloseSessionPage?: () => void;
   liveSessionIds: string[];
+  topPinned: string[];
+  onToggleTopPin: (sid: string) => void;
   users: User[];
   userFilter: string;
   projectFilter: string;
@@ -10772,44 +10836,7 @@ function LiveView({
   // component's. Only the morph origin is local: it anchors the open/close
   // animation to the row that was tapped, and a DOMRect cannot live in a URL.
   const [sheetOrigin, setSheetOrigin] = useState<DOMRect | null>(null);
-  const [topPinned, setTopPinned] = useState<string[]>(readPinnedSessions);
-  const topPinnedRef = useRef(topPinned);
-  topPinnedRef.current = topPinned;
-
-  // Top pins are browser-local workspace preferences shared by mobile and
-  // desktop. Sync other tabs without requiring server state.
   useEffect(() => {
-    const sync = (event: StorageEvent) => {
-      if (
-        event.key === PINNED_SESSIONS_KEY ||
-        event.key === LEGACY_MOBILE_PINNED_SESSIONS_KEY
-      ) {
-        setTopPinned(readPinnedSessions());
-      }
-    };
-    window.addEventListener("storage", sync);
-    return () => window.removeEventListener("storage", sync);
-  }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(PINNED_SESSIONS_KEY, JSON.stringify(topPinned));
-    } catch {
-      /* private mode / quota — non-fatal */
-    }
-  }, [topPinned]);
-
-  // Pins are browser-local, so deleting a session on the server does not clean
-  // them up automatically. Reconcile against the unfiltered live-session list:
-  // using the currently filtered `sessions` here would erase valid pins merely
-  // because the user switched project or owner.
-  useEffect(() => {
-    setTopPinned((current) => {
-      const next = retainLivePinnedSessions(current, liveSessionIds);
-      if (next.length === current.length) return current;
-      topPinnedRef.current = next;
-      return next;
-    });
     // The open session ended and is no longer listed: leave its page instead
     // of holding a URL that names nothing.
     //
@@ -10832,15 +10859,7 @@ function LiveView({
   const sessionsSeenRef = useRef(false);
   if (liveSessionIds.length) sessionsSeenRef.current = true;
 
-  const toggleTopPin = useCallback((sid: string) => {
-    const current = topPinnedRef.current;
-    const pinned = current.includes(sid);
-    const next = pinned ? current.filter((id) => id !== sid) : [...current, sid];
-    topPinnedRef.current = next;
-    setTopPinned(next);
-    haptic("selection");
-    toast.success(pinned ? "Session unpinned" : "Session pinned to top");
-  }, []);
+  const toggleTopPin = onToggleTopPin;
 
   // Narrow layout: a focus request goes straight to the session's page.
   useEffect(() => {

--- a/web/src/lib/pinned-sessions.ts
+++ b/web/src/lib/pinned-sessions.ts
@@ -1,7 +1,0 @@
-export function retainLivePinnedSessions(
-  pinnedSessionIds: string[],
-  liveSessionIds: readonly string[],
-): string[] {
-  const live = new Set(liveSessionIds);
-  return pinnedSessionIds.filter((sessionId) => live.has(sessionId));
-}

--- a/web/src/lib/session-pins.test.ts
+++ b/web/src/lib/session-pins.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import {
+  legacyPinnedSessions,
+  togglePinnedSession,
+} from "./session-pins";
+
+describe("session pin client helpers", () => {
+  test("deduplicates and validates legacy browser pins for one-time migration", () => {
+    expect(legacyPinnedSessions('["alpha", "", "alpha", 3, "beta"]')).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(legacyPinnedSessions("not json")).toEqual([]);
+    expect(legacyPinnedSessions(null)).toEqual([]);
+  });
+
+  test("optimistically toggles only the requested pin", () => {
+    expect(togglePinnedSession(["phone"], "laptop")).toEqual(["phone", "laptop"]);
+    expect(togglePinnedSession(["phone", "laptop"], "phone")).toEqual(["laptop"]);
+  });
+});

--- a/web/src/lib/session-pins.ts
+++ b/web/src/lib/session-pins.ts
@@ -1,0 +1,39 @@
+export const PINNED_SESSIONS_KEY = "lfg_pinned_sessions";
+export const LEGACY_MOBILE_PINNED_SESSIONS_KEY = "lfg_mobile_pinned_sessions";
+
+export function legacyPinnedSessions(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return [
+      ...new Set(
+        parsed.filter(
+          (value): value is string => typeof value === "string" && !!value,
+        ),
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+export function readLegacyPinnedSessions(storage: Storage = localStorage): string[] {
+  return [
+    ...new Set([
+      ...legacyPinnedSessions(storage.getItem(PINNED_SESSIONS_KEY)),
+      ...legacyPinnedSessions(storage.getItem(LEGACY_MOBILE_PINNED_SESSIONS_KEY)),
+    ]),
+  ];
+}
+
+export function clearLegacyPinnedSessions(storage: Storage = localStorage): void {
+  storage.removeItem(PINNED_SESSIONS_KEY);
+  storage.removeItem(LEGACY_MOBILE_PINNED_SESSIONS_KEY);
+}
+
+export function togglePinnedSession(current: readonly string[], sessionId: string): string[] {
+  return current.includes(sessionId)
+    ? current.filter((id) => id !== sessionId)
+    : [...current, sessionId];
+}


### PR DESCRIPTION
## Summary

- persist the ordered Pin to top list in the existing server SQLite database
- sync visible clients through bootstrap and the existing foreground poll
- mutate one session per request so stale devices cannot overwrite each other
- migrate both legacy localStorage keys once, merging without replacing server pins
- prune pins when their live session ends, preserving the existing live-only behavior

## Root cause

Pins were browser-local. On a cold start, LiveView initialized with the saved localStorage list and then immediately reconciled it against the initial empty live-session array, writing an empty list back before the first session response arrived. Browser-local state also could not synchronize between phone and laptop.

## Verification

- `bun test src/client-api-route-coverage.test.ts src/session-pins.test.ts test/session-pins-wiring.test.ts web/src/lib/session-pins.test.ts` — 15 pass
- `cd web && tsc --noEmit` — pass
- `tsc -p tsconfig.json --noEmit` — pass
- full suite — 2806 pass; the remaining deterministic failure is pre-existing on `main` in `test/bots-roster-ux.test.ts`, where the test expects a two-argument `botRosterPreview` call while `main` already calls it with one argument

No web bundle was rebuilt, following the current repository verification guidance.