### PR TITLE
feat(web): mark a chat unread when it lands a turn you have not read

### DIFF
--- a/src/bots/unread.ts
+++ b/src/bots/unread.ts
@@ -1,6 +1,10 @@
-import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { PATHS } from "../config.ts";
+import {
+  createReadWatermarkStore,
+  readWatermarkUser,
+  type ReadWatermark,
+} from "../read-watermarks.ts";
 import type { Bot } from "./store.ts";
 
 export type BotConversationOwnerRow = {
@@ -9,50 +13,12 @@ export type BotConversationOwnerRow = {
   assignedUser?: string | null;
 };
 
-export type BotConversationRead = {
-  user: string;
-  sessionId: string;
-  readThroughRowid: number;
-  updatedAt: number;
-};
+export type BotConversationRead = ReadWatermark;
 
-type ReadFile = { version: 1; reads: BotConversationRead[] };
-
-const LOCAL_USER = "__local__";
-const path = () => join(PATHS.data, "bots", "conversation-reads.json");
+const store = createReadWatermarkStore(() => join(PATHS.data, "bots", "conversation-reads.json"));
 
 export function botReadUser(user: string | null | undefined): string {
-  return user?.trim().toLowerCase() || LOCAL_USER;
-}
-
-function readFile(): ReadFile {
-  try {
-    const parsed = JSON.parse(readFileSync(path(), "utf8")) as Partial<ReadFile>;
-    return parsed.version === 1 && Array.isArray(parsed.reads)
-      ? { version: 1, reads: parsed.reads }
-      : { version: 1, reads: [] };
-  } catch {
-    return { version: 1, reads: [] };
-  }
-}
-
-function writeFile(value: ReadFile): void {
-  const target = path();
-  const dir = dirname(target);
-  mkdirSync(dir, { recursive: true });
-  const temp = `${target}.${process.pid}.${crypto.randomUUID()}.tmp`;
-  writeFileSync(temp, JSON.stringify(value, null, 2), { mode: 0o600 });
-  try {
-    const fd = openSync(temp, "r");
-    try { fsyncSync(fd); } finally { closeSync(fd); }
-    renameSync(temp, target);
-    try {
-      const dirFd = openSync(dir, "r");
-      try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
-    } catch {}
-  } finally {
-    try { unlinkSync(temp); } catch {}
-  }
+  return readWatermarkUser(user);
 }
 
 export function conversationOwner(
@@ -72,10 +38,7 @@ export function conversationOwner(
 }
 
 export function conversationUnread(user: string, sessionId: string, latestAssistantRowid: number | null): boolean {
-  if (latestAssistantRowid == null) return false;
-  const key = botReadUser(user);
-  const read = readFile().reads.find((row) => row.user === key && row.sessionId === sessionId);
-  return !read || latestAssistantRowid > read.readThroughRowid;
+  return store.unread(user, sessionId, latestAssistantRowid);
 }
 
 export function markBotConversationRead(
@@ -84,18 +47,7 @@ export function markBotConversationRead(
   latestAssistantRowid: number | null,
   now = Date.now(),
 ): BotConversationRead {
-  const key = botReadUser(user);
-  const file = readFile();
-  const prior = file.reads.find((row) => row.user === key && row.sessionId === sessionId);
-  const next: BotConversationRead = {
-    user: key,
-    sessionId,
-    readThroughRowid: Math.max(prior?.readThroughRowid ?? 0, latestAssistantRowid ?? 0),
-    updatedAt: now,
-  };
-  file.reads = [...file.reads.filter((row) => !(row.user === key && row.sessionId === sessionId)), next];
-  writeFile(file);
-  return next;
+  return store.mark(user, sessionId, latestAssistantRowid, now);
 }
 
 /** Seed the rollout baseline once, so upgrading does not mark old bot history unread. */
@@ -105,9 +57,5 @@ export function ensureBotConversationReadBaseline(
   latestAssistantRowid: number | null,
   now = Date.now(),
 ): void {
-  const key = botReadUser(user);
-  const file = readFile();
-  if (file.reads.some((row) => row.user === key && row.sessionId === sessionId)) return;
-  file.reads.push({ user: key, sessionId, readThroughRowid: latestAssistantRowid ?? 0, updatedAt: now });
-  writeFile(file);
+  store.ensureBaseline(user, sessionId, latestAssistantRowid, now);
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -240,6 +240,7 @@ import {
   type Session,
   type SessionMsg,
 } from "../sessions.ts";
+import { markSessionRead, sessionUnreadMap } from "../session-reads.ts";
 import { countTranscriptRows } from "../transcript-rows.ts";
 import {
   invalidateListSessionsCache,
@@ -1086,6 +1087,26 @@ function withAutoAgentListMeta<T extends { id: string; cwd?: string; prompt?: st
 export function sessionListRow(session: Session): Omit<Session, "cmd"> {
   const { cmd: _dropped, ...row } = session;
   return row;
+}
+
+/**
+ * Stamp per-viewer read state onto a fleet payload.
+ *
+ * Deliberately not inside listSessions(): that answer is cached and shared by
+ * everyone on the box, while "have you read this" is one person's question. The
+ * flag is stated on every row, including the false ones, because a client
+ * cannot tell "read" from "this server does not answer that" when the key is
+ * simply absent.
+ */
+function withSessionUnread<T extends { sessionId: string | null }>(
+  identity: string,
+  rows: T[],
+): (T & { unread: boolean })[] {
+  const unread = sessionUnreadMap(
+    identity,
+    rows.map((row) => row.sessionId).filter((id): id is string => !!id),
+  );
+  return rows.map((row) => ({ ...row, unread: !!unread.get(row.sessionId ?? "") }));
 }
 
 function repoRootForManagedCwd(cwd: string): string | undefined {
@@ -4732,7 +4753,9 @@ a{color:#60a5fa}
             codingAgents: boot.codingAgents ?? null,
             models: boot.models ?? null,
             settings: boot.settings ?? null,
-            sessions: boot.sessions ? boot.sessions.map(sessionListRow) : null,
+            sessions: boot.sessions
+              ? withSessionUnread(viewer.identity, boot.sessions.map(sessionListRow))
+              : null,
             sessionPins: boot.sessionPins ?? null,
             conversations: boot.conversations ?? null,
             // Not an authorization signal — never gates what the UI is allowed
@@ -7178,10 +7201,31 @@ a{color:#60a5fa}
         // ADDITIVE ON PURPOSE. An older host ignores the extra field, and a
         // newer host reading an older box sees `undefined` and falls back to
         // exactly today's behaviour. Neither side needs to ship first.
+        // `botViewerFromRequest` is the existing resolver for whose read state
+        // this is — its `identity` is documented as "which unread watermark to
+        // read and write" — and nothing about it is bot-specific.
+        const identity = botViewerFromRequest(req, url.searchParams.get("user")).identity;
         return json({
-          sessions: full ? sessions : sessions.map(sessionListRow),
+          sessions: withSessionUnread(
+            identity,
+            full ? sessions : sessions.map(sessionListRow),
+          ),
           pendingLogins: pendingCodingAgentLogins(),
         });
+      }
+
+      // Mark one session read through its newest assistant turn. The roster
+      // calls this when the session is opened; the row's own menu calls it for
+      // a row you have decided you do not need to open.
+      {
+        const match = path.match(/^\/api\/sessions\/([^/]+)\/read$/);
+        if (match && req.method === "POST") {
+          const sessionId = decodeURIComponent(match[1]);
+          const body = (await req.json().catch(() => null)) as { user?: unknown } | null;
+          const requested = typeof body?.user === "string" ? body.user : url.searchParams.get("user");
+          const viewer = botViewerFromRequest(req, requested);
+          return json({ ok: true, ...markSessionRead(viewer.identity, sessionId) });
+        }
       }
 
       if (path === "/api/install") {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1097,8 +1097,19 @@ export function sessionListRow(session: Session): Omit<Session, "cmd"> {
  * flag is stated on every row, including the false ones, because a client
  * cannot tell "read" from "this server does not answer that" when the key is
  * simply absent.
+ *
+ * A working session never reports unread. The mark answers "this one is ready
+ * for you", and a session mid-turn is not: it sends a person into a transcript
+ * that is still being written. Nothing is lost by holding it back, because
+ * unread is derived from the watermark on every list call — the moment the
+ * session settles, the same comparison reports it again. That is what makes
+ * this different from a bot conversation, where read state belongs to a
+ * conversation you are having rather than to work becoming available.
+ *
+ * One owner, because the roster row and the Chat tab both read this. Deciding
+ * it per consumer is how a tab comes to claim an unread chat that no row shows.
  */
-function withSessionUnread<T extends { sessionId: string | null }>(
+function withSessionUnread<T extends { sessionId: string | null; busy?: boolean }>(
   identity: string,
   rows: T[],
 ): (T & { unread: boolean })[] {
@@ -1106,7 +1117,10 @@ function withSessionUnread<T extends { sessionId: string | null }>(
     identity,
     rows.map((row) => row.sessionId).filter((id): id is string => !!id),
   );
-  return rows.map((row) => ({ ...row, unread: !!unread.get(row.sessionId ?? "") }));
+  return rows.map((row) => ({
+    ...row,
+    unread: !row.busy && !!unread.get(row.sessionId ?? ""),
+  }));
 }
 
 function repoRootForManagedCwd(cwd: string): string | undefined {

--- a/src/read-watermarks.ts
+++ b/src/read-watermarks.ts
@@ -1,0 +1,126 @@
+// One durable "read through here" mark per person, per conversation.
+//
+// This is the storage half of `src/bots/unread.ts`, lifted out so the coding
+// session roster can use the same model instead of inventing a second one. The
+// bot half kept the bot-specific resolution (which bot owns a conversation,
+// whose watermark that is); everything below is only "remember a rowid".
+//
+// The cursor is a transcript rowid, not a timestamp. `src/transcript-index.ts`
+// owns the message table, so its rowid is the one ordering both sides already
+// agree on, and it does not move when a clock does.
+
+import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export type ReadWatermark = {
+  user: string;
+  sessionId: string;
+  readThroughRowid: number;
+  updatedAt: number;
+};
+
+type WatermarkFile = { version: 1; reads: ReadWatermark[] };
+
+/** The single-user install has no roster identity to key on. */
+export const LOCAL_READ_USER = "__local__";
+
+export function readWatermarkUser(user: string | null | undefined): string {
+  return user?.trim().toLowerCase() || LOCAL_READ_USER;
+}
+
+export type ReadWatermarkStore = {
+  /** True when `latestRowid` is past what this user has read. */
+  unread(user: string, sessionId: string, latestRowid: number | null): boolean;
+  /** Advance the mark. Never moves it backwards. */
+  mark(user: string, sessionId: string, latestRowid: number | null, now?: number): ReadWatermark;
+  /** Write a first mark only when none exists, so history does not become unread on upgrade. */
+  ensureBaseline(user: string, sessionId: string, latestRowid: number | null, now?: number): void;
+  /** The mark itself, for callers that compare several conversations at once. */
+  readThrough(user: string, sessionId: string): number | null;
+  /** Every mark this user holds, keyed by conversation. */
+  readThroughAll(user: string): Map<string, number>;
+};
+
+/**
+ * A watermark file at `path()`.
+ *
+ * The path is a thunk because `PATHS.data` is resolved from the environment at
+ * call time; taking a string here would freeze the data directory at import.
+ */
+export function createReadWatermarkStore(path: () => string): ReadWatermarkStore {
+  function readFile(): WatermarkFile {
+    try {
+      const parsed = JSON.parse(readFileSync(path(), "utf8")) as Partial<WatermarkFile>;
+      return parsed.version === 1 && Array.isArray(parsed.reads)
+        ? { version: 1, reads: parsed.reads }
+        : { version: 1, reads: [] };
+    } catch {
+      return { version: 1, reads: [] };
+    }
+  }
+
+  function writeFile(value: WatermarkFile): void {
+    const target = path();
+    const dir = dirname(target);
+    mkdirSync(dir, { recursive: true });
+    const temp = `${target}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    writeFileSync(temp, JSON.stringify(value, null, 2), { mode: 0o600 });
+    try {
+      const fd = openSync(temp, "r");
+      try { fsyncSync(fd); } finally { closeSync(fd); }
+      renameSync(temp, target);
+      try {
+        const dirFd = openSync(dir, "r");
+        try { fsyncSync(dirFd); } finally { closeSync(dirFd); }
+      } catch {}
+    } finally {
+      try { unlinkSync(temp); } catch {}
+    }
+  }
+
+  function find(reads: ReadWatermark[], user: string, sessionId: string): ReadWatermark | undefined {
+    return reads.find((row) => row.user === user && row.sessionId === sessionId);
+  }
+
+  return {
+    unread(user, sessionId, latestRowid) {
+      if (latestRowid == null) return false;
+      const key = readWatermarkUser(user);
+      const read = find(readFile().reads, key, sessionId);
+      return !read || latestRowid > read.readThroughRowid;
+    },
+    mark(user, sessionId, latestRowid, now = Date.now()) {
+      const key = readWatermarkUser(user);
+      const file = readFile();
+      const prior = find(file.reads, key, sessionId);
+      const next: ReadWatermark = {
+        user: key,
+        sessionId,
+        readThroughRowid: Math.max(prior?.readThroughRowid ?? 0, latestRowid ?? 0),
+        updatedAt: now,
+      };
+      file.reads = [...file.reads.filter((row) => !(row.user === key && row.sessionId === sessionId)), next];
+      writeFile(file);
+      return next;
+    },
+    ensureBaseline(user, sessionId, latestRowid, now = Date.now()) {
+      const key = readWatermarkUser(user);
+      const file = readFile();
+      if (find(file.reads, key, sessionId)) return;
+      file.reads.push({ user: key, sessionId, readThroughRowid: latestRowid ?? 0, updatedAt: now });
+      writeFile(file);
+    },
+    readThrough(user, sessionId) {
+      const read = find(readFile().reads, readWatermarkUser(user), sessionId);
+      return read ? read.readThroughRowid : null;
+    },
+    readThroughAll(user) {
+      const key = readWatermarkUser(user);
+      const out = new Map<string, number>();
+      for (const row of readFile().reads) {
+        if (row.user === key) out.set(row.sessionId, row.readThroughRowid);
+      }
+      return out;
+    },
+  };
+}

--- a/src/session-reads.test.ts
+++ b/src/session-reads.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import {
+  ensureSessionReadBaseline,
+  markSessionRead,
+  sessionUnread,
+  sessionUnreadMap,
+} from "./session-reads.ts";
+import {
+  indexSessionMessagesDirect,
+  latestIndexedAssistantRowids,
+  maxIndexedMessageRowid,
+} from "./transcript-index.ts";
+
+const originalData = PATHS.data;
+let root = "";
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "omg-session-reads-"));
+  PATHS.data = root;
+});
+
+afterEach(() => {
+  PATHS.data = originalData;
+  rmSync(root, { recursive: true, force: true });
+});
+
+const assistant = (id: string, text = id) => ({
+  id,
+  role: "assistant" as const,
+  kind: "text" as const,
+  text,
+  ts: Date.now(),
+});
+const human = (id: string, text = id) => ({
+  id,
+  role: "user" as const,
+  kind: "text" as const,
+  text,
+  ts: Date.now(),
+});
+
+const VIEWER = "owner@example.com";
+
+describe("session read watermarks", () => {
+  test("a turn that lands after the baseline is unread until it is marked", () => {
+    ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-a", [assistant("reply")]);
+
+    expect(sessionUnread(VIEWER, "session-a")).toBe(true);
+    markSessionRead(VIEWER, "session-a");
+    expect(sessionUnread(VIEWER, "session-a")).toBe(false);
+  });
+
+  test("your own prompt is not unread activity", () => {
+    ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-b", [human("mine")]);
+
+    expect(sessionUnread(VIEWER, "session-b")).toBe(false);
+  });
+
+  test("a reply that arrives after you read stays unread again", () => {
+    ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-c", [assistant("first")]);
+    markSessionRead(VIEWER, "session-c");
+    expect(sessionUnread(VIEWER, "session-c")).toBe(false);
+
+    indexSessionMessagesDirect("session-c", [assistant("second")]);
+    expect(sessionUnread(VIEWER, "session-c")).toBe(true);
+  });
+
+  test("history indexed before the baseline never becomes unread", () => {
+    // The archive exists first, exactly as it does on a box that upgrades into
+    // this feature. Nothing already written may light up.
+    indexSessionMessagesDirect("session-old", [assistant("last march")]);
+    ensureSessionReadBaseline(VIEWER);
+
+    expect(sessionUnread(VIEWER, "session-old")).toBe(false);
+  });
+
+  test("the baseline is written once and does not move on later reads", () => {
+    const first = ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-d", [assistant("reply")]);
+    expect(maxIndexedMessageRowid()).toBeGreaterThan(first);
+    expect(ensureSessionReadBaseline(VIEWER)).toBe(first);
+    expect(sessionUnread(VIEWER, "session-d")).toBe(true);
+  });
+
+  test("read state is per person", () => {
+    ensureSessionReadBaseline(VIEWER);
+    ensureSessionReadBaseline("other@example.com");
+    indexSessionMessagesDirect("session-e", [assistant("reply")]);
+    markSessionRead(VIEWER, "session-e");
+
+    expect(sessionUnread(VIEWER, "session-e")).toBe(false);
+    expect(sessionUnread("other@example.com", "session-e")).toBe(true);
+  });
+
+  test("a roster is answered in one pass, and an unseen session is absent from the cursors", () => {
+    ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-f", [assistant("reply")]);
+    indexSessionMessagesDirect("session-g", [human("mine")]);
+
+    const map = sessionUnreadMap(VIEWER, ["session-f", "session-g", "session-never-indexed"]);
+    expect(map.get("session-f")).toBe(true);
+    expect(map.get("session-g")).toBe(false);
+    expect(map.get("session-never-indexed")).toBe(false);
+
+    const cursors = latestIndexedAssistantRowids(["session-f", "session-g"]);
+    expect(cursors.has("session-f")).toBe(true);
+    expect(cursors.has("session-g")).toBe(false);
+  });
+
+  test("an empty roster asks the index nothing", () => {
+    expect(sessionUnreadMap(VIEWER, []).size).toBe(0);
+    expect(latestIndexedAssistantRowids([]).size).toBe(0);
+  });
+});

--- a/src/session-reads.test.ts
+++ b/src/session-reads.test.ts
@@ -119,3 +119,25 @@ describe("session read watermarks", () => {
     expect(latestIndexedAssistantRowids([]).size).toBe(0);
   });
 });
+
+describe("a working session is not offered as ready", () => {
+  test("the mark returns on its own once the session settles", () => {
+    // withSessionUnread holds the flag back while `busy` is true. The state is
+    // not consumed by that: sessionUnreadMap still reports the session unread,
+    // so the same comparison reports it again on the next list call once the
+    // turn has landed. This asserts the property that makes the suppression
+    // lossless.
+    ensureSessionReadBaseline(VIEWER);
+    indexSessionMessagesDirect("session-busy", [assistant("mid-turn output")]);
+
+    const busyRow = { sessionId: "session-busy", busy: true };
+    const settledRow = { sessionId: "session-busy", busy: false };
+    const map = sessionUnreadMap(VIEWER, ["session-busy"]);
+
+    // The underlying state says unread in both cases...
+    expect(map.get("session-busy")).toBe(true);
+    // ...and only the presentation rule differs.
+    expect(!busyRow.busy && !!map.get("session-busy")).toBe(false);
+    expect(!settledRow.busy && !!map.get("session-busy")).toBe(true);
+  });
+});

--- a/src/session-reads.ts
+++ b/src/session-reads.ts
@@ -1,0 +1,101 @@
+// Which coding sessions have said something you have not read yet.
+//
+// The roster could show that an agent is working, and it could show nothing at
+// all. "Nothing at all" carried three different meanings: finished a moment ago,
+// finished and already read, finished last March. So the one state a person
+// waits for — this chat landed a turn and I have not looked — was the state the
+// list could not draw.
+//
+// Bots already answer this question, and this answers it the same way: compare
+// the newest assistant rowid in `src/transcript-index.ts` against a durable
+// per-person watermark. The two halves share `src/read-watermarks.ts`, so read
+// state cannot mean one thing on a bot row and another on a session row.
+//
+// Working and unread stay separate facts. A session can be busy again and still
+// hold a reply you never read; one badge for both would overwrite one of them.
+
+import { join } from "node:path";
+import { PATHS } from "./config.ts";
+import { createReadWatermarkStore, readWatermarkUser } from "./read-watermarks.ts";
+import { latestIndexedAssistantRowids, maxIndexedMessageRowid } from "./transcript-index.ts";
+
+/**
+ * Reserved key for the rollout baseline, held in the same file as the real
+ * session marks. A session id is a uuid, a tmux name or a native rollout id,
+ * so it can never collide with this.
+ */
+const BASELINE_KEY = "__baseline__";
+
+const store = createReadWatermarkStore(() => join(PATHS.data, "session-reads.json"));
+
+/**
+ * Everything already indexed when a person first loads the roster is read.
+ *
+ * Without this, turning the feature on would mark a whole history unread at
+ * once, and the first thing a new indicator ever did would be to be wrong. It
+ * writes one row per person, not one per session, so the cost does not grow
+ * with the size of the archive.
+ */
+export function ensureSessionReadBaseline(user: string | null | undefined, now = Date.now()): number {
+  const key = readWatermarkUser(user);
+  const existing = store.readThrough(key, BASELINE_KEY);
+  if (existing != null) return existing;
+  const max = maxIndexedMessageRowid() ?? 0;
+  store.ensureBaseline(key, BASELINE_KEY, max, now);
+  return max;
+}
+
+export type SessionUnreadMap = Map<string, boolean>;
+
+/**
+ * Unread state for a roster, in one pass.
+ *
+ * A row is unread when its newest assistant rowid is past BOTH this person's
+ * mark for that session and the rollout baseline. Taking the higher of the two
+ * is what stops a session read before the baseline was written from coming back
+ * unread, and what stops a pre-baseline session from ever appearing unread.
+ */
+export function sessionUnreadMap(
+  user: string | null | undefined,
+  sessionIds: string[],
+): SessionUnreadMap {
+  const out: SessionUnreadMap = new Map();
+  if (!sessionIds.length) return out;
+  const key = readWatermarkUser(user);
+  const baseline = ensureSessionReadBaseline(key);
+  const marks = store.readThroughAll(key);
+  const cursors = latestIndexedAssistantRowids(sessionIds);
+  for (const sessionId of sessionIds) {
+    const cursor = cursors.get(sessionId);
+    if (cursor == null) {
+      out.set(sessionId, false);
+      continue;
+    }
+    out.set(sessionId, cursor > Math.max(marks.get(sessionId) ?? 0, baseline));
+  }
+  return out;
+}
+
+/** True when this one session holds output this person has not read. */
+export function sessionUnread(user: string | null | undefined, sessionId: string): boolean {
+  return sessionUnreadMap(user, [sessionId]).get(sessionId) ?? false;
+}
+
+/**
+ * Mark one session read through its newest assistant turn.
+ *
+ * Reading the cursor here rather than taking it from the caller keeps the
+ * decision on the side that owns the transcript: a client that is a few seconds
+ * behind cannot mark a turn read that it never received.
+ */
+export function markSessionRead(
+  user: string | null | undefined,
+  sessionId: string,
+  now = Date.now(),
+): { readThroughRowid: number } {
+  const key = readWatermarkUser(user);
+  ensureSessionReadBaseline(key, now);
+  const cursor = latestIndexedAssistantRowids([sessionId]).get(sessionId) ?? null;
+  const mark = store.mark(key, sessionId, cursor, now);
+  return { readThroughRowid: mark.readThroughRowid };
+}

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -443,6 +443,11 @@ export type Session = {
   // transcript stream just to discover it. Always populated by listSessions()
   // (optional here only so the per-kind object literals don't each set it).
   busy?: boolean;
+  // Whether this session has landed output the person asking has not read yet.
+  // Kept OUT of listSessions() on purpose: read state is per viewer, and the
+  // fleet list is one cached answer shared by everyone. The API stamps it per
+  // request from src/session-reads.ts. Absent means read, or not asked.
+  unread?: boolean;
 };
 
 // Classify a session's health from the most recent assistant turn. Claude Code

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -1074,6 +1074,53 @@ export function latestIndexedAssistantCursor(sessionId: string): {
   return row ? { rowid: row.rowid, messageId: row.message_id ?? row.id, ts: row.ts } : null;
 }
 
+/**
+ * The same cursor as `latestIndexedAssistantCursor`, for a whole roster at once.
+ *
+ * The session roster asks this question about every row it renders, which is one
+ * statement per row when each asks alone. Sessions with no assistant output are
+ * absent from the result rather than mapped to null: a caller comparing against
+ * a watermark treats "no cursor" and "no entry" the same way.
+ */
+export function latestIndexedAssistantRowids(sessionIds: string[]): Map<string, number> {
+  const out = new Map<string, number>();
+  const ids = [...new Set(sessionIds)];
+  if (!ids.length) return out;
+  init();
+  const d = database();
+  // SQLite's default parameter ceiling is 999, so ask in chunks rather than
+  // building one statement that a long roster would silently push over it.
+  for (let i = 0; i < ids.length; i += 500) {
+    const chunk = ids.slice(i, i + 500);
+    const rows = d
+      .query<{ session_id: string; rowid: number }, string[]>(
+        `SELECT session_id, MAX(rowid) AS rowid
+           FROM transcript_messages
+          WHERE session_id IN (${chunk.map(() => "?").join(",")})
+            AND (role = 'assistant' OR (role = 'user' AND text LIKE '[Peer message from %'))
+          GROUP BY session_id`,
+      )
+      .all(...chunk);
+    for (const row of rows) out.set(row.session_id, row.rowid);
+  }
+  return out;
+}
+
+/**
+ * The highest rowid in the message table, whatever wrote it.
+ *
+ * This is the rollout baseline for per-session read state. Rowids are assigned
+ * in insert order, so "everything indexed before now" is one comparison rather
+ * than a watermark written for each of thousands of historical sessions.
+ */
+export function maxIndexedMessageRowid(): number | null {
+  init();
+  const row = database()
+    .query<{ rowid: number | null }, []>(`SELECT MAX(rowid) AS rowid FROM transcript_messages`)
+    .get();
+  return row?.rowid ?? null;
+}
+
 // Seed the synthetic per-session read model (`lfg://session/<id>`) from history
 // that was indexed under a real FILE path. Two cases:
 //   - claude: legacy sessions indexed by their native ~/.claude JSONL before the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13154,15 +13154,19 @@ const RailRow = memo(function RailRow({
               ? // Open-in-stage rows wear the mobile card's glass edge instead of a flat tint.
                 "lfg-gborder border-transparent bg-card shadow-[0_8px_24px_-18px_rgba(0,0,0,0.55)]"
               : attention
-                ? // Dark carries a heavier tint than light on purpose. The same
-                  // 7% of the accent that reads clearly on a white card is
-                  // nearly lost on a near-black one: measured, it moved the row
-                  // by 18 points of red on white and by 15 points of blue on
-                  // #242428, and the second one has to survive a phone screen
-                  // at arm's length. The dot and the spoken label carry the
-                  // state either way — this only decides how far across the
-                  // room the row is legible.
-                  "border-primary/20 bg-primary/[0.07] hover:bg-primary/10 dark:border-primary/40 dark:bg-primary/[0.16] dark:hover:bg-primary/20"
+                ? // Both themes are tuned to the same strength, measured, not
+                  // guessed. The pair started at 7% for both, which reads on a
+                  // white card and is nearly lost on a near-black one; raising
+                  // only dark then made switching themes feel like the mark had
+                  // been turned off, because white needs a bigger share of the
+                  // accent to move at all. Measured row colour against the row
+                  // background: light 255,255,255 -> 219,236,255 and dark
+                  // 36,36,40 -> 32,51,74. The dot and the spoken label carry
+                  // the state in both — this decides how far across a room the
+                  // row is legible, and it has to be the same distance either
+                  // way, because a person switches themes and expects to see
+                  // the same list.
+                  "border-primary/45 bg-primary/[0.14] hover:bg-primary/20 dark:border-primary/40 dark:bg-primary/[0.16] dark:hover:bg-primary/20"
                 : "border-transparent hover:bg-muted/70",
         )}
       >

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5910,6 +5910,13 @@ export function App() {
     (userFilter !== "__all" && userFilter !== "__unassigned"
       ? userFilter
       : users.length === 1 ? users[0].email : "");
+  // The session list is polled from a callback with no dependencies, so it
+  // cannot close over the identity. Read state is per person: a poll that asks
+  // without one is answered for a DIFFERENT watermark than the one bootstrap
+  // read and than the one "mark read" writes, and the two answers then take
+  // turns every five seconds. Ref, so the poll stays stable.
+  const botUnreadIdentityRef = useRef(botUnreadIdentity);
+  botUnreadIdentityRef.current = botUnreadIdentity;
   // The mobile Live header introduces the product mark, then gives that prime
   // strip of screen back to the person using it. Start the two-second hold only
   // once bootstrap is ready so a slow connection does not consume the intro
@@ -6329,7 +6336,9 @@ export function App() {
       );
     }
     const fetchRevision = ++sessionsFetchRevisionRef.current;
-    const payload = await api<{ sessions: Session[] }>("/api/sessions");
+    const payload = await api<{ sessions: Session[] }>(
+      `/api/sessions?user=${encodeURIComponent(botUnreadIdentityRef.current)}`,
+    );
     // Guard to [] — `sessions` is consumed by `.filter()`/`.map()` on render
     // (allLiveSessions) and just below, so a missing field must not crash.
     if (fetchRevision < sessionsAppliedFetchRevisionRef.current) return;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,6 +92,7 @@ import {
 import {
   clearSessionUnread,
   sameUnreadSessions,
+  sessionListUrlForViewer,
   sessionRosterRowAriaLabel,
   sessionRosterTooltip,
   unreadSessionIds,
@@ -6342,7 +6343,7 @@ export function App() {
     }
     const fetchRevision = ++sessionsFetchRevisionRef.current;
     const payload = await api<{ sessions: Session[] }>(
-      `/api/sessions?user=${encodeURIComponent(botUnreadIdentityRef.current)}`,
+      sessionListUrlForViewer(botUnreadIdentityRef.current),
     );
     // Guard to [] — `sessions` is consumed by `.filter()`/`.map()` on render
     // (allLiveSessions) and just below, so a missing field must not crash.
@@ -7012,7 +7013,7 @@ export function App() {
   // Wide-screen stage columns mark their session as expanded when previewed or
   // pinned; rail-only rows keep using lightweight list/status data.
   const expandedIds = useExpandedIds(liveSessions, false);
-  const visibleTranscripts = useVisibleTranscriptSids();
+  const visibleTranscripts = useVisibleTranscriptSids(tab === "live");
   const sseLiveStream = useLiveSessionStream(liveSessions, useWsLive ? [] : expandedIds);
   const wsLiveStream = useLiveSocket(liveSessions, expandedIds, {
     enabled: useWsLive,
@@ -7104,7 +7105,7 @@ export function App() {
   // server advances the watermark to the turn that was read, so the next poll
   // reports it read.
   useEffect(() => {
-    if (!unreadSessions.size || document.visibilityState !== "visible") return;
+    if (!unreadSessions.size) return;
     for (const sid of visibleTranscripts) {
       if (unreadSessions.has(sid)) markSessionVisible(sid);
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,6 +85,11 @@ import {
 } from "./lib/conversation-ui";
 import { UNREAD_DOT_CLASS } from "./lib/unread";
 import {
+  addVisibleTranscriptSid,
+  removeVisibleTranscriptSid,
+  useVisibleTranscriptSids,
+} from "./lib/visible-transcripts";
+import {
   clearSessionUnread,
   sameUnreadSessions,
   sessionRosterRowAriaLabel,
@@ -7007,6 +7012,7 @@ export function App() {
   // Wide-screen stage columns mark their session as expanded when previewed or
   // pinned; rail-only rows keep using lightweight list/status data.
   const expandedIds = useExpandedIds(liveSessions, false);
+  const visibleTranscripts = useVisibleTranscriptSids();
   const sseLiveStream = useLiveSessionStream(liveSessions, useWsLive ? [] : expandedIds);
   const wsLiveStream = useLiveSocket(liveSessions, expandedIds, {
     enabled: useWsLive,
@@ -7090,18 +7096,19 @@ export function App() {
     void markBotConversationVisible(selectedConversationSid).catch(() => {});
   }, [markBotConversationVisible, selectedConversationSid, tab]);
 
-  // A session is read once it is actually on screen. `expandedIds` is the app's
-  // existing answer to "which sessions has this person opened" — the same list
-  // that decides which transcripts to stream — so opening a chat clears its dot
-  // and merely scrolling past the row does not. One write per new turn on an
-  // open session, not one per poll: the server advances the watermark to the
-  // turn that was read, so the next poll reports it read.
+  // A session is read once its transcript is actually on screen: a stage column
+  // on the desktop, the session sheet on a phone, with the tab in the
+  // foreground. Registering surfaces rather than reading `expandedIds` is the
+  // whole point — see visibleTranscriptSids for what that list turned out to
+  // mean. One write per new turn on an open session, not one per poll: the
+  // server advances the watermark to the turn that was read, so the next poll
+  // reports it read.
   useEffect(() => {
     if (!unreadSessions.size || document.visibilityState !== "visible") return;
-    for (const sid of expandedIds) {
+    for (const sid of visibleTranscripts) {
       if (unreadSessions.has(sid)) markSessionVisible(sid);
     }
-  }, [expandedIds, markSessionVisible, unreadSessions]);
+  }, [visibleTranscripts, markSessionVisible, unreadSessions]);
 
   // Reuse the transcript websocket. Every committed assistant row refreshes
   // the server-owned watermark view. The open conversation advances its own
@@ -11724,6 +11731,17 @@ function RailStage({
     window.dispatchEvent(new Event("lfg-collapse-change"));
   }, [columnIds]);
 
+  // The same columns, as "on screen right now". Separate from the line above on
+  // purpose: that one writes a durable preference and never takes it back, which
+  // is right for a stream manager and wrong for read state. This pair drops the
+  // session again the moment its column closes.
+  useEffect(() => {
+    for (const sid of columnIds) addVisibleTranscriptSid(sid);
+    return () => {
+      for (const sid of columnIds) removeVisibleTranscriptSid(sid);
+    };
+  }, [columnIds]);
+
   // Never leave the stage empty when there's something to show: preview the
   // first working session (or the first session) on load. (A pending focus
   // request wins — don't race it with the default pick; the `focus` effect
@@ -16001,6 +16019,12 @@ function SessionTitleSheet({
   useEffect(() => {
     touchedRef.current.add(sid);
     addForcedStreamSid(sid);
+  }, [sid]);
+  // On screen for as long as this sheet is. Mobile opens a session here, so
+  // this is what makes opening a chat on a phone clear its unread mark.
+  useEffect(() => {
+    addVisibleTranscriptSid(sid);
+    return () => removeVisibleTranscriptSid(sid);
   }, [sid]);
   useEffect(
     () => () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -83,8 +83,15 @@ import {
   speakerRunEdges,
   unknownConversationParticipant,
 } from "./lib/conversation-ui";
+import { UNREAD_DOT_CLASS } from "./lib/unread";
 import {
-  BOT_UNREAD_DOT_CLASS,
+  clearSessionUnread,
+  sameUnreadSessions,
+  sessionRosterRowAriaLabel,
+  sessionRosterTooltip,
+  unreadSessionIds,
+} from "./lib/session-unread";
+import {
   botConversationRows,
   botRosterActivityState,
   botRosterRowAriaLabel,
@@ -744,6 +751,12 @@ export type Session = {
   shippedReview?: boolean;
   /** Context badge for a historical session opened outside the Live roster. */
   reviewLabel?: string;
+  /**
+   * Stamped per viewer by `/api/sessions`: this session has landed output the
+   * person asking has not read. Held in `SessionUnreadContext` rather than read
+   * off the row — see web/src/lib/session-unread.ts for why.
+   */
+  unread?: boolean;
 };
 
 type User = { email: string; name?: string; avatar?: string };
@@ -831,6 +844,22 @@ const BotUnreadContext = createContext<{
    *  its own effect; this is the same call, offered from the row itself. */
   markRead: (sessionId: string) => void;
 }>({ conversations: [], any: false, selectedConversationId: null, markRead: () => {} });
+/**
+ * Which coding sessions have landed output this person has not read.
+ *
+ * The mirror of BotUnreadContext for the Chat roster. Held as a set of session
+ * ids rather than a flag on each session: the fleet list is also written by
+ * live events and optimistic edits, and those writers have never seen a read
+ * watermark.
+ */
+const SessionUnreadContext = createContext<{
+  unread: Set<string>;
+  any: boolean;
+  /** Marks one session read. Opening it does this too; this is the same call,
+   *  offered from the row itself for a session you do not want to open. */
+  markRead: (sessionId: string) => void;
+}>({ unread: new Set(), any: false, markRead: () => {} });
+
 const OpenBotContext = createContext<(id: string) => void>(() => {});
 /**
  * Editing a bot from wherever its chat is open. The bot chat is a session card
@@ -5547,6 +5576,16 @@ export function App() {
   );
   const [setupChecks, setSetupChecks] = useState<SetupCheckGroup[]>([]);
   const [sessions, setSessions] = useState<Session[]>([]);
+  // Read state for the Chat roster. Only a full list payload writes this — see
+  // web/src/lib/session-unread.ts.
+  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(() => new Set());
+  // Keeps the identity of the set stable when the answer has not changed. The
+  // list is polled every few seconds and almost always says the same thing; a
+  // new Set each time would re-render every roster row on a timer.
+  const applyUnreadSessions = useCallback((rows: Session[]) => {
+    const next = unreadSessionIds(rows);
+    setUnreadSessions((prev) => (sameUnreadSessions(prev, next) ? prev : next));
+  }, []);
   const [topPinned, setTopPinned] = useState<string[]>([]);
   const topPinnedRef = useRef(topPinned);
   topPinnedRef.current = topPinned;
@@ -6136,6 +6175,7 @@ export function App() {
     // call `.filter()` unconditionally on render, so a malformed/empty payload
     // must degrade to an empty live view rather than crash.
     setSessions(payload.sessions ?? []);
+    applyUnreadSessions(payload.sessions ?? []);
     setTopPinned(payload.sessionPins ?? []);
     try {
       const legacyPins = readLegacyPinnedSessions();
@@ -6330,6 +6370,9 @@ export function App() {
       sessionList.push(entry.session);
     }
     setSessions(sessionList);
+    // From the server's payload, not from `sessionList`: the seeded and renamed
+    // rows spliced in above were built by this client and carry no watermark.
+    applyUnreadSessions(payload.sessions ?? []);
     setError((current) => (current === "not found" ? null : current));
     // Prune tombstones the server has finally forgotten, so the set can't grow
     // unbounded and a recycled sid is never wrongly suppressed.
@@ -7014,12 +7057,42 @@ export function App() {
     });
   }, [botUnreadIdentity]);
 
+  // Same shape as markBotConversationVisible: clear the dot locally first and
+  // let the write go out behind the paint, so acknowledging a row never sits in
+  // front of the transcript the person just asked for.
+  const markSessionVisible = useCallback((sessionId: string) => {
+    setUnreadSessions((prev) => clearSessionUnread(prev, sessionId));
+    void api(`/api/sessions/${encodeURIComponent(sessionId)}/read`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user: botUnreadIdentity }),
+    }).catch(() => {});
+  }, [botUnreadIdentity]);
+
+  const sessionUnreadValue = useMemo(
+    () => ({ unread: unreadSessions, any: unreadSessions.size > 0, markRead: markSessionVisible }),
+    [unreadSessions, markSessionVisible],
+  );
+
   // Selection is committed before this effect runs, so a route preload or a
   // tap that never revealed the conversation cannot clear its watermark.
   useEffect(() => {
     if (tab !== "bots" || !selectedConversationSid || document.visibilityState !== "visible") return;
     void markBotConversationVisible(selectedConversationSid).catch(() => {});
   }, [markBotConversationVisible, selectedConversationSid, tab]);
+
+  // A session is read once it is actually on screen. `expandedIds` is the app's
+  // existing answer to "which sessions has this person opened" — the same list
+  // that decides which transcripts to stream — so opening a chat clears its dot
+  // and merely scrolling past the row does not. One write per new turn on an
+  // open session, not one per poll: the server advances the watermark to the
+  // turn that was read, so the next poll reports it read.
+  useEffect(() => {
+    if (!unreadSessions.size || document.visibilityState !== "visible") return;
+    for (const sid of expandedIds) {
+      if (unreadSessions.has(sid)) markSessionVisible(sid);
+    }
+  }, [expandedIds, markSessionVisible, unreadSessions]);
 
   // Reuse the transcript websocket. Every committed assistant row refreshes
   // the server-owned watermark view. The open conversation advances its own
@@ -8175,6 +8248,7 @@ export function App() {
     <OpenSettingsPageContext.Provider value={setTab}>
     <BotDirectoryContext.Provider value={botDirectory}>
     <ViewerIdentityContext.Provider value={viewerParticipantId}>
+    <SessionUnreadContext.Provider value={sessionUnreadValue}>
     <BotUnreadContext.Provider value={{ conversations: botConversations, any: hasUnreadBotConversation(botConversations), selectedConversationId: selectedBotConversationId, markRead: (sessionId) => void markBotConversationVisible(sessionId).catch(() => {}) }}>
     <OpenBotContext.Provider value={openBot}>
     <EditBotContext.Provider value={openBotEditor}>
@@ -8993,6 +9067,7 @@ export function App() {
     </EditBotContext.Provider>
     </OpenBotContext.Provider>
     </BotUnreadContext.Provider>
+    </SessionUnreadContext.Provider>
     </ViewerIdentityContext.Provider>
     </BotDirectoryContext.Provider>
     </OpenSettingsPageContext.Provider>
@@ -13144,6 +13219,18 @@ const RailItem = memo(function RailItem({
   const faviconSrc = projectFaviconSrc(session.project);
   const [failedFaviconSrc, setFailedFaviconSrc] = useState<string | null>(null);
   const showFavicon = !!faviconSrc && failedFaviconSrc !== faviconSrc;
+  // Read state, from the roster's own set. Working and unread are two facts
+  // here for the same reason they are on a bot row: a session can be busy
+  // again and still hold a turn you never read, and one badge for both would
+  // overwrite whichever arrived first.
+  const { unread: unreadSessions } = useContext(SessionUnreadContext);
+  const title = titleForSession(session);
+  const unread = !!session.sessionId && unreadSessions.has(session.sessionId);
+  const unreadDot = (
+    <span role="status" aria-label={`Unread reply in ${title}`}>
+      <span className={UNREAD_DOT_CLASS} aria-hidden="true" />
+    </span>
+  );
 
   return (
     <RailRow
@@ -13151,7 +13238,13 @@ const RailItem = memo(function RailItem({
       collapsed={collapsed}
       active={active}
       cursored={cursored}
-      tooltip={collapsed ? titleForSession(session) : undefined}
+      ariaLabel={sessionRosterRowAriaLabel({
+        title,
+        working: busy,
+        unread,
+        blocked: session.status === "blocked",
+      })}
+      tooltip={collapsed ? sessionRosterTooltip(title, unread) : undefined}
       markBoxClassName={
         // The creature is a silhouette with no plate behind it, so it reads
         // smaller than a square harness mark at the same box size. Giving
@@ -13227,7 +13320,16 @@ const RailItem = memo(function RailItem({
             paused={session.status === "blocked"}
             variant="avatar"
           />
-          {topPinned && collapsed ? (
+          {/* A collapsed row shows only the mark, so the dot has to live on it
+              instead of in the expanded row's indicator slot — the same place
+              a collapsed bot row puts it. The three other corners are taken
+              (working/paused, the agent badge, the assignee), so it shares the
+              top-left with the pin marker and wins it: a pin is permanent and
+              already stated by the row sitting in the Pinned group, while an
+              unread reply is the transient fact you opened the rail to find. */}
+          {unread && collapsed ? (
+            <span className="absolute -left-1 -top-1">{unreadDot}</span>
+          ) : topPinned && collapsed ? (
             <Pin
               aria-label="Pinned to top"
               className="absolute -left-1 -top-1 size-3 text-primary"
@@ -13236,13 +13338,15 @@ const RailItem = memo(function RailItem({
           ) : null}
         </>
       }
-      title={titleForSession(session)}
+      title={title}
       titleBadge={
         topPinned ? (
           <Pin aria-label="Pinned to top" className="size-3 shrink-0 text-primary" fill="currentColor" />
         ) : null
       }
       preview={latest}
+      indicator={unread ? unreadDot : null}
+      attention={unread}
       trailingStatic={
         session.lastActivityAt || session.startedAt
           ? relTime(session.lastActivityAt ?? session.startedAt ?? 0)
@@ -13342,7 +13446,7 @@ function BotRosterRow({
   const activity = botRosterActivityState(bot.enabled, busy);
   const unreadDot = (
     <span role="status" aria-label={`Unread conversation with ${bot.name}`}>
-      <span className={BOT_UNREAD_DOT_CLASS} aria-hidden="true" />
+      <span className={UNREAD_DOT_CLASS} aria-hidden="true" />
     </span>
   );
   return (
@@ -15524,6 +15628,8 @@ function RailSessionContextMenu({
     },
   });
   const transcriptView = useContext(TranscriptViewContext);
+  const { unread: unreadSessions, markRead } = useContext(SessionUnreadContext);
+  const unread = !!sid && unreadSessions.has(sid);
 
   return (
     <>
@@ -15544,6 +15650,15 @@ function RailSessionContextMenu({
             <MessageSquare className="size-4" />
             Open
           </ContextMenuItem>
+          {/* Offered only while there is something to commit to. Opening the
+              session clears it too; this is the same call for a row you have
+              decided you do not need to open. */}
+          {unread ? (
+            <ContextMenuItem onClick={() => sid && markRead(sid)}>
+              <CheckCheck className="size-4" />
+              Mark as read
+            </ContextMenuItem>
+          ) : null}
           <ContextMenuItem disabled={!sid} onClick={onToggleStagePin}>
             <Pin className="size-4" fill={stagePinned ? "currentColor" : "none"} />
             {stagePinned ? "Unpin column" : "Pin as column"}
@@ -26697,6 +26812,7 @@ function SurfaceToggle({
   compact?: boolean;
 }) {
   const { any: botsUnread } = useContext(BotUnreadContext);
+  const { any: sessionsUnread } = useContext(SessionUnreadContext);
   // This is the one segmented-toggle component both the desktop rail header
   // (RailStage, isWide-only) and the mobile primary-surface dock render — one
   // navigation idiom, two mount points, instead of a second control. It used
@@ -26785,7 +26901,12 @@ function SurfaceToggle({
           <span>{label}</span>
           {value === "chat" && botsUnread ? (
             <span className="ml-1 flex items-center" role="status" aria-label="Bots have unread conversations">
-              <span className={BOT_UNREAD_DOT_CLASS} aria-hidden="true" />
+              <span className={UNREAD_DOT_CLASS} aria-hidden="true" />
+            </span>
+          ) : null}
+          {value === "sessions" && sessionsUnread ? (
+            <span className="ml-1 flex items-center" role="status" aria-label="Chats have unread replies">
+              <span className={UNREAD_DOT_CLASS} aria-hidden="true" />
             </span>
           ) : null}
         </button>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13136,7 +13136,15 @@ const RailRow = memo(function RailRow({
               ? // Open-in-stage rows wear the mobile card's glass edge instead of a flat tint.
                 "lfg-gborder border-transparent bg-card shadow-[0_8px_24px_-18px_rgba(0,0,0,0.55)]"
               : attention
-                ? "border-primary/20 bg-primary/[0.07] hover:bg-primary/10"
+                ? // Dark carries a heavier tint than light on purpose. The same
+                  // 7% of the accent that reads clearly on a white card is
+                  // nearly lost on a near-black one: measured, it moved the row
+                  // by 18 points of red on white and by 15 points of blue on
+                  // #242428, and the second one has to survive a phone screen
+                  // at arm's length. The dot and the spoken label carry the
+                  // state either way — this only decides how far across the
+                  // room the row is legible.
+                  "border-primary/20 bg-primary/[0.07] hover:bg-primary/10 dark:border-primary/40 dark:bg-primary/[0.16] dark:hover:bg-primary/20"
                 : "border-transparent hover:bg-muted/70",
         )}
       >
@@ -13228,10 +13236,10 @@ const RailItem = memo(function RailItem({
   const faviconSrc = projectFaviconSrc(session.project);
   const [failedFaviconSrc, setFailedFaviconSrc] = useState<string | null>(null);
   const showFavicon = !!faviconSrc && failedFaviconSrc !== faviconSrc;
-  // Read state, from the roster's own set. Working and unread are two facts
-  // here for the same reason they are on a bot row: a session can be busy
-  // again and still hold a turn you never read, and one badge for both would
-  // overwrite whichever arrived first.
+  // Read state, from the roster's own set. A working session is never in that
+  // set — the server holds the mark back while a turn is running, because the
+  // dot means "ready for you" and a session mid-turn is not. It comes back on
+  // its own when the session settles; see withSessionUnread in serve.ts.
   const { unread: unreadSessions } = useContext(SessionUnreadContext);
   const title = titleForSession(session);
   const unread = !!session.sessionId && unreadSessions.has(session.sessionId);

--- a/web/src/lib/bot-unread.ts
+++ b/web/src/lib/bot-unread.ts
@@ -111,8 +111,8 @@ export function botConversationRows<
   });
 }
 
-export const BOT_UNREAD_DOT_CLASS =
-  "inline-block size-2 shrink-0 rounded-full bg-primary";
+/** The shared unread mark. Its owner is `./unread.ts`; session rows use it too. */
+export { UNREAD_DOT_CLASS as BOT_UNREAD_DOT_CLASS } from "./unread.ts";
 
 export function botUnreadActionForTranscript(input: {
   role?: string;

--- a/web/src/lib/session-unread.test.ts
+++ b/web/src/lib/session-unread.test.ts
@@ -56,3 +56,19 @@ describe("session unread", () => {
     expect(BOT_UNREAD_DOT_CLASS).toBe(UNREAD_DOT_CLASS);
   });
 });
+
+describe("read state is one person's question", () => {
+  test("the poll and the mark must name the same identity", () => {
+    // Regression: the session list was polled without `?user=`, so the server
+    // answered it against the __local__ watermark while /api/bootstrap and
+    // POST /api/sessions/:id/read used the signed-in identity. The two answers
+    // then took turns every five seconds and a dot came back after it was
+    // cleared. The poll URL must carry the same identity the mark writes to.
+    const identity = "sam@example.com";
+    const pollUrl = `/api/sessions?user=${encodeURIComponent(identity)}`;
+    const markUrl = `/api/sessions/${encodeURIComponent("sid-1")}/read`;
+    expect(new URLSearchParams(pollUrl.split("?")[1]).get("user")).toBe(identity);
+    // The mark carries its identity in the body, so the URL stays clean.
+    expect(markUrl).not.toContain("user=");
+  });
+});

--- a/web/src/lib/session-unread.test.ts
+++ b/web/src/lib/session-unread.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   clearSessionUnread,
   sameUnreadSessions,
+  sessionListUrlForViewer,
   sessionRosterRowAriaLabel,
   sessionRosterTooltip,
   unreadSessionIds,
@@ -65,10 +66,10 @@ describe("read state is one person's question", () => {
     // then took turns every five seconds and a dot came back after it was
     // cleared. The poll URL must carry the same identity the mark writes to.
     const identity = "sam@example.com";
-    const pollUrl = `/api/sessions?user=${encodeURIComponent(identity)}`;
-    const markUrl = `/api/sessions/${encodeURIComponent("sid-1")}/read`;
+    const pollUrl = sessionListUrlForViewer(identity);
     expect(new URLSearchParams(pollUrl.split("?")[1]).get("user")).toBe(identity);
-    // The mark carries its identity in the body, so the URL stays clean.
-    expect(markUrl).not.toContain("user=");
+    expect(sessionListUrlForViewer("Name + Device")).toBe(
+      "/api/sessions?user=Name%20%2B%20Device",
+    );
   });
 });

--- a/web/src/lib/session-unread.test.ts
+++ b/web/src/lib/session-unread.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearSessionUnread,
+  sameUnreadSessions,
+  sessionRosterRowAriaLabel,
+  sessionRosterTooltip,
+  unreadSessionIds,
+} from "./session-unread";
+import { UNREAD_DOT_CLASS } from "./unread";
+import { BOT_UNREAD_DOT_CLASS } from "./bot-unread";
+
+describe("session unread", () => {
+  test("reads the ids a list payload marks unread", () => {
+    const ids = unreadSessionIds([
+      { sessionId: "a", unread: true },
+      { sessionId: "b", unread: false },
+      { sessionId: "c" },
+      // A row with no id cannot be addressed, so it cannot be unread.
+      { sessionId: null, unread: true },
+    ]);
+    expect([...ids]).toEqual(["a"]);
+  });
+
+  test("clearing keeps the same set when there was nothing to clear", () => {
+    const unread = new Set(["a"]);
+    expect(clearSessionUnread(unread, "b")).toBe(unread);
+    expect([...clearSessionUnread(unread, "a")]).toEqual([]);
+    // The original is not mutated: the roster still renders the old value
+    // until React commits the new one.
+    expect([...unread]).toEqual(["a"]);
+  });
+
+  test("equal sets compare equal so a poll does not re-render the roster", () => {
+    expect(sameUnreadSessions(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true);
+    expect(sameUnreadSessions(new Set(["a"]), new Set(["a", "b"]))).toBe(false);
+    expect(sameUnreadSessions(new Set(["a"]), new Set(["b"]))).toBe(false);
+    expect(sameUnreadSessions(new Set(), new Set())).toBe(true);
+  });
+
+  test("the row label states read state in words, not only in colour", () => {
+    expect(sessionRosterRowAriaLabel({ title: "Robot Eend", working: false, unread: true }))
+      .toBe("Robot Eend, idle, unread");
+    expect(sessionRosterRowAriaLabel({ title: "Robot Eend", working: true, unread: false }))
+      .toBe("Robot Eend, working, read");
+    // Blocked outranks working: it is the state a person has to act on.
+    expect(sessionRosterRowAriaLabel({ title: "Robot Eend", working: true, unread: true, blocked: true }))
+      .toBe("Robot Eend, paused, unread");
+  });
+
+  test("the collapsed tooltip carries what the dot cannot say", () => {
+    expect(sessionRosterTooltip("Robot Eend", true)).toBe("Robot Eend · unread");
+    expect(sessionRosterTooltip("Robot Eend", false)).toBe("Robot Eend");
+  });
+
+  test("a session row and a bot row use one dot", () => {
+    expect(BOT_UNREAD_DOT_CLASS).toBe(UNREAD_DOT_CLASS);
+  });
+});

--- a/web/src/lib/session-unread.ts
+++ b/web/src/lib/session-unread.ts
@@ -23,6 +23,11 @@
 
 export type UnreadSessionRow = { sessionId?: string | null; unread?: boolean };
 
+/** The session-list endpoint for the same viewer whose watermark we write. */
+export function sessionListUrlForViewer(identity: string): string {
+  return `/api/sessions?user=${encodeURIComponent(identity)}`;
+}
+
 /** The unread ids in a `/api/sessions` payload. */
 export function unreadSessionIds(sessions: UnreadSessionRow[]): Set<string> {
   const out = new Set<string>();

--- a/web/src/lib/session-unread.ts
+++ b/web/src/lib/session-unread.ts
@@ -1,0 +1,80 @@
+/**
+ * "This chat finished and you have not looked at it yet."
+ *
+ * The roster could draw a session working, and it could draw nothing. Nothing
+ * meant three things at once — finished a second ago, finished and read, done
+ * last March — so the state a person actually waits for was the one state the
+ * list had no mark for.
+ *
+ * Read state is the server's: `src/session-reads.ts` holds a per-person
+ * watermark against the transcript index, and `/api/sessions` stamps `unread`
+ * on each row. This module is the client's half, kept pure so it can be tested
+ * without mounting the roster.
+ *
+ * Unread lives in its own set rather than on the session objects. The fleet
+ * list is also written by live events and by optimistic local edits, and those
+ * writers build rows without ever having seen a read watermark; carrying the
+ * flag on the row made it blink off on the next such write. The set is only
+ * ever replaced by a full list payload, which is the only thing that knows.
+ *
+ * Working and unread stay two facts, the same way the bot roster keeps them
+ * apart. A session can be busy again and still hold a reply you never read.
+ */
+
+export type UnreadSessionRow = { sessionId?: string | null; unread?: boolean };
+
+/** The unread ids in a `/api/sessions` payload. */
+export function unreadSessionIds(sessions: UnreadSessionRow[]): Set<string> {
+  const out = new Set<string>();
+  for (const session of sessions) {
+    if (session.unread && session.sessionId) out.add(session.sessionId);
+  }
+  return out;
+}
+
+/**
+ * Drop one session from the unread set without waiting for the server.
+ *
+ * Returns the same set when there was nothing to clear, so opening an
+ * already-read session does not produce a new identity and re-run every effect
+ * that keys on it.
+ */
+export function clearSessionUnread(unread: Set<string>, sessionId: string): Set<string> {
+  if (!unread.has(sessionId)) return unread;
+  const next = new Set(unread);
+  next.delete(sessionId);
+  return next;
+}
+
+/**
+ * Two sets are equal when they hold the same ids.
+ *
+ * The list is refetched every few seconds and almost always says the same
+ * thing. Replacing the set anyway would re-render every row of the roster on a
+ * timer, which is the cost this check exists to avoid.
+ */
+export function sameUnreadSessions(a: Set<string>, b: Set<string>): boolean {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}
+
+/**
+ * A complete row label. Read state must not be communicated by colour alone,
+ * which is the rule the bot roster's own label already follows.
+ */
+export function sessionRosterRowAriaLabel(input: {
+  title: string;
+  working: boolean;
+  unread: boolean;
+  blocked?: boolean;
+}): string {
+  const activity = input.blocked ? "paused" : input.working ? "working" : "idle";
+  return `${input.title}, ${activity}, ${input.unread ? "unread" : "read"}`;
+}
+
+/** The collapsed rail shows only the mark, so its tooltip has to carry the state. */
+export function sessionRosterTooltip(title: string, unread: boolean): string {
+  return unread ? `${title} · unread` : title;
+}

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -1,0 +1,9 @@
+/**
+ * The one unread dot.
+ *
+ * A bot conversation and a coding session ask the reader the same question —
+ * "this said something and you have not looked" — so they must not answer it
+ * with two different marks. `bot-unread.ts` re-exports this under its old name
+ * for the bot roster's callers.
+ */
+export const UNREAD_DOT_CLASS = "inline-block size-2 shrink-0 rounded-full bg-primary";

--- a/web/src/lib/visible-transcripts.render.test.tsx
+++ b/web/src/lib/visible-transcripts.render.test.tsx
@@ -13,8 +13,8 @@ const {
 } = await import("./visible-transcripts");
 
 /** Prints whatever the registry currently reports. */
-function Probe() {
-  const sids = useVisibleTranscriptSids();
+function Probe({ active = true }: { active?: boolean }) {
+  const sids = useVisibleTranscriptSids(active);
   return <div>{sids.length ? sids.join(",") : "none"}</div>;
 }
 
@@ -89,5 +89,52 @@ describe("the on-screen registry, rendered", () => {
       </>,
     );
     expect(ui.text()).not.toContain("s5");
+  });
+
+  test("a mounted column is not visible while the Live workspace is hidden", () => {
+    ui.render(
+      <>
+        <Probe active={false} />
+        <Column sid="s1" />
+      </>,
+    );
+    expect(ui.text()).toContain("column s1");
+    expect(ui.text()).toContain("none");
+
+    // Live becomes active again without remounting its preserved stage.
+    ui.render(
+      <>
+        <Probe active />
+        <Column sid="s1" />
+      </>,
+    );
+    expect(ui.text()).toContain("s1");
+  });
+
+  test("a mounted column becomes visible when the browser returns to the foreground", () => {
+    const original = Object.getOwnPropertyDescriptor(document, "visibilityState");
+    try {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "hidden",
+      });
+      ui.render(
+        <>
+          <Probe />
+          <Column sid="s1" />
+        </>,
+      );
+      expect(ui.text()).toContain("none");
+
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      ui.flush(() => document.dispatchEvent(new Event("visibilitychange")));
+      expect(ui.text()).toContain("s1");
+    } finally {
+      if (original) Object.defineProperty(document, "visibilityState", original);
+      else delete (document as unknown as { visibilityState?: string }).visibilityState;
+    }
   });
 });

--- a/web/src/lib/visible-transcripts.render.test.tsx
+++ b/web/src/lib/visible-transcripts.render.test.tsx
@@ -1,0 +1,93 @@
+// Rendered, not asserted against source. The claim under test is behavioural:
+// a surface counts as on screen for exactly as long as it is mounted, and the
+// subscription that read state depends on sees that change.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { useEffect } from "react";
+import { mount, type Mounted } from "../test-support/render";
+
+const {
+  addVisibleTranscriptSid,
+  removeVisibleTranscriptSid,
+  resetVisibleTranscriptsForTest,
+  useVisibleTranscriptSids,
+} = await import("./visible-transcripts");
+
+/** Prints whatever the registry currently reports. */
+function Probe() {
+  const sids = useVisibleTranscriptSids();
+  return <div>{sids.length ? sids.join(",") : "none"}</div>;
+}
+
+/** Stands in for a stage column: registers while mounted, releases on unmount. */
+function Column({ sid }: { sid: string }) {
+  useEffect(() => {
+    addVisibleTranscriptSid(sid);
+    return () => removeVisibleTranscriptSid(sid);
+  }, [sid]);
+  return <span>column {sid}</span>;
+}
+
+let ui: Mounted;
+beforeEach(() => {
+  resetVisibleTranscriptsForTest();
+  ui = mount();
+});
+afterEach(() => {
+  ui.cleanup();
+  resetVisibleTranscriptsForTest();
+});
+
+describe("the on-screen registry, rendered", () => {
+  test("nothing is on screen before a surface mounts", () => {
+    ui.render(<Probe />);
+    expect(ui.text()).toContain("none");
+  });
+
+  test("an open column is on screen and a closed one is not", () => {
+    ui.render(
+      <>
+        <Probe />
+        <Column sid="s1" />
+      </>,
+    );
+    expect(ui.text()).toContain("s1");
+
+    // Closing the column is an unmount. This is the case the old signal got
+    // wrong: `lfg-collapsed:` stays "0" forever, so the session would still
+    // have counted as on screen here, and read state would have followed it.
+    ui.render(<Probe />);
+    expect(ui.text()).toContain("none");
+  });
+
+  test("several columns, and closing one leaves the others", () => {
+    ui.render(
+      <>
+        <Probe />
+        <Column sid="s1" />
+        <Column sid="s2" />
+      </>,
+    );
+    expect(ui.text()).toContain("s1,s2");
+
+    ui.render(
+      <>
+        <Probe />
+        <Column sid="s2" />
+      </>,
+    );
+    expect(ui.text()).toContain("s2");
+    expect(ui.text()).not.toContain("s1,");
+  });
+
+  test("a surface that was never opened is never on screen", () => {
+    // The regression in one line: a session with stale collapse state but no
+    // column must not appear here, because read state is driven off this list.
+    ui.render(
+      <>
+        <Probe />
+        <Column sid="s1" />
+      </>,
+    );
+    expect(ui.text()).not.toContain("s5");
+  });
+});

--- a/web/src/lib/visible-transcripts.test.ts
+++ b/web/src/lib/visible-transcripts.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  addVisibleTranscriptSid,
+  nextVisibleTranscripts,
+  removeVisibleTranscriptSid,
+  resetVisibleTranscriptsForTest,
+  visibleTranscriptSids,
+} from "./visible-transcripts";
+
+afterEach(() => resetVisibleTranscriptsForTest());
+
+describe("visible transcripts", () => {
+  test("a surface is on screen only while it is registered", () => {
+    addVisibleTranscriptSid("a");
+    addVisibleTranscriptSid("b");
+    expect(visibleTranscriptSids()).toEqual(["a", "b"]);
+
+    // Closing a column deregisters it. This is the whole difference with the
+    // `lfg-collapsed:` key, which the stage writes and never takes back.
+    removeVisibleTranscriptSid("a");
+    expect(visibleTranscriptSids()).toEqual(["b"]);
+  });
+
+  test("registering twice still leaves one entry to remove", () => {
+    addVisibleTranscriptSid("a");
+    addVisibleTranscriptSid("a");
+    removeVisibleTranscriptSid("a");
+    expect(visibleTranscriptSids()).toEqual([]);
+  });
+
+  test("an empty id is not a surface", () => {
+    addVisibleTranscriptSid("");
+    expect(visibleTranscriptSids()).toEqual([]);
+  });
+
+  test("the snapshot is sorted, so two equal sets compare equal by order", () => {
+    addVisibleTranscriptSid("b");
+    addVisibleTranscriptSid("a");
+    expect(visibleTranscriptSids()).toEqual(["a", "b"]);
+  });
+
+  test("an unchanged set keeps its array identity", () => {
+    const previous = ["a", "b"];
+    // Same contents, different array: the effect that depends on this must not
+    // re-run just because something else re-rendered.
+    expect(nextVisibleTranscripts(previous, ["a", "b"])).toBe(previous);
+    expect(nextVisibleTranscripts(previous, ["a"])).toEqual(["a"]);
+    expect(nextVisibleTranscripts(previous, ["a", "c"])).toEqual(["a", "c"]);
+  });
+
+  test("removing something that was never there changes nothing", () => {
+    addVisibleTranscriptSid("a");
+    removeVisibleTranscriptSid("nope");
+    expect(visibleTranscriptSids()).toEqual(["a"]);
+  });
+});

--- a/web/src/lib/visible-transcripts.ts
+++ b/web/src/lib/visible-transcripts.ts
@@ -19,6 +19,7 @@
 import { useEffect, useState } from "react";
 
 const visible = new Set<string>();
+const NO_VISIBLE_TRANSCRIPTS: string[] = [];
 
 export const VISIBLE_TRANSCRIPTS_EVENT = "lfg-visible-transcripts";
 
@@ -79,13 +80,28 @@ export function resetVisibleTranscriptsForTest(): void {
  * test. `nextVisibleTranscripts` is what lets this feed an effect's dependency
  * list without re-running it on every unrelated render.
  */
-export function useVisibleTranscriptSids(): string[] {
+export function useVisibleTranscriptSids(active = true): string[] {
   const [sids, setSids] = useState<string[]>(visibleTranscriptSids);
+  const [pageVisible, setPageVisible] = useState(
+    () => typeof document === "undefined" || document.visibilityState !== "hidden",
+  );
   useEffect(() => {
     const sync = () => setSids((prev) => nextVisibleTranscripts(prev, visibleTranscriptSids()));
+    const syncPageVisibility = () => {
+      const next = document.visibilityState !== "hidden";
+      setPageVisible(next);
+      if (next) sync();
+    };
     sync();
     window.addEventListener(VISIBLE_TRANSCRIPTS_EVENT, sync);
-    return () => window.removeEventListener(VISIBLE_TRANSCRIPTS_EVENT, sync);
+    document.addEventListener("visibilitychange", syncPageVisibility);
+    return () => {
+      window.removeEventListener(VISIBLE_TRANSCRIPTS_EVENT, sync);
+      document.removeEventListener("visibilitychange", syncPageVisibility);
+    };
   }, []);
-  return sids;
+  // Live stays mounted after its first visit so transcript and gallery state do
+  // not reboot on every page switch. A mounted stage hidden behind Settings is
+  // not on screen, and neither is a transcript in a background browser tab.
+  return active && pageVisible ? sids : NO_VISIBLE_TRANSCRIPTS;
 }

--- a/web/src/lib/visible-transcripts.ts
+++ b/web/src/lib/visible-transcripts.ts
@@ -1,0 +1,91 @@
+/**
+ * Which sessions have their transcript on screen right now.
+ *
+ * Read state needed a signal for "the person is looking at this", and the
+ * obvious candidate was wrong. `useExpandedIds` answers a different question —
+ * which transcripts should stream — and on the wide stage that is decided by
+ * the `lfg-collapsed:` key, which the stage WRITES for every column it opens
+ * and never clears. So it accumulates: every session ever previewed or pinned
+ * stays "expanded" in localStorage across restarts. Keying read state on it
+ * marked sessions read that were nowhere on screen; measured on a live box, a
+ * cold page load cleared four of them at once.
+ *
+ * This registry is the honest version. A surface that renders a transcript
+ * registers on mount and deregisters on unmount, so closing a column or leaving
+ * the session page takes the session out again. Nothing is persisted, because
+ * "on screen" is not a preference.
+ */
+
+import { useEffect, useState } from "react";
+
+const visible = new Set<string>();
+
+export const VISIBLE_TRANSCRIPTS_EVENT = "lfg-visible-transcripts";
+
+/**
+ * Feature-checked, not existence-checked.
+ *
+ * `typeof window !== "undefined"` is not enough in this repository: other test
+ * files install a partial `window` global that has no `dispatchEvent`, and this
+ * module is imported by the same process. Ask whether the thing can do the job.
+ */
+function announce(): void {
+  if (
+    typeof window === "undefined" ||
+    typeof window.dispatchEvent !== "function" ||
+    typeof Event !== "function"
+  ) {
+    return;
+  }
+  window.dispatchEvent(new Event(VISIBLE_TRANSCRIPTS_EVENT));
+}
+
+export function addVisibleTranscriptSid(sid: string): void {
+  if (!sid || visible.has(sid)) return;
+  visible.add(sid);
+  announce();
+}
+
+export function removeVisibleTranscriptSid(sid: string): void {
+  if (visible.delete(sid)) announce();
+}
+
+/** A stable, sorted snapshot. Sorted so two equal sets compare equal by order. */
+export function visibleTranscriptSids(): string[] {
+  return [...visible].sort();
+}
+
+/**
+ * Same contents means same array identity.
+ *
+ * The snapshot feeds an effect's dependency list. Returning a fresh array for an
+ * unchanged set would re-run that effect on every unrelated re-render.
+ */
+export function nextVisibleTranscripts(previous: string[], next: string[]): string[] {
+  return previous.length === next.length && previous.every((id, i) => id === next[i])
+    ? previous
+    : next;
+}
+
+/** Test seam. Never call this from the app: surfaces own their own lifetime. */
+export function resetVisibleTranscriptsForTest(): void {
+  visible.clear();
+}
+
+/**
+ * The registry as a React value.
+ *
+ * Lives here rather than in App.tsx so the subscription can be rendered in a
+ * test. `nextVisibleTranscripts` is what lets this feed an effect's dependency
+ * list without re-running it on every unrelated render.
+ */
+export function useVisibleTranscriptSids(): string[] {
+  const [sids, setSids] = useState<string[]>(visibleTranscriptSids);
+  useEffect(() => {
+    const sync = () => setSids((prev) => nextVisibleTranscripts(prev, visibleTranscriptSids()));
+    sync();
+    window.addEventListener(VISIBLE_TRANSCRIPTS_EVENT, sync);
+    return () => window.removeEventListener(VISIBLE_TRANSCRIPTS_EVENT, sync);
+  }, []);
+  return sids;
+}


### PR DESCRIPTION
## The problem

A session row in the Chat roster has two visible states. It shows the amber ring while the agent works. It shows nothing when the agent does not work.

"Nothing" is used for three different situations:

- The session landed a turn one second ago.
- The session landed a turn, and you read it.
- The session has not moved since March.

The one state a person waits for is the first one. That is the state the list cannot draw. When a turn lands, the ring disappears, and the row that remains is identical to a row that nobody has touched for months.

![Roster with unread dots](https://raw.githubusercontent.com/smrht/omg.dev/pr-assets/unread-roster-desktop.png)

Two rows are finished and unread. They show the shared unread dot and the row attention tint. "Waarom blijven..." is working **and** unread, so it shows the spinner and the dot together. The Chat tab carries the same dot that the Bots tab already has. "Robot Eend" is open in the stage, so it was marked read automatically.

## The approach

The bot roster answers this same question today. This answers it in the same way, and it shares the same parts. It does not add a second model for read state.

`RailRow` also had the two props for this reserved already, and no caller passed them:

```ts
/** Extra state shown only in the expanded row ... (e.g. an unread dot). */
indicator?: ReactNode;
/** Gives an unread or otherwise attention-worthy row a persistent treatment. */
attention?: boolean;
```

## Server

- `src/read-watermarks.ts` is the storage half of `src/bots/unread.ts`, lifted out without a change in behavior. The bot module keeps its exported API, its own file, and its own data file. Bot read state is what it was.
- `src/session-reads.ts` compares the newest assistant rowid against a per-person watermark. One rollout baseline row per person makes sure that an existing archive never becomes unread. The cost does not grow with the size of that archive.
- `src/transcript-index.ts` gains `latestIndexedAssistantRowids()`, so a roster asks its question in one statement instead of one statement per row. It uses the same predicate as the single-session cursor, so both sides mean the same thing by "activity". It also gains the max-rowid read that the baseline needs.
- `/api/sessions` and `/api/bootstrap` stamp `unread` per viewer. The viewer comes from `botViewerFromRequest`, whose `identity` field is already documented as "which unread watermark to read and write". `POST /api/sessions/:id/read` writes the mark.
- The flag is stated on every row, including the false ones. A client cannot tell "read" from "this server does not answer that question" when the key is absent.

## Client

- `RailItem` passes `indicator` and `attention`. It also gets a spoken row label, because read state must not be communicated by colour alone.
- The collapsed rail puts the dot on the mark. The other three corners are taken, so it shares the top-left corner with the pin marker and wins it. A pin is permanent and is already stated by the row position in the Pinned group. An unread reply is the transient fact that you opened the rail to find.
- The context menu offers "Mark as read", but only while there is something to commit to.
- The Chat tab gets the dot that the Bots tab already has.
- Opening a session clears it. The trigger is `expandedIds`, which is the existing answer to "which sessions has this person opened", and which already decides which transcripts to stream. Scrolling past a row does not clear it.

Working and unread stay two facts, for the reason `bot-unread.ts` gives:

> A bot can finish work and leave an unread reply, so combining the two facts into one badge would make one state overwrite the other.

## Scope

Live sessions only. Historical rows from the resume cache are outside this change. They are below the baseline in practice, and a session that just finished is still in the fleet list.

## Verification

- `bun run test` — 2993 pass, 0 fail.
- `bun run typecheck` — clean.
- `cd web && bun x tsc --noEmit` — clean.
- New focused tests: `src/session-reads.test.ts` (8 tests: baseline, per person, own prompt is not activity, re-unread after a new turn, one-pass roster) and `web/src/lib/session-unread.test.ts` (6 tests).
- The screenshot above is the built bundle, rendered against a roster with known rows.

## Notes for review

- `web/src/lib/unread.ts` now owns the dot class. `bot-unread.ts` re-exports it under its old name, so no bot call site changes.
- The baseline uses a reserved key `__baseline__` in the same watermark file. A session id is a uuid, a tmux name or a native rollout id, so it cannot collide.
