### PR TITLE
fix(mobile): keep bot-owned sessions out of the home list

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -67,6 +67,14 @@ import {
 } from "../src/omg/computer-shared-binding";
 
 /**
+ * A session once a named bot drives it. `botId` is populated on every session
+ * the server lists, but is not yet part of @omg-dev/protocol's OmgSession —
+ * same situation as the local type in app/bots/index.tsx — so it is read off
+ * the wire value with a narrow cast.
+ */
+type BotDrivenSession = OmgSession & { botId?: string };
+
+/**
  * A session and everything it spawned.
  *
  * Children are indented under their parent with a spine and an elbow, the way
@@ -722,13 +730,33 @@ export default function SessionsScreen() {
   }, [user?.name]);
 
   /**
+   * BOT-OWNED SESSIONS BELONG TO /bots, NOT TO THIS LIST.
+   *
+   * A session carries `botId` once a named bot drives it, and a delegated
+   * child inherits its parent's id (src/sessions.ts propagates it down the
+   * lineage), so testing the field alone removes the whole family. Filtered
+   * HERE, before buildSessionTree, rather than at each call site: this is the
+   * single answer to "which sessions does the home screen show", and the
+   * empty-state checks below read it too. Filtering roots after the tree was
+   * built would strand a bot child whose parent is not in the list.
+   *
+   * `botId` is on the wire (src/sessions.ts sets it on every listed session)
+   * but is not yet declared on @omg-dev/protocol's OmgSession, so it is read
+   * with the same narrow cast already used in app/bots/index.tsx.
+   */
+  const visibleSessions = useMemo(
+    () => sessions.filter((session) => !(session as BotDrivenSession).botId),
+    [sessions],
+  );
+
+  /**
    * Families, not rows. A session that spawned subagents owns them, and the
    * family travels together — see session-tree.ts for why the parent's own
    * flag is not enough to describe it.
    */
   const roots = useMemo(
-    () => buildSessionTree(sessions.filter((session) => projectPicker.matches(session))),
-    [sessions, projectPicker],
+    () => buildSessionTree(visibleSessions.filter((session) => projectPicker.matches(session))),
+    [visibleSessions, projectPicker],
   );
 
   /**
@@ -1276,13 +1304,13 @@ export default function SessionsScreen() {
           <SessionListSkeleton style={{ paddingTop: space.xl }} />
         ) : (
           <>
-            {sessions.length === 0 && loading ? (
+            {visibleSessions.length === 0 && loading ? (
               // First fetch on this machine, nothing on screen to disturb.
-              // Once `sessions` is non-empty, RefreshControl (pull-to-refresh)
+              // Once `visibleSessions` is non-empty, RefreshControl (pull-to-refresh)
               // is the loading affordance instead — real rows must never be
               // swapped out for skeletons under someone's thumb.
               <SessionListSkeleton style={{ paddingTop: space.xl }} />
-            ) : sessions.length === 0 && !loading ? (
+            ) : visibleSessions.length === 0 && !loading ? (
               <EmptyState
                 title="No sessions yet"
                 detail="Start one below and it shows up here."


### PR DESCRIPTION
The phone was the last surface still listing bot sessions in Chat.

The web dropped them when bots got their own surface (`80cb0738`, `7e5550f2`), but that filter lives at the `web/src/App.tsx` call sites via `isBotConversation`/`nodeIsBot`. Mobile ported `session-tree.ts` and `session-groups.ts` — which never carried the bot logic on either side — so the filter never came across. `mobile/app/index.tsx` filtered on project only.

## Verification

Against the live API (`GET /api/sessions`, 21 sessions): 12 carry `botId` and would now be hidden, including `Manager`, `iOS Manager`, `Landing + Funnel Optimization`, and their scheduled/delegated children. The 9 real sessions stay visible.

`bun run typecheck` in `mobile/` passes.

## Notes

- Filtered once into `visibleSessions`, before `buildSessionTree`. A delegated child inherits its parent's `botId` (`src/sessions.ts`), so testing the field alone drops the whole family. Filtering roots after the tree is built would strand a bot child whose parent is not in the list.
- The empty-state branches read the same value. Otherwise a fleet of only bot sessions shows neither a skeleton nor the empty state.
- `botId` is on the wire but not in `@omg-dev/protocol`'s `OmgSession`, so it is read with the same narrow cast already used in `mobile/app/bots/index.tsx`.

## Shipping

JS only. `git diff 35a66d3b0..HEAD -- mobile/package.json mobile/app.json` is empty, and `35a66d3b0` is the commit build 37 was built from, so this reaches the released App Store build over the air. No resubmission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)