### PR TITLE
fix(pi): resolve the proxy base from OMG_AI_URL

### DIFF
--- a/src/agents/backends/pi-session.ts
+++ b/src/agents/backends/pi-session.ts
@@ -9,7 +9,7 @@
 // own file-based config (~/.pi/agent/{auth,models}.json): the API key comes
 // from the sandbox's ANTHROPIC_API_KEY env var (pi resolves that on its own),
 // and ensurePiProviderConfig() below points pi's "anthropic" provider at the
-// sandbox's local LLM proxy (ANTHROPIC_BASE_URL) — there is no interactive
+// sandbox's local LLM proxy (OMG_AI_URL) — there is no interactive
 // /login step, which is exactly what this backend exists to avoid (unlike
 // "aisdk", which requires one against this proxy).
 //
@@ -127,12 +127,22 @@ const PI_PROXY_MODEL_IDS = ["deepseek/deepseek-v4-flash"];
 // instead of an in-process Model object since this harness shells out to the
 // pi CLI rather than embedding pi-agent-core directly.
 //
-// No-op outside a sandbox (no ANTHROPIC_BASE_URL) — pi keeps talking to the
+// No-op outside a sandbox (neither variable set) — pi keeps talking to the
 // real Anthropic API with whatever real credentials are configured there.
+export function resolvePiProxyBaseUrl(env: NodeJS.ProcessEnv): string | undefined {
+  // OMG_AI_URL is the platform's own endpoint, and the one to prefer: infra is
+  // dropping the vendor-named variables, which belong to the user rather than
+  // to us. An explicit ANTHROPIC_BASE_URL still wins so a developer can aim pi
+  // somewhere by hand. ANTHROPIC_BASE_URL carries the SDK's `/v1` suffix and
+  // OMG_AI_URL does not; pi's models.json wants the bare base, so strip it.
+  const raw = env.ANTHROPIC_BASE_URL?.trim() || env.OMG_AI_URL?.trim();
+  if (!raw) return undefined;
+  return raw.replace(/\/v1\/?$/, "").replace(/\/+$/, "") || undefined;
+}
+
 function ensurePiProviderConfig(): void {
-  const raw = process.env.ANTHROPIC_BASE_URL?.trim();
-  if (!raw) return;
-  const baseUrl = raw.replace(/\/v1\/?$/, "").replace(/\/+$/, "");
+  const baseUrl = resolvePiProxyBaseUrl(process.env);
+  if (!baseUrl) return;
   const dir = join(homedir(), ".pi", "agent");
   const file = join(dir, "models.json");
   // biome-ignore lint: pi's models.json shape isn't typed here — we only ever

--- a/src/pi-proxy-base-url.test.ts
+++ b/src/pi-proxy-base-url.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { resolvePiProxyBaseUrl } from "./agents/backends/pi-session.ts";
+
+// pi's models.json wants the bare proxy base. Infra injects OMG_AI_URL bare and
+// ANTHROPIC_BASE_URL with the SDK's `/v1` suffix, so both normalise to the same
+// value and pi routes identically whichever one the platform supplies.
+test("derives the proxy base from OMG_AI_URL", () => {
+  expect(resolvePiProxyBaseUrl({ OMG_AI_URL: "http://169.254.0.1:9090" })).toBe(
+    "http://169.254.0.1:9090",
+  );
+});
+
+test("strips a trailing slash from OMG_AI_URL", () => {
+  expect(resolvePiProxyBaseUrl({ OMG_AI_URL: "http://169.254.0.1:9090/" })).toBe(
+    "http://169.254.0.1:9090",
+  );
+});
+
+test("still accepts ANTHROPIC_BASE_URL, suffix and all", () => {
+  expect(resolvePiProxyBaseUrl({ ANTHROPIC_BASE_URL: "http://169.254.0.1:9090/v1" })).toBe(
+    "http://169.254.0.1:9090",
+  );
+});
+
+test("an explicit ANTHROPIC_BASE_URL outranks OMG_AI_URL", () => {
+  expect(
+    resolvePiProxyBaseUrl({
+      ANTHROPIC_BASE_URL: "https://gateway.example/v1",
+      OMG_AI_URL: "http://169.254.0.1:9090",
+    }),
+  ).toBe("https://gateway.example");
+});
+
+// The sudo forwarding in the infra agent template passes VAR="${VAR:-}", so an
+// unset variable arrives as an empty string rather than absent. That must read
+// as "not configured" and fall through, not as a base URL of "".
+test("an empty ANTHROPIC_BASE_URL falls through to OMG_AI_URL", () => {
+  expect(
+    resolvePiProxyBaseUrl({ ANTHROPIC_BASE_URL: "  ", OMG_AI_URL: "http://169.254.0.1:9090" }),
+  ).toBe("http://169.254.0.1:9090");
+});
+
+test("no managed variable means pi keeps its own configured credentials", () => {
+  expect(resolvePiProxyBaseUrl({})).toBeUndefined();
+  expect(resolvePiProxyBaseUrl({ ANTHROPIC_BASE_URL: "", OMG_AI_URL: "" })).toBeUndefined();
+});


### PR DESCRIPTION
## What changed

`ensurePiProviderConfig` read `ANTHROPIC_BASE_URL` only, and was a no-op when it was unset. Infra is dropping the vendor-named variables, because those names belong to the user. Without this, pi falls back to its own default of real `api.anthropic.com` with no credential.

`resolvePiProxyBaseUrl(env)` prefers an explicit `ANTHROPIC_BASE_URL`, then falls back to `OMG_AI_URL`. Empty strings read as absent — the sudo wrappers in the agent template pass `VAR="${VAR:-}"`, so an unset variable arrives as `""` rather than missing.

## Why it is safe to merge now

No behaviour change. Infra still injects `ANTHROPIC_BASE_URL`, and that keeps priority.

## Why it is urgent

This must ship **and be rebaked into the agent template** before the infra change (BennyKok/vibes) stops injecting the vendor variables. The template pin is currently `v0.1.114` from 2026-07-29, so a release alone is not enough.

## Verification

- `bun test src/pi-proxy-base-url.test.ts` — 6 pass
- `bun test src/pi-model-routing.test.ts src/pi-auth.test.ts src/agents/backends/pi-rpc-contract.test.ts` — 33 pass, 0 fail
- `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)