### PR TITLE
Add independent Fast mode for Codex and Claude

### DIFF
--- a/src/agents/backends/aisdk-session.ts
+++ b/src/agents/backends/aisdk-session.ts
@@ -342,6 +342,7 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
   const sessionIdArg = arg(argv, "--session");
   const model = arg(argv, "--model") ?? "opus";
   const effort = effortFor(arg(argv, "--thinking-level"));
+  let fastMode = argv.includes("--fast-mode");
   const cwd = arg(argv, "--cwd") ?? process.cwd();
   const tmuxName = arg(argv, "--managed-name") ?? arg(argv, "--tmux") ?? "";
   const recoveredAt = Number(arg(argv, "--recovered-at")) || null;
@@ -384,6 +385,7 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
     recoveryClaimBootId: recoveredAt ? bootId : null,
     recoveredAt,
     thinkingLevel: arg(argv, "--thinking-level") ?? null,
+    fastMode,
     cwd,
     model,
     busy: false,
@@ -517,6 +519,10 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
       // stream_event partial messages drive the live draft in the web UI.
       includePartialMessages: true,
       ...(effort ? { effort } : {}),
+      // Fast is provider-native and independent from effort. Put it in the
+      // flag layer so this session has deterministic on/off state without
+      // rewriting the user's Claude settings file.
+      settings: { fastMode },
       // env is a FULL replacement for the subprocess environment when set —
       // without a connected account, inherit process.env so the platform proxy
       // remains available. With a connected account, keep the full environment
@@ -670,6 +676,13 @@ export async function cmdAisdkSession(argv: string[]): Promise<void> {
         patchEntry(sessionId, { thinkingLevel: cmd.thinkingLevel });
       }).catch((error) => {
         console.error(`aisdk-session thinking-level change failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    } else if (cmd.type === "set_fast_mode") {
+      void q.applyFlagSettings({ fastMode: cmd.enabled }).then(() => {
+        fastMode = cmd.enabled;
+        patchEntry(sessionId, { fastMode });
+      }).catch((error) => {
+        console.error(`aisdk-session Fast-mode change failed: ${error instanceof Error ? error.message : String(error)}`);
       });
     } else if (cmd.type === "close") {
       shutdown();

--- a/src/agents/backends/codex-aisdk-session.ts
+++ b/src/agents/backends/codex-aisdk-session.ts
@@ -34,6 +34,10 @@ import { sessionTitleFromPrompt } from "../../omg-capabilities.ts";
 import { indexSessionMessagesDirect, reindexFileHistoryUnderSessionKey } from "../../transcript-index.ts";
 import { makeDraftPublisher } from "./draft.ts";
 import { codexOmgMcpConfig, type CodexConfigValue } from "../../codex-mcp-config.ts";
+import {
+  withCodexServiceTierConfig,
+  type CodexServiceTier,
+} from "../../service-tier.ts";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { initialCmdOffset, readNewCmdLines, writeCursor } from "./cmd-tail.ts";
 import {
@@ -130,8 +134,10 @@ export function createStallGate() {
  * makes codex reject the whole config ("invalid transport"), which fails the
  * launch before the model runs. See ../../codex-mcp-config.ts.
  */
-function omgMcpConfig(): { config?: { [key: string]: CodexConfigValue } } {
-  return codexOmgMcpConfig();
+function omgMcpConfig(serviceTier?: CodexServiceTier): { config?: { [key: string]: CodexConfigValue } } {
+  const base = codexOmgMcpConfig();
+  const config = withCodexServiceTierConfig(base.config, serviceTier);
+  return config ? { config } : {};
 }
 
 // Shared thread options for both the interactive harness and the one-shot
@@ -221,7 +227,7 @@ function codexCompletedItemMessage(item: Record<string, unknown>, turnNonce: str
 export async function pipeToCodexAiSdk(
   prompt: string,
   log: (s: string) => void,
-  opts: { model?: string; thinkingLevel?: string; cwd?: string } = {},
+  opts: { model?: string; thinkingLevel?: string; serviceTier?: CodexServiceTier; cwd?: string } = {},
 ): Promise<string> {
   const model = opts.model ?? "gpt-5.5";
   const cwd = opts.cwd ?? process.cwd();
@@ -229,7 +235,7 @@ export async function pipeToCodexAiSdk(
   const codexPathOverride = resolveCodexPathOverride();
   const codex = new Codex({
     ...(codexPathOverride ? { codexPathOverride } : {}),
-    ...omgMcpConfig(),
+    ...omgMcpConfig(opts.serviceTier),
   });
 
   log(`[runner] piping ${prompt.length} chars to codex via codex-sdk (${model})`);
@@ -271,6 +277,12 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
   const keyArg = arg(argv, "--key");
   const model = arg(argv, "--model") ?? "gpt-5.5";
   let thinkingLevel = arg(argv, "--thinking-level");
+  const requestedServiceTier = arg(argv, "--service-tier");
+  if (requestedServiceTier && requestedServiceTier !== "fast") {
+    console.error(`codex-aisdk-session: unsupported service tier "${requestedServiceTier}"`);
+    process.exit(1);
+  }
+  const serviceTier = requestedServiceTier as CodexServiceTier | undefined;
   const cwd = arg(argv, "--cwd") ?? process.cwd();
   const tmuxName = arg(argv, "--managed-name") ?? arg(argv, "--tmux") ?? "";
   const recoveredAt = Number(arg(argv, "--recovered-at")) || null;
@@ -304,7 +316,7 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
   // Omitting `env` inherits process.env (HOME → ~/.codex auth, LFG_* for MCP).
   const codex = new Codex({
     ...(codexPathOverride ? { codexPathOverride } : {}),
-    ...omgMcpConfig(),
+    ...omgMcpConfig(serviceTier),
   });
   let threadThinkingLevel = thinkingLevel;
   // Set when a stream stalls: the SDK handle is unusable afterwards, so the
@@ -330,6 +342,7 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
     recoveryClaimBootId: recoveredAt ? bootId : null,
     recoveredAt,
     thinkingLevel: thinkingLevel ?? null,
+    serviceTier,
     cwd,
     model,
     busy: false,

--- a/src/agents/backends/codex-aisdk-session.ts
+++ b/src/agents/backends/codex-aisdk-session.ts
@@ -282,7 +282,7 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
     console.error(`codex-aisdk-session: unsupported service tier "${requestedServiceTier}"`);
     process.exit(1);
   }
-  const serviceTier = requestedServiceTier as CodexServiceTier | undefined;
+  let serviceTier = requestedServiceTier as CodexServiceTier | undefined;
   const cwd = arg(argv, "--cwd") ?? process.cwd();
   const tmuxName = arg(argv, "--managed-name") ?? arg(argv, "--tmux") ?? "";
   const recoveredAt = Number(arg(argv, "--recovered-at")) || null;
@@ -314,10 +314,11 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
   const { Codex } = await import("@openai/codex-sdk");
   const codexPathOverride = resolveCodexPathOverride();
   // Omitting `env` inherits process.env (HOME → ~/.codex auth, LFG_* for MCP).
-  const codex = new Codex({
+  const createCodex = () => new Codex({
     ...(codexPathOverride ? { codexPathOverride } : {}),
     ...omgMcpConfig(serviceTier),
   });
+  let codex = createCodex();
   let threadThinkingLevel = thinkingLevel;
   // Set when a stream stalls: the SDK handle is unusable afterwards, so the
   // next turn must rebuild it from threadId instead of inheriting the wedge.
@@ -343,6 +344,7 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
     recoveredAt,
     thinkingLevel: thinkingLevel ?? null,
     serviceTier,
+    fastMode: serviceTier === "fast",
     cwd,
     model,
     busy: false,
@@ -502,6 +504,17 @@ export async function cmdCodexAisdkSession(argv: string[]): Promise<void> {
     } else if (cmd.type === "set_thinking_level") {
       thinkingLevel = cmd.thinkingLevel;
       patchEntry(key, { thinkingLevel });
+    } else if (cmd.type === "set_fast_mode") {
+      serviceTier = cmd.enabled ? "fast" : undefined;
+      // Fast lives on the Codex client config, not the reasoning options. A
+      // fresh SDK client + resumed thread applies it to the next turn while
+      // preserving both conversation and thinking level.
+      codex = createCodex();
+      threadNeedsRebuild = true;
+      patchEntry(key, {
+        fastMode: cmd.enabled,
+        serviceTier: cmd.enabled ? "fast" : null,
+      });
     } else if (cmd.type === "close") {
       shutdown();
     }

--- a/src/aisdk-registry.ts
+++ b/src/aisdk-registry.ts
@@ -55,7 +55,8 @@ export type AisdkEntry = {
   // omit this and continue to rely on the bounded polling fallback.
   commandWakeSignal?: "SIGUSR1";
   thinkingLevel?: string | null;
-  serviceTier?: CodexServiceTier;
+  serviceTier?: CodexServiceTier | null;
+  fastMode?: boolean;
   cwd: string;
   model: string;
   busy: boolean; // true while a turn is generating — feeds the live-view busy dot
@@ -100,6 +101,7 @@ export type AisdkCommand =
   | { type: "send"; text: string }
   | { type: "set_model"; model: string }
   | { type: "set_thinking_level"; thinkingLevel: string }
+  | { type: "set_fast_mode"; enabled: boolean }
   | { type: "interrupt" }
   | { type: "close" }
   // OpenCode (and future headless) interactive questions — option index is the

--- a/src/aisdk-registry.ts
+++ b/src/aisdk-registry.ts
@@ -18,6 +18,7 @@ import {
 import { join } from "node:path";
 import { PATHS } from "./config.ts";
 import { removeCursor } from "./agents/backends/cmd-tail.ts";
+import type { CodexServiceTier } from "./service-tier.ts";
 
 // Resolved per call, not captured at import. Tests point PATHS.data at a temp
 // dir after this module loads; a captured constant made them read and write the
@@ -54,6 +55,7 @@ export type AisdkEntry = {
   // omit this and continue to rely on the bounded polling fallback.
   commandWakeSignal?: "SIGUSR1";
   thinkingLevel?: string | null;
+  serviceTier?: CodexServiceTier;
   cwd: string;
   model: string;
   busy: boolean; // true while a turn is generating — feeds the live-view busy dot

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -17,6 +17,7 @@ import {
   spawnManagedOpencodeAisdkSession,
   spawnManagedPiSession,
 } from "./tmux.ts";
+import type { CodexServiceTier } from "./service-tier.ts";
 
 export type CodingAgentLaunchRequest = {
   agent: ActiveSessionAgentKind;
@@ -25,6 +26,7 @@ export type CodingAgentLaunchRequest = {
   prompt?: string;
   model?: string;
   thinkingLevel?: string;
+  serviceTier?: CodexServiceTier;
   sessionId: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
@@ -89,6 +91,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       model: request.model ?? "gpt-5.5",
       key: request.sessionId,
       thinkingLevel: request.thinkingLevel,
+      serviceTier: request.serviceTier,
       omgSessionId: request.sessionId,
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -27,6 +27,7 @@ export type CodingAgentLaunchRequest = {
   model?: string;
   thinkingLevel?: string;
   serviceTier?: CodexServiceTier;
+  fastMode?: boolean;
   sessionId: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
@@ -78,6 +79,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       model: request.model ?? "opus",
       sessionId: request.sessionId,
       thinkingLevel: request.thinkingLevel,
+      fastMode: request.fastMode,
       omgSessionId: request.sessionId,
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -458,7 +458,7 @@ import {
   resolveModelForAgent,
   thinkingLevelsForAgent,
 } from "../agent-catalog.ts";
-import { resolveSessionServiceTier } from "../service-tier.ts";
+import { resolveSessionFastMode } from "../fast-mode.ts";
 import {
   readModelDiscoveryCacheSync,
   refreshModelCatalog,
@@ -1241,6 +1241,9 @@ function persistManagedResume(session: Session): void {
     mtimeMs,
     backend: backend ?? undefined,
     model: session.model,
+    thinkingLevel: session.thinkingLevel,
+    serviceTier: session.serviceTier,
+    fastMode: session.fastMode === true || session.serviceTier === "fast",
     assignedUser: session.assignedUser,
     resumable: true,
   };
@@ -7544,6 +7547,9 @@ a{color:#60a5fa}
             nativeSessionId: resumeHandle,
             launchState: "launching",
             model: resumeModel,
+            thinkingLevel: cachedResume.thinkingLevel ?? undefined,
+            serviceTier: cachedResume.serviceTier ?? undefined,
+            fastMode: cachedResume.fastMode ?? cachedResume.serviceTier === "fast",
             ...(cachedResume.backend === "aisdk"
               ? { claudeAccountId: pinnedClaudeAccountId }
               : {}),
@@ -7574,6 +7580,9 @@ a{color:#60a5fa}
             cwd,
             prompt,
             model: resumeModel,
+            thinkingLevel: cachedResume.thinkingLevel ?? undefined,
+            serviceTier: cachedResume.serviceTier ?? undefined,
+            fastMode: cachedResume.fastMode ?? cachedResume.serviceTier === "fast",
             sessionId,
             resume: resumeHandle,
             omgUser: assignedUser,
@@ -7970,6 +7979,7 @@ a{color:#60a5fa}
           worktree?: boolean;
           model?: string;
           thinkingLevel?: string;
+          fastMode?: unknown;
           serviceTier?: unknown;
           claudeAccountId?: string;
           parentSessionId?: string;
@@ -8054,13 +8064,15 @@ a{color:#60a5fa}
             return err(400, `unknown thinking level "${thinkingLevel}" for ${agent} (expected one of ${allowed.join(", ")})`);
         }
         const resolvedModel = resolveModelForAgent(agent, model, thinkingLevel);
-        const serviceTierResult = resolveSessionServiceTier({
-          requested: body?.serviceTier,
+        const fastModeResult = resolveSessionFastMode({
+          requested: body?.fastMode,
+          legacyServiceTier: body?.serviceTier,
           agent,
           model: agent === "codex-aisdk" ? resolvedModel ?? "gpt-5.5" : resolvedModel,
         });
-        if (!serviceTierResult.ok) return err(400, serviceTierResult.error);
-        const serviceTier = serviceTierResult.serviceTier;
+        if (!fastModeResult.ok) return err(400, fastModeResult.error);
+        const fastMode = fastModeResult.enabled;
+        const serviceTier = fastModeResult.serviceTier;
         const requestedCwd = body?.cwd?.trim() || undefined;
         const parentId = body?.parentSessionId?.trim() || undefined;
         const spawnedBy = body?.spawnedBy?.trim() || (parentId ? "subagent" : undefined);
@@ -8199,6 +8211,7 @@ a{color:#60a5fa}
           model: launchModel,
           thinkingLevel,
           serviceTier,
+          fastMode,
           claudeAccountId,
           title: requestedTitle || body?.prompt?.slice(0, 72),
           project: repo.project,
@@ -8223,6 +8236,7 @@ a{color:#60a5fa}
           model: launchModel,
           thinkingLevel,
           serviceTier,
+          fastMode,
           sessionId: launchId,
           omgUser: assignedUser,
           containInAgentSlice: isSubagent,
@@ -9241,6 +9255,59 @@ a{color:#60a5fa}
           if (sess.tmuxName) patchManaged(sess.tmuxName, { thinkingLevel });
           invalidateListSessionsCache();
           return json({ ok: true, thinkingLevel });
+        }
+      }
+
+      // Fast is a latency/cost mode, not a reasoning level. SDK-backed
+      // sessions update their provider flag through the command file; native
+      // TUIs receive their own `/fast on|off` control command. Neither path
+      // creates a user turn or changes thinking/effort.
+      {
+        const m = path.match(/^\/api\/sessions\/([0-9a-fA-F-]{36})\/fast-mode$/);
+        if (m && req.method === "POST") {
+          const body = (await req.json().catch(() => null)) as {
+            enabled?: unknown;
+          } | null;
+          const sess = (await listSessions()).find(
+            (s) => s.sessionId === m[1] || s.nativeSessionId === m[1],
+          );
+          if (!sess) return err(404, "session not found");
+          const current = sess.fastMode === true || sess.serviceTier === "fast";
+          const requested = body?.enabled == null ? !current : body.enabled;
+          const resolved = resolveSessionFastMode({
+            requested,
+            agent: sess.agent ?? "",
+            model: sess.model,
+          });
+          if (!resolved.ok) return err(400, resolved.error);
+          const enabled = resolved.enabled;
+
+          if (sess.agent === "aisdk" || sess.agent === "codex-aisdk") {
+            const entry = findAisdkEntryByAnyId(m[1]);
+            if (!entry) return err(409, "session control process is unavailable");
+            appendAisdkCmd(entry.sessionId, { type: "set_fast_mode", enabled });
+            patchAisdkEntry(entry.sessionId, {
+              fastMode: enabled,
+              serviceTier: sess.agent === "codex-aisdk" && enabled ? "fast" : null,
+            });
+          } else if (sess.agent === "claude" || sess.agent === "codex") {
+            if (!sess.tmuxTarget)
+              return err(409, "session is not in a tmux pane — cannot change Fast mode");
+            enqueueMessage(m[1], `/fast ${enabled ? "on" : "off"}`);
+          } else {
+            return err(409, `Fast mode is not supported for ${sess.agent} sessions`);
+          }
+
+          if (sess.tmuxName) {
+            patchManaged(sess.tmuxName, {
+              fastMode: enabled,
+              serviceTier: sess.agent === "codex-aisdk" || sess.agent === "codex"
+                ? (enabled ? "fast" : null)
+                : null,
+            });
+          }
+          invalidateListSessionsCache();
+          return json({ ok: true, fastMode: enabled });
         }
       }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -458,6 +458,7 @@ import {
   resolveModelForAgent,
   thinkingLevelsForAgent,
 } from "../agent-catalog.ts";
+import { resolveSessionServiceTier } from "../service-tier.ts";
 import {
   readModelDiscoveryCacheSync,
   refreshModelCatalog,
@@ -7969,6 +7970,7 @@ a{color:#60a5fa}
           worktree?: boolean;
           model?: string;
           thinkingLevel?: string;
+          serviceTier?: unknown;
           claudeAccountId?: string;
           parentSessionId?: string;
           spawnedBy?: string;
@@ -8052,6 +8054,13 @@ a{color:#60a5fa}
             return err(400, `unknown thinking level "${thinkingLevel}" for ${agent} (expected one of ${allowed.join(", ")})`);
         }
         const resolvedModel = resolveModelForAgent(agent, model, thinkingLevel);
+        const serviceTierResult = resolveSessionServiceTier({
+          requested: body?.serviceTier,
+          agent,
+          model: agent === "codex-aisdk" ? resolvedModel ?? "gpt-5.5" : resolvedModel,
+        });
+        if (!serviceTierResult.ok) return err(400, serviceTierResult.error);
+        const serviceTier = serviceTierResult.serviceTier;
         const requestedCwd = body?.cwd?.trim() || undefined;
         const parentId = body?.parentSessionId?.trim() || undefined;
         const spawnedBy = body?.spawnedBy?.trim() || (parentId ? "subagent" : undefined);
@@ -8189,6 +8198,7 @@ a{color:#60a5fa}
           launchState: "launching",
           model: launchModel,
           thinkingLevel,
+          serviceTier,
           claudeAccountId,
           title: requestedTitle || body?.prompt?.slice(0, 72),
           project: repo.project,
@@ -8212,6 +8222,7 @@ a{color:#60a5fa}
           prompt,
           model: launchModel,
           thinkingLevel,
+          serviceTier,
           sessionId: launchId,
           omgUser: assignedUser,
           containInAgentSlice: isSubagent,

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { agentSupportsFastMode, resolveSessionFastMode } from "./fast-mode.ts";
+
+describe("session Fast mode", () => {
+  test("supports Codex and Claude without coupling to thinking effort", () => {
+    expect(agentSupportsFastMode("codex-aisdk")).toBe(true);
+    expect(agentSupportsFastMode("aisdk")).toBe(true);
+    expect(agentSupportsFastMode("opencode")).toBe(false);
+
+    expect(resolveSessionFastMode({
+      requested: true,
+      agent: "codex-aisdk",
+      model: "gpt-5.6-sol",
+    })).toEqual({ ok: true, enabled: true, serviceTier: "fast" });
+    expect(resolveSessionFastMode({
+      requested: true,
+      agent: "aisdk",
+      model: "opus",
+    })).toEqual({ ok: true, enabled: true });
+  });
+
+  test("accepts explicit off and the old Tibo serviceTier request", () => {
+    expect(resolveSessionFastMode({
+      requested: false,
+      agent: "aisdk",
+      model: "opus",
+    })).toEqual({ ok: true, enabled: false });
+    expect(resolveSessionFastMode({
+      requested: undefined,
+      legacyServiceTier: "fast",
+      agent: "codex-aisdk",
+      model: "gpt-5.6-luna",
+    })).toEqual({ ok: true, enabled: true, serviceTier: "fast" });
+  });
+
+  test("rejects unsupported agents, Codex models, and malformed values", () => {
+    expect(resolveSessionFastMode({
+      requested: true,
+      agent: "opencode",
+      model: "zai/glm",
+    })).toEqual({ ok: false, error: "Fast mode is not supported for opencode sessions" });
+    expect(resolveSessionFastMode({
+      requested: true,
+      agent: "codex-aisdk",
+      model: "gpt-5.3-codex-spark",
+    })).toEqual({
+      ok: false,
+      error: 'Fast mode is not supported for model "gpt-5.3-codex-spark"',
+    });
+    expect(resolveSessionFastMode({
+      requested: "on",
+      agent: "aisdk",
+      model: "opus",
+    })).toEqual({ ok: false, error: "fastMode must be a boolean" });
+  });
+});

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -1,0 +1,65 @@
+import {
+  codexModelSupportsFast,
+  type CodexServiceTier,
+} from "./service-tier.ts";
+
+export type FastModeResolution =
+  | { ok: true; enabled: boolean; serviceTier?: CodexServiceTier }
+  | { ok: false; error: string };
+
+export function agentSupportsFastMode(agent: string): boolean {
+  return agent === "codex" ||
+    agent === "codex-aisdk" ||
+    agent === "claude" ||
+    agent === "aisdk";
+}
+
+/**
+ * Validate Fast independently from reasoning effort.
+ *
+ * `legacyServiceTier` keeps requests from the original Tibo-only UI working
+ * while clients migrate to the provider-neutral `fastMode` flag.
+ */
+export function resolveSessionFastMode(input: {
+  requested: unknown;
+  legacyServiceTier?: unknown;
+  agent: string;
+  model?: string | null;
+}): FastModeResolution {
+  let enabled: boolean;
+  if (input.requested == null || input.requested === "") {
+    if (
+      input.legacyServiceTier == null ||
+      input.legacyServiceTier === "" ||
+      input.legacyServiceTier === "default"
+    ) {
+      enabled = false;
+    } else if (input.legacyServiceTier === "fast") {
+      enabled = true;
+    } else {
+      return { ok: false, error: 'unknown service tier (expected "default" or "fast")' };
+    }
+  } else if (typeof input.requested === "boolean") {
+    enabled = input.requested;
+  } else {
+    return { ok: false, error: "fastMode must be a boolean" };
+  }
+
+  if (!enabled) return { ok: true, enabled: false };
+  if (!agentSupportsFastMode(input.agent)) {
+    return { ok: false, error: `Fast mode is not supported for ${input.agent} sessions` };
+  }
+  if (
+    (input.agent === "codex" || input.agent === "codex-aisdk") &&
+    !codexModelSupportsFast(input.model)
+  ) {
+    return { ok: false, error: `Fast mode is not supported for model "${input.model ?? ""}"` };
+  }
+  return {
+    ok: true,
+    enabled: true,
+    ...(input.agent === "codex" || input.agent === "codex-aisdk"
+      ? { serviceTier: "fast" as const }
+      : {}),
+  };
+}

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -18,6 +18,7 @@ import { dirname } from "node:path";
 import { PATHS } from "./config.ts";
 import { OMG_CAPABILITY_VERSION } from "./omg-capabilities.ts";
 import { tmuxHasSession } from "./tmux.ts";
+import type { CodexServiceTier } from "./service-tier.ts";
 
 function registryPath(): string {
   return `${PATHS.data}/managed-sessions.json`;
@@ -44,6 +45,8 @@ export type ManagedSession = {
   model?: string;
   /** Reasoning effort selected for subsequent turns, when the agent supports it. */
   thinkingLevel?: string;
+  /** Codex account service tier selected when this session launched. */
+  serviceTier?: CodexServiceTier;
   /** Isolated Claude subscription account pinned when this session launched. */
   claudeAccountId?: string;
   title?: string;

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -46,7 +46,9 @@ export type ManagedSession = {
   /** Reasoning effort selected for subsequent turns, when the agent supports it. */
   thinkingLevel?: string;
   /** Codex account service tier selected when this session launched. */
-  serviceTier?: CodexServiceTier;
+  serviceTier?: CodexServiceTier | null;
+  /** Provider-native low-latency mode, independent from reasoning effort. */
+  fastMode?: boolean;
   /** Isolated Claude subscription account pinned when this session launched. */
   claudeAccountId?: string;
   title?: string;

--- a/src/migrations/resume-cache/007_fast_mode.sql
+++ b/src/migrations/resume-cache/007_fast_mode.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE resumable_sessions ADD COLUMN thinking_level TEXT;
+ALTER TABLE resumable_sessions ADD COLUMN service_tier TEXT;
+ALTER TABLE resumable_sessions ADD COLUMN fast_mode INTEGER NOT NULL DEFAULT 0;
+
+PRAGMA user_version = 7;
+
+COMMIT;

--- a/src/resume-cache-historical.test.ts
+++ b/src/resume-cache-historical.test.ts
@@ -108,4 +108,29 @@ describe("historical session cache", () => {
       "claude",
     ]);
   });
+
+  test("round-trips Fast and thinking state for cold resume", () => {
+    upsertResumableRows([{
+      sessionId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      cwd: "/home/dev/repos/lfg",
+      project: "lfg",
+      title: "Fast Claude session",
+      lastActivityAt: 5_000,
+      lastUserText: "keep going",
+      agent: "claude",
+      backend: "aisdk",
+      path: "lfg://cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      mtimeMs: 5_000,
+      model: "opus",
+      thinkingLevel: "low",
+      fastMode: true,
+      managed: true,
+    }]);
+
+    expect(queryResumableCache().sessions[0]).toMatchObject({
+      thinkingLevel: "low",
+      fastMode: true,
+      model: "opus",
+    });
+  });
 });

--- a/src/resume-cache-migration.test.ts
+++ b/src/resume-cache-migration.test.ts
@@ -90,6 +90,11 @@ describe("resume cache migration", () => {
       "utf8",
     );
     db.exec(contractTitleSql);
+    const fastModeSql = readFileSync(
+      new URL("./migrations/resume-cache/007_fast_mode.sql", import.meta.url),
+      "utf8",
+    );
+    db.exec(fastModeSql);
 
     const columns = db.query<{ name: string }, []>("PRAGMA table_info(resumable_sessions)").all();
     expect(columns.map((column) => column.name)).toEqual(expect.arrayContaining([
@@ -99,6 +104,9 @@ describe("resume cache migration", () => {
       "assigned_user",
       "managed",
       "resumable",
+      "thinking_level",
+      "service_tier",
+      "fast_mode",
     ]));
     expect(db.query<{ session_id: string }, []>(
       "SELECT session_id FROM resumable_sessions WHERE resumable = 1 ORDER BY session_id",
@@ -121,7 +129,7 @@ describe("resume cache migration", () => {
     expect(db.query<{ mtime_ms: number }, []>(
       "SELECT mtime_ms FROM resumable_sessions WHERE session_id = 'managed-session'",
     ).get()?.mtime_ms).toBe(42);
-    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(6);
+    expect(db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version).toBe(7);
     db.close();
   });
 });

--- a/src/resume-cache.ts
+++ b/src/resume-cache.ts
@@ -105,6 +105,9 @@ type Row = {
   backend: string | null;
   resume_handle: string | null;
   model: string | null;
+  thinking_level: string | null;
+  service_tier: string | null;
+  fast_mode: number;
   assigned_user: string | null;
   managed: number;
   resumable: number;
@@ -187,6 +190,13 @@ function init(): Database {
     );
     d.exec(migration);
   }
+  if (version < 7) {
+    const migration = readFileSync(
+      new URL("./migrations/resume-cache/007_fast_mode.sql", import.meta.url),
+      "utf8",
+    );
+    d.exec(migration);
+  }
   initialized = true;
   return d;
 }
@@ -212,6 +222,9 @@ function toSession(row: Row): ResumableSession {
     backend: (row.backend || undefined) as ResumableSession["backend"],
     resumeHandle: row.resume_handle,
     model: row.model,
+    thinkingLevel: row.thinking_level,
+    serviceTier: row.service_tier === "fast" ? "fast" : null,
+    fastMode: row.fast_mode === 1 || row.service_tier === "fast",
     assignedUser: row.assigned_user,
   };
 }
@@ -236,8 +249,9 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
   const stmt = d.query(`
     INSERT INTO resumable_sessions
       (session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-       backend, resume_handle, model, assigned_user, managed, resumable)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       backend, resume_handle, model, thinking_level, service_tier, fast_mode,
+       assigned_user, managed, resumable)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(session_id) DO UPDATE SET
       cwd = excluded.cwd,
       project = excluded.project,
@@ -250,6 +264,9 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
       backend = excluded.backend,
       resume_handle = excluded.resume_handle,
       model = excluded.model,
+      thinking_level = excluded.thinking_level,
+      service_tier = excluded.service_tier,
+      fast_mode = excluded.fast_mode,
       assigned_user = COALESCE(excluded.assigned_user, resumable_sessions.assigned_user),
       managed = excluded.managed,
       resumable = excluded.resumable
@@ -269,6 +286,9 @@ export function upsertResumableRows(rows: ResumableCacheRow[]): void {
         r.backend ?? null,
         r.resumeHandle ?? null,
         r.model ?? null,
+        r.thinkingLevel ?? null,
+        r.serviceTier ?? null,
+        r.fastMode ? 1 : 0,
         r.assignedUser ?? null,
         r.managed ? 1 : 0,
         r.resumable === false ? 0 : 1,
@@ -341,7 +361,8 @@ export function getCachedResumableSession(sessionId: string): ResumableSession |
   const row = d
     .query<Row, [string]>(`
       SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-             backend, resume_handle, model, assigned_user, managed, resumable
+             backend, resume_handle, model, thinking_level, service_tier, fast_mode,
+             assigned_user, managed, resumable
       FROM resumable_sessions
       WHERE session_id = ? AND resumable = 1
     `)
@@ -471,7 +492,8 @@ export function queryResumableCache(opts: ResumableQuery = {}): ResumableQueryRe
   const rows = d
     .query<Row, (string | number)[]>(`
       SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-             backend, resume_handle, model, assigned_user, managed, resumable
+             backend, resume_handle, model, thinking_level, service_tier, fast_mode,
+             assigned_user, managed, resumable
       FROM resumable_sessions
       ${whereSql}
       ORDER BY last_activity_at IS NULL, last_activity_at DESC, session_id DESC
@@ -535,7 +557,8 @@ export function queryHistoricalCache(opts: HistoricalQuery = {}): HistoricalQuer
   const rows = d
     .query<Row, (string | number)[]>(`
       SELECT session_id, cwd, project, title, last_user_text, last_activity_at, agent, path, mtime_ms,
-             backend, resume_handle, model, assigned_user, managed, resumable
+             backend, resume_handle, model, thinking_level, service_tier, fast_mode,
+             assigned_user, managed, resumable
       FROM resumable_sessions
       ${whereSql}
       ORDER BY last_activity_at IS NULL, last_activity_at DESC, session_id DESC

--- a/src/service-tier.test.ts
+++ b/src/service-tier.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  codexModelSupportsFast,
+  codexServiceTierArgs,
+  resolveSessionServiceTier,
+  withCodexServiceTierConfig,
+} from "./service-tier.ts";
+
+describe("Codex service tier", () => {
+  test("recognizes the supported Fast model families", () => {
+    expect(codexModelSupportsFast("gpt-5.6-sol")).toBe(true);
+    expect(codexModelSupportsFast("gpt-5.6-luna")).toBe(true);
+    expect(codexModelSupportsFast("gpt-5.5")).toBe(true);
+    expect(codexModelSupportsFast("gpt-5.4")).toBe(true);
+    expect(codexModelSupportsFast("gpt-5.4-mini")).toBe(false);
+    expect(codexModelSupportsFast("gpt-5.3-codex-spark")).toBe(false);
+  });
+
+  test("accepts Fast only for supported Codex sessions", () => {
+    expect(resolveSessionServiceTier({
+      requested: "fast",
+      agent: "codex-aisdk",
+      model: "gpt-5.6-sol",
+    })).toEqual({ ok: true, serviceTier: "fast" });
+    expect(resolveSessionServiceTier({
+      requested: "fast",
+      agent: "aisdk",
+      model: "gpt-5.6-sol",
+    })).toEqual({ ok: false, error: "Fast service tier is not supported for aisdk sessions" });
+    expect(resolveSessionServiceTier({
+      requested: "fast",
+      agent: "codex-aisdk",
+      model: "gpt-5.3-codex-spark",
+    })).toEqual({
+      ok: false,
+      error: 'Fast service tier is not supported for model "gpt-5.3-codex-spark"',
+    });
+    expect(resolveSessionServiceTier({
+      requested: "priority",
+      agent: "codex-aisdk",
+      model: "gpt-5.6-sol",
+    })).toEqual({ ok: false, error: 'unknown service tier (expected "default" or "fast")' });
+  });
+
+  test("omitted and default tiers keep ordinary launches unchanged", () => {
+    expect(resolveSessionServiceTier({
+      requested: undefined,
+      agent: "aisdk",
+      model: "opus",
+    })).toEqual({ ok: true });
+    expect(resolveSessionServiceTier({
+      requested: "default",
+      agent: "codex-aisdk",
+      model: "gpt-5.6-sol",
+    })).toEqual({ ok: true });
+    expect(codexServiceTierArgs()).toEqual([]);
+  });
+
+  test("adds both required Codex Fast overrides without losing MCP config", () => {
+    expect(codexServiceTierArgs("fast")).toEqual([
+      "-c",
+      'service_tier="fast"',
+      "-c",
+      "features.fast_mode=true",
+    ]);
+    expect(withCodexServiceTierConfig({
+      mcp_servers: { omg: { env: { OMG_SESSION_ID: "sid" } } },
+      features: { another_feature: true },
+    }, "fast")).toEqual({
+      mcp_servers: { omg: { env: { OMG_SESSION_ID: "sid" } } },
+      service_tier: "fast",
+      features: { another_feature: true, fast_mode: true },
+    });
+  });
+});

--- a/src/service-tier.ts
+++ b/src/service-tier.ts
@@ -1,0 +1,62 @@
+export type CodexServiceTier = "fast";
+
+export type CodexConfigValue =
+  | string
+  | number
+  | boolean
+  | CodexConfigValue[]
+  | { [key: string]: CodexConfigValue };
+
+export type ServiceTierResolution =
+  | { ok: true; serviceTier?: CodexServiceTier }
+  | { ok: false; error: string };
+
+/** Codex currently advertises Fast tier for GPT-5.4, GPT-5.5 and GPT-5.6. */
+export function codexModelSupportsFast(model: string | null | undefined): boolean {
+  if (!model) return false;
+  return /^gpt-5\.(?:6(?:-|$)|5(?:-|$)|4$)/.test(model);
+}
+
+/** Validate the untrusted service-tier field from a new-session request. */
+export function resolveSessionServiceTier(input: {
+  requested: unknown;
+  agent: string;
+  model?: string | null;
+}): ServiceTierResolution {
+  if (input.requested == null || input.requested === "" || input.requested === "default") {
+    return { ok: true };
+  }
+  if (input.requested !== "fast") {
+    return { ok: false, error: 'unknown service tier (expected "default" or "fast")' };
+  }
+  if (input.agent !== "codex-aisdk" && input.agent !== "codex") {
+    return { ok: false, error: `Fast service tier is not supported for ${input.agent} sessions` };
+  }
+  if (!codexModelSupportsFast(input.model)) {
+    return { ok: false, error: `Fast service tier is not supported for model "${input.model ?? ""}"` };
+  }
+  return { ok: true, serviceTier: "fast" };
+}
+
+export function codexServiceTierArgs(serviceTier?: CodexServiceTier): string[] {
+  return serviceTier === "fast"
+    ? ["-c", 'service_tier="fast"', "-c", "features.fast_mode=true"]
+    : [];
+}
+
+/** Merge Fast tier into SDK config without discarding per-session MCP config. */
+export function withCodexServiceTierConfig(
+  base: { [key: string]: CodexConfigValue } | undefined,
+  serviceTier?: CodexServiceTier,
+): { [key: string]: CodexConfigValue } | undefined {
+  if (serviceTier !== "fast") return base;
+  const features = base?.features;
+  const featureObject = features && !Array.isArray(features) && typeof features === "object"
+    ? features
+    : {};
+  return {
+    ...(base ?? {}),
+    service_tier: "fast",
+    features: { ...featureObject, fast_mode: true },
+  };
+}

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -115,6 +115,7 @@ function launchRecovered(
       key: entry.sessionId,
       resume: entry.threadId,
       thinkingLevel: entry.thinkingLevel ?? undefined,
+      serviceTier: managed.serviceTier ?? entry.serviceTier,
     });
   }
   if (entry.agent === "opencode") {

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -115,7 +115,7 @@ function launchRecovered(
       key: entry.sessionId,
       resume: entry.threadId,
       thinkingLevel: entry.thinkingLevel ?? undefined,
-      serviceTier: managed.serviceTier ?? entry.serviceTier,
+      serviceTier: managed.serviceTier ?? entry.serviceTier ?? undefined,
     });
   }
   if (entry.agent === "opencode") {
@@ -175,6 +175,7 @@ function launchRecovered(
     ...common,
     sessionId: entry.sessionId,
     thinkingLevel: entry.thinkingLevel ?? undefined,
+    fastMode: managed.fastMode ?? entry.fastMode ?? false,
     claudeAccountId: managed.claudeAccountId,
   });
 }

--- a/src/session-service-tier.test.ts
+++ b/src/session-service-tier.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  managedCodexAisdkSessionArgv,
+  managedCodexSessionArgv,
+} from "./tmux.ts";
+
+function configOverrides(argv: string[]): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < argv.length - 1; i++) {
+    if (argv[i] === "-c") values.push(argv[i + 1]);
+  }
+  return values;
+}
+
+describe("Codex Fast launch transport", () => {
+  test("direct Codex receives Fast service-tier config", () => {
+    const argv = managedCodexSessionArgv({
+      name: "lfg-fast-test",
+      cwd: "/tmp/lfg-fast-test",
+      model: "gpt-5.6-sol",
+      thinkingLevel: "high",
+      serviceTier: "fast",
+    });
+
+    expect(configOverrides(argv)).toContain('service_tier="fast"');
+    expect(configOverrides(argv)).toContain("features.fast_mode=true");
+    expect(configOverrides(argv)).toContain('reasoning_effort="high"');
+  });
+
+  test("the Codex SDK harness receives Fast as an explicit launch argument", () => {
+    const argv = managedCodexAisdkSessionArgv({
+      name: "lfg-fast-test",
+      cwd: "/tmp/lfg-fast-test",
+      model: "gpt-5.6-sol",
+      key: "session-key",
+      thinkingLevel: "high",
+      serviceTier: "fast",
+    });
+
+    expect(argv.slice(argv.indexOf("--service-tier"), argv.indexOf("--service-tier") + 2)).toEqual([
+      "--service-tier",
+      "fast",
+    ]);
+    expect(argv.slice(argv.indexOf("--thinking-level"), argv.indexOf("--thinking-level") + 2)).toEqual([
+      "--thinking-level",
+      "high",
+    ]);
+  });
+
+  test("ordinary launches do not receive Fast config", () => {
+    const direct = managedCodexSessionArgv({
+      name: "lfg-default-test",
+      cwd: "/tmp/lfg-default-test",
+      model: "gpt-5.6-sol",
+    });
+    const sdk = managedCodexAisdkSessionArgv({
+      name: "lfg-default-test",
+      cwd: "/tmp/lfg-default-test",
+      model: "gpt-5.6-sol",
+      key: "session-key",
+    });
+
+    expect(configOverrides(direct)).not.toContain('service_tier="fast"');
+    expect(sdk).not.toContain("--service-tier");
+  });
+});

--- a/src/session-service-tier.test.ts
+++ b/src/session-service-tier.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  managedAisdkSessionArgv,
   managedCodexAisdkSessionArgv,
   managedCodexSessionArgv,
 } from "./tmux.ts";
@@ -62,5 +63,34 @@ describe("Codex Fast launch transport", () => {
 
     expect(configOverrides(direct)).not.toContain('service_tier="fast"');
     expect(sdk).not.toContain("--service-tier");
+  });
+});
+
+describe("Claude Fast launch transport", () => {
+  test("passes Fast separately from a lower effort", () => {
+    const argv = managedAisdkSessionArgv({
+      name: "lfg-claude-fast-test",
+      cwd: "/tmp/lfg-claude-fast-test",
+      model: "opus",
+      sessionId: "session-key",
+      thinkingLevel: "low",
+      fastMode: true,
+    });
+
+    expect(argv).toContain("--fast-mode");
+    expect(argv.slice(argv.indexOf("--thinking-level"), argv.indexOf("--thinking-level") + 2)).toEqual([
+      "--thinking-level",
+      "low",
+    ]);
+  });
+
+  test("ordinary Claude launches omit Fast", () => {
+    expect(managedAisdkSessionArgv({
+      name: "lfg-claude-default-test",
+      cwd: "/tmp/lfg-claude-default-test",
+      model: "opus",
+      sessionId: "session-key",
+      thinkingLevel: "medium",
+    })).not.toContain("--fast-mode");
   });
 });

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -428,6 +428,7 @@ export type Session = {
   thinkingLevel?: string | null;
   /** Fast when Codex launched on its higher-throughput account service tier. */
   serviceTier?: "fast" | null;
+  fastMode?: boolean;
   // Health of the session as far as the build is concerned. "ok" = running
   // normally; "blocked" = the session can't make forward progress until a
   // human acts (e.g. its model was retired/disabled, or the agent ran out of
@@ -674,6 +675,10 @@ export function managedLaunchRow(
         : modelAlias(model),
     thinkingLevel: m.thinkingLevel ?? null,
     serviceTier: m.serviceTier ?? directEntry?.serviceTier ?? null,
+    fastMode:
+      m.fastMode ??
+      directEntry?.fastMode ??
+      (m.serviceTier === "fast" || directEntry?.serviceTier === "fast"),
     // The harness is gone, so there is nobody left to retry: a dead session
     // with a recorded reason is blocked, and says so. computeStatus cannot
     // reach this conclusion on its own — it keys off `apiError`, which lives on
@@ -2700,6 +2705,7 @@ export async function listSessions(): Promise<Session[]> {
         p.cmd.match(/reasoning_effort=(?:"([^"]+)"|'([^']+)'|(\S+))/)?.slice(1).find(Boolean) ??
         null,
       serviceTier: managedRec?.serviceTier ?? null,
+      fastMode: managedRec?.fastMode ?? (managedRec?.serviceTier === "fast"),
       ...computeStatus(last, null),
     });
   }
@@ -3091,6 +3097,10 @@ export async function listSessions(): Promise<Session[]> {
       model: publicAgent === "aisdk" || isPi ? modelAlias(e.model) : e.model,
       thinkingLevel: e.thinkingLevel ?? managedRec?.thinkingLevel ?? null,
       serviceTier: e.serviceTier ?? managedRec?.serviceTier ?? null,
+      fastMode:
+        e.fastMode ??
+        managedRec?.fastMode ??
+        (e.serviceTier === "fast" || managedRec?.serviceTier === "fast"),
       ...(e.recoveredAt
         ? {
             status: "blocked" as const,
@@ -3442,6 +3452,9 @@ export type ResumableSession = {
   backend?: "aisdk" | "codex-aisdk" | "opencode" | "pi" | "grok" | "cursor" | "fx" | "copilot" | "jcode";
   resumeHandle?: string | null;
   model?: string | null;
+  thinkingLevel?: string | null;
+  serviceTier?: "fast" | null;
+  fastMode?: boolean;
   assignedUser?: string | null;
 };
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -426,6 +426,8 @@ export type Session = {
   // without a live effort control or older sessions launched before it was
   // tracked.
   thinkingLevel?: string | null;
+  /** Fast when Codex launched on its higher-throughput account service tier. */
+  serviceTier?: "fast" | null;
   // Health of the session as far as the build is concerned. "ok" = running
   // normally; "blocked" = the session can't make forward progress until a
   // human acts (e.g. its model was retired/disabled, or the agent ran out of
@@ -671,6 +673,7 @@ export function managedLaunchRow(
         ? model
         : modelAlias(model),
     thinkingLevel: m.thinkingLevel ?? null,
+    serviceTier: m.serviceTier ?? directEntry?.serviceTier ?? null,
     // The harness is gone, so there is nobody left to retry: a dead session
     // with a recorded reason is blocked, and says so. computeStatus cannot
     // reach this conclusion on its own — it keys off `apiError`, which lives on
@@ -2696,6 +2699,7 @@ export async function listSessions(): Promise<Session[]> {
         managedRec?.thinkingLevel ??
         p.cmd.match(/reasoning_effort=(?:"([^"]+)"|'([^']+)'|(\S+))/)?.slice(1).find(Boolean) ??
         null,
+      serviceTier: managedRec?.serviceTier ?? null,
       ...computeStatus(last, null),
     });
   }
@@ -3086,6 +3090,7 @@ export async function listSessions(): Promise<Session[]> {
       // be explicit about intent.
       model: publicAgent === "aisdk" || isPi ? modelAlias(e.model) : e.model,
       thinkingLevel: e.thinkingLevel ?? managedRec?.thinkingLevel ?? null,
+      serviceTier: e.serviceTier ?? managedRec?.serviceTier ?? null,
       ...(e.recoveredAt
         ? {
             status: "blocked" as const,

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -16,6 +16,10 @@ import {
   resolveClaudeAccount,
 } from "./claude-accounts.ts";
 import { agentTmpEnv } from "./tmp-reclaim.ts";
+import {
+  codexServiceTierArgs,
+  type CodexServiceTier,
+} from "./service-tier.ts";
 
 // Known-good Claude model alias to launch with when a caller doesn't specify
 // one. Never launch a managed `claude` bare — see spawnManagedSession. Opus is
@@ -693,17 +697,19 @@ export function relaunchSessionWithModel(opts: {
   return { ok: true };
 }
 
-export function spawnManagedCodexSession(opts: {
+export type ManagedCodexSessionOptions = {
   name: string;
   cwd: string;
   prompt?: string;
   model?: string;
   thinkingLevel?: string;
+  serviceTier?: CodexServiceTier;
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
-}): { ok: boolean; error?: string } {
-  const dec = new TextDecoder();
+};
+
+export function managedCodexSessionArgv(opts: ManagedCodexSessionOptions): string[] {
   const argv = [
     "tmux",
     "new-session",
@@ -724,10 +730,17 @@ export function spawnManagedCodexSession(opts: {
   ];
   if (opts.model) argv.push("--model", opts.model);
   if (opts.thinkingLevel) argv.push("-c", `reasoning_effort=${JSON.stringify(opts.thinkingLevel)}`);
+  argv.push(...codexServiceTierArgs(opts.serviceTier));
   const prompt = withOmgRuntimeContract(opts.prompt);
   if (prompt?.trim()) argv.push("--", prompt);
   addSessionEnv(argv, opts.omgSessionId, opts.omgUser, opts.name);
   containTmuxCommand(argv, codexBin(), opts.containInAgentSlice, opts);
+  return argv;
+}
+
+export function spawnManagedCodexSession(opts: ManagedCodexSessionOptions): { ok: boolean; error?: string } {
+  const dec = new TextDecoder();
+  const argv = managedCodexSessionArgv(opts);
   const create = Bun.spawnSync(argv);
   if (create.exitCode !== 0)
     return { ok: false, error: dec.decode(create.stderr) || "new-session failed" };
@@ -1130,13 +1143,14 @@ export function spawnManagedAisdkSession(opts: {
 // at the codex harness and passes the control-plane KEY (--key) rather
 // than a deterministic --session id — codex assigns its thread id only after the
 // first turn, so the key is all we know up front (see the harness header).
-export function spawnManagedCodexAisdkSession(opts: {
+export type ManagedCodexAisdkSessionOptions = {
   name: string;
   cwd: string;
   prompt?: string;
   model: string;
   key: string;
   thinkingLevel?: string;
+  serviceTier?: CodexServiceTier;
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
@@ -1144,14 +1158,9 @@ export function spawnManagedCodexAisdkSession(opts: {
   // fresh persistent thread — the harness seeds its threadId with it.
   resume?: string;
   recoveredAt?: number;
-}): ManagedHarnessSpawnResult {
-  // Harmless for codex: ensureFolderTrusted only patches ~/.claude.json and is a
-  // no-op when that file (or the project entry) is absent. Codex doesn't gate on
-  // it, but keeping it costs nothing and keeps this in lockstep with the Claude
-  // spawn helper.
-  ensureFolderTrusted(opts.cwd);
-  // Spawn the harness module directly (not via the lfg CLI) so it has no
-  // dependency on the rest of the command surface.
+};
+
+export function managedCodexAisdkSessionArgv(opts: ManagedCodexAisdkSessionOptions): string[] {
   const harnessPath = `${import.meta.dir}/agents/backends/codex-aisdk-session.ts`;
   const argv = [
     process.execPath, harnessPath,
@@ -1161,10 +1170,23 @@ export function spawnManagedCodexAisdkSession(opts: {
     "--managed-name", opts.name,
   ];
   if (opts.thinkingLevel) argv.push("--thinking-level", opts.thinkingLevel);
+  if (opts.serviceTier) argv.push("--service-tier", opts.serviceTier);
   if (opts.resume) argv.push("--resume", opts.resume);
   if (opts.recoveredAt) argv.push("--recovered-at", String(opts.recoveredAt));
   const prompt = withOmgRuntimeContract(opts.prompt);
   if (prompt?.trim()) argv.push("--", prompt);
+  return argv;
+}
+
+export function spawnManagedCodexAisdkSession(opts: ManagedCodexAisdkSessionOptions): ManagedHarnessSpawnResult {
+  // Harmless for codex: ensureFolderTrusted only patches ~/.claude.json and is a
+  // no-op when that file (or the project entry) is absent. Codex doesn't gate on
+  // it, but keeping it costs nothing and keeps this in lockstep with the Claude
+  // spawn helper.
+  ensureFolderTrusted(opts.cwd);
+  // Spawn the harness module directly (not via the lfg CLI) so it has no
+  // dependency on the rest of the command surface.
+  const argv = managedCodexAisdkSessionArgv(opts);
   return spawnManagedHarness(argv, {
     name: opts.name,
     cwd: opts.cwd,

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -608,6 +608,7 @@ export function spawnManagedSession(opts: {
   prompt?: string;
   model?: string;
   thinkingLevel?: string;
+  fastMode?: boolean;
   // When set, resume the on-disk transcript with this sessionId (`claude
   // --resume <id>`) instead of starting a fresh conversation — the way lfg
   // brings a closed/dead session back after the box (and its tmux server +
@@ -643,6 +644,7 @@ export function spawnManagedSession(opts: {
   // vocabulary onto it (see claudeEffortFor). Omitted → CLI default effort.
   const effort = claudeEffortFor(opts.thinkingLevel);
   if (effort) claudeArgv.push("--effort", effort);
+  if (opts.fastMode) claudeArgv.push("--settings", JSON.stringify({ fastMode: true }));
   // `--` terminates option parsing so the variadic --add-dir can't swallow the
   // positional prompt as a second directory (which strands the new session at
   // an empty composer — the first message never gets submitted).
@@ -1095,24 +1097,22 @@ export function cursorRelaunchArgv(opts: {
 
 // Spawn a headless "aisdk" session directly. I/O and lifecycle are registry /
 // command-file driven; no tmux pane is involved.
-export function spawnManagedAisdkSession(opts: {
+export type ManagedAisdkSessionOptions = {
   name: string;
   cwd: string;
   prompt?: string;
   model: string;
   sessionId: string;
   thinkingLevel?: string;
+  fastMode?: boolean;
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
   claudeAccountId?: string;
   recoveredAt?: number;
-}): ManagedHarnessSpawnResult {
-  // The provider drives the bundled claude binary, which still honors the trust
-  // dialog — pre-accept it so the first turn doesn't hang.
-  ensureFolderTrusted(opts.cwd);
-  // Spawn the harness module directly (not via the lfg CLI) so it has no
-  // dependency on the rest of the command surface.
+};
+
+export function managedAisdkSessionArgv(opts: ManagedAisdkSessionOptions): string[] {
   const harnessPath = `${import.meta.dir}/agents/backends/aisdk-session.ts`;
   const argv = [
     process.execPath, harnessPath,
@@ -1121,14 +1121,23 @@ export function spawnManagedAisdkSession(opts: {
     "--cwd", opts.cwd,
     "--managed-name", opts.name,
   ];
-  // Forward the requested thinking level; the harness maps it onto the
-  // claude-code provider's `effort` option (see aisdk-session.ts).
   if (opts.thinkingLevel) argv.push("--thinking-level", opts.thinkingLevel);
-  const claudeAccountId = opts.claudeAccountId ?? resolveClaudeAccount()?.id;
-  if (claudeAccountId) argv.push("--claude-account", claudeAccountId);
+  if (opts.fastMode) argv.push("--fast-mode");
+  if (opts.claudeAccountId) argv.push("--claude-account", opts.claudeAccountId);
   if (opts.recoveredAt) argv.push("--recovered-at", String(opts.recoveredAt));
   const prompt = withOmgRuntimeContract(opts.prompt);
   if (prompt?.trim()) argv.push("--", prompt);
+  return argv;
+}
+
+export function spawnManagedAisdkSession(opts: ManagedAisdkSessionOptions): ManagedHarnessSpawnResult {
+  // The provider drives the bundled claude binary, which still honors the trust
+  // dialog — pre-accept it so the first turn doesn't hang.
+  ensureFolderTrusted(opts.cwd);
+  // Spawn the harness module directly (not via the lfg CLI) so it has no
+  // dependency on the rest of the command surface.
+  const claudeAccountId = opts.claudeAccountId ?? resolveClaudeAccount()?.id;
+  const argv = managedAisdkSessionArgv({ ...opts, claudeAccountId });
   return spawnManagedHarness(argv, {
     name: opts.name,
     cwd: opts.cwd,

--- a/test/thinking-level-label.test.ts
+++ b/test/thinking-level-label.test.ts
@@ -297,8 +297,10 @@ describe("thinking level menu", () => {
     expect(source).toContain(
       "function submit(e?: FormEvent, overrideText?: string, overrideThinking?: ThinkingLevel)",
     );
-    expect(source).toContain("const launchThinkingLevel = overrideThinking ?? thinkingLevel");
-    expect(source).toContain("thinkingLevels={agentSupportsThinking(agent) ? thinkingLevels : []}");
+    expect(source).toContain("thinkingLevel: overrideThinking ?? thinkingLevel");
+    expect(source).toContain("const launchThinkingLevel = tiboLaunch.thinkingLevel as ThinkingLevel");
+    expect(source).toContain("tiboModeActive");
+    expect(source).toContain("agentSupportsThinking(agent)");
     expect(source).toContain("submit(undefined, undefined, next)");
     // A press that opened the scrubber owns its trailing click even when the
     // scrub was abandoned — cancelling must not fall through to "start anyway".

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -277,6 +277,12 @@ import {
   togglePinnedSession,
 } from "./lib/session-pins";
 import { pendingLiveFocusRequest } from "./lib/live-focus";
+import {
+  canUseTiboMode,
+  readTiboMode,
+  resolveTiboLaunch,
+  writeTiboMode,
+} from "./lib/tibo-mode";
 import { ConnectionStatusToasts } from "./ConnectionStatus";
 import type {
   ClipboardEvent,
@@ -355,6 +361,7 @@ import {
   Trash2,
   TriangleAlert,
   UserRound,
+  Zap,
   Camera,
   X,
   Ellipsis,
@@ -750,6 +757,7 @@ export type Session = {
   assignedUser?: string | null;
   model?: string | null;
   thinkingLevel?: string | null;
+  serviceTier?: "fast" | null;
   parentSessionId?: string | null;
   parentNativeSessionId?: string | null;
   parentAgent?: string | null;
@@ -17387,6 +17395,15 @@ const onTouchStart = (e: ReactTouchEvent) => {
             {session.model}
           </span>
         ) : null)}
+        {session.serviceTier === "fast" ? (
+          <span
+            title="Tibo mode: Fast service tier"
+            className="flex shrink-0 items-center gap-1 rounded-full bg-gradient-to-r from-orange-500/16 to-fuchsia-500/14 px-2 py-0.5 text-[10px] font-semibold text-orange-700 ring-1 ring-inset ring-orange-400/25 dark:text-orange-300"
+          >
+            <Zap className="size-3 fill-orange-400 text-orange-500" />
+            Tibo
+          </span>
+        ) : null}
         {/* Redundant on wide screens: the rail row for this session already
             carries the same state on its avatar, so only the narrow (no-rail)
             grid layout needs it here. */}
@@ -20809,6 +20826,7 @@ function NewSessionDialog({
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
     () => savedThinkingLevel(),
   );
+  const [tiboMode, setTiboModeState] = useState(() => readTiboMode(localStorage));
   // Default the owner to the active profile, falling back to the first known user
   // — never empty when a roster exists. An unowned session lands unassigned, and
   // the live view's auto-default filter (which flips to a specific user) then
@@ -21272,6 +21290,8 @@ function NewSessionDialog({
 
   const models = catalog.models[agent] ?? AGENT_MODELS[agent];
   const thinkingLevels = useAgentThinkingLevels(agent, model);
+  const tiboModeAvailable = canUseTiboMode({ agent, model, thinkingLevels });
+  const tiboModeActive = tiboMode && tiboModeAvailable;
   // When the live view is filtered to a specific project, lock new sessions to
   // that project's repo (and hide the picker below). Falls back to the normal
   // localStorage/first-repo default when viewing "All projects" or when the
@@ -21348,6 +21368,20 @@ function NewSessionDialog({
       setThinkingLevel(thinkingLevels.includes("high") ? "high" : thinkingLevels[0]);
     }
   }, [thinkingLevel, thinkingLevels]);
+  useEffect(() => {
+    if (tiboModeActive && thinkingLevel !== "high") setThinkingLevel("high");
+  }, [tiboModeActive, thinkingLevel]);
+
+  function setTiboMode(enabled: boolean) {
+    setTiboModeState(enabled);
+    writeTiboMode(localStorage, enabled);
+    if (enabled && tiboModeAvailable) setThinkingLevel("high");
+  }
+
+  function changeComposerThinkingLevel(next: ThinkingLevel) {
+    if (tiboModeActive && next !== "high") setTiboMode(false);
+    setThinkingLevel(next);
+  }
 
   const visibleAgentOptions = useMemo(() => {
     return configuredLaunchOptions(codingAgents, accessMode);
@@ -21420,8 +21454,14 @@ function NewSessionDialog({
     }
     const launchUser = resolveRosterUser(user, users) || null;
     const launchAgent = agent;
-    const launchModel = model;
-    const launchThinkingLevel = overrideThinking ?? thinkingLevel;
+    const tiboLaunch = resolveTiboLaunch({
+      enabled: tiboMode,
+      available: tiboModeAvailable,
+      model,
+      thinkingLevel: overrideThinking ?? thinkingLevel,
+    });
+    const launchModel = tiboLaunch.model;
+    const launchThinkingLevel = tiboLaunch.thinkingLevel as ThinkingLevel;
     const launchClaudeAccountId = launchAgent === "aisdk" ? claudeAccountId || undefined : undefined;
     const stashed = stagePromptSend({
       contextKey: "new-session",
@@ -21483,6 +21523,7 @@ function NewSessionDialog({
             agent: launchAgent,
             model: launchModel,
             thinkingLevel: thinkingLevels.length ? launchThinkingLevel : undefined,
+            serviceTier: tiboLaunch.serviceTier,
             claudeAccountId: launchClaudeAccountId,
             overLimit: overLimit || undefined,
           }),
@@ -21658,10 +21699,19 @@ function NewSessionDialog({
         agent={agent}
         value={thinkingLevel}
         levels={thinkingLevels}
-        onChange={setThinkingLevel}
+        onChange={changeComposerThinkingLevel}
         flat={variant === "inline"}
         immersive
       />
+
+      {agent === "codex" || agent === "codex-aisdk" ? (
+        <TiboModePill
+          enabled={tiboModeActive}
+          available={tiboModeAvailable}
+          onToggle={() => setTiboMode(!tiboMode)}
+          flat={variant === "inline"}
+        />
+      ) : null}
 
 
       {!projectScoped && (
@@ -21939,9 +21989,15 @@ function NewSessionDialog({
           <ComposerStartButton
             disabled={!canSubmit}
             thinkingLevel={thinkingLevel}
-            thinkingLevels={agentSupportsThinking(agent) ? thinkingLevels : []}
+            thinkingLevels={
+              tiboModeActive
+                ? ["high"]
+                : agentSupportsThinking(agent)
+                  ? thinkingLevels
+                  : []
+            }
             onLaunch={(next) => {
-              setThinkingLevel(next);
+              changeComposerThinkingLevel(next);
               submit(undefined, undefined, next);
             }}
           />
@@ -23014,6 +23070,55 @@ function ComposerStartButton({
 
       {scrub.panel}
     </>
+  );
+}
+
+function TiboModePill({
+  enabled,
+  available,
+  onToggle,
+  flat = false,
+}: {
+  enabled: boolean;
+  available: boolean;
+  onToggle: () => void;
+  flat?: boolean;
+}) {
+  const description = available
+    ? enabled
+      ? "Tibo mode is on: Fast service tier and High thinking"
+      : "Turn on Tibo mode: Fast service tier and High thinking"
+    : "Tibo mode requires a GPT-5.4, GPT-5.5, or GPT-5.6 Codex model";
+
+  return (
+    <button
+      type="button"
+      aria-label={description}
+      aria-pressed={enabled}
+      title={description}
+      disabled={!available}
+      onClick={onToggle}
+      className={cn(
+        "relative inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs font-semibold outline-none transition-all duration-200 focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-35",
+        flat && !enabled ? "px-1.5 text-muted-foreground" : "bg-muted text-muted-foreground",
+        enabled &&
+          "bg-gradient-to-r from-orange-500/22 via-fuchsia-500/20 to-violet-500/22 text-foreground ring-1 ring-inset ring-orange-400/45 shadow-[0_0_18px_rgba(249,115,22,0.22)]",
+      )}
+    >
+      <Zap
+        className={cn(
+          "size-3.5",
+          enabled && "fill-orange-400 text-orange-500 animate-pulse motion-reduce:animate-none",
+        )}
+      />
+      <span>Tibo</span>
+      {enabled ? (
+        <>
+          <span aria-hidden="true" className="text-[11px] text-orange-500/70">·</span>
+          <span className="text-[11px] text-orange-600 dark:text-orange-300">Fast + High</span>
+        </>
+      ) : null}
+    </button>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -283,6 +283,12 @@ import {
   resolveTiboLaunch,
   writeTiboMode,
 } from "./lib/tibo-mode";
+import {
+  composerSupportsFastMode,
+  parseFastChatCommand,
+  readFastMode,
+  writeFastMode,
+} from "./lib/fast-mode";
 import { ConnectionStatusToasts } from "./ConnectionStatus";
 import type {
   ClipboardEvent,
@@ -758,6 +764,7 @@ export type Session = {
   model?: string | null;
   thinkingLevel?: string | null;
   serviceTier?: "fast" | null;
+  fastMode?: boolean;
   parentSessionId?: string | null;
   parentNativeSessionId?: string | null;
   parentAgent?: string | null;
@@ -14894,6 +14901,38 @@ function SessionChatBody({
     const text = (overrideText ?? messageText).trim();
     const files = attachments;
     if (!sid || (!text && !files.length)) return;
+    const fastCommand = parseFastChatCommand(text);
+    if (fastCommand.matched) {
+      if (files.length) {
+        onError("Fast is a session control command; send attachments separately.");
+        return;
+      }
+      if (fastCommand.error) {
+        onError(fastCommand.error);
+        return;
+      }
+      const currentFast = session.fastMode === true || session.serviceTier === "fast";
+      const enabled = fastCommand.enabled ?? !currentFast;
+      setSending(true);
+      onError(null);
+      try {
+        const result = await api<{ fastMode: boolean }>(`/api/sessions/${sid}/fast-mode`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled }),
+        });
+        setMessageTextState("");
+        toast.success(`Fast mode ${result.fastMode ? "on" : "off"}`, {
+          description: "Thinking effort was not changed.",
+        });
+        await onRefresh();
+      } catch (err) {
+        onError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setSending(false);
+      }
+      return;
+    }
     // A queued send is a genuinely different state from a steered one: the agent
     // is still on the previous turn and has not read this text yet. The bubble
     // carries that state itself (waiting style, pinned under the
@@ -17395,13 +17434,13 @@ const onTouchStart = (e: ReactTouchEvent) => {
             {session.model}
           </span>
         ) : null)}
-        {session.serviceTier === "fast" ? (
+        {session.fastMode === true || session.serviceTier === "fast" ? (
           <span
-            title="Tibo mode: Fast service tier"
-            className="flex shrink-0 items-center gap-1 rounded-full bg-gradient-to-r from-orange-500/16 to-fuchsia-500/14 px-2 py-0.5 text-[10px] font-semibold text-orange-700 ring-1 ring-inset ring-orange-400/25 dark:text-orange-300"
+            title="Fast mode is on"
+            className="flex shrink-0 items-center gap-1 rounded-full bg-sky-500/12 px-2 py-0.5 text-[10px] font-semibold text-sky-700 ring-1 ring-inset ring-sky-400/25 dark:text-sky-300"
           >
-            <Zap className="size-3 fill-orange-400 text-orange-500" />
-            Tibo
+            <Gauge className="size-3 text-sky-500" aria-hidden="true" />
+            Fast
           </span>
         ) : null}
         {/* Redundant on wide screens: the rail row for this session already
@@ -20826,6 +20865,7 @@ function NewSessionDialog({
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
     () => savedThinkingLevel(),
   );
+  const [fastMode, setFastModeState] = useState(() => readFastMode(localStorage, agent));
   const [tiboMode, setTiboModeState] = useState(() => readTiboMode(localStorage));
   // Default the owner to the active profile, falling back to the first known user
   // — never empty when a roster exists. An unowned session lands unassigned, and
@@ -21290,8 +21330,11 @@ function NewSessionDialog({
 
   const models = catalog.models[agent] ?? AGENT_MODELS[agent];
   const thinkingLevels = useAgentThinkingLevels(agent, model);
+  const fastModeAvailable = composerSupportsFastMode({ agent, model });
+  const fastModeEnabled = fastMode && fastModeAvailable;
   const tiboModeAvailable = canUseTiboMode({ agent, model, thinkingLevels });
-  const tiboModeActive = tiboMode && tiboModeAvailable;
+  const tiboModeActive =
+    tiboMode && tiboModeAvailable && fastModeEnabled && thinkingLevel === "high";
   // When the live view is filtered to a specific project, lock new sessions to
   // that project's repo (and hide the picker below). Falls back to the normal
   // localStorage/first-repo default when viewing "All projects" or when the
@@ -21369,17 +21412,41 @@ function NewSessionDialog({
     }
   }, [thinkingLevel, thinkingLevels]);
   useEffect(() => {
+    setFastModeState(readFastMode(localStorage, agent));
+  }, [agent]);
+  useEffect(() => {
     if (tiboModeActive && thinkingLevel !== "high") setThinkingLevel("high");
   }, [tiboModeActive, thinkingLevel]);
 
   function setTiboMode(enabled: boolean) {
     setTiboModeState(enabled);
     writeTiboMode(localStorage, enabled);
-    if (enabled && tiboModeAvailable) setThinkingLevel("high");
+    if (enabled && tiboModeAvailable) {
+      setFastModeState(true);
+      writeFastMode(localStorage, agent, true);
+      setThinkingLevel("high");
+    } else if (!enabled && tiboModeActive) {
+      setFastModeState(false);
+      writeFastMode(localStorage, agent, false);
+    }
+  }
+
+  function setFastMode(enabled: boolean) {
+    setFastModeState(enabled);
+    writeFastMode(localStorage, agent, enabled);
+    if (!enabled && tiboMode) {
+      setTiboModeState(false);
+      writeTiboMode(localStorage, false);
+    }
   }
 
   function changeComposerThinkingLevel(next: ThinkingLevel) {
-    if (tiboModeActive && next !== "high") setTiboMode(false);
+    if (tiboModeActive && next !== "high") {
+      // Leaving High exits the Tibo preset, but normal Fast deliberately stays
+      // on. Fast and reasoning effort are independent provider controls.
+      setTiboModeState(false);
+      writeTiboMode(localStorage, false);
+    }
     setThinkingLevel(next);
   }
 
@@ -21462,6 +21529,7 @@ function NewSessionDialog({
     });
     const launchModel = tiboLaunch.model;
     const launchThinkingLevel = tiboLaunch.thinkingLevel as ThinkingLevel;
+    const launchFastMode = fastModeEnabled || tiboLaunch.fastMode === true;
     const launchClaudeAccountId = launchAgent === "aisdk" ? claudeAccountId || undefined : undefined;
     const stashed = stagePromptSend({
       contextKey: "new-session",
@@ -21523,7 +21591,7 @@ function NewSessionDialog({
             agent: launchAgent,
             model: launchModel,
             thinkingLevel: thinkingLevels.length ? launchThinkingLevel : undefined,
-            serviceTier: tiboLaunch.serviceTier,
+            fastMode: launchFastMode,
             claudeAccountId: launchClaudeAccountId,
             overLimit: overLimit || undefined,
           }),
@@ -21703,6 +21771,14 @@ function NewSessionDialog({
         flat={variant === "inline"}
         immersive
       />
+
+      {fastModeAvailable ? (
+        <FastModePill
+          enabled={fastModeEnabled}
+          onToggle={() => setFastMode(!fastModeEnabled)}
+          flat={variant === "inline"}
+        />
+      ) : null}
 
       {agent === "codex" || agent === "codex-aisdk" ? (
         <TiboModePill
@@ -23070,6 +23146,39 @@ function ComposerStartButton({
 
       {scrub.panel}
     </>
+  );
+}
+
+function FastModePill({
+  enabled,
+  onToggle,
+  flat = false,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+  flat?: boolean;
+}) {
+  const description = enabled
+    ? "Fast mode is on. Thinking effort stays unchanged. Use /fast off in chat to disable."
+    : "Turn on Fast mode without changing thinking effort. You can also use /fast in chat.";
+
+  return (
+    <button
+      type="button"
+      aria-label={description}
+      aria-pressed={enabled}
+      title={description}
+      onClick={onToggle}
+      className={cn(
+        "relative inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-xs font-semibold outline-none transition-all duration-200 focus-visible:ring-2 focus-visible:ring-ring",
+        flat && !enabled ? "px-1.5 text-muted-foreground" : "bg-muted text-muted-foreground",
+        enabled &&
+          "bg-sky-500/14 text-sky-800 ring-1 ring-inset ring-sky-400/35 shadow-[0_0_14px_rgba(14,165,233,0.16)] dark:text-sky-200",
+      )}
+    >
+      <Gauge className={cn("size-3.5", enabled && "text-sky-500")} aria-hidden="true" />
+      <span>Fast</span>
+    </button>
   );
 }
 

--- a/web/src/lib/fast-mode.test.ts
+++ b/web/src/lib/fast-mode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  composerSupportsFastMode,
+  fastModeStorageKey,
+  parseFastChatCommand,
+  readFastMode,
+  writeFastMode,
+} from "./fast-mode";
+
+describe("normal Fast mode", () => {
+  test("supports eligible Codex models and Claude", () => {
+    expect(composerSupportsFastMode({ agent: "codex-aisdk", model: "gpt-5.6-luna" })).toBe(true);
+    expect(composerSupportsFastMode({ agent: "codex-aisdk", model: "gpt-5.3-codex-spark" })).toBe(false);
+    expect(composerSupportsFastMode({ agent: "aisdk", model: "opus" })).toBe(true);
+    expect(composerSupportsFastMode({ agent: "opencode", model: "glm" })).toBe(false);
+  });
+
+  test("stores Codex and Claude preferences independently", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => void values.set(key, value),
+    };
+    writeFastMode(storage, "codex-aisdk", true);
+    writeFastMode(storage, "aisdk", false);
+    expect(readFastMode(storage, "codex",)).toBe(true);
+    expect(readFastMode(storage, "claude")).toBe(false);
+    expect(fastModeStorageKey("codex-aisdk")).not.toBe(fastModeStorageKey("aisdk"));
+  });
+
+  test("parses the chat control without swallowing ordinary prompts", () => {
+    expect(parseFastChatCommand("/fast")).toEqual({ matched: true });
+    expect(parseFastChatCommand(" /FAST on ")).toEqual({ matched: true, enabled: true });
+    expect(parseFastChatCommand("/fast off")).toEqual({ matched: true, enabled: false });
+    expect(parseFastChatCommand("explain /fast mode")).toEqual({ matched: false });
+    expect(parseFastChatCommand("/faster")).toEqual({ matched: false });
+    expect(parseFastChatCommand("/fast maybe")).toEqual({
+      matched: true,
+      error: 'Use "/fast", "/fast on", or "/fast off".',
+    });
+  });
+});

--- a/web/src/lib/fast-mode.ts
+++ b/web/src/lib/fast-mode.ts
@@ -1,0 +1,54 @@
+export type FastChatCommand =
+  | { matched: false }
+  | { matched: true; enabled?: boolean; error?: string };
+
+export function fastModeStorageKey(agent: string): string {
+  const provider = agent === "codex" || agent === "codex-aisdk"
+    ? "codex"
+    : agent === "claude" || agent === "aisdk"
+      ? "claude"
+      : agent;
+  return `omg_fast_mode_${provider}`;
+}
+
+export function readFastMode(
+  storage: { getItem(key: string): string | null },
+  agent: string,
+): boolean {
+  return storage.getItem(fastModeStorageKey(agent)) === "on";
+}
+
+export function writeFastMode(
+  storage: { setItem(key: string, value: string): void },
+  agent: string,
+  enabled: boolean,
+): void {
+  storage.setItem(fastModeStorageKey(agent), enabled ? "on" : "off");
+}
+
+export function composerSupportsFastMode(input: {
+  agent: string;
+  model?: string | null;
+}): boolean {
+  if (input.agent === "claude" || input.agent === "aisdk") return true;
+  if (input.agent !== "codex" && input.agent !== "codex-aisdk") return false;
+  return !!input.model && /^gpt-5\.(?:6(?:-|$)|5(?:-|$)|4$)/.test(input.model);
+}
+
+/** Parse only the complete control command, never arbitrary prompt text. */
+export function parseFastChatCommand(text: string): FastChatCommand {
+  const trimmed = text.trim();
+  if (!/^\/fast(?:\s|$)/i.test(trimmed)) return { matched: false };
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return { matched: true };
+  if (parts.length === 2 && /^on$/i.test(parts[1])) {
+    return { matched: true, enabled: true };
+  }
+  if (parts.length === 2 && /^off$/i.test(parts[1])) {
+    return { matched: true, enabled: false };
+  }
+  return {
+    matched: true,
+    error: 'Use "/fast", "/fast on", or "/fast off".',
+  };
+}

--- a/web/src/lib/tibo-mode.test.ts
+++ b/web/src/lib/tibo-mode.test.ts
@@ -35,7 +35,7 @@ describe("Tibo mode", () => {
     })).toEqual({
       model: "gpt-5.6-luna",
       thinkingLevel: "high",
-      serviceTier: "fast",
+      fastMode: true,
     });
   });
 

--- a/web/src/lib/tibo-mode.test.ts
+++ b/web/src/lib/tibo-mode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TIBO_MODE_STORAGE_KEY,
+  canUseTiboMode,
+  readTiboMode,
+  resolveTiboLaunch,
+  writeTiboMode,
+} from "./tibo-mode";
+
+describe("Tibo mode", () => {
+  test("is available only for supported Codex models with High thinking", () => {
+    expect(canUseTiboMode({
+      agent: "codex-aisdk",
+      model: "gpt-5.6-sol",
+      thinkingLevels: ["low", "medium", "high"],
+    })).toBe(true);
+    expect(canUseTiboMode({
+      agent: "codex-aisdk",
+      model: "gpt-5.3-codex-spark",
+      thinkingLevels: ["low", "medium", "high"],
+    })).toBe(false);
+    expect(canUseTiboMode({
+      agent: "aisdk",
+      model: "gpt-5.6-sol",
+      thinkingLevels: ["high"],
+    })).toBe(false);
+  });
+
+  test("keeps the selected model while applying Fast and High", () => {
+    expect(resolveTiboLaunch({
+      enabled: true,
+      available: true,
+      model: "gpt-5.6-luna",
+      thinkingLevel: "minimal",
+    })).toEqual({
+      model: "gpt-5.6-luna",
+      thinkingLevel: "high",
+      serviceTier: "fast",
+    });
+  });
+
+  test("does not alter ordinary or unavailable launches", () => {
+    expect(resolveTiboLaunch({
+      enabled: false,
+      available: true,
+      model: "gpt-5.6-sol",
+      thinkingLevel: "low",
+    })).toEqual({ model: "gpt-5.6-sol", thinkingLevel: "low" });
+    expect(resolveTiboLaunch({
+      enabled: true,
+      available: false,
+      model: "gpt-5.3-codex-spark",
+      thinkingLevel: "low",
+    })).toEqual({ model: "gpt-5.3-codex-spark", thinkingLevel: "low" });
+  });
+
+  test("persists the user's preference", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => void values.set(key, value),
+    };
+    writeTiboMode(storage, true);
+    expect(values.get(TIBO_MODE_STORAGE_KEY)).toBe("on");
+    expect(readTiboMode(storage)).toBe(true);
+    writeTiboMode(storage, false);
+    expect(readTiboMode(storage)).toBe(false);
+  });
+});

--- a/web/src/lib/tibo-mode.ts
+++ b/web/src/lib/tibo-mode.ts
@@ -1,0 +1,49 @@
+export const TIBO_MODE_STORAGE_KEY = "omg_tibo_mode";
+
+type StorageReader = { getItem(key: string): string | null };
+type StorageWriter = { setItem(key: string, value: string): void };
+
+export function modelSupportsTiboMode(model: string | null | undefined): boolean {
+  if (!model) return false;
+  return /^gpt-5\.(?:6(?:-|$)|5(?:-|$)|4$)/.test(model);
+}
+
+export function canUseTiboMode(input: {
+  agent: string;
+  model?: string | null;
+  thinkingLevels: readonly string[];
+}): boolean {
+  return (
+    (input.agent === "codex" || input.agent === "codex-aisdk") &&
+    modelSupportsTiboMode(input.model) &&
+    input.thinkingLevels.includes("high")
+  );
+}
+
+export function readTiboMode(storage: StorageReader): boolean {
+  return storage.getItem(TIBO_MODE_STORAGE_KEY) === "on";
+}
+
+export function writeTiboMode(storage: StorageWriter, enabled: boolean): void {
+  storage.setItem(TIBO_MODE_STORAGE_KEY, enabled ? "on" : "off");
+}
+
+export function resolveTiboLaunch<T extends string>(input: {
+  enabled: boolean;
+  available: boolean;
+  model: string;
+  thinkingLevel: T;
+}): {
+  model: string;
+  thinkingLevel: T | "high";
+  serviceTier?: "fast";
+} {
+  if (!input.enabled || !input.available) {
+    return { model: input.model, thinkingLevel: input.thinkingLevel };
+  }
+  return {
+    model: input.model,
+    thinkingLevel: "high",
+    serviceTier: "fast",
+  };
+}

--- a/web/src/lib/tibo-mode.ts
+++ b/web/src/lib/tibo-mode.ts
@@ -36,7 +36,7 @@ export function resolveTiboLaunch<T extends string>(input: {
 }): {
   model: string;
   thinkingLevel: T | "high";
-  serviceTier?: "fast";
+  fastMode?: true;
 } {
   if (!input.enabled || !input.available) {
     return { model: input.model, thinkingLevel: input.thinkingLevel };
@@ -44,6 +44,6 @@ export function resolveTiboLaunch<T extends string>(input: {
   return {
     model: input.model,
     thinkingLevel: "high",
-    serviceTier: "fast",
+    fastMode: true,
   };
 }


### PR DESCRIPTION
Closes #249

## Summary

- adds a normal accessible Fast toggle for both Codex and Claude without changing thinking/effort
- supports `/fast`, `/fast on`, and `/fast off` inside an active chat through a control endpoint, so the command is never sent as model prompt text
- keeps Tibo as an optional Codex preset that selects Fast + High; lowering thinking exits Tibo while Fast stays on
- applies Codex Fast through its service tier and Claude Fast through Claude Code session flag settings, including live toggles
- persists Fast and thinking state through runtime recovery and cold resume

## Verification

- 23 focused Fast, launch, migration, resume-cache, and composer tests pass
- root and web TypeScript checks pass
- production web build passes
- client/server route-coverage test passes for the new Fast endpoint
- full monorepo suite: 3,088 pass, 1 skip; 4 unrelated `setup-agent-probe` failures reproduce against unchanged origin/main setup/test sources in this environment