### PR TITLE
feat(claude): recognize CLAUDE_CODE_OAUTH_TOKEN as a connected account

### DIFF
--- a/src/claude-accounts.test.ts
+++ b/src/claude-accounts.test.ts
@@ -16,6 +16,7 @@ import {
 describe("Claude account registry", () => {
   const originalHome = process.env.HOME;
   const originalStore = process.env.LFG_CLAUDE_ACCOUNTS_PATH;
+  const originalEnvToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
   let root = "";
 
   function connect(configDir: string, token: string): void {
@@ -43,6 +44,9 @@ describe("Claude account registry", () => {
     root = mkdtempSync(join(tmpdir(), "lfg-claude-accounts-"));
     process.env.HOME = join(root, "home");
     process.env.LFG_CLAUDE_ACCOUNTS_PATH = join(root, "data", "accounts.json");
+    // Every case here is about stored logins. The environment token would
+    // connect the default account and change what each list assertion sees.
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
   }
 
   afterEach(() => {
@@ -50,6 +54,8 @@ describe("Claude account registry", () => {
     else process.env.HOME = originalHome;
     if (originalStore === undefined) delete process.env.LFG_CLAUDE_ACCOUNTS_PATH;
     else process.env.LFG_CLAUDE_ACCOUNTS_PATH = originalStore;
+    if (originalEnvToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalEnvToken;
     if (root) rmSync(root, { recursive: true, force: true });
     root = "";
   });

--- a/src/claude-accounts.ts
+++ b/src/claude-accounts.ts
@@ -9,7 +9,11 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { PATHS } from "./config.ts";
-import { claudeOauthToken, claudeSignInIsDead } from "./claude-creds.ts";
+import {
+  claudeAccountUsesEnvToken,
+  claudeOauthToken,
+  claudeSignInIsDead,
+} from "./claude-creds.ts";
 
 export const DEFAULT_CLAUDE_ACCOUNT_ID = "default";
 
@@ -24,6 +28,12 @@ export type ClaudeAccount = {
    * say why rather than looking like an account that was never set up.
    */
   needsReconnect: boolean;
+  /**
+   * The credential is CLAUDE_CODE_OAUTH_TOKEN from the environment, not a login
+   * stored on this box. Nothing here can sign it out, and no browser sign-in
+   * was involved, so the row must not read as one.
+   */
+  fromEnv?: boolean;
   removable: boolean;
   createdAt: number;
 };
@@ -104,12 +114,14 @@ function defaultAccount(): StoredClaudeAccount {
 
 function publicAccount(account: StoredClaudeAccount): ClaudeAccount {
   const dead = claudeSignInIsDead(account.configDir);
+  const fromEnv = claudeAccountUsesEnvToken(account.configDir);
   return {
     id: account.id,
     number: account.number,
     label: account.label,
     connected: !dead && claudeOauthToken(account.configDir) !== null,
     needsReconnect: dead,
+    ...(fromEnv ? { fromEnv: true } : {}),
     removable: account.id !== DEFAULT_CLAUDE_ACCOUNT_ID,
     createdAt: account.createdAt,
   };

--- a/src/claude-creds-oauth-token-env.test.ts
+++ b/src/claude-creds-oauth-token-env.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CLAUDE_ENV_TOKEN_KEY,
+  claudeAccessToken,
+  claudeAccountEnv,
+  claudeAccountUsesEnvToken,
+  claudeOauthToken,
+  claudeSignInIsDead,
+  resetClaudeCredsCacheForTests,
+} from "./claude-creds.ts";
+
+// CLAUDE_CODE_OAUTH_TOKEN is what `claude setup-token` prints. The CLI accepts
+// it as a login, so LFG has to report the same account the CLI would use.
+describe("CLAUDE_CODE_OAUTH_TOKEN as a connected account", () => {
+  const originalHome = process.env.HOME;
+  const originalToken = process.env[CLAUDE_ENV_TOKEN_KEY];
+  let testHome = "";
+
+  // The real Keychain reader is not scoped to $HOME, so a signed-in macOS
+  // maintainer would otherwise see their own token in every assertion here.
+  const noKeychain = () => null;
+
+  const writeStoredLogin = (dir: string, accessToken: string) => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken,
+          refreshToken: "stored-refresh",
+          expiresAt: Date.now() + 3_600_000,
+        },
+      }),
+    );
+  };
+
+  beforeEach(() => {
+    resetClaudeCredsCacheForTests();
+    testHome = mkdtempSync(join(tmpdir(), "lfg-claude-env-token-"));
+    process.env.HOME = testHome;
+    delete process.env[CLAUDE_ENV_TOKEN_KEY];
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalToken === undefined) delete process.env[CLAUDE_ENV_TOKEN_KEY];
+    else process.env[CLAUDE_ENV_TOKEN_KEY] = originalToken;
+    if (testHome) rmSync(testHome, { recursive: true, force: true });
+    testHome = "";
+    resetClaudeCredsCacheForTests();
+  });
+
+  test("an empty box with the variable set reports a connected account", () => {
+    expect(claudeOauthToken(undefined, noKeychain)).toBeNull();
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "sk-ant-oat01-from-env";
+    expect(claudeOauthToken(undefined, noKeychain)).toBe("sk-ant-oat01-from-env");
+    expect(claudeAccountUsesEnvToken()).toBe(true);
+  });
+
+  test("whitespace alone is not a credential", () => {
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "   ";
+    expect(claudeOauthToken(undefined, noKeychain)).toBeNull();
+    expect(claudeAccountUsesEnvToken()).toBe(false);
+  });
+
+  test("the variable outranks a stored login, as it does for the CLI itself", () => {
+    writeStoredLogin(join(testHome, ".claude"), "from-file");
+    expect(claudeOauthToken(undefined, noKeychain)).toBe("from-file");
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "from-env";
+    expect(claudeOauthToken(undefined, noKeychain)).toBe("from-env");
+  });
+
+  test("an env-backed account is never reported as a dead sign-in", () => {
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "from-env";
+    expect(claudeSignInIsDead(undefined, noKeychain)).toBe(false);
+  });
+
+  test("an isolated account ignores the process-wide variable", () => {
+    const isolated = join(testHome, "accounts", "account-2");
+    mkdirSync(isolated, { recursive: true });
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "from-env";
+    expect(claudeOauthToken(isolated, noKeychain)).toBeNull();
+    expect(claudeAccountUsesEnvToken(isolated)).toBe(false);
+  });
+
+  test("the usage token comes from the variable with no refresh attempt", async () => {
+    process.env[CLAUDE_ENV_TOKEN_KEY] = "from-env";
+    expect(await claudeAccessToken()).toBe("from-env");
+  });
+});
+
+describe("claudeAccountEnv and the environment token", () => {
+  const original = process.env[CLAUDE_ENV_TOKEN_KEY];
+  afterEach(() => {
+    if (original === undefined) delete process.env[CLAUDE_ENV_TOKEN_KEY];
+    else process.env[CLAUDE_ENV_TOKEN_KEY] = original;
+  });
+
+  test("the default account keeps the variable, because it may be the credential", () => {
+    const env = claudeAccountEnv(
+      { PATH: "/usr/bin", [CLAUDE_ENV_TOKEN_KEY]: "from-env", ANTHROPIC_API_KEY: "platform" },
+      true,
+    );
+    expect(env).toEqual({ PATH: "/usr/bin", [CLAUDE_ENV_TOKEN_KEY]: "from-env" });
+  });
+
+  test("an isolated account drops the variable, or every account bills to one login", () => {
+    const env = claudeAccountEnv(
+      { PATH: "/usr/bin", [CLAUDE_ENV_TOKEN_KEY]: "from-env" },
+      true,
+      "/data/claude/account-2",
+    );
+    expect(env).toEqual({ PATH: "/usr/bin", CLAUDE_CONFIG_DIR: "/data/claude/account-2" });
+  });
+});

--- a/src/claude-creds.test.ts
+++ b/src/claude-creds.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  CLAUDE_ENV_TOKEN_KEY,
   claudeOauthToken,
   claudeSignInIsDead,
   resetClaudeCredsCacheForTests,
@@ -11,6 +12,7 @@ import {
 
 describe("Claude account credentials", () => {
   const originalHome = process.env.HOME;
+  const originalEnvToken = process.env[CLAUDE_ENV_TOKEN_KEY];
   let testHome = "";
 
   // Stand in for a machine with nothing in the Keychain. The real reader is not
@@ -21,11 +23,16 @@ describe("Claude account credentials", () => {
 
   beforeEach(() => {
     resetClaudeCredsCacheForTests();
+    // These cases are about the stored login. A maintainer with the variable
+    // exported would otherwise see it answer every read.
+    delete process.env[CLAUDE_ENV_TOKEN_KEY];
   });
 
   afterEach(() => {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
+    if (originalEnvToken === undefined) delete process.env[CLAUDE_ENV_TOKEN_KEY];
+    else process.env[CLAUDE_ENV_TOKEN_KEY] = originalEnvToken;
     if (testHome) rmSync(testHome, { recursive: true, force: true });
     testHome = "";
     resetClaudeCredsCacheForTests();

--- a/src/claude-creds.ts
+++ b/src/claude-creds.ts
@@ -43,6 +43,21 @@ export const CLAUDE_PLATFORM_ENV_KEYS = [
   "ANTHROPIC_BASE_URL",
 ] as const;
 
+/**
+ * The subscription OAuth token `claude setup-token` prints, read from the
+ * environment.
+ *
+ * This is a user login, so it counts as a connected account. That is why it is
+ * deliberately NOT in CLAUDE_PLATFORM_ENV_KEYS: those variables are stripped at
+ * the launch boundary precisely because an account is connected, and stripping
+ * this one would delete the credential that made the account connected.
+ *
+ * The value is never validated. The CLI does not validate it either — `claude
+ * auth status` reports a logged-in account for any non-empty string — so a bad
+ * token surfaces as a failing session, not as a disconnected account.
+ */
+export const CLAUDE_ENV_TOKEN_KEY = "CLAUDE_CODE_OAUTH_TOKEN";
+
 function defaultConfigDir(): string {
   return join(process.env.HOME ?? homedir(), ".claude");
 }
@@ -58,6 +73,22 @@ function readCredsFile(configDir = defaultConfigDir()): ClaudeCreds | null {
   } catch {
     return null;
   }
+}
+
+function envOauthToken(source: NodeJS.ProcessEnv = process.env): string | null {
+  return source[CLAUDE_ENV_TOKEN_KEY]?.trim() || null;
+}
+
+/**
+ * Whether the account at `configDir` is backed by the environment token rather
+ * than by a stored login.
+ *
+ * Only the default account can be: the variable is process-wide, and an
+ * isolated account is defined by its own config directory.
+ */
+export function claudeAccountUsesEnvToken(configDir?: string): boolean {
+  if (configDir && configDir !== defaultConfigDir()) return false;
+  return envOauthToken() !== null;
 }
 
 function readCredsKeychain(): ClaudeCreds | null {
@@ -103,8 +134,28 @@ export function claudeOauthToken(
  * tell "signed in" from "sign-in is dead" need the expiry and the refresh token
  * too, and reading the file twice through two slightly different code paths is
  * how those two answers drift apart.
+ *
+ * The environment token comes first for the default account, because that is
+ * the precedence the Claude CLI itself applies: a launched subprocess
+ * authenticates with CLAUDE_CODE_OAUTH_TOKEN whatever the credentials file
+ * holds. Reporting the stored login ahead of it would name an account that no
+ * session actually runs as.
  */
 export function claudeOauthRecord(
+  configDir?: string,
+  readKeychain: () => ClaudeCreds | null = readCredsKeychain,
+): ClaudeOauth | null {
+  if (claudeAccountUsesEnvToken(configDir)) {
+    // No refresh token and no expiry: this credential is renewed by whoever set
+    // the variable, not by us, so it can never be "dead" the way a stored one
+    // can.
+    return { accessToken: envOauthToken()! };
+  }
+  return storedOauthRecord(configDir, readKeychain);
+}
+
+/** File- or Keychain-backed record only. The environment token is not stored. */
+function storedOauthRecord(
   configDir?: string,
   readKeychain: () => ClaudeCreds | null = readCredsKeychain,
 ): ClaudeOauth | null {
@@ -383,6 +434,9 @@ async function refreshUnderLock(configDir: string): Promise<string | null> {
  */
 export async function claudeAccessToken(configDir?: string): Promise<string | null> {
   const dir = configDir ?? defaultConfigDir();
+  // Same precedence as claudeOauthRecord. An environment token also needs no
+  // refresh, so returning it here skips the whole lock-and-rotate path.
+  if (claudeAccountUsesEnvToken(configDir)) return envOauthToken();
   const creds = readCredsFile(dir);
   const oauth = creds?.claudeAiOauth;
   if (!oauth?.accessToken) return claudeOauthToken(configDir);
@@ -412,6 +466,12 @@ export function claudeAccountEnv(
 ): Record<string, string> | undefined {
   if (!accountConnected) return undefined;
   const blocked = new Set<string>(CLAUDE_PLATFORM_ENV_KEYS);
+  const isolated = !!configDir && configDir !== defaultConfigDir();
+  // An isolated account is defined by its config directory. CLAUDE_CODE_OAUTH_TOKEN
+  // is process-wide and takes precedence over that directory's credentials, so
+  // leaving it in place would run every account on one login. The default
+  // account keeps it: there it IS the credential.
+  if (isolated) blocked.add(CLAUDE_ENV_TOKEN_KEY);
   const env = Object.fromEntries(
     Object.entries(source).filter(
       (entry): entry is [string, string] =>

--- a/src/coding-agents.test.ts
+++ b/src/coding-agents.test.ts
@@ -812,6 +812,7 @@ describe("coding agent visibility", () => {
     setEnv("HOME", tmpHome);
     setEnv("PATH", tmpHome);
     setEnv("ANTHROPIC_API_KEY", undefined);
+    setEnv("CLAUDE_CODE_OAUTH_TOKEN", undefined);
     setEnv("OPENAI_API_KEY", undefined);
     setEnv("XAI_API_KEY", undefined);
     setEnv("CURSOR_API_KEY", undefined);

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -1340,9 +1340,11 @@ async function statusFor(kind: CodingAgentKind): Promise<CodingAgentStatus> {
     addAuth(
       "Claude auth",
       accountConnected || !!process.env.ANTHROPIC_API_KEY,
-      "use Login below or set ANTHROPIC_API_KEY",
+      "use Login below, or set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY",
     );
-    instructions.push("Add Claude accounts below, or set ANTHROPIC_API_KEY.");
+    instructions.push(
+      "Add Claude accounts below, or set CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token`, or set ANTHROPIC_API_KEY.",
+    );
   } else if (kind === "codex" || kind === "codex-aisdk") {
     accountConnected = await hasCodexAccountAuth();
     addBinary("Codex CLI", codexPath());

--- a/src/tmux-claude-env.test.ts
+++ b/src/tmux-claude-env.test.ts
@@ -32,4 +32,20 @@ describe("Claude account launch environment", () => {
       ...command,
     ]);
   });
+
+  // CLAUDE_CODE_OAUTH_TOKEN is process-wide and outranks the config directory,
+  // so an isolated account that inherited it would run on the wrong login.
+  test("removes the environment token for an isolated account", () => {
+    const argv = claudeAccountLaunchCommand(["claude"], true, "/data/claude/account-2");
+    expect(argv).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(argv.indexOf("CLAUDE_CODE_OAUTH_TOKEN")).toBeGreaterThan(0);
+    expect(argv[argv.indexOf("CLAUDE_CODE_OAUTH_TOKEN") - 1]).toBe("-u");
+  });
+
+  // The default account may BE the environment token. Unsetting it there would
+  // delete the credential that made the account connected.
+  test("keeps the environment token for the default account", () => {
+    const argv = claudeAccountLaunchCommand(["claude"], true);
+    expect(argv).not.toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
 });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { reposRoot } from "./projects";
 import { OMG_CAPABILITY_VERSION, withOmgRuntimeContract } from "./omg-capabilities.ts";
 import {
+  CLAUDE_ENV_TOKEN_KEY,
   CLAUDE_PLATFORM_ENV_KEYS,
   claudeOauthToken,
 } from "./claude-creds.ts";
@@ -298,7 +299,11 @@ export function claudeAccountLaunchCommand(
   return [
     envBin,
     ...CLAUDE_PLATFORM_ENV_KEYS.flatMap((key) => ["-u", key]),
-    ...(configDir ? [`CLAUDE_CONFIG_DIR=${configDir}`] : []),
+    // configDir is set only for an isolated account. CLAUDE_CODE_OAUTH_TOKEN is
+    // process-wide and outranks that directory, so it has to go with it or every
+    // account runs on one login. The default account keeps the variable, where
+    // it may be the credential itself.
+    ...(configDir ? ["-u", CLAUDE_ENV_TOKEN_KEY, `CLAUDE_CONFIG_DIR=${configDir}`] : []),
     ...command,
   ];
 }

--- a/src/usage-providers.test.ts
+++ b/src/usage-providers.test.ts
@@ -9,6 +9,7 @@ describe("usage providers", () => {
   const originalHome = process.env.HOME;
   const originalStore = process.env.LFG_CLAUDE_ACCOUNTS_PATH;
   const originalFetch = globalThis.fetch;
+  const originalEnvToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
   let root = "";
 
   function connect(configDir: string, token: string): void {
@@ -46,6 +47,9 @@ describe("usage providers", () => {
     root = mkdtempSync(join(tmpdir(), "lfg-usage-providers-"));
     process.env.HOME = join(root, "home");
     process.env.LFG_CLAUDE_ACCOUNTS_PATH = join(root, "data", "accounts.json");
+    // The default account is asserted to use "token-one". The environment token
+    // outranks the stored file, so it would answer for that account instead.
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     connect(join(process.env.HOME, ".claude"), "token-one");
     const second = createClaudeAccount();
     connect(claudeAccountConfigDir(second.id)!, "token-two");
@@ -58,6 +62,8 @@ describe("usage providers", () => {
     else process.env.HOME = originalHome;
     if (originalStore === undefined) delete process.env.LFG_CLAUDE_ACCOUNTS_PATH;
     else process.env.LFG_CLAUDE_ACCOUNTS_PATH = originalStore;
+    if (originalEnvToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    else process.env.CLAUDE_CODE_OAUTH_TOKEN = originalEnvToken;
     if (root) rmSync(root, { recursive: true, force: true });
     root = "";
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -607,6 +607,11 @@ export type ClaudeAccountInfo = {
   connected: boolean;
   /** Stored sign-in is dead and only a browser login can revive it. */
   needsReconnect?: boolean;
+  /**
+   * Credential is CLAUDE_CODE_OAUTH_TOKEN from the environment. It outranks any
+   * stored login, so a browser sign-in cannot change what this account uses.
+   */
+  fromEnv?: boolean;
   removable: boolean;
   createdAt: number;
 };

--- a/web/src/views/coding-agents-page.tsx
+++ b/web/src/views/coding-agents-page.tsx
@@ -367,6 +367,14 @@ export default function CodingAgentsPage({
                             Sign-in expired
                           </span>
                         ) : null}
+                        {/* The variable outranks any stored login, so the row
+                            has to name it. Otherwise this reads as a browser
+                            sign-in that the user never made. */}
+                        {account.fromEnv ? (
+                          <span className="block truncate text-[11px] text-muted-foreground">
+                            From CLAUDE_CODE_OAUTH_TOKEN
+                          </span>
+                        ) : null}
                       </span>
                       {account.connected ? (
                         <>
@@ -374,16 +382,21 @@ export default function CodingAgentsPage({
                           {/* Signing in again is the only repair for an account
                               whose token the CLI can no longer renew, so the
                               action stays reachable while it reads Connected —
-                              a row that can only be deleted is a dead end. */}
-                          <button
-                            type="button"
-                            onClick={() => onLogin(agent.key, account.id)}
-                            title={`Sign in to ${account.label} again`}
-                            aria-label={`Sign in to ${account.label} again`}
-                            className="flex size-7 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground"
-                          >
-                            <RotateCcw className="size-3.5" />
-                          </button>
+                              a row that can only be deleted is a dead end.
+                              An env-backed account is the exception: the
+                              variable wins over whatever a browser login
+                              stores, so the button could not change anything. */}
+                          {account.fromEnv ? null : (
+                            <button
+                              type="button"
+                              onClick={() => onLogin(agent.key, account.id)}
+                              title={`Sign in to ${account.label} again`}
+                              aria-label={`Sign in to ${account.label} again`}
+                              className="flex size-7 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                            >
+                              <RotateCcw className="size-3.5" />
+                            </button>
+                          )}
                         </>
                       ) : (
                         <Button


### PR DESCRIPTION
A box authenticated only through CLAUDE_CODE_OAUTH_TOKEN reported the default Claude account as disconnected, and the Coding Agents page asked the user to log in again. The Claude CLI treats that variable as a login, so a session launched from such a box worked while the UI insisted no account existed. Read the same credential the CLI reads.

Credential resolution (src/claude-creds.ts):

- Add CLAUDE_ENV_TOKEN_KEY and claudeAccountUsesEnvToken(). Only the default account can be env-backed: the variable is process-wide, and an isolated account is defined by its own config directory.
- claudeOauthRecord() checks the environment first for the default account and returns a record with no refresh token and no expiry. That mirrors the CLI's own precedence, where a launched subprocess authenticates with the variable whatever the credentials file holds. Reporting the stored login ahead of it would name an account no session actually runs as. It also means claudeSignInIsDead() is false for an env-backed account: nothing here can renew or kill a credential that someone else set.
- The stored file and Keychain path moves to storedOauthRecord(), so the two answers keep reading through one code path.
- claudeAccessToken() takes the same precedence and skips the whole lock-and-rotate path, because an environment token needs no refresh.
- An empty or whitespace-only value is not a credential.
- The key is deliberately NOT in CLAUDE_PLATFORM_ENV_KEYS. Those keys are stripped at the launch boundary precisely because an account is connected, and stripping this one would delete the credential that made the account connected.

Account isolation (src/claude-creds.ts, src/tmux.ts):

- claudeAccountEnv() and claudeAccountLaunchCommand() unset the variable for an isolated account. It outranks CLAUDE_CONFIG_DIR, so an inherited value would run every account on one login and bill it there. The default account keeps it, where it may be the credential.

Surfacing (src/claude-accounts.ts, web/):

- The public account record carries fromEnv, and the row reads "From CLAUDE_CODE_OAUTH_TOKEN".
- The re-login button is hidden for an env-backed account. The variable wins over whatever a browser sign-in stores, so the button could not change what the account uses.
- The Claude setup instruction now names CLAUDE_CODE_OAUTH_TOKEN alongside ANTHROPIC_API_KEY.

Tests:

- New src/claude-creds-oauth-token-env.test.ts covers connection from an empty box, whitespace rejection, precedence over a stored login, the never-dead sign-in, isolated-account rejection, the usage token, and both claudeAccountEnv() cases.
- src/tmux-claude-env.test.ts asserts the launch argv unsets the variable for an isolated account and keeps it for the default one.
- Existing suites that assert on stored logins now clear the variable in setup. Without that, a maintainer with it exported sees it answer reads those cases attribute to a file.

The value is never validated, and the CLI does not validate it either, so a bad token surfaces as a failing session rather than a disconnected account.

Verification: focused suites pass (claude-creds, claude-creds-oauth-token-env, claude-accounts, tmux-claude-env, coding-agents, usage-providers); root and web type checks are clean. The full suite has three unrelated failures: two in session-usage.test.ts need `systemd-run --user`, which has no bus in this container, and one load-sensitive timeout in session-files.test.ts that passes in isolation.