### PR TITLE
fix(mobile): the offline and mock ladders sell the same two tiers

### DIFF
--- a/mobile/src/omg/billing.ts
+++ b/mobile/src/omg/billing.ts
@@ -152,12 +152,6 @@ const MOCK_ACCOUNT_TOKEN = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
  */
 const MOCK_CATALOG: unknown = [
   {
-    productId: "dev.omg.computer.computer_s20.monthly.v1",
-    plan: "computer_s20",
-    label: "Starter",
-    specs: { parallelAgents: 3, vcpus: 2, memoryMb: 4096, diskGb: 16, computeHours: 20, alwaysOn: false },
-  },
-  {
     productId: "dev.omg.computer.computer_s40.monthly.v1",
     plan: "computer_s40",
     label: "Starter Plus",
@@ -169,15 +163,14 @@ const MOCK_CATALOG: unknown = [
     label: "Personal",
     specs: { parallelAgents: 5, vcpus: 4, memoryMb: 8192, diskGb: 64, computeHours: 150, alwaysOn: false },
   },
-  {
-    productId: "dev.omg.computer.computer_10.monthly.v1",
-    plan: "computer_10",
-    label: "Pro",
-    specs: { parallelAgents: 16, vcpus: 8, memoryMb: 16384, diskGb: 128, computeHours: 300, alwaysOn: false },
-  },
   // Always On is not sold on iOS, so the mock does not pretend it is. A mock
   // that shows a rung production won't is a screenshot waiting to mislead
   // someone — including whoever reviews this screen next.
+  //
+  // Starter and Pro left on 2026-09-01 for the same reason, when they left
+  // STOREKIT_PLAN_ORDER on the control plane. Pro upgrades belong on the web;
+  // Starter is a rung the web offer has never sold. Two tiles here because
+  // production sells two.
 ];
 
 /** The same list with every `specs` null — a server that can sell but cannot describe. */

--- a/mobile/src/omg/plan-specs.ts
+++ b/mobile/src/omg/plan-specs.ts
@@ -173,14 +173,25 @@ export function parseCatalogTiers(value: unknown): CatalogTier[] | null {
  * same list, so an Always On subscriber on the web now reads "This account is
  * billed on the web" instead of "Your Always On plan is billed on the web".
  * Every call site already treats the label as optional for exactly this reason.
+ *
+ * ── Starter and Pro left too, 2026-09-01 ──────────────────────────────────
+ *
+ * `computer_s20` and `computer_10` were removed for the same reason and at the
+ * same time as they left STOREKIT_PLAN_ORDER on the control plane: Pro
+ * upgrades belong on the web, and Starter is a rung the web offer has never
+ * sold. This list is only reached when the control plane publishes no catalog,
+ * so leaving them here would have meant the degraded path quietly selling two
+ * rungs the healthy path does not.
+ *
+ * Neither removal risks the money-taken-and-rejected failure above. Both ids
+ * are still mapped in `OMG_APP_STORE_CONFIG.products`, so a transaction for
+ * either is still attributable — that map was deliberately NOT narrowed.
+ *
+ * They do pay the same label cost as Always On. An App Store subscriber on
+ * Pro reads "This account is billed on the App Store" without the plan name.
+ * That was free on 2026-09-01 because nothing had been sold through Apple yet.
  */
 export const FALLBACK_TIERS: readonly CatalogTier[] = [
-  {
-    productId: "dev.omg.computer.computer_s20.monthly.v1",
-    plan: "computer_s20",
-    label: "Starter",
-    specs: null,
-  },
   {
     productId: "dev.omg.computer.computer_s40.monthly.v1",
     plan: "computer_s40",
@@ -191,12 +202,6 @@ export const FALLBACK_TIERS: readonly CatalogTier[] = [
     productId: "dev.omg.computer.computer_5.monthly.v1",
     plan: "computer_5",
     label: "Personal",
-    specs: null,
-  },
-  {
-    productId: "dev.omg.computer.computer_10.monthly.v1",
-    plan: "computer_10",
-    label: "Pro",
     specs: null,
   },
 ] as const;


### PR DESCRIPTION
Client half of `BennyKok/vibes#1608`, which narrows `STOREKIT_PLAN_ORDER` to Starter Plus and Personal. Pro upgrades belong on the web; Starter is a rung the web offer has never sold.

**Merge order:** vibes#1608 is the one that actually changes what the paywall shows, and it is held until the App Store prices are corrected. This PR only fixes the two lists that would otherwise disagree with it.

- `FALLBACK_TIERS` is reached only when the control plane publishes no catalog. Four rungs there meant the degraded path quietly selling two the healthy path does not.
- `MOCK_CATALOG` had the same drift. That file already argues the point — *"A mock that shows a rung production won't is a screenshot waiting to mislead someone."* It listed four. Production sells two.

Neither removal risks the money-taken-and-rejected failure the header warns about: both ids stay mapped in `OMG_APP_STORE_CONFIG.products`, which was deliberately not narrowed.

They do pay the Always On label cost — an App Store subscriber on Pro reads *"This account is billed on the App Store"* with no plan name. Free today because nothing has been sold through Apple yet.

`bun run typecheck` in `mobile/` passes. No test asserted the four-tier fallback.

JS only, so this ships over the air when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)