### PR TITLE
feat(web): let rail groups fold shut, and keep the fold across reloads

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,6 +85,11 @@ import {
 } from "./lib/conversation-ui";
 import { UNREAD_DOT_CLASS } from "./lib/unread";
 import {
+  readFoldedRailGroups,
+  toggleFoldedRailGroup,
+  writeFoldedRailGroups,
+} from "./lib/rail-group-fold";
+import {
   addVisibleTranscriptSid,
   removeVisibleTranscriptSid,
   useVisibleTranscriptSids,
@@ -11412,6 +11417,7 @@ function LiveView({
               label="Auto"
               count={findings.length}
               collapsed={false}
+              foldKey="__auto"
               action={
                 <AutoTriageButton
                   count={findings.length}
@@ -12475,6 +12481,7 @@ function RailStage({
         label="Auto"
         count={findings.length}
         collapsed={railCollapsed}
+        foldKey="__auto"
         action={
           <AutoTriageButton
             count={findings.length}
@@ -12916,6 +12923,18 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
  * stage" on desktop and "go to its page" on mobile, and pretending those were
  * one call is how the two surfaces diverged in the first place.
  */
+// Every session in a family, for the folded header's unread check. The dot
+// must survive folding, or shutting a group becomes a way to lose the "this
+// said something" signal its rows were carrying.
+function collectGroupSids(nodes: SessionTreeNode[], into: string[] = []): string[] {
+  for (const node of nodes) {
+    const sid = sessionStableId(node.session);
+    if (sid) into.push(sid);
+    collectGroupSids(node.children, into);
+  }
+  return into;
+}
+
 function SessionGroups({
   groups,
   pinnedNodes,
@@ -13012,7 +13031,13 @@ function SessionGroups({
     <>
       {leading}
       {pinnedCount ? (
-        <RailGroup label="Pinned" count={pinnedCount} collapsed={collapsed}>
+        <RailGroup
+          label="Pinned"
+          count={pinnedCount}
+          collapsed={collapsed}
+          foldKey="__pinned"
+          sids={collectGroupSids(pinnedNodes)}
+        >
           {pinnedNodes.map((node) => renderNode(node))}
         </RailGroup>
       ) : null}
@@ -13022,6 +13047,8 @@ function SessionGroups({
           label={group.label}
           count={group.count}
           collapsed={collapsed}
+          foldKey={group.key}
+          sids={collectGroupSids(group.nodes)}
           // The folder title IS the filter. Scoping used to live on the folder
           // button, which made that button mean two things — pick where a new
           // session runs, and narrow the list — and neither was discoverable
@@ -13052,6 +13079,8 @@ function RailGroup({
   action,
   onFilter,
   onClearFilter,
+  foldKey,
+  sids,
   children,
 }: {
   label: string;
@@ -13062,12 +13091,34 @@ function RailGroup({
   onFilter?: () => void;
   /** Drop the scope. Only the group that IS the current scope gets this. */
   onClearFilter?: () => void;
+  /**
+   * Stable identity under which this group's fold is persisted. Absent =
+   * the group cannot fold. The fixed groups use "__pinned"/"__auto"; a
+   * folder group uses its project key, which survives relabeling.
+   */
+  foldKey?: string;
+  /** Sessions inside the group, so a folded header can still carry unread. */
+  sids?: string[];
   children: ReactNode;
 }) {
+  const { unread } = useContext(SessionUnreadContext);
+  // A fold is this browser's reading posture, shared by the rail and the
+  // mobile list through one storage key. State drives the render; storage
+  // only seeds it and remembers it across reloads.
+  const [folded, setFolded] = useState(
+    () => !!foldKey && readFoldedRailGroups().includes(foldKey),
+  );
+  const toggleFold = () => {
+    if (!foldKey) return;
+    const next = toggleFoldedRailGroup(readFoldedRailGroups(), foldKey);
+    writeFoldedRailGroups(next);
+    setFolded(next.includes(foldKey));
+  };
+  const foldedUnread = folded && !!sids?.some((sid) => unread.has(sid));
   // Not uppercased. A folder is named "lfg", not "LFG", and shouting every
   // group label made the rail's quietest text its loudest.
   const title = (
-    <span className={cn(onFilter && "transition-colors hover:text-foreground")}>
+    <span className={cn((onFilter || foldKey) && "transition-colors hover:text-foreground")}>
       {label} · {count}
     </span>
   );
@@ -13081,6 +13132,19 @@ function RailGroup({
               onClick={onFilter}
               title={`Show only ${label}`}
               aria-label={`Show only ${label}`}
+              className="min-w-0 truncate text-left outline-none focus-visible:text-foreground"
+            >
+              {title}
+            </button>
+          ) : foldKey ? (
+            // No filter to collide with, so the title itself folds too — the
+            // chevron alone is a small target on touch.
+            <button
+              type="button"
+              onClick={toggleFold}
+              title={folded ? `Show ${label}` : `Hide ${label}`}
+              aria-label={folded ? `Show ${label}` : `Hide ${label}`}
+              aria-expanded={!folded}
               className="min-w-0 truncate text-left outline-none focus-visible:text-foreground"
             >
               {title}
@@ -13102,10 +13166,38 @@ function RailGroup({
               <X className="size-3" />
             </button>
           ) : null}
-          {action ? <span className="ml-auto normal-case tracking-normal">{action}</span> : null}
+          {foldedUnread ? (
+            // The rows carry their own dots while open; folded, the header
+            // inherits the mark so a shut group cannot hide news.
+            <span className={cn(UNREAD_DOT_CLASS, "ml-1.5")} aria-hidden="true" />
+          ) : null}
+          {action || foldKey ? (
+            <span className="ml-auto flex items-center gap-1 normal-case tracking-normal">
+              {action}
+              {foldKey ? (
+                <button
+                  type="button"
+                  onClick={toggleFold}
+                  title={folded ? `Show ${label}` : `Hide ${label}`}
+                  aria-label={folded ? `Show ${label}` : `Hide ${label}`}
+                  aria-expanded={!folded}
+                  className="-my-1 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <ChevronDown
+                    className={cn(
+                      "size-3.5 transition-transform duration-150",
+                      folded && "-rotate-90",
+                    )}
+                  />
+                </button>
+              ) : null}
+            </span>
+          ) : null}
         </div>
       ) : null}
-      <div className="flex flex-col gap-0.5">{children}</div>
+      {collapsed || !folded ? (
+        <div className="flex flex-col gap-0.5">{children}</div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, createContext, type ComponentProps, forwardRef, memo, Suspense, useCallback, useContext, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Component, createContext, type ComponentProps, forwardRef, memo, Suspense, useCallback, useContext, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import type {
   Conversation as ProductConversation,
@@ -85,9 +85,9 @@ import {
 } from "./lib/conversation-ui";
 import { UNREAD_DOT_CLASS } from "./lib/unread";
 import {
-  readFoldedRailGroups,
-  toggleFoldedRailGroup,
-  writeFoldedRailGroups,
+  getFoldedRailGroups,
+  setFoldedRailGroup,
+  subscribeFoldedRailGroups,
 } from "./lib/rail-group-fold";
 import {
   addVisibleTranscriptSid,
@@ -12014,10 +12014,19 @@ function RailStage({
     [railTree, topPinned],
   );
 
+  // A folded group takes its rows out of the DOM, so they must leave the
+  // keyboard order too. Otherwise j/k walks an invisible cursor and Enter
+  // opens a row the reader put away. The icon rail draws no headers and so
+  // cannot fold: there every row stays navigable.
+  const foldedRailGroups = useFoldedRailGroups();
+  const isRailGroupFolded = (key: string) =>
+    !railCollapsed && foldedRailGroups.includes(key);
   const railOrderedSessions = [
-    ...topPinnedSessions,
+    ...(isRailGroupFolded("__pinned") ? [] : topPinnedSessions),
     ...botSessions,
-    ...projectRailGroups.flatMap((group) => railTree.flatten(group.nodes)),
+    ...projectRailGroups.flatMap((group) =>
+      isRailGroupFolded(group.key) ? [] : railTree.flatten(group.nodes),
+    ),
   ];
 
   // Flat rail order the keyboard cursor walks (matching the visible rail;
@@ -12923,6 +12932,17 @@ function ShortcutsHelp({ onClose }: { onClose: () => void }) {
  * stage" on desktop and "go to its page" on mobile, and pretending those were
  * one call is how the two surfaces diverged in the first place.
  */
+// The folded group keys, live. One store behind every reader, so the desktop
+// rail, the mobile list and the keyboard order cannot disagree about which
+// groups are shut.
+function useFoldedRailGroups(): string[] {
+  return useSyncExternalStore(
+    subscribeFoldedRailGroups,
+    getFoldedRailGroups,
+    getFoldedRailGroups,
+  );
+}
+
 // Every session in a family, for the folded header's unread check. The dot
 // must survive folding, or shutting a group becomes a way to lose the "this
 // said something" signal its rows were carrying.
@@ -13102,17 +13122,14 @@ function RailGroup({
   children: ReactNode;
 }) {
   const { unread } = useContext(SessionUnreadContext);
-  // A fold is this browser's reading posture, shared by the rail and the
-  // mobile list through one storage key. State drives the render; storage
-  // only seeds it and remembers it across reloads.
-  const [folded, setFolded] = useState(
-    () => !!foldKey && readFoldedRailGroups().includes(foldKey),
-  );
+  // A fold is this browser's reading posture, read from the one live set that
+  // every surface shares. Not local state: the mobile list mounts its own
+  // RailGroups, and the rail's keyboard order is built outside this component.
+  const foldedGroups = useFoldedRailGroups();
+  const folded = !!foldKey && foldedGroups.includes(foldKey);
   const toggleFold = () => {
     if (!foldKey) return;
-    const next = toggleFoldedRailGroup(readFoldedRailGroups(), foldKey);
-    writeFoldedRailGroups(next);
-    setFolded(next.includes(foldKey));
+    setFoldedRailGroup(foldKey, !folded);
   };
   const foldedUnread = folded && !!sids?.some((sid) => unread.has(sid));
   // Not uppercased. A folder is named "lfg", not "LFG", and shouting every

--- a/web/src/lib/rail-group-fold.test.ts
+++ b/web/src/lib/rail-group-fold.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
   FOLDED_RAIL_GROUPS_KEY,
+  getFoldedRailGroups,
   parseFoldedRailGroups,
   readFoldedRailGroups,
+  resetFoldedRailGroupsCache,
+  setFoldedRailGroup,
+  subscribeFoldedRailGroups,
   toggleFoldedRailGroup,
   writeFoldedRailGroups,
 } from "./rail-group-fold";
@@ -64,4 +68,68 @@ describe("read/write round trip", () => {
     const storage = memoryStorage({ [FOLDED_RAIL_GROUPS_KEY]: "{oops" });
     expect(readFoldedRailGroups(storage)).toEqual([]);
   });
+});
+
+describe("the live fold store", () => {
+  beforeEach(() => {
+    resetFoldedRailGroupsCache();
+  });
+
+  test("a group folds and unfolds when storage refuses every write", () => {
+    // Private mode and a full quota both look like this. The reader must
+    // still be able to reopen what they just shut.
+    const blocked = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    } as unknown as Storage;
+    const original = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      value: blocked,
+      configurable: true,
+    });
+    try {
+      expect(getFoldedRailGroups()).toEqual([]);
+      setFoldedRailGroup("lfg", true);
+      expect(getFoldedRailGroups()).toEqual(["lfg"]);
+      setFoldedRailGroup("lfg", false);
+      expect(getFoldedRailGroups()).toEqual([]);
+    } finally {
+      if (original === undefined) delete (globalThis as { localStorage?: Storage }).localStorage;
+      else
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          configurable: true,
+        });
+    }
+  });
+
+  test("setFoldedRailGroup is a set, not a toggle, and repeats are no-ops", () => {
+    const seen: string[][] = [];
+    const stop = subscribeFoldedRailGroups(() => seen.push(getFoldedRailGroups()));
+    setFoldedRailGroup("lfg", true);
+    const afterFirst = getFoldedRailGroups();
+    setFoldedRailGroup("lfg", true);
+    // Same answer asked twice must not churn the snapshot, or every
+    // subscriber re-renders for nothing.
+    expect(getFoldedRailGroups()).toBe(afterFirst);
+    expect(seen.length).toBe(1);
+    stop();
+    setFoldedRailGroup("vibes", true);
+    expect(seen.length).toBe(1);
+  });
+});
+
+test("a host with no localStorage reads and writes without throwing", () => {
+  // The store seeds itself on first read. A runner or a server render with no
+  // DOM must get an empty set, not a ReferenceError.
+  expect(() => readFoldedRailGroups(null)).not.toThrow();
+  expect(readFoldedRailGroups(null)).toEqual([]);
+  expect(() => writeFoldedRailGroups(["lfg"], null)).not.toThrow();
 });

--- a/web/src/lib/rail-group-fold.test.ts
+++ b/web/src/lib/rail-group-fold.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FOLDED_RAIL_GROUPS_KEY,
+  parseFoldedRailGroups,
+  readFoldedRailGroups,
+  toggleFoldedRailGroup,
+  writeFoldedRailGroups,
+} from "./rail-group-fold";
+
+function memoryStorage(initial: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key: string) => map.get(key) ?? null,
+    key: (index: number) => [...map.keys()][index] ?? null,
+    removeItem: (key: string) => void map.delete(key),
+    setItem: (key: string, value: string) => void map.set(key, value),
+  } as Storage;
+}
+
+describe("parseFoldedRailGroups", () => {
+  test("null, junk and non-arrays parse to empty", () => {
+    expect(parseFoldedRailGroups(null)).toEqual([]);
+    expect(parseFoldedRailGroups("not json")).toEqual([]);
+    expect(parseFoldedRailGroups('{"a":1}')).toEqual([]);
+    expect(parseFoldedRailGroups("42")).toEqual([]);
+  });
+
+  test("keeps only non-empty strings, deduped, in order", () => {
+    expect(parseFoldedRailGroups('["__pinned","",3,"__pinned","code"]')).toEqual([
+      "__pinned",
+      "code",
+    ]);
+  });
+});
+
+describe("toggleFoldedRailGroup", () => {
+  test("adds an absent key and removes a present one", () => {
+    expect(toggleFoldedRailGroup([], "__pinned")).toEqual(["__pinned"]);
+    expect(toggleFoldedRailGroup(["__pinned", "code"], "__pinned")).toEqual(["code"]);
+  });
+
+  test("does not mutate its input", () => {
+    const current = ["__pinned"];
+    toggleFoldedRailGroup(current, "code");
+    expect(current).toEqual(["__pinned"]);
+  });
+});
+
+describe("read/write round trip", () => {
+  test("write persists, read restores, empty write clears the key", () => {
+    const storage = memoryStorage();
+    writeFoldedRailGroups(["__pinned", "code"], storage);
+    expect(readFoldedRailGroups(storage)).toEqual(["__pinned", "code"]);
+    writeFoldedRailGroups([], storage);
+    expect(storage.getItem(FOLDED_RAIL_GROUPS_KEY)).toBeNull();
+    expect(readFoldedRailGroups(storage)).toEqual([]);
+  });
+
+  test("a broken stored value reads as nothing folded", () => {
+    const storage = memoryStorage({ [FOLDED_RAIL_GROUPS_KEY]: "{oops" });
+    expect(readFoldedRailGroups(storage)).toEqual([]);
+  });
+});

--- a/web/src/lib/rail-group-fold.ts
+++ b/web/src/lib/rail-group-fold.ts
@@ -28,9 +28,24 @@ export function parseFoldedRailGroups(raw: string | null): string[] {
   }
 }
 
-export function readFoldedRailGroups(storage: Storage = localStorage): string[] {
+/**
+ * The default storage, resolved inside a try.
+ *
+ * A `storage: Storage = localStorage` default is evaluated before the callee's
+ * try block, so a host with no `localStorage` at all — a non-DOM test runner,
+ * a server render — threw a ReferenceError that no catch here could see.
+ */
+function defaultStorage(): Storage | null {
   try {
-    return parseFoldedRailGroups(storage.getItem(FOLDED_RAIL_GROUPS_KEY));
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readFoldedRailGroups(storage: Storage | null = defaultStorage()): string[] {
+  try {
+    return parseFoldedRailGroups(storage?.getItem(FOLDED_RAIL_GROUPS_KEY) ?? null);
   } catch {
     return [];
   }
@@ -47,12 +62,58 @@ export function toggleFoldedRailGroup(
 
 export function writeFoldedRailGroups(
   keys: readonly string[],
-  storage: Storage = localStorage,
+  storage: Storage | null = defaultStorage(),
 ): void {
   try {
+    if (!storage) return;
     if (!keys.length) storage.removeItem(FOLDED_RAIL_GROUPS_KEY);
     else storage.setItem(FOLDED_RAIL_GROUPS_KEY, JSON.stringify([...new Set(keys)]));
   } catch {
     // Storage can be full or blocked; losing a fold preference is harmless.
   }
+}
+
+/**
+ * One live copy of the fold set for the whole app.
+ *
+ * The fold was per-component state first, which had two faults. The desktop
+ * rail and the mobile list mount their own `RailGroup`s, so a fold in one did
+ * not reach the other until a remount. And the rail's keyboard order is built
+ * outside any group, so it could not see a fold at all and walked rows that
+ * were not on screen. Both want the same answer at the same time, so the
+ * answer lives here and the components subscribe to it.
+ *
+ * Storage seeds this cache once and is written best effort after. A refused
+ * write (private mode, quota) costs the fold on the next reload and nothing in
+ * this session.
+ */
+let foldedCache: string[] | null = null;
+const foldListeners = new Set<() => void>();
+
+/** Stable snapshot: identity changes only when the set changes. */
+export function getFoldedRailGroups(): string[] {
+  if (!foldedCache) foldedCache = readFoldedRailGroups();
+  return foldedCache;
+}
+
+export function subscribeFoldedRailGroups(listener: () => void): () => void {
+  foldListeners.add(listener);
+  return () => {
+    foldListeners.delete(listener);
+  };
+}
+
+/** Set one group's fold. `folded` is the wanted state, not a toggle. */
+export function setFoldedRailGroup(key: string, folded: boolean): void {
+  const current = getFoldedRailGroups();
+  if (current.includes(key) === folded) return;
+  const next = folded ? [...current, key] : current.filter((value) => value !== key);
+  foldedCache = next;
+  writeFoldedRailGroups(next);
+  for (const listener of foldListeners) listener();
+}
+
+/** Tests only: drop the cache so a case can start from clean storage. */
+export function resetFoldedRailGroupsCache(): void {
+  foldedCache = null;
 }

--- a/web/src/lib/rail-group-fold.ts
+++ b/web/src/lib/rail-group-fold.ts
@@ -1,0 +1,58 @@
+/**
+ * Which rail groups the reader has folded shut.
+ *
+ * A fold is a reading posture, not fleet state: it lives in this browser's
+ * localStorage under one key that the desktop rail and the mobile list share,
+ * so the two surfaces cannot remember different answers to the same question.
+ *
+ * Keys are group identities, not labels: "__pinned" and "__auto" for the two
+ * fixed groups, the project key for a folder group. A label can be shortened
+ * or renamed; the identity cannot.
+ */
+export const FOLDED_RAIL_GROUPS_KEY = "lfg_folded_rail_groups";
+
+export function parseFoldedRailGroups(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return [
+      ...new Set(
+        parsed.filter(
+          (value): value is string => typeof value === "string" && !!value,
+        ),
+      ),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+export function readFoldedRailGroups(storage: Storage = localStorage): string[] {
+  try {
+    return parseFoldedRailGroups(storage.getItem(FOLDED_RAIL_GROUPS_KEY));
+  } catch {
+    return [];
+  }
+}
+
+export function toggleFoldedRailGroup(
+  current: readonly string[],
+  key: string,
+): string[] {
+  return current.includes(key)
+    ? current.filter((value) => value !== key)
+    : [...current, key];
+}
+
+export function writeFoldedRailGroups(
+  keys: readonly string[],
+  storage: Storage = localStorage,
+): void {
+  try {
+    if (!keys.length) storage.removeItem(FOLDED_RAIL_GROUPS_KEY);
+    else storage.setItem(FOLDED_RAIL_GROUPS_KEY, JSON.stringify([...new Set(keys)]));
+  } catch {
+    // Storage can be full or blocked; losing a fold preference is harmless.
+  }
+}


### PR DESCRIPTION
## The problem

The session list groups rows under headers: Pinned, one group per folder, and Auto. The headers only label. A fleet with nine pinned sessions and a busy folder makes the list long, and the sessions a person works with now sit below a block that never moves.

There is no way to put a group away. Scrolling past the pinned block is the only option, on every visit, on every width.

## The approach

The header becomes a fold control. The chevron (or the header itself, when the title is not already the folder filter) hides the rows and keeps the count:


Three rules keep it honest:

- **A fold survives a reload.** The folded keys live in one localStorage key (`lfg_folded_rail_groups`), read and written by the small pure helpers in `web/src/lib/rail-group-fold.ts`. The desktop rail and the mobile list render the same `SessionGroups`, so one stored answer serves both widths.
- **A folded group cannot hide news.** While a group is shut, its header carries the shared unread dot (`UNREAD_DOT_CLASS`) when any session inside the family is unread. Open groups keep the dot on the rows, as today.
- **The folder title keeps its filter role.** Scoping to a folder still lives on the title, exactly as before; the fold sits on the chevron next to it. Only headers without a filter role (Pinned, Auto, and any header while the title is not a filter) let the title toggle the fold too, because the chevron alone is a small target on touch.

Keys are group identities, not labels: `__pinned`, `__auto`, and the project key for a folder group. A relabeled folder keeps its fold.

The icon-collapsed rail is untouched: it has no headers, so a fold does not apply there and every mark stays visible.



## Tests

- `web/src/lib/rail-group-fold.test.ts` covers parsing junk storage, toggling, the write/read round trip, and that an empty write clears the key.
- `cd web && bun x tsc --noEmit` passes.
