### PR TITLE
feat(artifacts): show any file to the user with omg_display_file

### DIFF
--- a/mobile/src/omg/transcript.tsx
+++ b/mobile/src/omg/transcript.tsx
@@ -556,6 +556,15 @@ export function TranscriptEntry({
     return <DisplayedImage message={message} />;
   }
 
+  // A displayed file is an artifact, never prose. Its caption arrives in
+  // `text`, and the `!message.text` guard below therefore used to let it fall
+  // all the way through to the markdown renderer — so an agent that handed you
+  // a PDF handed you a grey sentence about a PDF instead. That is the same bug
+  // `DisplayedImage` above exists to fix, and it is one branch earlier here.
+  if (message.kind === "file" && (message.url || message.artifactId)) {
+    return <AttachmentEntry message={message} />;
+  }
+
   const isAttachment =
     !!message.url || !!message.artifactId || message.kind === "image" || message.kind === "file";
   if (isAttachment && !message.text) return <AttachmentEntry message={message} />;
@@ -1203,7 +1212,8 @@ function DisplayedImage({ message }: { message: Entry }) {
 export function AttachmentEntry({ message }: { message: Entry }) {
   const { colors, type, space, radius } = useTheme();
   const isImage = message.kind === "image" || !!message.mimeType?.startsWith("image/");
-  const label = message.name ?? message.caption ?? message.alt ?? (isImage ? "Image" : "File");
+  const label =
+    message.name ?? message.caption ?? message.alt ?? message.text ?? (isImage ? "Image" : "File");
   const size =
     typeof message.size === "number" && message.size > 0
       ? `${Math.max(1, Math.round(message.size / 1024))} KB`

--- a/src/artifact-headers.test.ts
+++ b/src/artifact-headers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { contentDisposition } from "./artifact-headers.ts";
+
+describe("contentDisposition", () => {
+  test("names an ordinary file both ways", () => {
+    expect(contentDisposition("attachment", "q3-report.pdf")).toBe(
+      `attachment; filename="q3-report.pdf"; filename*=UTF-8''q3-report.pdf`,
+    );
+    expect(contentDisposition("inline", "notes.txt")).toStartWith("inline; ");
+  });
+
+  // The name comes from a path the agent chose. A raw CR/LF here would let it
+  // append headers or a body to the response.
+  test("cannot inject a header break", () => {
+    const header = contentDisposition("attachment", "a\r\nX-Injected: yes\r\n\r\nbody.pdf");
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
+    expect(header).not.toContain("X-Injected: yes\r");
+  });
+
+  test("cannot escape the quoted filename parameter", () => {
+    const header = contentDisposition("attachment", 'evil".pdf');
+    // Exactly two quotes: the ones this function opened and closed.
+    expect(header.match(/"/g)?.length).toBe(2);
+    expect(contentDisposition("attachment", "back\\slash.pdf")).not.toContain("\\");
+  });
+
+  test("carries a non-ASCII name in filename* and degrades the ASCII copy", () => {
+    const header = contentDisposition("attachment", "報告.pdf");
+    expect(header).toContain(`filename="__.pdf"`);
+    expect(header).toContain(`filename*=UTF-8''${encodeURIComponent("報告.pdf")}`);
+  });
+
+  test("never emits an empty ASCII filename", () => {
+    expect(contentDisposition("attachment", "")).toContain(`filename="file"`);
+    expect(contentDisposition("attachment", "\u0000\u0001")).toContain(`filename="__"`);
+    // Whitespace is printable ASCII but is not a name.
+    expect(contentDisposition("attachment", "   ")).toContain(`filename="file"`);
+  });
+
+  test("bounds a hostile length", () => {
+    const header = contentDisposition("attachment", "a".repeat(5000));
+    expect(header.length).toBeLessThan(600);
+  });
+});

--- a/src/artifact-headers.ts
+++ b/src/artifact-headers.ts
@@ -1,0 +1,32 @@
+// How artifact bytes are handed to a browser.
+//
+// This is a security boundary, not formatting. `GET /api/artifacts/:id` serves
+// agent-chosen bytes from the app's own origin, and the artifact route answers
+// every "file" artifact with the attachment disposition this builds. That is
+// what stops an agent-written `.html` or `.svg` from executing as the user:
+// the browser saves it instead of interpreting it.
+
+/**
+ * Build an RFC 6266 `Content-Disposition`.
+ *
+ * The name comes from a source path the AGENT chose. It can hold quotes,
+ * backslashes, control characters, CR/LF, or non-ASCII. A raw byte reaching
+ * this header is a response-splitting bug, so nothing is interpolated
+ * unescaped: the `filename` parameter is stripped to printable ASCII with the
+ * quoting characters removed, and the real name is carried by the
+ * percent-encoded `filename*`, which cannot contain a delimiter at all.
+ */
+export function contentDisposition(kind: "inline" | "attachment", name: string): string {
+  const ascii =
+    name
+      // Everything outside printable ASCII, which removes CR, LF and NUL.
+      .replace(/[^\x20-\x7e]/g, "_")
+      // The two characters that could close or escape the quoted string.
+      .replace(/["\\]/g, "_")
+      .slice(0, 200)
+      // A name that is only spaces is printable but is not a name.
+      .trim() || "file";
+  // encodeURIComponent leaves no delimiter, quote, or space unescaped.
+  const encoded = encodeURIComponent(name).slice(0, 300);
+  return `${kind}; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}

--- a/src/artifacts.test.ts
+++ b/src/artifacts.test.ts
@@ -5,9 +5,11 @@ import { join } from "node:path";
 import { PATHS } from "./config.ts";
 import {
   collapseArtifactRetryMessages,
+  createFileArtifact,
   createImageArtifact,
   deleteArtifact,
   getImageArtifact,
+  imageArtifactToMessage,
   publishHtmlArtifact,
   updateHtmlArtifactRefresh,
   type ArtifactRefreshConfig,
@@ -125,5 +127,106 @@ describe("stable HTML artifact ownership", () => {
       html: "<!doctype html><html><body>collision</body></html>",
     })).toThrow("different media kind");
     expect(getImageArtifact(image.id)?.media).toBe("image");
+  });
+});
+
+describe("file artifacts", () => {
+  const originalData = PATHS.data;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "lfg-artifact-file-"));
+    PATHS.data = join(root, "data");
+  });
+
+  afterEach(() => {
+    PATHS.data = originalData;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function source(name: string, body = "x"): string {
+    const path = join(root, name);
+    writeFileSync(path, body);
+    return path;
+  }
+
+  test("types a known document format and copies the bytes into the store", () => {
+    const artifact = createFileArtifact({
+      sessionId: SESSION_A,
+      path: source("report.pdf", "%PDF-1.4 body"),
+      caption: "Q3 report",
+    });
+
+    expect(artifact.media).toBe("file");
+    expect(artifact.mimeType).toBe("application/pdf");
+    expect(artifact.name).toBe("report.pdf");
+    expect(artifact.caption).toBe("Q3 report");
+    expect(readFileSync(artifact.filePath, "utf8")).toBe("%PDF-1.4 body");
+  });
+
+  test("types an audio clip so the transcript can play it", () => {
+    const artifact = createFileArtifact({ sessionId: SESSION_A, path: source("clip.mp3") });
+    expect(artifact.mimeType).toBe("audio/mpeg");
+  });
+
+  // The whole point of the kind: an unrecognized format is still displayable.
+  // Image and video reject instead, which is why they cannot carry a document.
+  test("accepts an unknown extension as an opaque download", () => {
+    const artifact = createFileArtifact({ sessionId: SESSION_A, path: source("data.parquet") });
+    expect(artifact.mimeType).toBe("application/octet-stream");
+  });
+
+  test("accepts a file with no extension at all", () => {
+    const artifact = createFileArtifact({ sessionId: SESSION_A, path: source("Makefile") });
+    expect(artifact.mimeType).toBe("application/octet-stream");
+    expect(artifact.name).toBe("Makefile");
+  });
+
+  // Every file artifact is served as an attachment, so the stored type cannot
+  // make a browser render anything. This keeps script-bearing formats off a
+  // real content type anyway, so that relaxing the disposition later fails
+  // safe instead of silently becoming an execution bug.
+  test.each([
+    ["page.html", "<script>alert(1)</script>"],
+    ["page.htm", "<script>alert(1)</script>"],
+    ["vector.svg", "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"],
+    ["doc.xhtml", "<html xmlns='http://www.w3.org/1999/xhtml'/>"],
+    ["feed.xml", "<?xml version='1.0'?><root/>"],
+  ])("stores %s as an opaque type, never a renderable one", (name, body) => {
+    const artifact = createFileArtifact({ sessionId: SESSION_A, path: source(name, body) });
+    expect(artifact.mimeType).toBe("application/octet-stream");
+  });
+
+  test("rejects a relative path and a missing file", () => {
+    expect(() => createFileArtifact({ sessionId: SESSION_A, path: "report.pdf" })).toThrow(
+      /absolute/,
+    );
+    expect(() =>
+      createFileArtifact({ sessionId: SESSION_A, path: join(root, "absent.pdf") }),
+    ).toThrow();
+  });
+
+  test("renders as a file message carrying its own artifact url", () => {
+    const artifact = createFileArtifact({
+      sessionId: SESSION_A,
+      path: source("rows.csv", "a,b\n1,2\n"),
+      caption: "Export",
+    });
+    const message = imageArtifactToMessage(artifact);
+
+    expect(message.kind).toBe("file");
+    expect(message.mimeType).toBe("text/csv; charset=utf-8");
+    expect(message.url).toBe(`/api/artifacts/${artifact.id}`);
+    expect(message.name).toBe("rows.csv");
+    expect(message.text).toBe("Export");
+  });
+
+  test("collapses an identical file retry the way media retries collapse", () => {
+    const base = { kind: "file", name: "report.pdf", mimeType: "application/pdf", size: 9 };
+    const messages = [
+      { ...base, id: "artifact-a", ts: 10_000 },
+      { ...base, id: "artifact-b", ts: 30_000 },
+    ];
+    expect(collapseArtifactRetryMessages(messages).map((m) => m.id)).toEqual(["artifact-a"]);
   });
 });

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -27,13 +27,18 @@ function indexPath(): string {
 const UUID = /^[0-9a-fA-F-]{36}$/;
 const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
 const MAX_VIDEO_BYTES = 250 * 1024 * 1024;
+const MAX_FILE_BYTES = 100 * 1024 * 1024;
 // Agents commonly retry a display tool after a transport/indexing error.  The
 // media copy may already be durable at that point, so treat an identical call
 // in this short window as the same publish instead of creating a second chat
 // message.  Deliberately displaying the same file again later still works.
 const RETRY_DEDUPE_MS = 5 * 60 * 1000;
 
-export type MediaKind = "image" | "video" | "html";
+export type MediaKind = "image" | "video" | "html" | "file";
+
+// The kinds whose bytes are copied into the store from a source path. "html"
+// is authored in-band and never goes through `createMediaArtifact`.
+export type StoredMediaKind = "image" | "video" | "file";
 
 export type ArtifactRefreshStatus = "idle" | "running" | "success" | "error";
 
@@ -70,11 +75,61 @@ const VIDEO_TYPES: Record<string, string> = {
   ".ogv": "video/ogg",
 };
 
+// "file" is the general kind: a PDF, an audio clip, a spreadsheet, an archive.
+// Unlike image and video it does NOT reject unknown extensions, because the
+// point of the kind is to carry whatever the agent produced. An extension that
+// is absent here is still stored and still displayed; it is simply typed
+// `application/octet-stream`.
+//
+// This table only decides what the DOWNLOADED file is labelled as. Every file
+// artifact is served as an attachment (see the artifact byte route), so no
+// entry here can cause a browser to render anything. Script-bearing formats
+// are still left out as a second line of defence, so that a future change
+// which relaxes the disposition cannot silently become an execution bug.
+const FILE_TYPES: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".opus": "audio/ogg",
+  ".flac": "audio/flac",
+  ".txt": "text/plain; charset=utf-8",
+  ".log": "text/plain; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+  ".tsv": "text/tab-separated-values; charset=utf-8",
+  ".json": "application/json",
+};
+
+const FALLBACK_FILE_TYPE = "application/octet-stream";
+
+const MEDIA_TYPES: Record<StoredMediaKind, Record<string, string>> = {
+  image: IMAGE_TYPES,
+  video: VIDEO_TYPES,
+  file: FILE_TYPES,
+};
+
+const MEDIA_MAX_BYTES: Record<StoredMediaKind, number> = {
+  image: MAX_IMAGE_BYTES,
+  video: MAX_VIDEO_BYTES,
+  file: MAX_FILE_BYTES,
+};
+
+const MEDIA_TYPE_ERROR: Record<StoredMediaKind, string> = {
+  image: "only png, jpg, jpeg, webp, and gif images can be displayed",
+  video: "only mp4, m4v, webm, mov, and ogv videos can be displayed",
+  // Unreachable: the file table falls back instead of rejecting.
+  file: "this file cannot be displayed",
+};
+
 export type ImageArtifact = {
   id: string;
   sessionId: string;
   createdAt: number;
-  // "image" (default for legacy entries that predate video support) or "video".
+  // "image" is the default for legacy entries that predate the other kinds.
   media?: MediaKind;
   sourcePath: string;
   sourceMtimeMs?: number;
@@ -184,12 +239,21 @@ function cleanText(value: string | undefined, max: number): string | undefined {
   return text ? text.slice(0, max) : undefined;
 }
 
-function imageMimeFor(path: string): string | null {
-  return IMAGE_TYPES[extname(path).toLowerCase()] ?? null;
+function mediaMimeFor(path: string, media: StoredMediaKind): string | null {
+  const mime = MEDIA_TYPES[media][extname(path).toLowerCase()] ?? null;
+  // Image and video reject an unlisted extension. "file" accepts it and
+  // downgrades to an opaque download instead, so the kind stays general.
+  if (!mime && media === "file") return FALLBACK_FILE_TYPE;
+  return mime;
 }
 
-function videoMimeFor(path: string): string | null {
-  return VIDEO_TYPES[extname(path).toLowerCase()] ?? null;
+// The stored copy keeps the source extension so the served bytes carry a
+// recognizable name. `extname` on a resolved absolute path cannot contain a
+// separator, but it can contain arbitrary punctuation, and this value is
+// concatenated into a path. Only accept a plain alphanumeric suffix.
+function safeExt(sourcePath: string): string {
+  const ext = extname(sourcePath).toLowerCase();
+  return /^\.[a-z0-9]{1,12}$/.test(ext) ? ext : "";
 }
 
 function createMediaArtifact(
@@ -199,7 +263,7 @@ function createMediaArtifact(
     caption?: string;
     alt?: string;
   },
-  media: MediaKind,
+  media: StoredMediaKind,
   dimensions?: { width: number; height: number },
 ): ImageArtifact {
   const sessionId = input.sessionId.trim();
@@ -207,16 +271,10 @@ function createMediaArtifact(
 
   if (!isAbsolute(input.path)) throw new Error(`${media} path must be absolute`);
   const sourcePath = resolve(input.path);
-  const mimeType = media === "video" ? videoMimeFor(sourcePath) : imageMimeFor(sourcePath);
-  if (!mimeType) {
-    throw new Error(
-      media === "video"
-        ? "only mp4, m4v, webm, mov, and ogv videos can be displayed"
-        : "only png, jpg, jpeg, webp, and gif images can be displayed",
-    );
-  }
+  const mimeType = mediaMimeFor(sourcePath, media);
+  if (!mimeType) throw new Error(MEDIA_TYPE_ERROR[media]);
 
-  const maxBytes = media === "video" ? MAX_VIDEO_BYTES : MAX_IMAGE_BYTES;
+  const maxBytes = MEDIA_MAX_BYTES[media];
   const st = statSync(sourcePath);
   if (!st.isFile()) throw new Error(`${media} path is not a file`);
   if (st.size <= 0) throw new Error(`${media} file is empty`);
@@ -257,8 +315,7 @@ function createMediaArtifact(
   const dir = filesDir();
   mkdirSync(dir, { recursive: true });
   const id = `${Date.now().toString(36)}-${randomBytes(6).toString("hex")}`;
-  const ext = extname(sourcePath).toLowerCase();
-  const filePath = join(dir, `${id}${ext}`);
+  const filePath = join(dir, `${id}${safeExt(sourcePath)}`);
   copyFileSync(sourcePath, filePath);
 
   const artifact: ImageArtifact = {
@@ -311,6 +368,21 @@ export function createVideoArtifact(input: {
   alt?: string;
 }): ImageArtifact {
   return createMediaArtifact(input, "video");
+}
+
+/**
+ * Display any other file: a PDF, an audio clip, a CSV, an archive. The kind is
+ * deliberately one bucket rather than one kind per format. The stored
+ * `mimeType` is what decides the presentation, so a new format needs a
+ * renderer, not a new artifact kind or a migration.
+ */
+export function createFileArtifact(input: {
+  sessionId: string;
+  path: string;
+  caption?: string;
+  alt?: string;
+}): ImageArtifact {
+  return createMediaArtifact(input, "file");
 }
 
 // HTML artifacts are UPDATABLE: an intentional publish bumps the user-facing
@@ -515,7 +587,10 @@ export function collapseArtifactRetryMessages<T extends {
   const out: T[] = [];
   const lastBySignature = new Map<string, number>();
   for (const message of messages) {
-    if ((message.kind !== "image" && message.kind !== "video") || message.ts == null) {
+    if (
+      (message.kind !== "image" && message.kind !== "video" && message.kind !== "file") ||
+      message.ts == null
+    ) {
       out.push(message);
       continue;
     }
@@ -536,7 +611,14 @@ export function collapseArtifactRetryMessages<T extends {
 }
 
 export function hydrateImageArtifactMessage(message: SessionMsg): SessionMsg | ImageArtifactMessage {
-  if (message.kind !== "image" && message.kind !== "video" && message.kind !== "html") return message;
+  if (
+    message.kind !== "image" &&
+    message.kind !== "video" &&
+    message.kind !== "html" &&
+    message.kind !== "file"
+  ) {
+    return message;
+  }
   const artifactId = message.id?.startsWith("artifact-") ? message.id.slice("artifact-".length) : null;
   if (!artifactId) return message;
   const artifact = getImageArtifact(artifactId);

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -889,6 +889,37 @@ export function buildOmgMcpServer(): McpServer {
   );
 
   server.registerTool(
+    "omg_display_file",
+    {
+      title: "Display File In omg.dev",
+      description:
+        "Give the user a local file in the omg.dev session transcript: a PDF, an audio clip, a CSV, a log, an archive, or any other document. The transcript shows a named card with its size and a download button; the file is downloaded, not rendered in place. Use omg_display_image for screenshots and omg_display_video for recordings, which do render inline.",
+      inputSchema: {
+        path: z.string().min(1).describe("Absolute path to the file on this machine. Any file type is accepted, up to 100 MB."),
+        caption: z.string().optional().describe("Short caption shown under the file. Say what the file is and why it matters."),
+        alt: z.string().optional().describe("Short accessible description of the file contents."),
+        sessionId: z.string().optional().describe("Target omg.dev session id. Defaults to OMG_SESSION_ID."),
+      },
+    },
+    async ({ path, caption, alt, sessionId }) => {
+      const sid = await activeSessionId(sessionId);
+      const data = await api<ImageArtifactResponse>(
+        `/api/sessions/${encodeURIComponent(sid)}/artifacts/files`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path, caption, alt }),
+        },
+      );
+      return result({
+        displayed: true,
+        sessionId: shortSid(sid),
+        artifact: data.artifact,
+      });
+    },
+  );
+
+  server.registerTool(
     "omg_publish_artifact",
     {
       title: "Publish HTML Artifact In omg.dev",

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -478,8 +478,10 @@ import {
   type GlobalSettings,
 } from "../settings.ts";
 import { listSkillCatalog, searchSkillCatalog, withoutSkillKeywords } from "../skills-catalog.ts";
+import { contentDisposition } from "../artifact-headers.ts";
 import {
   collapseArtifactRetryMessages,
+  createFileArtifact,
   createImageArtifact,
   createVideoArtifact,
   deleteArtifact,
@@ -8518,12 +8520,23 @@ a{color:#60a5fa}
               },
             });
           }
+          // A "file" artifact is never rendered by omg.dev, only downloaded.
+          // These bytes are agent-chosen and are served from the app's own
+          // origin, so anything the browser would INTERPRET here is something
+          // the agent can execute as the user. Forcing the attachment for the
+          // whole kind means there is no allowlist to keep correct: a `.html`
+          // or `.svg` the agent wrote is saved, never run. Do not relax this
+          // to add an inline preview without solving that first.
+          const isFileArtifact = (artifact.media ?? "image") === "file";
           const baseHeaders: Record<string, string> = {
             "Content-Type": contentType,
             "Cache-Control": "private, max-age=31536000, immutable",
             "X-Content-Type-Options": "nosniff",
             // Video seeking (and Safari playback) needs byte-range support.
             "Accept-Ranges": "bytes",
+            ...(isFileArtifact
+              ? { "Content-Disposition": contentDisposition("attachment", artifact.name) }
+              : {}),
           };
           // Honor a single-range request so the <video> element can seek without
           // re-downloading the whole file. Bun.file().slice() streams the slice.
@@ -8720,6 +8733,35 @@ a{color:#60a5fa}
             return json({ ok: true, artifact, message: imageArtifactToMessage(artifact), indexed: true });
           } catch (e) {
             return err(400, e instanceof Error ? e.message : "could not create video artifact");
+          }
+        }
+      }
+
+      {
+        // Any other file the agent wants to put in front of the user: a PDF,
+        // an audio clip, a CSV, an archive. One route for all of them — the
+        // stored mime type, not the artifact kind, decides the presentation.
+        const m = path.match(/^\/api\/sessions\/([0-9a-fA-F-]{36})\/artifacts\/files$/);
+        if (m && req.method === "POST") {
+          const body = (await req.json().catch(() => null)) as {
+            path?: string;
+            caption?: string;
+            alt?: string;
+          } | null;
+          if (!body?.path?.trim()) return err(400, "path required");
+          try {
+            const transcriptPath = await resolveTranscript(m[1]);
+            const indexPath = transcriptPath ?? sessionIndexKey(m[1]);
+            const artifact = createFileArtifact({
+              sessionId: m[1],
+              path: body.path,
+              caption: body.caption,
+              alt: body.alt,
+            });
+            indexArtifactMessage(indexPath, m[1], artifact);
+            return json({ ok: true, artifact, message: imageArtifactToMessage(artifact), indexed: true });
+          } catch (e) {
+            return err(400, e instanceof Error ? e.message : "could not create file artifact");
           }
         }
       }

--- a/src/live-ws.ts
+++ b/src/live-ws.ts
@@ -233,7 +233,9 @@ function artifactIdFromUrl(url?: string): string | null {
 }
 
 function mediaIdentity(message: { kind?: string; id?: string | null; artifactId?: string; url?: string; ts?: number | null; name?: string; size?: number; text?: string }): string | null {
-  if (message.kind !== "image" && message.kind !== "video") return message.id ?? null;
+  if (message.kind !== "image" && message.kind !== "video" && message.kind !== "file") {
+    return message.id ?? null;
+  }
   const artifactId = message.artifactId || artifactIdFromUrl(message.url);
   if (artifactId) return `artifact-${artifactId}`;
   if (message.url) return `media-${message.kind}-${message.url}`;

--- a/src/omg-capabilities.test.ts
+++ b/src/omg-capabilities.test.ts
@@ -161,7 +161,7 @@ describe("omg.dev runtime capabilities", () => {
     expect(OMG_CAPABILITIES.map((item) => item.tool)).toEqual([
       "omg_create_owned_bot / omg_update_self / omg_list_owned_bots / omg_send_message_to_peer",
       "omg_ship",
-      "omg_display_image / omg_display_video",
+      "omg_display_image / omg_display_video / omg_display_file",
       "omg_input",
       "omg_find_sessions",
       "omg_close_session",
@@ -176,6 +176,7 @@ describe("omg.dev runtime capabilities", () => {
     expect(mcpSource).not.toContain('registerTool(\n    "omg_output"');
     expect(mcpSource).toContain('registerTool(\n    "omg_display_image"');
     expect(mcpSource).toContain('registerTool(\n    "omg_display_video"');
+    expect(mcpSource).toContain('registerTool(\n    "omg_display_file"');
     expect(mcpSource).toContain('registerTool(\n    "omg_ship"');
     expect(mcpSource).not.toContain('registerTool(\n    "omg_ask_question"');
     expect(mcpSource).not.toContain('"advisor"');

--- a/src/omg-capabilities.ts
+++ b/src/omg-capabilities.ts
@@ -4,7 +4,7 @@ import { DEFAULT_MAX_BOT_SCHEDULES } from "./settings.ts";
 // Bump whenever an agent-facing omg.dev capability or its operating guidance
 // changes. Managed sessions persist the value they launched with, which lets
 // the UI identify long-lived sessions whose MCP/tool catalog predates a ship.
-export const OMG_CAPABILITY_VERSION = "2026-08-21.1";
+export const OMG_CAPABILITY_VERSION = "2026-09-01.1";
 
 export const OMG_CAPABILITIES = [
   {
@@ -20,9 +20,9 @@ export const OMG_CAPABILITIES = [
       "This is how finished work reaches the human — a session that never ships is invisible. Post a headline, a tweet-length result and the strongest evidence. Posting does not close the session. Never ship planning, partial, or blocked work.",
   },
   {
-    tool: "omg_display_image / omg_display_video",
-    useWhen: "A local screenshot or recording would provide useful visual evidence in the omg.dev transcript.",
-    guidance: "Use these only for image/video evidence. Communicate with the human through normal assistant messages.",
+    tool: "omg_display_image / omg_display_video / omg_display_file",
+    useWhen: "A local screenshot, recording, or file would be useful evidence in the omg.dev transcript.",
+    guidance: "Use omg_display_file for a PDF, an audio clip, a CSV, a log, or any other document. Use these to show artifacts, not to talk: communicate with the human through normal assistant messages.",
   },
   {
     tool: "omg_input",
@@ -66,7 +66,7 @@ export function shortSessionId(id: string): string {
 
 export const OMG_MCP_INSTRUCTIONS = [
   `This is omg.dev's agent capability server (capability version ${OMG_CAPABILITY_VERSION}).`,
-  "Communicate with the human through normal assistant messages. Use omg_display_image or omg_display_video when local visual evidence is useful.",
+  "Communicate with the human through normal assistant messages. Use omg_display_image or omg_display_video when local visual evidence is useful, and omg_display_file to put a PDF, an audio clip, a CSV, or any other document in front of the user.",
   // Scoped to task sessions on purpose. These instructions reach every session
   // the MCP server answers, bots included, and an unscoped "ship or stay
   // invisible" told a named bot the exact opposite of its own envelope — which
@@ -81,7 +81,7 @@ export function omgRuntimeContract(): string {
   return [
     `=== omg.dev RUNTIME CONTRACT (capability version ${OMG_CAPABILITY_VERSION}) ===`,
     "- You are an omg.dev-managed coding agent. Communicate with the human through normal assistant messages; omg.dev tool calls do not replace those replies.",
-    "- Use `omg_display_image` or `omg_display_video` when a local screenshot or recording provides useful evidence in the omg.dev transcript.",
+    "- Use `omg_display_image` or `omg_display_video` when a local screenshot or recording provides useful evidence in the omg.dev transcript. Use `omg_display_file` for any other file the user should see: a PDF, an audio clip, a CSV, a log, an archive.",
     "- Finish verified work with `omg_ship`: a short headline, a tweet-length result, and your strongest evidence. Publishing does not close the session, so keep working if anything is left. Never ship planning, partial, or blocked work.",
     "- Shipped is not deployed. If deployment was requested, verify it before you claim it.",
     "- Decide and continue when safe. Use `omg_input` only for an irreversible, risky, or ambiguous decision; it is fire-and-forget, so do not poll.",

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -285,7 +285,7 @@ export type SessionMsg = {
   // whole chunk again.
   id: string | null;
   role: string;
-  kind: "text" | "thinking" | "tool_use" | "tool_result" | "image" | "video" | "html";
+  kind: "text" | "thinking" | "tool_use" | "tool_result" | "image" | "video" | "html" | "file";
   text: string;
   ts: number | null;
   // True only for a genuine upstream API-error turn (Claude Code stamps the

--- a/src/shipped.ts
+++ b/src/shipped.ts
@@ -59,10 +59,12 @@ export type ShipPostHydrated = Omit<ShipPostRevision, "media"> & {
   firstTs: number;
   mediaItems: Array<{
     artifactId: string;
-    kind: "image" | "video" | "html";
+    kind: "image" | "video" | "html" | "file";
     url: string;
     name: string;
     caption?: string;
+    mimeType?: string;
+    size?: number;
     version?: number;
     updatedAt?: number;
     lastRefreshedAt?: number;
@@ -306,10 +308,12 @@ export function listShipPosts(
           const message = imageArtifactToMessage(artifact);
           return {
             artifactId: id,
-            kind: (artifact.media ?? "image") as "image" | "video" | "html",
+            kind: (artifact.media ?? "image") as "image" | "video" | "html" | "file",
             url: message.url,
             name: artifact.name,
             caption: artifact.caption,
+            mimeType: artifact.mimeType,
+            size: artifact.size,
             version: artifact.version,
             updatedAt: artifact.updatedAt ?? artifact.createdAt,
             lastRefreshedAt: artifact.refresh?.lastSuccessAt,

--- a/src/transcript-index.ts
+++ b/src/transcript-index.ts
@@ -741,7 +741,14 @@ function rowMessage(row: IndexedMessageRow): SessionMsg | ImageArtifactMessage {
     ts: row.ts,
     author,
   };
-  if (row.kind !== "image" && row.kind !== "video" && row.kind !== "html") return base;
+  if (
+    row.kind !== "image" &&
+    row.kind !== "video" &&
+    row.kind !== "html" &&
+    row.kind !== "file"
+  ) {
+    return base;
+  }
 
   // Prefer the JOIN payload so the page/live stream never needs a second
   // artifact-store pass to learn url/size/caption.
@@ -1440,7 +1447,7 @@ export async function indexedMessagePage(
           END
         WHERE m.path = ? AND m.order_seq < ?
           AND (
-            m.kind NOT IN ('image', 'video', 'html')
+            m.kind NOT IN ('image', 'video', 'html', 'file')
             OR m.message_id NOT LIKE 'artifact-%'
             OR a.id IS NOT NULL
           )
@@ -1621,7 +1628,7 @@ export function indexedMessagesAfterRowid(
             END
           WHERE m.path = ? AND m.rowid > ?
             AND (
-              m.kind NOT IN ('image', 'video', 'html')
+              m.kind NOT IN ('image', 'video', 'html', 'file')
               OR m.message_id NOT LIKE 'artifact-%'
               OR a.id IS NOT NULL
             )

--- a/src/transcript-rows.ts
+++ b/src/transcript-rows.ts
@@ -56,7 +56,7 @@ export function toolGroupLabel(items: ChatRenderMessage[]): string {
   return parts.join(" · ") || `${items.length} step${items.length === 1 ? "" : "s"}`;
 }
 
-function artifactKindForTool(message: ChatRenderMessage): "image" | "video" | "html" | null {
+function artifactKindForTool(message: ChatRenderMessage): "image" | "video" | "html" | "file" | null {
   if (message.kind !== "tool_use") return null;
   const name = toolName(message.text);
   // The tools are registered as omg_*; the lfg_* spellings are kept so
@@ -64,6 +64,7 @@ function artifactKindForTool(message: ChatRenderMessage): "image" | "video" | "h
   if (matchesTool(name, "display_image")) return "image";
   if (matchesTool(name, "display_video")) return "video";
   if (matchesTool(name, "publish_artifact")) return "html";
+  if (matchesTool(name, "display_file")) return "file";
   return null;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -159,6 +159,7 @@ import {
   AuthenticatedArtifactImage,
   AuthenticatedArtifactVideo,
 } from "./components/authenticated-artifact";
+import { ArtifactFileCard } from "./components/artifact-file-card";
 import {
   NativeArtifact,
   NativeArtifactEmbed,
@@ -1803,6 +1804,16 @@ function ArtifactViewerPage({
               title={label}
               onNeedsFrame={setFramed}
               className={cn("block w-full", framed && "h-full")}
+            />
+          </div>
+        ) : artifact.kind === "file" ? (
+          <div className="flex h-full items-start justify-center overflow-auto bg-background p-4">
+            <ArtifactFileCard
+              url={artifact.url}
+              name={artifact.name}
+              mimeType={artifact.mimeType}
+              size={artifact.size}
+              caption={artifact.caption}
             />
           </div>
         ) : artifact.kind === "video" ? (
@@ -19848,6 +19859,22 @@ const MessageBubble = memo(function MessageBubble({
     );
   }
 
+  if (message.kind === "file" && message.url) {
+    return (
+      <AiMessage className={cn("msg", entering && "lfg-msg-in")} from="assistant">
+        <MessageContent className="not-prose w-full max-w-[min(42rem,92vw)] p-0">
+          <ArtifactFileCard
+            url={message.url}
+            name={message.name}
+            mimeType={message.mimeType}
+            size={message.size}
+            caption={message.caption || message.text || message.alt}
+          />
+        </MessageContent>
+      </AiMessage>
+    );
+  }
+
   if ((message.kind === "image" || message.kind === "video") && message.url) {
     const isVideo = message.kind === "video";
     const label =
@@ -26406,7 +26433,7 @@ function UsagePage() {
 
 export type GalleryArtifact = {
   id: string;
-  kind: "image" | "video" | "html";
+  kind: "image" | "video" | "html" | "file";
   url: string;
   name: string;
   title?: string;
@@ -26426,10 +26453,12 @@ export type GalleryArtifact = {
 
 export type ShipMediaItem = {
   artifactId: string;
-  kind: "image" | "video" | "html";
+  kind: "image" | "video" | "html" | "file";
   url: string;
   name: string;
   caption?: string;
+  mimeType?: string;
+  size?: number;
   version?: number;
   updatedAt?: number;
   lastRefreshedAt?: number;

--- a/web/src/components/artifact-file-card.test.tsx
+++ b/web/src/components/artifact-file-card.test.tsx
@@ -1,0 +1,199 @@
+// Render-level guard for the general "file" artifact card.
+//
+// Two regressions this exists to catch:
+//
+//   - A displayed file falling through to the prose renderer, so an agent that
+//     meant to hand you a PDF hands you a grey sentence about a PDF. That is
+//     the bug the mobile transcript actually had.
+//   - The card fetching the file's bytes just to draw itself. A file artifact
+//     can be 100 MB, and a transcript can hold several.
+//
+// Both are only visible at the DOM, which is why this mounts the component
+// rather than reading its source.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { OmgTransport } from "@omg-dev/client";
+
+import { mount, type Mounted } from "../test-support/render";
+
+const { createSameOriginTransport } = await import("@omg-dev/client");
+const { configureOmgTransport } = await import("../lib/omg-client");
+const { ArtifactFileCard, formatFileSize } = await import("./artifact-file-card");
+
+let ui: Mounted;
+let fetched: string[];
+
+function installTransport(options: { direct: boolean }) {
+  const transport: OmgTransport = {
+    async fetch(path: string) {
+      fetched.push(path);
+      return new Response(new Blob(["bytes"], { type: "application/octet-stream" }));
+    },
+    async request() {
+      throw new Error("request is not used by the file card");
+    },
+    async openSocket() {
+      throw new Error("socket is not used by the file card");
+    },
+    async openLiveSocket() {
+      throw new Error("socket is not used by the file card");
+    },
+    ...(options.direct ? { assetUrl: (path: string) => path } : {}),
+  };
+  configureOmgTransport(transport);
+}
+
+beforeEach(() => {
+  fetched = [];
+  ui = mount();
+  installTransport({ direct: true });
+});
+
+afterEach(() => {
+  ui.cleanup();
+  configureOmgTransport(createSameOriginTransport());
+});
+
+describe("ArtifactFileCard", () => {
+  test("names a file and offers a download instead of dropping it into prose", async () => {
+    await ui.flushAsync(() => {
+      ui.render(
+        <ArtifactFileCard
+          url="/api/artifacts/a1"
+          name="q3-report.pdf"
+          mimeType="application/pdf"
+          size={2048}
+          caption="Q3 report"
+        />,
+      );
+    });
+
+    expect(ui.text()).toContain("q3-report.pdf");
+    expect(ui.text()).toContain("2 KB");
+    expect(ui.text()).toContain("Q3 report");
+    const link = ui.query("a[download]") as HTMLAnchorElement | null;
+    expect(link?.getAttribute("href")).toBe("/api/artifacts/a1");
+    expect(link?.getAttribute("download")).toBe("q3-report.pdf");
+  });
+
+  // The card is deliberately not a viewer. An embed would mean handing
+  // agent-chosen bytes to the browser to interpret on this origin.
+  test.each([
+    ["application/pdf", "spec.pdf"],
+    ["audio/mpeg", "note.mp3"],
+    ["text/csv; charset=utf-8", "rows.csv"],
+    ["application/octet-stream", "archive.zip"],
+  ])("renders %s as a download card with no embedded viewer", async (mimeType, name) => {
+    await ui.flushAsync(() => {
+      ui.render(<ArtifactFileCard url="/api/artifacts/a2" name={name} mimeType={mimeType} />);
+    });
+
+    expect(ui.query("object")).toBeNull();
+    expect(ui.query("iframe")).toBeNull();
+    expect(ui.query("embed")).toBeNull();
+    expect(ui.query("audio")).toBeNull();
+    expect(ui.query("video")).toBeNull();
+    expect(ui.text()).toContain(name);
+  });
+
+  test("downloads nothing to draw the card on either transport", async () => {
+    await ui.flushAsync(() => {
+      ui.render(
+        <ArtifactFileCard url="/api/artifacts/a3" name="big.zip" mimeType="application/zip" />,
+      );
+    });
+    expect(fetched).toEqual([]);
+
+    installTransport({ direct: false });
+    ui.remount();
+    await ui.flushAsync(() => {
+      ui.render(
+        <ArtifactFileCard url="/api/artifacts/a4" name="big.zip" mimeType="application/zip" />,
+      );
+    });
+    // No anchor to preload: the bytes are fetched by the click handler.
+    expect(fetched).toEqual([]);
+    expect(ui.query("a[download]")).toBeNull();
+    expect(ui.query("button")).not.toBeNull();
+  });
+
+  test("fetches the bytes when a signed-transport download is clicked", async () => {
+    // The component saves the blob by clicking a synthetic <a download>. A real
+    // browser honours `download` and stays put; happy-dom instead NAVIGATES the
+    // shared window to the blob URL, which silently breaks every test file that
+    // runs after this one. Intercept the click: it keeps the environment clean
+    // and lets us assert what the anchor was actually given.
+    const anchorProto = (globalThis as unknown as {
+      window: { HTMLAnchorElement: { prototype: HTMLAnchorElement } };
+    }).window.HTMLAnchorElement.prototype;
+    const realClick = anchorProto.click;
+    const clicked: Array<{ href: string; download: string }> = [];
+    anchorProto.click = function patched(this: HTMLAnchorElement) {
+      clicked.push({ href: this.getAttribute("href") ?? "", download: this.download });
+    };
+
+    try {
+      installTransport({ direct: false });
+      await ui.flushAsync(() => {
+        ui.render(
+          <ArtifactFileCard url="/api/artifacts/a5" name="clip.wav" mimeType="audio/wav" />,
+        );
+      });
+
+      await ui.flushAsync(async () => {
+        (ui.query("button") as HTMLButtonElement).click();
+        // onClick is fire-and-forget, so `click()` returns before the fetch
+        // chain finishes. Settle it INSIDE act, or its final setState lands in
+        // a later test's act block and breaks that test instead of this one.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(fetched).toEqual(["/api/artifacts/a5"]);
+      expect(clicked.length).toBe(1);
+      expect(clicked[0].href).toStartWith("blob:");
+      expect(clicked[0].download).toBe("clip.wav");
+      // Settled, not still in flight.
+      expect((ui.query("button") as HTMLButtonElement).disabled).toBe(false);
+    } finally {
+      anchorProto.click = realClick;
+    }
+  });
+
+  test("does not repeat the caption when it is the same as the file name", async () => {
+    await ui.flushAsync(() => {
+      ui.render(
+        <ArtifactFileCard
+          url="/api/artifacts/a6"
+          name="rows.csv"
+          mimeType="text/csv; charset=utf-8"
+          caption="rows.csv"
+        />,
+      );
+    });
+
+    expect(ui.query('[data-slot="file-caption"]')).toBeNull();
+  });
+
+  test("shows a caption that says something the file name does not", async () => {
+    await ui.flushAsync(() => {
+      ui.render(
+        <ArtifactFileCard
+          url="/api/artifacts/a7"
+          name="rows.csv"
+          mimeType="text/csv; charset=utf-8"
+          caption="Every signup in August"
+        />,
+      );
+    });
+
+    expect(ui.query('[data-slot="file-caption"]')?.textContent).toBe("Every signup in August");
+  });
+});
+
+describe("formatFileSize", () => {
+  test("reports bytes, KB, MB, and GB", () => {
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(2048)).toBe("2 KB");
+    expect(formatFileSize(1048576)).toBe("1.0 MB");
+    expect(formatFileSize(1073741824)).toBe("1.0 GB");
+  });
+});

--- a/web/src/components/artifact-file-card.tsx
+++ b/web/src/components/artifact-file-card.tsx
@@ -1,0 +1,162 @@
+import { Download, File as FileIcon, FileAudio, FileSpreadsheet, FileText } from "lucide-react";
+import { useState } from "react";
+
+import { omgDirectUrl, omgFetch } from "../lib/omg-client";
+import { cn } from "../lib/utils";
+
+/**
+ * The card for the general "file" artifact kind: a PDF, an audio clip, a CSV,
+ * an archive, anything the agent wants to hand the reader that is not a
+ * screenshot or a recording.
+ *
+ * It names the file and downloads it. It does not render it.
+ *
+ * That is a deliberate limit, and it is what keeps this safe. These bytes are
+ * agent-chosen and are served from the app's own origin, so anything the
+ * browser would INTERPRET here is something the agent can execute as the user.
+ * The server answers every file artifact with `Content-Disposition:
+ * attachment`, so there is no allowlist to get wrong and no embed to sandbox.
+ * Adding an inline preview means reopening that question first.
+ */
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(bytes < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+function fileIcon(mimeType: string | undefined) {
+  const mime = (mimeType || "").toLowerCase().split(";")[0].trim();
+  if (mime.startsWith("audio/")) return FileAudio;
+  if (mime === "text/csv" || mime === "text/tab-separated-values") return FileSpreadsheet;
+  if (mime === "application/pdf" || mime.startsWith("text/") || mime === "application/json") {
+    return FileText;
+  }
+  return FileIcon;
+}
+
+export type ArtifactFileCardProps = {
+  url: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  caption?: string;
+  className?: string;
+};
+
+/**
+ * Download the artifact, without fetching it to draw the card.
+ *
+ * The two transports need different mechanics. Same-origin hands back a URL
+ * the browser can load itself, so an anchor is the whole implementation. A
+ * hosted transport signs each request and an anchor cannot carry that header,
+ * so the bytes have to come through `omgFetch` and become an object URL.
+ *
+ * That fetch happens ON CLICK, never on render. A file artifact can be 100 MB
+ * and a transcript can hold several, so fetching eagerly to prepare a link
+ * nobody clicked would download the lot just to scroll past them.
+ */
+function DownloadControl({
+  url,
+  name,
+  label,
+  className,
+}: {
+  url: string;
+  name?: string;
+  label: string;
+  className?: string;
+}) {
+  const direct = omgDirectUrl(url);
+  const [busy, setBusy] = useState(false);
+
+  if (direct !== null) {
+    return (
+      <a href={direct} download={name || ""} className={className}>
+        <Download className="size-4" aria-hidden="true" />
+        <span className="sr-only">{`Download ${label}`}</span>
+      </a>
+    );
+  }
+
+  const fetchAndSave = async () => {
+    if (busy) return;
+    setBusy(true);
+    let objectUrl: string | null = null;
+    try {
+      const response = await omgFetch(url);
+      if (!response.ok) throw new Error(`artifact ${response.status}`);
+      objectUrl = URL.createObjectURL(await response.blob());
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = name || "download";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    } catch {
+      // Nothing to recover: the file stays listed and the click can be retried.
+    } finally {
+      // Revoking immediately is safe — the browser has already taken the bytes
+      // it needs from a synchronous click.
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={busy}
+      onClick={fetchAndSave}
+      className={cn(className, busy && "opacity-50")}
+    >
+      <Download className="size-4" aria-hidden="true" />
+      <span className="sr-only">{busy ? `Downloading ${label}` : `Download ${label}`}</span>
+    </button>
+  );
+}
+
+export function ArtifactFileCard({
+  url,
+  name,
+  mimeType,
+  size,
+  caption,
+  className,
+}: ArtifactFileCardProps) {
+  const Icon = fileIcon(mimeType);
+  const label = name || caption || "File";
+  return (
+    <div
+      className={cn(
+        "not-prose flex w-full max-w-[min(34rem,92vw)] flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm",
+        className,
+      )}
+    >
+      <div className="flex w-0 min-w-full items-center gap-3 px-3 py-2">
+        <Icon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
+        {size ? (
+          <span className="shrink-0 text-xs text-muted-foreground">{formatFileSize(size)}</span>
+        ) : null}
+        <DownloadControl
+          url={url}
+          name={name}
+          label={label}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        />
+      </div>
+      {caption && caption !== label ? (
+        <div
+          data-slot="file-caption"
+          className="box-border w-0 min-w-full border-t border-border px-3 py-2 text-xs text-muted-foreground"
+        >
+          <span className="block truncate">{caption}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/lib/chat-row-height.ts
+++ b/web/src/lib/chat-row-height.ts
@@ -62,6 +62,11 @@ export const MEDIA_CARD_CHROME_PX = 34;
 /** `max-h-[24rem]` on the media element itself. */
 export const MEDIA_MAX_PX = 384;
 
+/** File card: the icon/name/size/download row (`py-2` + text line box) plus
+ *  the card's top and bottom border. A file artifact is never rendered inline,
+ *  so unlike media this row has no variable body to account for. */
+export const FILE_CARD_CHROME_PX = 42;
+
 /** `-webkit-line-clamp: 10` on `.user-bubble-clamp` (index.css). */
 export const USER_BUBBLE_CLAMP_LINES = 10;
 
@@ -132,6 +137,7 @@ export type RowMessage = ChatRenderMessage & {
   height?: number | null;
   html?: string | null;
   caption?: string | null;
+  name?: string | null;
   failed?: boolean;
   interrupted?: boolean;
 };
@@ -646,6 +652,14 @@ export function mediaHeight(
   return drawn + MEDIA_CARD_CHROME_PX;
 }
 
+/**
+ * A file row: a fixed name/size/download strip, plus a caption row when the
+ * caption says something the file name does not.
+ */
+export function fileHeight(hasCaption: boolean): number {
+  return FILE_CARD_CHROME_PX + (hasCaption ? MEDIA_CARD_CHROME_PX : 0);
+}
+
 // ---------------------------------------------------------------------------
 // Rows
 // ---------------------------------------------------------------------------
@@ -664,6 +678,10 @@ export function messageRowHeight(message: RowMessage, ctx: RowContext): number {
   if (message.kind === "image" || message.kind === "video") {
     const cardWidth = ctx.mediaWidth ?? ctx.assistant.contentWidth;
     return mediaHeight(message.width, message.height, cardWidth);
+  }
+  if (message.kind === "file") {
+    const caption = message.caption || message.text;
+    return fileHeight(Boolean(caption && caption !== message.name));
   }
 
   const rawText = message.text ?? "";

--- a/web/src/lib/session-ui.tsx
+++ b/web/src/lib/session-ui.tsx
@@ -83,10 +83,14 @@ export function timeAgo(value?: number | null): string {
  */
 export type ViewerArtifact = {
   url: string;
-  kind: "image" | "video" | "html";
+  kind: "image" | "video" | "html" | "file";
   title?: string;
   caption?: string;
   name?: string;
+  // File artifacts pick their presentation from the mime type, and show the
+  // size on the card. Unused by the image/video/html branches.
+  mimeType?: string;
+  size?: number;
   version?: number;
   // Changes on every successful content write, including data-only refreshes.
   // Kept separate from the user-facing authored revision.

--- a/web/src/lib/transcript-view.ts
+++ b/web/src/lib/transcript-view.ts
@@ -41,7 +41,12 @@ export function messagesForTranscriptView<T extends TranscriptViewMessage>(
 
   return messages.flatMap((message) => {
     if (message.role === "user") return [message];
-    if (message.kind === "image" || message.kind === "video" || message.kind === "html") {
+    if (
+      message.kind === "image" ||
+      message.kind === "video" ||
+      message.kind === "html" ||
+      message.kind === "file"
+    ) {
       return [message];
     }
     if (!isOmgOutputTool(message)) return [];

--- a/web/src/useLiveSocket.ts
+++ b/web/src/useLiveSocket.ts
@@ -256,7 +256,9 @@ function artifactIdFromUrl(url?: string): string | null {
 }
 
 function mediaIdentity(message: Message): string | null {
-  if (message.kind !== "image" && message.kind !== "video") return message.id ?? null;
+  if (message.kind !== "image" && message.kind !== "video" && message.kind !== "file") {
+    return message.id ?? null;
+  }
   const artifactId = message.artifactId || artifactIdFromUrl(message.url);
   if (artifactId) return `artifact-${artifactId}`;
   if (message.url) return `media-${message.kind}-${message.url}`;

--- a/web/src/views/shipped-page.tsx
+++ b/web/src/views/shipped-page.tsx
@@ -7,6 +7,7 @@ import { useContext, useEffect, useMemo, useRef, useState, type ReactNode } from
 import {
   CheckCheck,
   ChevronRight,
+  FileText,
   LayoutDashboard,
   Loader2,
   MessageSquareText,
@@ -95,6 +96,8 @@ function ShipMediaThumb({
       kind: item.kind,
       caption: item.caption,
       name: item.name,
+      mimeType: item.mimeType,
+      size: item.size,
       version: item.version,
       cacheKey: item.updatedAt,
     });
@@ -119,6 +122,10 @@ function ShipMediaThumb({
         // fetch + parse per row. The Artifacts page is where previews belong.
         <span className="flex size-full items-center justify-center bg-primary/10 text-primary">
           <LayoutDashboard className="size-4" />
+        </span>
+      ) : item.kind === "file" ? (
+        <span className="flex size-full items-center justify-center bg-muted text-muted-foreground">
+          <FileText className="size-4" />
         </span>
       ) : (
         <span className="flex size-full items-center justify-center bg-black/80 text-white/80">


### PR DESCRIPTION
## What

The agent could only show an image, a video, or an HTML artifact. A PDF, an audio clip, a CSV or a log had no way to reach the reader. This adds a fourth artifact kind, `file`, plus an `omg_display_file` tool and a `POST /api/sessions/:id/artifacts/files` route.

The transcript shows a named card with the size and a download button. Nothing renders in place.

## Why one kind and not one per format

The stored mime type decides the presentation, so a new format needs a renderer branch and nothing else. Both `transcript_messages.kind` and `artifacts.media` are free-text, so there is **no migration**.

## The safety argument

These bytes are agent-chosen and are served from the app's own origin, so anything the browser would *interpret* is something the agent can execute as the user. Every file artifact is answered with `Content-Disposition: attachment`, so there is no inline allowlist to keep correct: an agent-written `.html` or `.svg` is saved, never run. Image, video and HTML responses are untouched.

Dropping inline previews deleted the allowlist, both preview components, the PDF/audio height constants, and the mime-based presentation switch.

## Also fixed

- The card used to fetch the file's bytes to draw itself. A file can be 100 MB and a transcript can hold several. The fetch is now on click.
- Mobile had the same bug the `DisplayedImage` branch exists to fix: a file carrying a caption fell past every branch into the markdown renderer, so an agent that handed you a PDF handed you a sentence about a PDF.

## Verification

Against a running server on `127.0.0.1`:

| case | result |
|---|---|
| `POST .../artifacts/files` with a PDF | artifact created and indexed |
| `GET /api/artifacts/:id` (PDF) | `application/pdf` + `attachment` + `nosniff` |
| `GET /api/artifacts/:id` (`.html` source) | `application/octet-stream` + `attachment` |
| `GET /api/artifacts/:id` (image) | inline, **no** disposition — no regression |
| transcript read-back | `kind: file` with correct mime and url |

Full suite **3225 pass / 0 fail**. Root, web **and** mobile type checks clean.

## Note for reviewers

`web/src/components/artifact-file-card.test.tsx` stubs `HTMLAnchorElement.prototype.click`. This is not incidental: the component triggers a download by clicking a synthetic `<a download>`, and while a real browser saves the file and stays put, **happy-dom navigates the shared window to the blob URL** and silently breaks every test file that runs afterwards. Worth knowing before anyone adds another download.

## Not included

`omg_send_to_origin` still rejects anything that is not an image or a video, so a PDF shows in the transcript but will not go out to a channel like iMessage. Left deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)