### PR TITLE
fix(web): restore iOS text selection and make chat swipe optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Recent product updates and deployment notes.
 
+## August 26, 2026 - iPhone text selection works normally
+
+- **Long-press uses the native iPhone selection controls again.** A user can
+  select and adjust any part of a message, while the separate copy button
+  remains available for copying the whole message in one tap.
+
 ## August 25, 2026 - OpenCode Go models appear without a Claude account (v0.6.14)
 
 - **An OpenCode Go key alone now unlocks OpenCode's paid models.** If OpenCode
@@ -77,7 +83,6 @@ Recent product updates and deployment notes.
   top of each other. The renderer also picks up the 2.6 accessibility and
   download fixes. Long code and tables stay full height, so the transcript
   layout model still matches what you see.
-
 ## August 24, 2026 - Bot roster status is quieter (v0.6.7)
 
 - **Unread is one small dot on its conversation row.** Unread rows no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Recent product updates and deployment notes.
 
+## August 26, 2026 - Chat navigation swipe can be disabled
+
+- **Swipe between chats is now optional per device.** The new switch under
+  Settings > More > This device disables only the horizontal chat-switching
+  gesture; vertical scrolling, native text selection, and other gestures keep
+  working normally.
+
 ## August 26, 2026 - iPhone text selection works normally
 
 - **Long-press uses the native iPhone selection controls again.** A user can

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -320,7 +320,6 @@ import {
   Sun,
   Monitor,
   TerminalSquare,
-  TextSelect,
   Trash2,
   TriangleAlert,
   UserRound,
@@ -19015,9 +19014,6 @@ function OmgInstructionsBlock({
   );
 }
 
-const MESSAGE_LONG_PRESS_MS = 460;
-const MESSAGE_LONG_PRESS_SLOP_PX = 10;
-
 async function copyMessageText(text: string): Promise<void> {
   if (navigator.clipboard?.writeText) {
     await navigator.clipboard.writeText(text);
@@ -19045,21 +19041,8 @@ function MessageActions({
   children: ReactNode;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const timerRef = useRef<number | null>(null);
-  const originRef = useRef({ x: 0, y: 0 });
-  const longPressFiredRef = useRef(false);
-  const [menuAt, setMenuAt] = useState<{ x: number; y: number } | null>(null);
   const [selecting, setSelecting] = useState(false);
   const [copied, setCopied] = useState(false);
-
-  const clearTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => clearTimer, [clearTimer]);
 
   const copy = useCallback(async () => {
     if (!text) return;
@@ -19074,82 +19057,23 @@ function MessageActions({
     }
   }, [text]);
 
-  const selectText = useCallback(() => {
-    const content = contentRef.current;
-    if (!content) return;
-    setSelecting(true);
-    setMenuAt(null);
-    // Apply user-select:text before creating the range so iOS shows its native
-    // selection handles instead of immediately collapsing the selection.
-    window.requestAnimationFrame(() => {
-      const selection = window.getSelection();
-      const range = document.createRange();
-      range.selectNodeContents(content);
-      selection?.removeAllRanges();
-      selection?.addRange(range);
-    });
-  }, []);
-
   useEffect(() => {
-    if (!selecting) return;
     const onSelectionChange = () => {
       const selection = window.getSelection();
       const content = contentRef.current;
-      if (
-        !selection ||
-        selection.isCollapsed ||
-        !content ||
-        !selection.anchorNode ||
-        !selection.focusNode ||
-        !content.contains(selection.anchorNode) ||
-        !content.contains(selection.focusNode)
-      ) {
-        setSelecting(false);
-      }
+      const selectionTouchesMessage = Boolean(
+        selection &&
+          !selection.isCollapsed &&
+          content &&
+          selection.anchorNode &&
+          selection.focusNode &&
+          (content.contains(selection.anchorNode) || content.contains(selection.focusNode)),
+      );
+      setSelecting(selectionTouchesMessage);
     };
     document.addEventListener("selectionchange", onSelectionChange);
     return () => document.removeEventListener("selectionchange", onSelectionChange);
-  }, [selecting]);
-
-  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!text || (event.pointerType !== "touch" && event.pointerType !== "pen")) return;
-    if ((event.target as HTMLElement).closest("button, a, input, textarea")) return;
-    longPressFiredRef.current = false;
-    originRef.current = { x: event.clientX, y: event.clientY };
-    clearTimer();
-    timerRef.current = window.setTimeout(() => {
-      timerRef.current = null;
-      longPressFiredRef.current = true;
-      window.getSelection()?.removeAllRanges();
-      haptic("selection");
-      setMenuAt({ x: originRef.current.x, y: originRef.current.y });
-    }, MESSAGE_LONG_PRESS_MS);
-  };
-
-  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (timerRef.current === null) return;
-    if (
-      Math.abs(event.clientX - originRef.current.x) > MESSAGE_LONG_PRESS_SLOP_PX ||
-      Math.abs(event.clientY - originRef.current.y) > MESSAGE_LONG_PRESS_SLOP_PX
-    ) {
-      clearTimer();
-    }
-  };
-
-  const endPress = (event: React.PointerEvent<HTMLDivElement>) => {
-    clearTimer();
-    if (longPressFiredRef.current) {
-      event.preventDefault();
-      longPressFiredRef.current = false;
-    }
-  };
-
-  const menuStyle = menuAt
-    ? {
-        left: Math.max(12, Math.min(menuAt.x - 72, window.innerWidth - 156)),
-        top: Math.max(12, Math.min(menuAt.y - 58, window.innerHeight - 116)),
-      }
-    : undefined;
+  }, []);
 
   return (
     <div
@@ -19175,13 +19099,6 @@ function MessageActions({
           : "max-w-[min(92%,calc(100%-2.25rem))] items-start",
         selecting && "is-selecting",
       )}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={endPress}
-      onPointerCancel={endPress}
-      onContextMenu={(event) => {
-        if (window.matchMedia?.("(pointer: coarse)").matches) event.preventDefault();
-      }}
     >
       <div ref={contentRef} className="min-w-0 max-w-full">
         {children}
@@ -19207,46 +19124,6 @@ function MessageActions({
           {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
         </button>
       ) : null}
-      {menuAt
-        ? createPortal(
-            <div
-              className="fixed inset-0 z-[180]"
-              role="presentation"
-              onPointerDown={() => setMenuAt(null)}
-            >
-              <div
-                role="menu"
-                aria-label="Message actions"
-                className="dark fixed min-w-36 rounded-2xl bg-popover p-1 text-popover-foreground shadow-2xl ring-1 ring-foreground/10"
-                style={menuStyle}
-                onPointerDown={(event) => event.stopPropagation()}
-              >
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm outline-none hover:bg-foreground/10 focus-visible:bg-foreground/10"
-                  onClick={() => {
-                    setMenuAt(null);
-                    void copy();
-                  }}
-                >
-                  <Copy className="size-4" />
-                  Copy
-                </button>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className="flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-sm outline-none hover:bg-foreground/10 focus-visible:bg-foreground/10"
-                  onClick={selectText}
-                >
-                  <TextSelect className="size-4" />
-                  Select text
-                </button>
-              </div>
-            </div>,
-            document.body,
-          )
-        : null}
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -264,6 +264,7 @@ import type {
 import {
   Activity,
   Archive,
+  ArrowLeftRight,
   ArrowDown,
   ArrowUp,
   Bot,
@@ -331,6 +332,7 @@ import { toast } from "@/lib/notify";
 import { haptic } from "@/lib/haptics";
 import { feedback } from "@/lib/feedback";
 import { useUiFeedbackPrefs, setUiFeedbackPrefs } from "@/lib/ui-feedback-prefs";
+import { useNavigationPrefs, setNavigationPrefs } from "@/lib/navigation-prefs";
 import { useProjectListPrefs, setProjectListPrefs } from "@/lib/project-list-prefs";
 import { useSendMorph } from "@/lib/use-send-morph";
 import { reportError } from "./lib/report-error";
@@ -15746,6 +15748,7 @@ function SessionTitleSheet({
   onTogglePin?: (sid: string) => void;
   onClose: () => void;
 }) {
+  const navigationPrefs = useNavigationPrefs();
   const [error, setError] = useState<string | null>(null);
   const [renamingInline, setRenamingInline] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -15856,6 +15859,7 @@ function SessionTitleSheet({
   // horizontal swipe is committed, so scrolling and controls behave normally.
   // Native non-passive listeners (React's are passive) so preventDefault holds.
   useEffect(() => {
+    if (!navigationPrefs.swipeBetweenChats) return;
     const body = bodyRef.current;
     if (!body) return;
     const SWIPE_COMMIT = 60; // px of travel needed to flip sessions
@@ -15935,7 +15939,7 @@ function SessionTitleSheet({
       body.removeEventListener("touchend", onEnd);
       body.removeEventListener("touchcancel", onEnd);
     };
-  }, [go, prevSid, nextSid]);
+  }, [go, navigationPrefs.swipeBetweenChats, prevSid, nextSid]);
 
   // The transform that maps the full-screen panel onto the title's rect.
   // transform-origin is the top-left corner, so scale shrinks toward (0,0) and
@@ -26319,6 +26323,7 @@ function MoreView({
   connection: ConnectionState | null;
 }) {
   const uiFeedback = useUiFeedbackPrefs();
+  const navigationPrefs = useNavigationPrefs();
 
   return (
     <div className="mx-auto max-w-xl space-y-8 pb-10" data-lfg-page-column>
@@ -26447,6 +26452,19 @@ function MoreView({
               checked={uiFeedback.sound}
               onCheckedChange={(v) => setUiFeedbackPrefs({ sound: v })}
               aria-label="Toggle UI sound effects"
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+            <div className="flex items-center gap-3">
+              <span className="flex size-7 items-center justify-center rounded-[7px] bg-primary text-white">
+                <ArrowLeftRight className="size-4" />
+              </span>
+              <span className="text-sm font-medium">Swipe between chats</span>
+            </div>
+            <Switch
+              checked={navigationPrefs.swipeBetweenChats}
+              onCheckedChange={(v) => setNavigationPrefs({ swipeBetweenChats: v })}
+              aria-label="Toggle swipe between chats"
             />
           </div>
         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -757,14 +757,10 @@ html[data-lfg-embed="true"].lfg-keyboard-open {
     font-size: 11px;
   }
 
-  /* The visible copy button steps out of the way until hover/focus on
-     pointer-precise (mouse/trackpad) devices, which have no other way to
-     reach it. Long press already owns copy on touch: the pointer-coarse
-     block below used to force this button to full opacity too, which put a
-     second, always-visible copy control next to every mobile bubble and
-     duplicated that gesture on screen. Leaving it at opacity 0 (still
-     reachable via focus-within, e.g. an external keyboard) keeps touch on
-     just the one, intended interaction.
+  /* The whole-message copy button steps out of the way until hover/focus on
+     pointer-precise devices. Touch has no hover, so the coarse-pointer rule
+     below keeps the button visible. Long press remains free for the browser's
+     native word/range selection instead of duplicating this action.
 
      pointer-events go with the opacity. The button is positioned out of flow
      beside its bubble, so an invisible-but-clickable box would sit in the
@@ -789,17 +785,9 @@ html[data-lfg-embed="true"].lfg-keyboard-open {
   }
 
   @media (pointer: coarse) {
-    .message-actions-wrap {
-      touch-action: pan-y;
-      -webkit-touch-callout: none;
-      -webkit-user-select: none;
-      user-select: none;
-    }
-
-    .message-actions-wrap.is-selecting,
-    .message-actions-wrap.is-selecting * {
-      -webkit-user-select: text;
-      user-select: text;
+    .message-copy-button {
+      opacity: 1;
+      pointer-events: auto;
     }
 
     /* WebKit paints native selection handles outside the selected line box.

--- a/web/src/lib/navigation-prefs.test.ts
+++ b/web/src/lib/navigation-prefs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { parseNavigationPrefs } from "./navigation-prefs";
+
+describe("navigation preferences", () => {
+  test("keeps swipe-between-chats enabled for existing users", () => {
+    expect(parseNavigationPrefs(null)).toEqual({ swipeBetweenChats: true });
+    expect(parseNavigationPrefs("{}")).toEqual({ swipeBetweenChats: true });
+  });
+
+  test("restores an explicit disabled preference", () => {
+    expect(parseNavigationPrefs('{"swipeBetweenChats":false}')).toEqual({
+      swipeBetweenChats: false,
+    });
+  });
+
+  test("falls back safely when browser storage is malformed", () => {
+    expect(parseNavigationPrefs("not json")).toEqual({ swipeBetweenChats: true });
+  });
+});

--- a/web/src/lib/navigation-prefs.ts
+++ b/web/src/lib/navigation-prefs.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+
+// Browser-local navigation preferences. Kept separate from sound/haptics so a
+// gesture setting cannot accidentally become part of feedback behavior.
+
+export type NavigationPrefs = {
+  swipeBetweenChats: boolean;
+};
+
+const STORAGE_KEY = "lfg_navigation";
+const DEFAULTS: NavigationPrefs = { swipeBetweenChats: true };
+
+let cache: NavigationPrefs | null = null;
+const listeners = new Set<(prefs: NavigationPrefs) => void>();
+
+export function parseNavigationPrefs(raw: string | null): NavigationPrefs {
+  if (!raw) return { ...DEFAULTS };
+  try {
+    const parsed = JSON.parse(raw) as Partial<NavigationPrefs>;
+    return {
+      swipeBetweenChats: parsed.swipeBetweenChats ?? DEFAULTS.swipeBetweenChats,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+function read(): NavigationPrefs {
+  if (typeof window === "undefined") return { ...DEFAULTS };
+  try {
+    return parseNavigationPrefs(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export function getNavigationPrefs(): NavigationPrefs {
+  if (!cache) cache = read();
+  return cache;
+}
+
+export function setNavigationPrefs(patch: Partial<NavigationPrefs>): void {
+  const next = { ...getNavigationPrefs(), ...patch };
+  cache = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {}
+  for (const listener of listeners) listener(next);
+}
+
+export function subscribeNavigationPrefs(
+  listener: (prefs: NavigationPrefs) => void,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useNavigationPrefs(): NavigationPrefs {
+  return useSyncExternalStore(
+    subscribeNavigationPrefs,
+    getNavigationPrefs,
+    getNavigationPrefs,
+  );
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    cache = read();
+    for (const listener of listeners) listener(cache);
+  });
+}

--- a/web/src/message-copy-button-layout.test.ts
+++ b/web/src/message-copy-button-layout.test.ts
@@ -30,7 +30,7 @@ const MESSAGE_ACTIONS = APP.slice(APP.indexOf("function MessageActions("));
 // The wrap is the positioned parent; the button is the element inside it.
 const WRAP_CLASSES = MESSAGE_ACTIONS.slice(
   MESSAGE_ACTIONS.indexOf('"message-actions-wrap'),
-  MESSAGE_ACTIONS.indexOf("onPointerDown={onPointerDown}"),
+  MESSAGE_ACTIONS.indexOf('<div ref={contentRef}'),
 );
 const BUTTON_CLASSES = MESSAGE_ACTIONS.slice(
   MESSAGE_ACTIONS.indexOf('"message-copy-button'),

--- a/web/src/mobile-copy-button.test.ts
+++ b/web/src/mobile-copy-button.test.ts
@@ -1,5 +1,5 @@
-// Regression coverage for hiding the always-visible per-message copy button
-// on mobile while keeping the long-press copy gesture and the desktop button.
+// Regression coverage for keeping native text selection and whole-message copy
+// as two separate actions on touch devices.
 //
 // App.tsx is a large, side-effect-bearing entry module (mounts the app on
 // import in a browser context), so — following the same pattern already used
@@ -26,14 +26,16 @@ describe("mobile message copy button", () => {
     expect(CSS).toMatch(rule);
   });
 
-  test("the pointer-coarse (touch) media block no longer forces the button visible", () => {
-    const coarseBlockMatch = /@media \(pointer: coarse\) \{([\s\S]*?)\n  \}/.exec(CSS);
-    expect(coarseBlockMatch).not.toBeNull();
-    const coarseBlock = coarseBlockMatch![1];
-    // This is exactly the regression this test guards: touch devices used to
-    // get `.message-copy-button { opacity: 1; }` here, duplicating the
-    // long-press gesture with an always-visible button on every bubble.
-    expect(coarseBlock).not.toContain(".message-copy-button");
+  test("is visible and tappable for a coarse pointer", () => {
+    const coarseStart = CSS.indexOf(
+      "@media (pointer: coarse) {",
+      CSS.indexOf(".group\\/message:hover"),
+    );
+    const coarseEnd = CSS.indexOf("  .msg-text.markdown hr", coarseStart);
+    expect(coarseStart).toBeGreaterThan(-1);
+    expect(coarseEnd).toBeGreaterThan(coarseStart);
+    const coarseBlock = CSS.slice(coarseStart, coarseEnd);
+    expect(coarseBlock).toMatch(/\.message-copy-button\s*\{[^}]*opacity:\s*1;[^}]*pointer-events:\s*auto;/);
   });
 
   test("hover reveals only for a fine pointer, while keyboard focus works everywhere", () => {
@@ -43,19 +45,43 @@ describe("mobile message copy button", () => {
   });
 });
 
-describe("mobile long-press copy gesture (App.tsx MessageActions)", () => {
-  test("long-press is still wired up for touch/pen pointers", () => {
-    expect(APP).toContain('event.pointerType !== "touch" && event.pointerType !== "pen"');
-    expect(APP).toMatch(/MESSAGE_LONG_PRESS_MS\s*=\s*\d+/);
+describe("native mobile message selection", () => {
+  const messageActions = APP.slice(
+    APP.indexOf("function MessageActions("),
+    APP.indexOf("// Memoized:", APP.indexOf("function MessageActions(")),
+  );
+  const coarseStart = CSS.indexOf(
+    "@media (pointer: coarse) {",
+    CSS.indexOf(".group\\/message:hover"),
+  );
+  const coarseEnd = CSS.indexOf("  .msg-text.markdown hr", coarseStart);
+  const coarseBlock = CSS.slice(coarseStart, coarseEnd);
+
+  test("does not suppress the native iOS callout or text selection", () => {
+    expect(coarseBlock).not.toContain("-webkit-touch-callout: none");
+    expect(coarseBlock).not.toContain("-webkit-user-select: none");
+    expect(coarseBlock).not.toContain("user-select: none");
   });
 
-  test("the long-press action menu still offers Copy", () => {
-    const menuSection = APP.slice(APP.indexOf("Message actions"));
-    expect(menuSection.slice(0, 800)).toContain("Copy");
+  test("does not intercept long-press or replace it with a custom menu", () => {
+    expect(APP).not.toContain("MESSAGE_LONG_PRESS_MS");
+    expect(APP).not.toContain("TextSelect");
+    expect(messageActions).not.toContain("MESSAGE_LONG_PRESS_MS");
+    expect(messageActions).not.toContain("onPointerDown=");
+    expect(messageActions).not.toContain("onContextMenu=");
+    expect(messageActions).not.toContain("Select text");
+    expect(messageActions).not.toContain("removeAllRanges");
   });
 
-  test("the visible (desktop) copy button and its copied/uncopied labels are still rendered", () => {
-    expect(APP).toContain("message-copy-button");
-    expect(APP).toContain('aria-label={copied ? "Message copied" : "Copy message"}');
+  test("tracks native selections so WebKit handles can escape message clipping", () => {
+    expect(messageActions).toContain('document.addEventListener("selectionchange", onSelectionChange)');
+    expect(messageActions).toContain("content.contains(selection.anchorNode) ||");
+    expect(messageActions).toContain("content.contains(selection.focusNode)");
+  });
+
+  test("keeps whole-message copy as a separate button", () => {
+    expect(messageActions).toContain("message-copy-button");
+    expect(messageActions).toContain("onClick={() => void copy()}");
+    expect(messageActions).toContain('aria-label={copied ? "Message copied" : "Copy message"}');
   });
 });

--- a/web/src/other-human-message-avatar.test.ts
+++ b/web/src/other-human-message-avatar.test.ts
@@ -146,11 +146,11 @@ describe("OtherHumanMessageBubble: avatar, accessible name, and bot-reply separa
     expect(avatar).toMatch(/initial/);
   });
 
-  test("reuses UserBubble (same copy/long-press/clamp affordances) with a distinguishing tint, not the viewer's own tint", () => {
+  test("reuses UserBubble (same copy/native-selection/clamp affordances) with a distinguishing tint, not the viewer's own tint", () => {
     expect(component).toContain("<UserBubble html={html} otherAuthor />");
   });
 
-  test("passes isUser={false} to MessageActions so copy/long-press position on the correct side", () => {
+  test("passes isUser={false} to MessageActions so the copy button stays on the correct side", () => {
     expect(component).toContain('<MessageActions text={message.text || ""} isUser={false}>');
   });
 });
@@ -224,7 +224,7 @@ describe("grouping: consecutive other-human beats hide repeated name+face", () =
 
 describe("no horizontal overflow at 390px: the other-human bubble reuses the existing width caps", () => {
   test("MessageActions already caps non-user content at 92%-of-row minus the copy-button gutter — reused as-is", () => {
-    const actions = slice("function MessageActions(", "onPointerDown={onPointerDown}");
+    const actions = slice("function MessageActions(", '<div ref={contentRef}');
     expect(actions).toContain("max-w-[min(92%,calc(100%-2.25rem))]");
   });
 

--- a/web/src/session-swipe-setting.test.ts
+++ b/web/src/session-swipe-setting.test.ts
@@ -1,0 +1,32 @@
+// Source-level integration coverage follows the existing App.tsx regression
+// tests: importing App mounts the full browser app, so the focused seam is its
+// actual hook, touch-listener effect, and Settings switch wiring.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WEB = join(import.meta.dir, "..");
+const APP = readFileSync(join(WEB, "src/App.tsx"), "utf8");
+
+describe("swipe-between-chats device preference", () => {
+  test("gates only the full-session horizontal swipe listener", () => {
+    const sheet = APP.slice(
+      APP.indexOf("function SessionTitleSheet("),
+      APP.indexOf("function SessionCard(", APP.indexOf("function SessionTitleSheet(")),
+    );
+    expect(sheet).toContain("useNavigationPrefs()");
+    expect(sheet).toContain("if (!navigationPrefs.swipeBetweenChats) return;");
+    expect(sheet).toContain('body.addEventListener("touchmove", onMove, { passive: false })');
+    expect(sheet).toContain("[go, navigationPrefs.swipeBetweenChats, prevSid, nextSid]");
+  });
+
+  test("exposes a browser-local Settings switch", () => {
+    const more = APP.slice(APP.indexOf("function MoreView("), APP.indexOf("function UsageView("));
+    expect(more).toContain("useNavigationPrefs()");
+    expect(more).toContain("Swipe between chats");
+    expect(more).toContain("checked={navigationPrefs.swipeBetweenChats}");
+    expect(more).toContain("setNavigationPrefs({ swipeBetweenChats: v })");
+    expect(more).toContain('aria-label="Toggle swipe between chats"');
+  });
+});


### PR DESCRIPTION
## Summary

- Restore native partial text selection in chat messages on iOS.
- Keep the existing whole-message `Copy message` action.
- Add a per-device `Swipe between chats` switch under Settings > More. Swipe navigation remains enabled by default.

## Why

Message content disabled native selection, while the full-screen horizontal swipe handler competed with the same touch gestures people use to select text on iPhone. This change lets the browser handle message selection normally and gives users control over horizontal chat navigation.

The navigation preference is stored locally because it describes how the current device should handle touch gestures.

## Tests

- 50 focused selection, copy, avatar, and swipe regression tests pass in the combined v0.6.14 build.
- Root and web TypeScript checks pass.
- The production web build passes.
- At a 390 x 844 mobile viewport, disabling swipe kept the active session unchanged after a 260 px horizontal touch gesture. Vertical touch scrolling still moved the transcript.
