### PR TITLE
fix(sessions): the participant row lists people, not bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Recent product updates and deployment notes.
 
+## September 1, 2026 - The bot is named once in a header, not three times (v0.6.29)
+
+- **A bot no longer appears three times in one session header.** The header
+  already carries the bot as the title and as the "driven by" badge. The
+  participant row listed it a third time, as a pill between the people. The row
+  now shows people only.
+- **The faces sit together again.** The bot pill was placed between the two
+  people, so the group of faces was split apart. The people are now next to
+  each other, and the person the session belongs to keeps the coloured ring.
+- **A session with one person and a bot shows no faces.** One person is not a
+  group, and the bot is named elsewhere in the same header.
+
 ## September 1, 2026 - Custom instructions for every session (v0.6.28)
 
 - **Settings now holds your standing instructions.** Settings has a new "Custom

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16763,7 +16763,7 @@ function SessionTitleSheet({
               roster has to be here too — the card header this mirrors is not
               on screen. Compact, and self-hiding below two participants, so a
               solo session's header is byte-for-byte what it was. */}
-          <SessionParticipantRow session={session} compact typingIds={typingIds} />
+          <SessionParticipantRow session={session} typingIds={typingIds} />
           {session.shippedReview ? (
             <span className="shrink-0 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-600 dark:text-emerald-400">
               Shipped
@@ -17081,23 +17081,10 @@ function ForkSessionDialog({
  * data so it can be render-tested; this resolves the roster and the bot
  * directory from context for the ~dozen call sites that pass a Session.
  */
-function SessionParticipantRow({
-  session,
-  compact = false,
-  typingIds,
-}: {
-  session: Session;
-  compact?: boolean;
-  typingIds?: readonly string[];
-}) {
-  const botDirectory = useContext(BotDirectoryContext);
-  const participants = activeConversationParticipants(session);
-  const botLook = useCallback((botId: string) => botDirectory.get(botId), [botDirectory]);
+function SessionParticipantRow({ session, typingIds }: { session: Session; typingIds?: readonly string[] }) {
   return (
     <ConversationParticipantRow
-      participants={participants}
-      botLook={botLook}
-      compact={compact}
+      participants={activeConversationParticipants(session)}
       typingIds={typingIds}
     />
   );
@@ -17540,7 +17527,7 @@ const onTouchStart = (e: ReactTouchEvent) => {
                     OtherHumanMessageBubble), not on the card that represents
                     the bot itself. */}
                 {headerBot ? null : (
-                  <SessionParticipantRow session={session} compact={isMobile} typingIds={typingIds} />
+                  <SessionParticipantRow session={session} typingIds={typingIds} />
                 )}
               </div>
             </button>

--- a/web/src/components/conversation-presence.test.tsx
+++ b/web/src/components/conversation-presence.test.tsx
@@ -84,9 +84,9 @@ describe("faces", () => {
     expect(ui.text()).toContain("+2");
   });
 
-  test("a bot participant keeps its own mascot treatment", () => {
-    ui.render(<ConversationParticipantRow participants={[ANA, BOT]} />);
-    expect(ui.query("[aria-label='Scout, bot']")).not.toBeNull();
+  test("a bot participant is not drawn in the roster", () => {
+    ui.render(<ConversationParticipantRow participants={[ANA, BEN, BOT]} />);
+    expect(ui.query("[aria-label='Scout, bot']")).toBeNull();
   });
 });
 
@@ -170,11 +170,25 @@ describe("the pile is the only avatar display on the header", () => {
     expect(ui.query(".-ml-1.first\\:ml-0")).not.toBeNull();
   });
 
-  test("a bot sits beside the pile instead of overlapping it", () => {
+  test("a bot is never drawn here — the header names it elsewhere", () => {
+    ui.render(<ConversationParticipantRow participants={[ANA, BEN, BOT]} />);
+    expect(ui.query("[aria-label='Scout, bot']")).toBeNull();
+    expect(ui.text()).not.toContain("Scout");
+    expect(ui.query("[aria-label='Ana, owner']") ?? ui.query("[aria-label='Ana, member']")).not.toBeNull();
+    expect(ui.query("[aria-label='Ben, member']")).not.toBeNull();
+  });
+
+  test("one human plus a bot draws nothing, because that is one person", () => {
     ui.render(<ConversationParticipantRow participants={[ANA, BOT]} />);
-    const bot = ui.query("[aria-label='Scout, bot']");
-    expect(bot).not.toBeNull();
-    expect(bot!.className).toContain("ml-1");
-    expect(bot!.className).not.toContain("-ml-1");
+    expect(ui.host.innerHTML).toBe("");
+  });
+
+  test("the label and the overflow count people, not bots", () => {
+    const many = [ANA, BEN, BOT, human("human:c", "Cy"), human("human:d", "Di"),
+                  human("human:e", "Ed"), human("human:f", "Fi"), human("human:g", "Gi")];
+    ui.render(<ConversationParticipantRow participants={many} />);
+    const row = ui.query("[aria-label^='Conversation participants']")!;
+    expect(row.getAttribute("aria-label")).not.toContain("Scout");
+    expect(ui.text()).toContain("+2");
   });
 });

--- a/web/src/components/conversation-presence.tsx
+++ b/web/src/components/conversation-presence.tsx
@@ -4,24 +4,16 @@
  * Extracted from App.tsx rather than written there because App.tsx mounts the
  * whole app on import, so nothing inside it can be rendered in a test (see
  * AGENTS.md). These take plain data instead of a Session so they stay pure:
- * the caller resolves the roster and the bot directory.
+ * the caller resolves the roster.
  */
 import type { ConversationParticipant } from "../../../src/conversation-contract";
-import { BotAvatar, type BotColorway, type BotShape } from "./BotAvatar";
 import { conversationParticipantDisplayName } from "../lib/conversation-ui";
 import { cn } from "../lib/utils";
-
-/** Just enough of a bot to draw its mascot. */
-export type ParticipantBotLook = { shape?: BotShape; colorway?: BotColorway };
 
 const MAX_FACES = 5;
 
 function displayName(participant: ConversationParticipant): string {
   return conversationParticipantDisplayName(participant);
-}
-
-function botIdOf(participant: ConversationParticipant): string {
-  return participant.id.startsWith("bot:") ? participant.id.slice(4) : participant.id;
 }
 
 /**
@@ -95,80 +87,54 @@ export function HumanFace({
 }
 
 /**
- * The header roster, as one overlapping pile.
+ * The header roster: the humans in this conversation, as one overlapping pile.
  *
- * This is the only avatar display on the session header. It used to share that
- * header with a standalone SessionAssigneeAvatar, which drew the assignee a
- * second time. The assignee is a participant like any other, so the owner is
- * marked with a tinted ring here instead of getting its own avatar.
+ * PEOPLE ONLY. Every header that mounts this already names the bot somewhere
+ * else in the same bar — as the header identity and title when the session is
+ * the bot's own chat, and as the "driven by <bot>" badge otherwise. Listing the
+ * bot here too put its name in one header three times: title, pill, badge.
+ *
+ * This is also the only avatar display on that header. It used to share it with
+ * a standalone SessionAssigneeAvatar, which drew the assignee a second time.
+ * The assignee is a participant like any other, so the owner is marked with a
+ * tinted ring here instead of getting its own avatar.
  *
  * Owner comes from `participant.role`, which the server already seeds from the
  * assigned user. Matching on the assignee email would need a hash that lives in
  * a server module the browser bundle must not import.
  *
- * Hidden below two participants, so a session you work on alone is unchanged.
+ * Hidden below two people, so a session you work on alone is unchanged. A bot
+ * is not company: one human plus a bot draws nothing now, because the bot is
+ * named elsewhere and a lone face says nothing the header did not already say.
  */
 export function ConversationParticipantRow({
   participants,
-  botLook,
-  compact = false,
   typingIds,
 }: {
   participants: ConversationParticipant[];
-  botLook?: (botId: string) => ParticipantBotLook | undefined;
-  compact?: boolean;
   /** Participant ids currently typing. Others render exactly as before. */
   typingIds?: readonly string[];
 }) {
-  if (participants.length < 2) return null;
+  const people = participants.filter((participant) => participant.kind === "human");
+  if (people.length < 2) return null;
   const typing = new Set(typingIds ?? []);
   return (
     <div
       className="mt-0.5 flex min-w-0 max-w-full items-center overflow-hidden"
-      aria-label={`Conversation participants: ${participants.map(displayName).join(", ")}`}
+      aria-label={`Conversation participants: ${people.map(displayName).join(", ")}`}
     >
-      {participants.slice(0, MAX_FACES).map((participant) => {
-        const name = displayName(participant);
-        if (participant.kind === "bot") {
-          const botId = botIdOf(participant);
-          const bot = botLook?.(botId);
-          return (
-            <span
-              key={participant.id}
-              className={cn(
-                "flex min-w-0 shrink items-center rounded-full bg-muted text-[10px] leading-none text-muted-foreground",
-                // A bot pill can carry a name, so it sits beside the pile
-                // rather than overlapping into it.
-                "ml-1 first:ml-0",
-                compact ? "size-4 justify-center" : "gap-1 px-1.5 py-0.5",
-              )}
-              title={`${name} · bot`}
-              aria-label={`${name}, bot`}
-            >
-              <BotAvatar
-                shape={bot?.shape}
-                colorway={bot?.colorway}
-                size={14}
-                state="idle"
-                seed={botId.length}
-              />
-              {!compact ? <span className="max-w-20 truncate">{name}</span> : null}
-            </span>
-          );
-        }
-        return (
-          <HumanFace
-            key={participant.id}
-            participant={participant}
-            typing={typing.has(participant.id)}
-            owner={participant.role === "owner"}
-            className="-ml-1 first:ml-0"
-          />
-        );
-      })}
-      {participants.length > MAX_FACES ? (
+      {people.slice(0, MAX_FACES).map((participant) => (
+        <HumanFace
+          key={participant.id}
+          participant={participant}
+          typing={typing.has(participant.id)}
+          owner={participant.role === "owner"}
+          className="-ml-1 first:ml-0"
+        />
+      ))}
+      {people.length > MAX_FACES ? (
         <span className="ml-1.5 shrink-0 text-[10px] text-muted-foreground">
-          +{participants.length - MAX_FACES}
+          +{people.length - MAX_FACES}
         </span>
       ) : null}
     </div>

--- a/web/src/other-human-message-avatar.test.ts
+++ b/web/src/other-human-message-avatar.test.ts
@@ -55,8 +55,13 @@ describe("no human creator/owner chip in a persistent-bot conversation header", 
     // this only gates it off specifically when the card is the authoritative
     // bot conversation surface (headerBot truthy), which is the exact case
     // the screenshot bug was filed against.
-    expect(APP).toContain(
-      "{headerBot ? null : (\n                  <SessionParticipantRow session={session} compact={isMobile} typingIds={typingIds} />\n                )}",
+    // Whitespace-normalised: this is a source assertion (see the file header),
+    // and pinning exact JSX indentation made it fail twice on pure reformats of
+    // a line whose behaviour had not changed. It cannot become a render test
+    // yet, because SessionCard is not exported from App.tsx.
+    const flat = APP.replace(/\s+/g, " ");
+    expect(flat).toContain(
+      "{headerBot ? null : ( <SessionParticipantRow session={session} typingIds={typingIds} /> )}",
     );
   });
 


### PR DESCRIPTION
## The bug

A bot-driven session header named its bot three times: the title, the `driven by <bot>` badge, and a pill inside `ConversationParticipantRow`.

Worse, the pill sat *between* the two humans in participant order, so the pile never had two adjacent faces and never overlapped. The avatar grouping added in v0.6.27 had no visible effect on exactly the headers with the most people in them.

## The fix

The row is people only. Every header that mounts it already names the bot — as the header identity and title when the session is the bot's own chat (`headerBot`), and as `DrivenByBotBadge` otherwise. The pill was redundant on every surface that could render it.

That makes the bot path dead, so it is deleted rather than left behind a flag: the `BotAvatar` import, `ParticipantBotLook`, `botIdOf`, the `botLook` prop and its `useCallback` in the adapter, and the `compact` prop, whose only job was choosing between a bot pill with a name and one without.

The `< 2` threshold now counts **people**. One human plus a bot draws nothing, where it used to draw the pair.

## Verification

Checked in the running app against real data, not only in tests. The "Ad" conversation (angel owner, benny member, one bot) renders two overlapping faces with angel ringed, and `querySelector("[aria-label$=', bot']")` returns nothing.

- `bun run test`: 3233 pass, 1 skip, 0 fail.
- Root and web type checks clean.

## Not in this change

The `[Message from <email> to bot <name>]` marker leaks into the bubble on this surface. Stripping is gated on `!!bot` (`App.tsx`), which is false here. Reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)