### PR TITLE
fix(sessions): title codex exec sessions by their real prompt

### DIFF
--- a/src/codex-exec-first-prompt.test.ts
+++ b/src/codex-exec-first-prompt.test.ts
@@ -1,0 +1,119 @@
+// `codex exec` rollouts carry no `user_message` event. The prompt a
+// non-interactive run was given is written only as a `response_item` with
+// role "user", and the rollout head scan used to ignore those — so every
+// exec session fell back to `basename(cwd)` and a batch of runs in one
+// directory produced N identical, unidentifiable rows in the roster and in
+// resume history.
+//
+// These tests pin both halves of the contract: the interactive
+// `user_message` event still wins, and the exec fallback picks the real
+// prompt rather than the synthetic wrapper blocks codex injects ahead of it.
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { firstUserTextFromTop } from "./sessions.ts";
+
+const roots: string[] = [];
+
+function rollout(lines: unknown[]): string {
+  const root = mkdtempSync(join(tmpdir(), "omg-codex-exec-"));
+  roots.push(root);
+  const path = join(root, "rollout.jsonl");
+  writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return path;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const meta = (source: string) => ({
+  timestamp: "2026-01-02T03:04:05.000Z",
+  type: "session_meta",
+  payload: {
+    id: "00000000-0000-4000-8000-000000000000",
+    cwd: "/home/dev/repos/vibes",
+    originator: source === "exec" ? "codex_exec" : "codex_cli_rs",
+    source,
+  },
+});
+
+const userItem = (text: string) => ({
+  timestamp: "2026-01-02T03:04:06.000Z",
+  type: "response_item",
+  payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+});
+
+const developerItem = (text: string) => ({
+  timestamp: "2026-01-02T03:04:06.000Z",
+  type: "response_item",
+  payload: { type: "message", role: "developer", content: [{ type: "input_text", text }] },
+});
+
+const userEvent = (message: string) => ({
+  timestamp: "2026-01-02T03:04:07.000Z",
+  type: "event_msg",
+  payload: { type: "user_message", message },
+});
+
+const RECOMMENDED_PLUGINS =
+  "<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n</recommended_plugins>";
+
+describe("first user prompt of a codex rollout", () => {
+  test("an interactive rollout still reads its user_message event", async () => {
+    const path = rollout([
+      meta("cli"),
+      developerItem("You are Codex, an agent based on GPT-5."),
+      userEvent("Rename the deploy script"),
+    ]);
+    expect(await firstUserTextFromTop(path)).toBe("Rename the deploy script");
+  });
+
+  test("a user_message event wins over an earlier response_item user turn", async () => {
+    // The two coexist in interactive rollouts: codex records the turn once as
+    // an event and again as a request item. The event is the canonical one and
+    // must keep winning, or the fallback would quietly change existing titles.
+    const path = rollout([
+      meta("cli"),
+      userItem("Human: raw request-item copy"),
+      userEvent("Rename the deploy script"),
+    ]);
+    expect(await firstUserTextFromTop(path)).toBe("Rename the deploy script");
+  });
+
+  test("a codex exec rollout falls back to its request-item prompt", async () => {
+    const path = rollout([
+      meta("exec"),
+      developerItem("You are Codex, an agent based on GPT-5."),
+      userItem(RECOMMENDED_PLUGINS),
+      userItem("Generate one photorealistic hero image for the kitchen page"),
+    ]);
+    expect(await firstUserTextFromTop(path)).toBe(
+      "Generate one photorealistic hero image for the kitchen page",
+    );
+  });
+
+  test("synthetic wrapper blocks never become the title", async () => {
+    for (const block of [
+      RECOMMENDED_PLUGINS,
+      "<environment_context>\n  <current_date>2026-01-02</current_date>\n</environment_context>",
+      "<user_instructions>\nRepository guidance.\n</user_instructions>",
+      "<plugins>\n  <plugin>example</plugin>\n</plugins>",
+      "<skill>\n<name>imagegen</name>\n</skill>",
+    ]) {
+      const path = rollout([meta("exec"), userItem(block)]);
+      expect(await firstUserTextFromTop(path)).toBeNull();
+    }
+  });
+
+  test("the exec prompt is trimmed and keeps its conversation prefix stripped", async () => {
+    const path = rollout([meta("exec"), userItem("  Human: Ship the changelog\n\n")]);
+    expect(await firstUserTextFromTop(path)).toBe("Ship the changelog");
+  });
+
+  test("a rollout with no user turn at all stays null so the caller can fall back", async () => {
+    const path = rollout([meta("exec"), developerItem("You are Codex.")]);
+    expect(await firstUserTextFromTop(path)).toBeNull();
+  });
+});

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1587,15 +1587,55 @@ async function codexThreads(opts?: { sinceMs?: number }): Promise<CodexThread[]>
   return out;
 }
 
-async function firstUserTextFromTop(path: string): Promise<string | null> {
+// Synthetic user turns codex writes ahead of the real prompt. They are
+// role "user" request items, so the exec fallback below has to look past them
+// or every non-interactive session would be titled "recommended_plugins".
+// Only tags observed in real rollouts (and in the codex binary's own strings)
+// are listed; this is deliberately not a catch-all for "starts with a tag",
+// because a genuine prompt may well open with markup.
+const CODEX_SYNTHETIC_USER_BLOCK =
+  /^<(?:recommended_plugins|environment_context|user_instructions|plugins|skill)[\s>]/;
+
+/**
+ * The prompt a codex rollout was started with, read from its head.
+ *
+ * Interactive runs record it as an `event_msg`/`user_message`, which is the
+ * canonical form and stays the primary source. `codex exec` never emits that
+ * event: its only user turn is a `response_item` message with role "user",
+ * which normalizeCodexLine drops (request items duplicate the conversation).
+ * Without the fallback every exec rollout returned null and the caller titled
+ * it `basename(cwd)` — so a batch of exec runs in one directory showed up as N
+ * identical, unidentifiable rows in the roster and in resume history.
+ */
+export async function firstUserTextFromTop(path: string): Promise<string | null> {
   try {
     const text = await Bun.file(path).slice(0, 256 * 1024).text();
+    let requestItemPrompt: string | null = null;
     for (const line of text.split("\n")) {
       const m = normalizeCodexLine(line);
       if (m?.role === "user" && m.kind === "text") return m.text.trim();
+      if (requestItemPrompt === null) requestItemPrompt = codexRequestItemUserText(line);
     }
+    return requestItemPrompt;
   } catch {}
   return null;
+}
+
+function codexRequestItemUserText(line: string): string | null {
+  // Cheap reject before a second JSON.parse of the same line: only user turns
+  // can match, and the head scan runs over every rollout on the box.
+  if (!line.includes('"user"')) return null;
+  let x: { type?: string; payload?: { type?: string; role?: string; content?: unknown } };
+  try {
+    x = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  const p = x.payload;
+  if (x.type !== "response_item" || p?.type !== "message" || p.role !== "user") return null;
+  const text = stripConversationPrefix(codexContentText(p.content).trim()).trim();
+  if (!text || CODEX_SYNTHETIC_USER_BLOCK.test(text)) return null;
+  return text;
 }
 
 function codexPromptFromCmd(cmd: string): string | null {


### PR DESCRIPTION
## What breaks

Every session created by `codex exec` shows up in the Live roster and in Resume
history with the name of its working directory. Run a batch of eight `codex exec`
calls in one repo and you get eight identical rows called `my-repo` — nothing to
tell them apart.

## Why

`firstUserTextFromTop()` in `src/sessions.ts` scans the head of a rollout through
`normalizeCodexLine()`, which only accepts a user turn from an
`event_msg` line of type `user_message`. Interactive codex sessions write that
event; `codex exec` does not. A non-interactive run records its prompt only as a
`response_item` message with `role: "user"`, and `normalizeCodexLine` deliberately
drops role user/developer/system request items because they duplicate the
conversation.

So `firstUserText` is `null` for every exec rollout, and the call sites fall back
to `title = cwd ? basename(cwd) : project`.

### The wrinkle

Recent codex versions (verified on codex-cli 0.149.0) inject synthetic user turns
ahead of the real prompt, so a naive fallback titles every exec session
`recommended_plugins`. Across 763 rollouts on one box, the leading tags actually
seen on request-item user turns were `<recommended_plugins>` (728),
`<skill>` (10) and `<environment_context>` (2); `<user_instructions>` and
`<plugins>` appear in the codex binary's own strings.

## Fix

`user_message` events stay the primary and preferred source — nothing changes for
interactive sessions. Only when the head contains no such event does the scan fall
back to the first request-item user turn, skipping the known synthetic wrapper
blocks. The match is an explicit tag list rather than "starts with a tag", since a
real prompt may well open with markup.

Cost is unchanged in practice: the same 256 KB head, one cheap substring reject
before a line is parsed a second time, and the fallback candidate is only kept
until a `user_message` event is found.

## Before / after

| | Before | After |
|---|---|---|
| Interactive session | first prompt | first prompt (unchanged) |
| `codex exec` session | `my-repo` | `Generate one photorealistic hero image…` |
| 8 exec runs in one dir | 8 rows named `my-repo` | 8 distinct prompts |

Replayed over a real history of 763 rollouts: rollouts with a usable title go from
584 to 733, and 0 of them are titled after a synthetic block.

## Tests

New `src/codex-exec-first-prompt.test.ts` builds fixture rollouts in a temp dir
(no machine-local files) and pins both halves of the contract: the `user_message`
event still wins, including when a request-item user turn appears earlier in the
file; an exec rollout resolves to its real prompt; each synthetic wrapper block
resolves to `null` so the caller can still fall back; trimming and the existing
conversation-prefix stripping are preserved.

Red before the change (2 failures), green after. `firstUserTextFromTop` is
exported so the test can drive real behavior instead of asserting on source text.

```
bun test src/codex-exec-first-prompt.test.ts   6 pass, 0 fail
bun run test                                   2985 pass, 1 skip, 0 fail (351 files)
bun run typecheck                              clean
```
