### PR TITLE
fix(opencode): expose connected provider models and variants

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -69,6 +69,21 @@ describe("curateOpenCodeModels", () => {
       "opencode-go/kimi-k3",
     ]);
   });
+
+  test("keeps every model from an authenticated custom provider", () => {
+    const models = [
+      ...DISCOVERED,
+      "zai-coding-plan/glm-5.2",
+      "zai-coding-plan/glm-5.3",
+      "zai-coding-plan/glm-5.3-highspeed",
+    ];
+    const out = curateOpenCodeModels(models, ["zai-coding-plan"]);
+    expect(out.filter((model) => model.startsWith("zai-coding-plan/"))).toEqual([
+      "zai-coding-plan/glm-5.2",
+      "zai-coding-plan/glm-5.3",
+      "zai-coding-plan/glm-5.3-highspeed",
+    ]);
+  });
 });
 
 function codingAgent(

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -180,6 +180,8 @@ export type ModelCatalogItem = {
   defaultModel: string;
   models: string[];
   thinkingLevels: string[];
+  /** Model-specific levels for providers whose variants differ per model. */
+  thinkingLevelsByModel?: Record<string, string[]>;
   session: boolean;
   auto: boolean;
   visible?: boolean;
@@ -370,7 +372,10 @@ function opencodeFamily(model: string): string | null {
   return null;
 }
 
-export function curateOpenCodeModels(models: string[]): string[] {
+export function curateOpenCodeModels(
+  models: string[],
+  connectedProviderIds: readonly string[] = [],
+): string[] {
   const out: string[] = [];
   // OpenCode publishes credential-free models in its live catalog. Keep these
   // dynamic instead of pinning one release in LFG: anonymous installs can then
@@ -413,6 +418,11 @@ export function curateOpenCodeModels(models: string[]): string[] {
     "fugu",
   ];
   for (const family of order) addLatest(out, byFamily.get(family) ?? []);
+  const connected = new Set(connectedProviderIds);
+  for (const model of models) {
+    const provider = model.slice(0, model.indexOf("/"));
+    if (connected.has(provider) && !out.includes(model)) out.push(model);
+  }
   return out.length ? out : models.slice(0, 16);
 }
 
@@ -462,9 +472,13 @@ function curateFxModels(models: string[]): string[] {
   return out.length ? out : models;
 }
 
-function curateModels(agent: CodingAgentKind, models: string[]): string[] {
+function curateModels(
+  agent: CodingAgentKind,
+  models: string[],
+  connectedProviderIds: readonly string[] = [],
+): string[] {
   if (agent === "cursor") return curateCursorModels(models);
-  if (agent === "opencode") return curateOpenCodeModels(models);
+  if (agent === "opencode") return curateOpenCodeModels(models, connectedProviderIds);
   if (agent === "codex" || agent === "codex-aisdk") return curateCodexModels(models);
   if (agent === "grok") return curateGrokModels(models);
   if (agent === "fx") return curateFxModels(models);
@@ -480,8 +494,11 @@ export function rawModelsForAgent(agent: CodingAgentKind): string[] {
   return discoveredModelsOrFallback(fallback, provider);
 }
 
-export function modelsForAgent(agent: CodingAgentKind): string[] {
-  return curateModels(agent, rawModelsForAgent(agent));
+export function modelsForAgent(
+  agent: CodingAgentKind,
+  connectedProviderIds: readonly string[] = [],
+): string[] {
+  return curateModels(agent, rawModelsForAgent(agent), connectedProviderIds);
 }
 
 export function resolveModelForAgent(
@@ -515,7 +532,16 @@ export function resolveModelForAgent(
   return [...variants].sort((a, b) => score(b) - score(a))[0]?.raw ?? model;
 }
 
-export function thinkingLevelsForAgent(agent: string): readonly string[] | null {
+export function thinkingLevelsForAgent(
+  agent: string,
+  model?: string,
+): readonly string[] | null {
+  if (agent === "opencode") {
+    const variants = readModelDiscoveryCacheSync()?.providers?.opencode?.variants ?? {};
+    if (model) return variants[model] ?? null;
+    const levels = [...new Set(Object.values(variants).flat())];
+    return levels.length ? levels : null;
+  }
   if (agent === "claude" || agent === "aisdk") return CLAUDE_THINKING_LEVELS;
   // grok and pi drive their own CLIs with narrower vocabularies; offering more
   // hands the user a level that either kills the session or does nothing.
@@ -593,6 +619,12 @@ function openCodeConnectedFrom(codingAgents: CodingAgentInfo[]): boolean {
   return codingAgents.find((agent) => agent.key === "opencode")?.status.accountConnected === true;
 }
 
+function openCodeProvidersFrom(codingAgents: CodingAgentInfo[]): string[] {
+  return (codingAgents.find((agent) => agent.key === "opencode")?.status.providers ?? [])
+    .filter((provider) => provider.connected)
+    .map((provider) => provider.id);
+}
+
 /** Models the current user can honestly launch from the picker. */
 export function accessibleModelsForAgent(
   key: CodingAgentKind,
@@ -652,11 +684,12 @@ export function defaultModelForAgent(
 ): string {
   const accountConnected = hasConnectedModelAccount(codingAgents);
   const openCodeConnected = openCodeConnectedFrom(codingAgents);
+  const openCodeProviders = openCodeProvidersFrom(codingAgents);
   return defaultModelForCatalogItem(
     key,
     accessibleModelsForAgent(
       key,
-      modelsForAgent(key),
+      modelsForAgent(key, key === "opencode" ? openCodeProviders : []),
       accountConnected,
       piProvidersFrom(codingAgents),
       openCodeConnected,
@@ -669,22 +702,37 @@ export function listModelCatalog(codingAgents: CodingAgentInfo[] = []): ModelCat
   const configured = new Map(codingAgents.map((agent) => [agent.key, agent]));
   const accountConnected = hasConnectedModelAccount(codingAgents);
   const openCodeConnected = openCodeConnectedFrom(codingAgents);
+  const openCodeProviders = openCodeProvidersFrom(codingAgents);
   const piProviders = piProvidersFrom(codingAgents);
   return MODEL_CATALOG_KEYS.map((key) => {
     const status = configured.get(key);
     const models = accessibleModelsForAgent(
       key,
-      modelsForAgent(key),
+      modelsForAgent(key, key === "opencode" ? openCodeProviders : []),
       accountConnected,
       piProviders,
       openCodeConnected,
     );
+    const thinkingLevelsByModel = key === "opencode"
+      ? Object.fromEntries(
+          models.flatMap((model) => {
+            const levels = thinkingLevelsForAgent(key, model);
+            return levels?.length ? [[model, [...levels]]] : [];
+          }),
+        )
+      : undefined;
+    const thinkingLevels = key === "opencode"
+      ? [...new Set(Object.values(thinkingLevelsByModel ?? {}).flat())]
+      : [...(thinkingLevelsForAgent(key) ?? [])];
     return {
       key,
       label: LABELS[key],
       defaultModel: defaultModelForCatalogItem(key, models, accountConnected && openCodeConnected),
       models,
-      thinkingLevels: [...(thinkingLevelsForAgent(key) ?? [])],
+      thinkingLevels,
+      ...(thinkingLevelsByModel && Object.keys(thinkingLevelsByModel).length
+        ? { thinkingLevelsByModel }
+        : {}),
       session: key !== "claude" && key !== "codex",
       auto: (AUTO_AGENT_BACKENDS as readonly string[]).includes(key),
       visible: status?.visible,

--- a/src/agent-thinking-levels.test.ts
+++ b/src/agent-thinking-levels.test.ts
@@ -66,7 +66,8 @@ describe("levels offered per agent", () => {
   });
 
   test("agents with no reasoning knob still report none", () => {
-    expect(thinkingLevelsForAgent("opencode")).toBeNull();
+    // OpenCode is intentionally absent: its levels come from each discovered
+    // model's `variants`, covered by the model-discovery regression tests.
     expect(thinkingLevelsForAgent("copilot")).toBeNull();
   });
 });

--- a/src/agents/backends/opencode-aisdk-session.test.ts
+++ b/src/agents/backends/opencode-aisdk-session.test.ts
@@ -3,11 +3,29 @@ import {
   answersForIndex,
   isTrustedUploadPermission,
   pendingToPrompt,
+  opencodePromptBody,
   permissionToPrompt,
   sessionErrorText,
   shouldPublishDraftPart,
   toolPartMessages,
 } from "./opencode-aisdk-session.ts";
+
+describe("OpenCode model variants", () => {
+  test("forwards the selected thinking level as OpenCode's prompt variant", () => {
+    expect(opencodePromptBody("zai-coding-plan/glm-5.3", "max", "hello")).toEqual({
+      model: { providerID: "zai-coding-plan", modelID: "glm-5.3" },
+      variant: "max",
+      parts: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  test("omits the variant for models without a selected level", () => {
+    expect(opencodePromptBody("opencode/deepseek-v4-flash-free", undefined, "hello")).toEqual({
+      model: { providerID: "opencode", modelID: "deepseek-v4-flash-free" },
+      parts: [{ type: "text", text: "hello" }],
+    });
+  });
+});
 
 describe("opencode draft streaming", () => {
   test("does not publish OpenCode's streamed user prompt as an assistant draft", () => {

--- a/src/agents/backends/opencode-aisdk-session.ts
+++ b/src/agents/backends/opencode-aisdk-session.ts
@@ -92,6 +92,23 @@ function modelRef(model: string): { providerID: string; modelID: string } | unde
   return { providerID: model.slice(0, i), modelID: model.slice(i + 1) };
 }
 
+/** @internal exported for unit tests */
+export function opencodePromptBody(
+  model: string,
+  thinkingLevel: string | undefined,
+  prompt: string,
+): {
+  model?: { providerID: string; modelID: string };
+  variant?: string;
+  parts: Array<{ type: "text"; text: string }>;
+} {
+  return {
+    ...(modelRef(model) ? { model: modelRef(model) } : {}),
+    ...(thinkingLevel ? { variant: thinkingLevel } : {}),
+    parts: [{ type: "text", text: prompt }],
+  };
+}
+
 type OcPart = {
   id?: string;
   type?: string;
@@ -444,7 +461,7 @@ async function autoRejectPendingQuestions(baseUrl: string, sessionId: string): P
 export async function pipeToOpencodeAiSdk(
   prompt: string,
   log: (s: string) => void,
-  opts: { model?: string; cwd?: string } = {},
+  opts: { model?: string; thinkingLevel?: string; cwd?: string } = {},
 ): Promise<string> {
   const model = opts.model ?? "opencode/big-pickle";
   const cwd = opts.cwd ?? process.cwd();
@@ -469,10 +486,7 @@ export async function pipeToOpencodeAiSdk(
       res = (await client.session.prompt({
         path: { id: ocId },
         query: { directory: cwd },
-        body: {
-          ...(modelRef(model) ? { model: modelRef(model) } : {}),
-          parts: [{ type: "text", text: prompt }],
-        },
+        body: opencodePromptBody(model, opts.thinkingLevel, prompt),
       })) as { error?: unknown; data?: { parts?: OcPart[] } };
     } finally {
       clearInterval(rejectTimer);
@@ -494,6 +508,7 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
   // synthetic direct-index path.
   const keyArg = arg(argv, "--key");
   let model = arg(argv, "--model") ?? "anthropic/claude-sonnet-4-6";
+  let thinkingLevel = arg(argv, "--thinking-level");
   const cwd = arg(argv, "--cwd") ?? process.cwd();
   const tmuxName = arg(argv, "--managed-name") ?? arg(argv, "--tmux") ?? "";
   const recoveredAt = Number(arg(argv, "--recovered-at")) || null;
@@ -619,6 +634,7 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
     recoveredAt,
     cwd,
     model,
+    thinkingLevel: thinkingLevel ?? null,
     busy: false,
     prompt: null,
     title: initialPrompt ? initialPrompt.slice(0, 72) : null,
@@ -1009,10 +1025,7 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
         client.session.prompt({
           path: { id: ocSessionId! },
           query: { directory: cwd },
-          body: {
-            ...(modelRef(model) ? { model: modelRef(model) } : {}),
-            parts: [{ type: "text", text: prompt }],
-          },
+          body: opencodePromptBody(model, thinkingLevel, prompt),
         }),
         failed.promise,
       ]);
@@ -1134,6 +1147,12 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
       if (next) {
         model = next;
         patchEntry(key, { model });
+      }
+    } else if (cmd.type === "set_thinking_level") {
+      const next = cmd.thinkingLevel.trim();
+      if (next) {
+        thinkingLevel = next;
+        patchEntry(key, { thinkingLevel });
       }
     } else if (cmd.type === "answer") {
       void handleAnswerQuestion(cmd.index);

--- a/src/auto/runner.ts
+++ b/src/auto/runner.ts
@@ -255,7 +255,11 @@ async function runSelectedBackend(
     onLog(`[auto] opencode run (${prompt.length} chars) in ${cwd} [model: ${agent.model ?? "default"}]`);
     const { pipeToOpencodeAiSdk } = await import("../agents/backends/opencode-aisdk-session.ts");
     return await runInCwd(cwd, () =>
-      pipeToOpencodeAiSdk(prompt, onLog, { cwd, model: agent.model }),
+      pipeToOpencodeAiSdk(prompt, onLog, {
+        cwd,
+        model: agent.model,
+        thinkingLevel: agent.thinkingLevel,
+      }),
     );
   }
   if (backend === "grok") {

--- a/src/auto/store.ts
+++ b/src/auto/store.ts
@@ -183,16 +183,17 @@ export async function getAutoAgent(id: string): Promise<AutoAgent | null> {
 
 /**
  * Keep a thinking level only if the backend that will run it actually accepts
- * that level. Returns undefined for a backend with no reasoning knob at all
- * (opencode), and for a level outside the backend's own vocabulary (a claude
+ * that level. Returns undefined for a backend with no reasoning knob, and for
+ * a level outside the backend's own or selected model's vocabulary (a claude
  * "max" surviving a switch to grok, whose CLI exits on it).
  */
 export function sanitizeThinkingLevel(
   level: string | undefined,
   backend: string | undefined,
+  model?: string,
 ): string | undefined {
   if (!level) return undefined;
-  const allowed = thinkingLevelsForAgent(backend ?? "aisdk");
+  const allowed = thinkingLevelsForAgent(backend ?? "aisdk", model);
   return allowed?.includes(level) ? level : undefined;
 }
 
@@ -275,7 +276,11 @@ export async function saveAutoAgent(input: {
     // the level the agent held as claude — writing a record that no longer
     // validates. Nothing re-checks a stored row, so the break only surfaced
     // later, at launch, as a 400 from POST /api/sessions/new.
-    thinkingLevel: sanitizeThinkingLevel(input.thinkingLevel ?? existing?.thinkingLevel, backend),
+    thinkingLevel: sanitizeThinkingLevel(
+      input.thinkingLevel ?? existing?.thinkingLevel,
+      backend,
+      input.model ?? existing?.model,
+    ),
     tools: input.tools ?? existing?.tools,
     lastRunAt: existing?.lastRunAt,
   };

--- a/src/bots/store.ts
+++ b/src/bots/store.ts
@@ -233,7 +233,7 @@ export async function createBot(input: {
     capabilities: input.capabilities,
     agent,
     model: input.model,
-    thinkingLevel: sanitizeThinkingLevel(input.thinkingLevel, agent),
+    thinkingLevel: sanitizeThinkingLevel(input.thinkingLevel, agent, input.model),
     claudeAccountId: sanitizeBotClaudeAccountId(input.claudeAccountId, agent),
     cwd: input.cwd,
     owner: input.owner,
@@ -263,6 +263,7 @@ function applyPatch(current: Bot, patch: BotPatch): Bot {
     thinkingLevel: sanitizeThinkingLevel(
       Object.hasOwn(patch, "thinkingLevel") ? patch.thinkingLevel : current.thinkingLevel,
       agent,
+      patch.model ?? current.model,
     ),
     // Same rule as the thinking level: carry the pin forward on a plain edit,
     // but never past a backend switch that has no Claude accounts at all.

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -101,6 +101,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       prompt: request.prompt,
       model: request.model,
       key: request.sessionId,
+      thinkingLevel: request.thinkingLevel,
       omgSessionId: request.sessionId,
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,

--- a/src/commands/agents-auto.ts
+++ b/src/commands/agents-auto.ts
@@ -186,7 +186,7 @@ export function parseBackendSelection(
 
   const thinkingLevel = option(args, "--thinking-level")?.trim();
   if (thinkingLevel) {
-    const allowed = thinkingLevelsForAgent(backend);
+    const allowed = thinkingLevelsForAgent(backend, model);
     if (!allowed) fail(`thinking levels are not supported for ${backend} auto agents`);
     if (!allowed.includes(thinkingLevel)) {
       fail(`unknown thinking level "${thinkingLevel}" for ${backend} (expected one of ${allowed.join(", ")})`);

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -481,7 +481,8 @@ async function createSubagent({
     throw new Error(`unknown agent "${agent}"`);
   }
   if (thinkingLevel) {
-    const allowed = thinkingLevelsForAgent(agent);
+    const model = rawModel?.trim() || MODEL_OPTIONS[agent as keyof typeof MODEL_OPTIONS].defaultModel;
+    const allowed = thinkingLevelsForAgent(agent, model);
     if (!allowed || !allowed.includes(thinkingLevel)) {
       throw new Error(`unknown thinking level "${thinkingLevel}" for ${agent}`);
     }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -2420,7 +2420,7 @@ function validateBotAgent(
   if (agent === "jcode" && model && !/^[A-Za-z0-9_.:\/\-[\],=]{1,160}$/.test(model))
     return { error: "invalid jcode model name" };
   if (thinkingLevel) {
-    const allowed = thinkingLevelsForAgent(agent);
+    const allowed = thinkingLevelsForAgent(agent, model);
     if (!allowed) return { error: `thinkingLevel is not supported for ${agent} bots` };
     if (!allowed.includes(thinkingLevel))
       return { error: `unknown thinking level "${thinkingLevel}" for ${agent} (expected one of ${allowed.join(", ")})` };
@@ -3330,7 +3330,7 @@ export function resolveAutoAgentRuntime(
     return { ok: false, status: 400, error: "invalid opencode model name" };
   const thinkingLevel = b.thinkingLevel?.trim() || undefined;
   if (thinkingLevel) {
-    const allowed = thinkingLevelsForAgent(autoBackend);
+    const allowed = thinkingLevelsForAgent(autoBackend, model);
     if (!allowed)
       return {
         ok: false,
@@ -7665,15 +7665,13 @@ a{color:#60a5fa}
           return err(400, "invalid jcode model name");
         const thinkingLevel = body?.thinkingLevel?.trim() || undefined;
         // Thinking mode is supported on every agent kind that exposes a
-        // reasoning-effort knob: Codex (reasoning_effort) and Claude (the claude
-        // CLI's --effort / the claude-code provider's `effort`). opencode is the
-        // lone exception — its provider exposes no per-call thinking control
-        // (effort is set in opencode's own model config instead). Validate the
-        // value against THAT agent's own level set so an out-of-range value (a
+        // reasoning-effort knob. OpenCode exposes it as a model-specific
+        // `variant`, so validate against the selected model rather than against
+        // a global OpenCode vocabulary. An out-of-range value (a
         // voice-supplied `none` for Claude, or `max` for Codex) is a clean 400
         // rather than a session that boots straight into a provider error.
         if (thinkingLevel) {
-          const allowed = thinkingLevelsForAgent(agent);
+          const allowed = thinkingLevelsForAgent(agent, model);
           if (!allowed)
             return err(400, `thinkingLevel is not supported for ${agent} sessions`);
           if (!allowed.includes(thinkingLevel))
@@ -8812,7 +8810,7 @@ a{color:#60a5fa}
           if (!thinkingLevel) return err(400, "expected { thinkingLevel }");
           const sess = (await listSessions()).find((s) => s.sessionId === m[1]);
           if (!sess) return err(404, "session not found");
-          const supported = thinkingLevelsForAgent(sess.agent);
+          const supported = thinkingLevelsForAgent(sess.agent, sess.model ?? undefined);
           // Claude Agent SDK supports `max` as a launch option, but its live
           // Settings API currently accepts only through `xhigh`.
           const allowed = sess.agent === "aisdk"
@@ -8823,7 +8821,7 @@ a{color:#60a5fa}
           if (!allowed.includes(thinkingLevel))
             return err(400, `unknown thinking level "${thinkingLevel}" for ${sess.agent} (expected one of ${allowed.join(", ")})`);
 
-          if (sess.agent === "aisdk" || sess.agent === "codex-aisdk" || sess.agent === "pi" || (sess.agent === "jcode" && sess.runtime === "command-file")) {
+          if (sess.agent === "aisdk" || sess.agent === "codex-aisdk" || sess.agent === "opencode" || sess.agent === "pi" || (sess.agent === "jcode" && sess.runtime === "command-file")) {
             const entry = findAisdkEntryByAnyId(m[1]);
             if (!entry) return err(409, "session control process is unavailable");
             appendAisdkCmd(entry.sessionId, { type: "set_thinking_level", thinkingLevel });

--- a/src/commands/subagent.ts
+++ b/src/commands/subagent.ts
@@ -203,7 +203,7 @@ async function cmdCreate(args: string[]) {
   const model = option(args, "--model")?.trim() || MODEL_OPTIONS[agent as keyof typeof MODEL_OPTIONS].defaultModel;
   const thinkingLevel = option(args, "--thinking-level")?.trim();
   if (thinkingLevel) {
-    const allowed = thinkingLevelsForAgent(agent);
+    const allowed = thinkingLevelsForAgent(agent, model);
     if (!allowed || !allowed.includes(thinkingLevel)) {
       console.error(`unknown thinking level "${thinkingLevel}" for ${agent}`);
       process.exit(1);

--- a/src/model-discovery.test.ts
+++ b/src/model-discovery.test.ts
@@ -3,6 +3,7 @@ import {
   providersDueForRetry,
   parseFxModels,
   parseJcodeModels,
+  parseOpenCodeModels,
   retryDelayMs,
   type ModelDiscoveryCache,
   type DiscoveredModelProvider,
@@ -156,5 +157,40 @@ describe("Jcode model discovery", () => {
         }),
       ),
     ).toEqual({ models: ["auto", "glm-5", "e2e-model"], labels: {} });
+  });
+});
+
+describe("OpenCode model discovery", () => {
+  test("reads provider variants from verbose model output", () => {
+    const parsed = parseOpenCodeModels(`zai-coding-plan/glm-5.3
+{
+  "id": "glm-5.3",
+  "providerID": "zai-coding-plan",
+  "name": "GLM-5.3",
+  "variants": {
+    "low": { "reasoningEffort": "low" },
+    "high": { "reasoningEffort": "high" },
+    "max": { "reasoningEffort": "max" }
+  }
+}
+opencode/deepseek-v4-flash-free
+{
+  "id": "deepseek-v4-flash-free",
+  "providerID": "opencode",
+  "name": "DeepSeek V4 Flash Free",
+  "variants": {}
+}`);
+
+    expect(parsed.models).toEqual([
+      "zai-coding-plan/glm-5.3",
+      "opencode/deepseek-v4-flash-free",
+    ]);
+    expect(parsed.labels).toEqual({
+      "zai-coding-plan/glm-5.3": "GLM-5.3",
+      "opencode/deepseek-v4-flash-free": "DeepSeek V4 Flash Free",
+    });
+    expect(parsed.variants).toEqual({
+      "zai-coding-plan/glm-5.3": ["low", "high", "max"],
+    });
   });
 });

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -13,6 +13,8 @@ export type DiscoveredModelProvider = {
   command?: string[];
   models: string[];
   labels?: Record<string, string>;
+  /** Per-model provider variants, such as OpenCode reasoning effort levels. */
+  variants?: Record<string, string[]>;
   error?: string;
   refreshedAt: number;
   durationMs: number;
@@ -169,7 +171,7 @@ function commandFor(key: ProviderKey): string[] | null {
   }
   if (key === "opencode") {
     const bin = opencodePath();
-    return bin ? [bin, "models"] : null;
+    return bin ? [bin, "models", "--verbose"] : null;
   }
   if (key === "fx") {
     const bin = fxPath();
@@ -253,6 +255,42 @@ function parsePlainModelLines(text: string): { models: string[]; labels: Record<
   return { models: ids, labels };
 }
 
+export function parseOpenCodeModels(text: string): {
+  models: string[];
+  labels: Record<string, string>;
+  variants: Record<string, string[]>;
+} {
+  const models: string[] = [];
+  const labels: Record<string, string> = {};
+  const variants: Record<string, string[]> = {};
+  const clean = cleanText(text);
+  const blocks = clean.matchAll(
+    /^([A-Za-z0-9_.:/\-[\],=]+)\r?\n(\{[\s\S]*?^\})/gm,
+  );
+  for (const match of blocks) {
+    const id = cleanId(match[1] ?? "");
+    if (!id) continue;
+    try {
+      const metadata = JSON.parse(match[2] ?? "{}") as {
+        name?: unknown;
+        variants?: unknown;
+      };
+      addModel(models, labels, id, typeof metadata.name === "string" ? metadata.name : undefined);
+      if (!metadata.variants || typeof metadata.variants !== "object" || Array.isArray(metadata.variants)) continue;
+      const levels = Object.keys(metadata.variants).filter((level) => cleanId(level) === level);
+      if (levels.length) variants[id] = levels;
+    } catch {
+      // One malformed metadata block must not hide the remaining providers.
+    }
+  }
+  // Older OpenCode builds may accept --verbose but still print only ids.
+  if (!models.length) {
+    const plain = parsePlainModelLines(clean);
+    return { ...plain, variants };
+  }
+  return { models, labels, variants };
+}
+
 export function parseJcodeModels(text: string): { models: string[]; labels: Record<string, string> } {
   const parsed = JSON.parse(text) as {
     models?: Array<string | { model?: unknown; available?: unknown }>;
@@ -289,11 +327,15 @@ export function parseFxModels(text: string): { models: string[]; labels: Record<
   return { models: ids, labels };
 }
 
-function parseModels(key: ProviderKey, text: string): { models: string[]; labels: Record<string, string> } {
+function parseModels(key: ProviderKey, text: string): {
+  models: string[];
+  labels: Record<string, string>;
+  variants?: Record<string, string[]>;
+} {
   if (key === "codex" || key === "codex-aisdk") return parseCodexModels(text);
   if (key === "grok") return parseBulletModels(text);
   if (key === "cursor") return parseDashListModels(text);
-  if (key === "opencode") return parsePlainModelLines(text);
+  if (key === "opencode") return parseOpenCodeModels(text);
   if (key === "fx") return parseFxModels(text);
   if (key === "jcode") return parseJcodeModels(text);
   return { models: [], labels: {} };
@@ -387,6 +429,7 @@ async function discoverProvider(key: ProviderKey): Promise<DiscoveredModelProvid
       command,
       models: parsed.models,
       labels: Object.keys(parsed.labels).length ? parsed.labels : undefined,
+      variants: parsed.variants && Object.keys(parsed.variants).length ? parsed.variants : undefined,
       refreshedAt,
       durationMs: Math.round((performance.now() - started) * 1000) / 1000,
     };

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -122,6 +122,7 @@ function launchRecovered(
       ...common,
       key: entry.sessionId,
       resume: entry.threadId,
+      thinkingLevel: entry.thinkingLevel ?? undefined,
     });
   }
   if (entry.agent === "pi") {

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -1228,6 +1228,7 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   prompt?: string;
   model: string;
   key: string;
+  thinkingLevel?: string;
   omgSessionId?: string;
   omgUser?: string | null;
   resume?: string;
@@ -1248,6 +1249,7 @@ export function spawnManagedOpencodeAisdkSession(opts: {
     "--cwd", opts.cwd,
     "--managed-name", opts.name,
   ];
+  if (opts.thinkingLevel) argv.push("--thinking-level", opts.thinkingLevel);
   if (opts.resume) argv.push("--resume", opts.resume);
   if (opts.recoveredAt) argv.push("--recovered-at", String(opts.recoveredAt));
   const prompt = withOmgRuntimeContract(opts.prompt);

--- a/test/thinking-level-backend-switch.test.ts
+++ b/test/thinking-level-backend-switch.test.ts
@@ -63,12 +63,15 @@ describe("auto agent store: thinking level survives only a compatible backend", 
 describe("web: every session launch gates thinkingLevel on the launching agent", () => {
   test("no /api/sessions/new body sends an ungated thinkingLevel", async () => {
     const source = await readFile("web/src/App.tsx", "utf8");
-    // Each POST body that carries a level must gate it on the agent it is
-    // actually launching, via agentSupportsThinking(...).
+    // Each POST body that inherits a level must gate it on the exact agent and
+    // model it is launching. OpenCode variants are model-specific, so an
+    // agent-only check is no longer sufficient.
     const bodies = [...source.matchAll(/thinkingLevel:\s*([^,\n]+)/g)].map((m) => m[1].trim());
     const ungated = bodies.filter(
       (expr) =>
-        expr.includes("sourceAgent?.thinkingLevel") && !expr.includes("agentSupportsThinking"),
+        expr.includes("sourceAgent?.thinkingLevel") &&
+        !expr.includes("thinkingLevelsForSelection") &&
+        !expr.includes("agentSupportsThinking"),
     );
     expect(ungated).toEqual([]);
   });
@@ -83,7 +86,7 @@ describe("web: every session launch gates thinkingLevel on the launching agent",
     // The level is judged against the resolved launch agent, not the source.
     expect(fn).toContain("const launchAgent = opts.agent ?? sourceAgent?.agent ?? \"aisdk\"");
     expect(fn).toContain(
-      "thinkingLevel: agentSupportsThinking(launchAgent) ? inheritedThinkingLevel : undefined",
+      "thinkingLevel: thinkingLevelsForSelection(modelCatalog, launchAgent, launchModel).length",
     );
     // ...and the agent sent is the same one that decision was made against.
     expect(fn).toContain("agent: launchAgent,");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -978,6 +978,7 @@ type ModelCatalogItem = {
   defaultModel: string;
   models: string[];
   thinkingLevels: string[];
+  thinkingLevelsByModel?: Record<string, string[]>;
   session: boolean;
   auto: boolean;
   visible?: boolean;
@@ -1206,8 +1207,8 @@ export type { AgentKind } from "./lib/coding-agent-options";
 
 // Which agents honor a thinking/reasoning-effort level. Claude (CLI + ai-sdk)
 // takes an `effort`; Codex (CLI + ai-sdk) takes a `reasoning_effort` — both
-// accept the low/medium/high/xhigh values the picker offers. OpenCode's provider
-// exposes no reasoning knob, so the selector is hidden for it.
+// accept the low/medium/high/xhigh values the picker offers. OpenCode maps this
+// control to the selected model's provider-specific `variant`.
 function agentSupportsThinking(agent: AgentKind): boolean {
   return (
     agent === "claude" ||
@@ -1216,6 +1217,7 @@ function agentSupportsThinking(agent: AgentKind): boolean {
     agent === "cursor" ||
     agent === "codex" ||
     agent === "codex-aisdk" ||
+    agent === "opencode" ||
     agent === "jcode" ||
     agent === "pi"
   );
@@ -1274,6 +1276,7 @@ type AgentModelCatalog = {
   models: Record<AgentKind, string[]>;
   defaults: Record<AgentKind, string>;
   thinkingLevels: Record<AgentKind, string[]>;
+  thinkingLevelsByModel: Record<AgentKind, Record<string, string[]>>;
 };
 
 function buildAgentModelCatalog(items?: ModelCatalogItem[] | null): AgentModelCatalog {
@@ -1284,13 +1287,17 @@ function buildAgentModelCatalog(items?: ModelCatalogItem[] | null): AgentModelCa
   const thinkingLevels = Object.fromEntries(
     Object.entries(AGENT_THINKING_LEVELS).map(([key, value]) => [key, [...value]]),
   ) as Record<AgentKind, string[]>;
+  const thinkingLevelsByModel = Object.fromEntries(
+    Object.keys(AGENT_MODELS).map((key) => [key, {}]),
+  ) as Record<AgentKind, Record<string, string[]>>;
   for (const item of items ?? []) {
     if (!AGENT_MODELS[item.key] || !item.models?.length) continue;
     models[item.key] = item.models;
     defaults[item.key] = item.defaultModel || defaults[item.key];
     thinkingLevels[item.key] = item.thinkingLevels ?? thinkingLevels[item.key];
+    thinkingLevelsByModel[item.key] = item.thinkingLevelsByModel ?? {};
   }
-  return { models, defaults, thinkingLevels };
+  return { models, defaults, thinkingLevels, thinkingLevelsByModel };
 }
 
 const AgentModelCatalogContext = createContext<AgentModelCatalog>(
@@ -1311,9 +1318,21 @@ function useAgentDefaultModel(agent: AgentKind): string {
   return catalog.defaults[agent] ?? AGENT_DEFAULT_MODEL[agent];
 }
 
-function useAgentThinkingLevels(agent: AgentKind): string[] {
-  const catalog = useAgentModelCatalog();
+function thinkingLevelsForSelection(
+  catalog: AgentModelCatalog,
+  agent: AgentKind,
+  model?: string,
+): string[] {
+  if (model && catalog.thinkingLevelsByModel[agent]?.[model]) {
+    return catalog.thinkingLevelsByModel[agent][model];
+  }
+  if (model && agent === "opencode") return [];
   return catalog.thinkingLevels[agent] ?? AGENT_THINKING_LEVELS[agent] ?? [];
+}
+
+function useAgentThinkingLevels(agent: AgentKind, model?: string): string[] {
+  const catalog = useAgentModelCatalog();
+  return thinkingLevelsForSelection(catalog, agent, model);
 }
 
 // Kept in sync with AUTO_AGENT_BACKENDS in src/agent-catalog.ts by construction:
@@ -7108,6 +7127,7 @@ export function App() {
     // back and the launch 400'd ("thinkingLevel is not supported for opencode
     // sessions") on a request the user never asked for.
     const launchAgent = opts.agent ?? sourceAgent?.agent ?? "aisdk";
+    const launchModel = opts.model ?? sourceAgent?.model;
     const inheritedThinkingLevel = opts.thinkingLevel ?? sourceAgent?.thinkingLevel;
     const agentCwd = sourceAgent?.cwd;
     const cwd = agentCwd || localStorage.getItem("lfg_v2_repo") || repos[0]?.cwd || "";
@@ -7132,8 +7152,10 @@ export function App() {
             title: title || undefined,
             user: owner || undefined,
             agent: launchAgent,
-            model: opts.model ?? sourceAgent?.model,
-            thinkingLevel: agentSupportsThinking(launchAgent) ? inheritedThinkingLevel : undefined,
+            model: launchModel,
+            thinkingLevel: thinkingLevelsForSelection(modelCatalog, launchAgent, launchModel).length
+              ? inheritedThinkingLevel
+              : undefined,
             overLimit: overLimit || undefined,
             // Only Claude has accounts to pin. No `?? sourceAgent` fallback here:
             // the sheet seeds its state FROM the source agent, so an absent value
@@ -7458,7 +7480,9 @@ export function App() {
           user: owner || undefined,
           agent: launchAgent,
           model: launchModel,
-          thinkingLevel: agentSupportsThinking(launchAgent) ? savedThinkingLevel() : undefined,
+          thinkingLevel: thinkingLevelsForSelection(modelCatalog, launchAgent, launchModel).length
+            ? savedThinkingLevel()
+            : undefined,
         }),
       });
       if (res.sessionId) markCreatedSid(res.sessionId);
@@ -15732,6 +15756,7 @@ const LIVE_THINKING_AGENTS = new Set([
   "codex-aisdk",
   "grok",
   "cursor",
+  "opencode",
   "pi",
 ]);
 
@@ -15746,7 +15771,7 @@ function SessionThinkingLevelSubmenu({
 }) {
   const sid = session.sessionId;
   const agent = session.agent as AgentKind | undefined;
-  const supportedLevels = useAgentThinkingLevels(agent ?? "aisdk");
+  const supportedLevels = useAgentThinkingLevels(agent ?? "aisdk", session.model ?? undefined);
   const levels = agent === "aisdk"
     ? supportedLevels.filter((level) => level !== "max")
     : supportedLevels;
@@ -16425,7 +16450,7 @@ function ForkSessionDialog({
   const [prompt, setPrompt] = useState("");
   const sid = session.sessionId;
   const models = catalog.models[agent] ?? AGENT_MODELS[agent];
-  const thinkingLevels = useAgentThinkingLevels(agent);
+  const thinkingLevels = useAgentThinkingLevels(agent, model);
   const selectedLaunchId =
     agent === "aisdk" && claudeAccountId ? `aisdk:${claudeAccountId}` : agent;
   // Same composer plumbing as the new-session composer: eager uploads, drag &
@@ -16472,7 +16497,7 @@ function ForkSessionDialog({
     }
     localStorage.setItem("lfg_fork_agent", agent);
     localStorage.setItem(`lfg_fork_model_${agent}`, model);
-    if (agentSupportsThinking(agent)) localStorage.setItem("lfg_thinking_level", thinkingLevel);
+    if (thinkingLevels.length) localStorage.setItem("lfg_thinking_level", thinkingLevel);
     const text = (overrideText ?? prompt).trim();
     const attached = files.attachments;
     onClose();
@@ -16491,7 +16516,7 @@ function ForkSessionDialog({
             user: session.assignedUser || undefined,
             agent,
             model,
-            thinkingLevel: agentSupportsThinking(agent) ? thinkingLevel : undefined,
+            thinkingLevel: thinkingLevels.length ? thinkingLevel : undefined,
             claudeAccountId: agent === "aisdk" ? claudeAccountId || undefined : undefined,
             archiveSource: continuing || undefined,
           }),
@@ -21093,7 +21118,7 @@ function NewSessionDialog({
   }, [open, defaultUser, users]);
 
   const models = catalog.models[agent] ?? AGENT_MODELS[agent];
-  const thinkingLevels = useAgentThinkingLevels(agent);
+  const thinkingLevels = useAgentThinkingLevels(agent, model);
   // When the live view is filtered to a specific project, lock new sessions to
   // that project's repo (and hide the picker below). Falls back to the normal
   // localStorage/first-repo default when viewing "All projects" or when the
@@ -21273,7 +21298,7 @@ function NewSessionDialog({
     localStorage.setItem("lfg_v2_agent", launchAgent);
     localStorage.setItem("lfg_v2_repo", selectedRepo);
     localStorage.setItem(`lfg_model_${launchAgent}`, launchModel);
-    if (agentSupportsThinking(launchAgent)) localStorage.setItem("lfg_thinking_level", launchThinkingLevel);
+    if (thinkingLevels.length) localStorage.setItem("lfg_thinking_level", launchThinkingLevel);
     if (launchAgent === "claude") localStorage.setItem("lfg_model", launchModel);
     if (launchUser) localStorage.setItem("lfg_user", launchUser);
     // Keep both composer variants mounted while the session boots so the
@@ -21304,7 +21329,7 @@ function NewSessionDialog({
             user: launchUser || undefined,
             agent: launchAgent,
             model: launchModel,
-            thinkingLevel: agentSupportsThinking(launchAgent) ? launchThinkingLevel : undefined,
+            thinkingLevel: thinkingLevels.length ? launchThinkingLevel : undefined,
             claudeAccountId: launchClaudeAccountId,
             overLimit: overLimit || undefined,
           }),
@@ -23083,7 +23108,7 @@ function AgentModelRow<K extends AgentKind>({
   const catalog = useAgentModelCatalog();
   const accessMode = useContext(AgentAccessModeContext);
   const models = useAgentModels(backend);
-  const thinkingLevels = useAgentThinkingLevels(backend);
+  const thinkingLevels = useAgentThinkingLevels(backend, model);
   const defaultModelFor = (key: AgentKind) =>
     catalog.defaults[key] ?? AGENT_DEFAULT_MODEL[key];
   // The catalog is keyed by the full AgentKind union; `scheduledOnly` narrows it
@@ -23295,7 +23320,7 @@ function FindingSheet({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const backendModels = useAgentModels(backend);
   const backendDefaultModel = useAgentDefaultModel(backend);
-  const supportsThinking = agentSupportsThinking(backend);
+  const supportsThinking = useAgentThinkingLevels(backend, model).length > 0;
 
   useEffect(() => {
     if (!backendModels.includes(model)) setModel(backendDefaultModel);
@@ -23783,7 +23808,7 @@ function NewAutoAgentComposer({
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(savedThinkingLevel());
   const backendModels = useAgentModels(backend);
   const backendDefaultModel = useAgentDefaultModel(backend);
-  const supportsThinking = agentSupportsThinking(backend);
+  const supportsThinking = useAgentThinkingLevels(backend, model).length > 0;
 
   useEffect(() => {
     if (!backendModels.includes(model)) setModel(backendDefaultModel);
@@ -23981,7 +24006,7 @@ function AgentEditorSheet({
   const nextPreview = useMemo(() => nextRunAt(schedule, tz), [schedule, tz]);
   const backendModels = useAgentModels(backend);
   const backendDefaultModel = useAgentDefaultModel(backend);
-  const supportsThinking = agentSupportsThinking(backend);
+  const supportsThinking = useAgentThinkingLevels(backend, model).length > 0;
 
   useEffect(() => {
     if (!backendModels.includes(model)) setModel(backendDefaultModel);
@@ -27583,6 +27608,7 @@ function BotEditorPage({
   const [rotationError, setRotationError] = useState(editing ? bot.rotationError : undefined);
   const models = useAgentModels(backend);
   const backendDefault = useAgentDefaultModel(backend);
+  const botThinkingLevels = useAgentThinkingLevels(backend, model);
   useEffect(() => {
     if (!models.includes(model)) setModel(backendDefault);
   }, [backendDefault, model, models]);
@@ -27625,7 +27651,7 @@ function BotEditorPage({
       persona: persona.trim(),
       agent: backend,
       model: model || undefined,
-      thinkingLevel: agentSupportsThinking(backend) ? thinkingLevel : undefined,
+      thinkingLevel: botThinkingLevels.length ? thinkingLevel : undefined,
       claudeAccountId: backend === "aisdk" ? livePin || null : null,
       cwd: cwd || undefined,
       enabled,


### PR DESCRIPTION
## Summary

- discover OpenCode model metadata with `opencode models --verbose`
- retain every model belonging to an authenticated OpenCode provider instead of dropping unknown provider families
- expose model-specific variants in the catalog and picker
- forward the selected variant on managed prompts, including live changes and scheduled/bot launches

## Root cause

The discovery process saw the Coding Plan models, but OpenCode curation only retained hard-coded provider families. Discovery also used non-verbose output, so model variants were unavailable, and the managed OpenCode backend explicitly rejected thinking-level selection.

## Verification

- `bun run test`: 2875 pass, 1 skip, 0 fail
- root TypeScript check: pass
- web TypeScript check: pass
- live self-hosted catalog: all six `zai-coding-plan/*` models present
- live managed session: `zai-coding-plan/glm-5.3` with variant `max` returned the expected response