### PR TITLE
fix(mobile): treat an untouched foregrounded app as away

### DIFF
--- a/mobile/src/omg/idle.ts
+++ b/mobile/src/omg/idle.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * How long a FOREGROUNDED app may go untouched before the person counts as
+ * away.
+ *
+ * The same number the dashboard uses, for the same reason. Presence is what
+ * holds a cloud Computer out of hibernation, and "the app is foregrounded" is
+ * not evidence that anybody is there. On the web that gap billed a paying
+ * account 6.80 compute hours out of the 7.49 after midnight on 2026-09-01,
+ * against a 40-hour monthly allowance, while its owner slept.
+ *
+ * A phone is less exposed than a browser tab, because iOS backgrounds the app
+ * when the screen auto-locks and backgrounding already releases the lease. It
+ * is not unexposed: auto-lock can be set to Never, and the leak is then exactly
+ * the browser's.
+ *
+ * Ten minutes is chosen against the worse failure, which is pausing under
+ * somebody who is still working. It is far longer than reading a diff or
+ * watching an agent run, and the control plane refuses to pause a machine whose
+ * agent is busy or launching regardless, so going idle mid-run releases the
+ * lease and changes nothing.
+ */
+export const USER_IDLE_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Is somebody actually operating this app?
+ *
+ * `foregrounded` answers "is the app on screen". This adds "and has anyone
+ * touched it recently", which is the half that decides whether compute is being
+ * used or merely billed.
+ *
+ * Returns `markActive` rather than subscribing to anything itself: React Native
+ * has no global input event, so the touch has to be observed by a view. The
+ * provider passes it to a responder-capture that never intercepts.
+ */
+export function useUserActive(foregrounded: boolean): {
+  active: boolean;
+  markActive: () => void;
+} {
+  const [idle, setIdle] = useState(false);
+  // Mirrors `idle` so a touch can rearm the timer without a state update.
+  // Every touch would otherwise re-render the whole provider subtree.
+  const idleRef = useRef(false);
+  const rearmRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    // A backgrounded app is already away, and the clock would be measuring a
+    // screen nobody can touch.
+    if (!foregrounded) {
+      rearmRef.current = null;
+      return;
+    }
+    // Coming back to the app IS the interaction. Requiring a second gesture
+    // would strand someone on a machine they just opened.
+    if (idleRef.current) {
+      idleRef.current = false;
+      setIdle(false);
+    }
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const arm = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        idleRef.current = true;
+        setIdle(true);
+      }, USER_IDLE_TIMEOUT_MS);
+    };
+    rearmRef.current = arm;
+    arm();
+    return () => {
+      rearmRef.current = null;
+      if (timer) clearTimeout(timer);
+    };
+  }, [foregrounded]);
+
+  const markActive = useCallback(() => {
+    if (idleRef.current) {
+      idleRef.current = false;
+      setIdle(false);
+    }
+    rearmRef.current?.();
+  }, []);
+
+  return { active: foregrounded && !idle, markActive };
+}

--- a/mobile/src/omg/provider.tsx
+++ b/mobile/src/omg/provider.tsx
@@ -20,12 +20,13 @@ import {
   useState,
   type PropsWithChildren,
 } from "react";
-import { AppState } from "react-native";
+import { AppState, StyleSheet, View } from "react-native";
 
 import { CLOUD_BINDING_ID, CONTROLPLANE_ORIGIN, STORAGE_KEYS } from "./config";
 import { getAuthToken, getSession, signOut as authSignOut, type SignedInUser } from "./auth";
 import { forgetAllTransports, getHostedTransport } from "./transport";
 import { unregisterForPushNotifications } from "./push";
+import { useUserActive } from "./idle";
 import { startCloudPresence } from "./presence";
 import { waitForReady, type ComputerReadiness } from "./readiness";
 import {
@@ -432,6 +433,23 @@ export function OmgProvider({ children }: PropsWithChildren) {
   }, []);
 
   /**
+   * On screen is not the same as in use.
+   *
+   * Backgrounding releases the lease, and on a phone that covers most of the
+   * ways a person leaves. It does not cover all of them: auto-lock can be set
+   * to Never, and an app left open on a desk then renews forever and bills
+   * compute all night. See USER_IDLE_TIMEOUT_MS for the measurement that found
+   * this on the web client.
+   */
+  const { active: userActive, markActive } = useUserActive(foregrounded);
+  // Declines every gesture it sees (`false`), so observing costs the UI below
+  // nothing. Returning true here would swallow the whole app's touches.
+  const noteTouch = useCallback(() => {
+    markActive();
+    return false;
+  }, [markActive]);
+
+  /**
    * Presence is the keep-awake demand channel for a cloud Computer.
    *
    * The control plane pauses a Computer after a grace period with no
@@ -448,7 +466,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
    * instead of one grace period later.
    */
   useEffect(() => {
-    if (authStatus !== "signed-in" || bindingId !== CLOUD_BINDING_ID || !foregrounded) {
+    if (authStatus !== "signed-in" || bindingId !== CLOUD_BINDING_ID || !userActive) {
       return;
     }
     const lease = startCloudPresence(controlPlane);
@@ -457,7 +475,7 @@ export function OmgProvider({ children }: PropsWithChildren) {
       presenceStopRef.current = null;
       lease.stop();
     };
-  }, [authStatus, bindingId, foregrounded]);
+  }, [authStatus, bindingId, userActive]);
 
   const signOut = useCallback(async () => {
     // Release the presence lease before the token goes away; a release sent
@@ -571,8 +589,30 @@ export function OmgProvider({ children }: PropsWithChildren) {
     ],
   );
 
-  return <Context.Provider value={value}>{children}</Context.Provider>;
+  return (
+    <Context.Provider value={value}>
+      {/*
+        React Native has no global input event, so the touch has to be observed
+        by a view. Both `...ResponderCapture` handlers record the gesture and
+        then return false, which declines it: this wrapper sees every touch and
+        intercepts none of them, so nothing below it loses a tap or a scroll.
+      */}
+      <View
+        style={styles.root}
+        onStartShouldSetResponderCapture={noteTouch}
+        onMoveShouldSetResponderCapture={noteTouch}
+      >
+        {children}
+      </View>
+    </Context.Provider>
+  );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});
 
 export function useOmg(): OmgContextValue {
   const value = useContext(Context);


### PR DESCRIPTION
Port of the dashboard fix in [vibes#1611](https://github.com/BennyKok/vibes/pull/1611) to the native client, which holds its **own** presence lease.

## Problem

`mobile/src/omg/presence.ts` renews while `AppState.currentState !== "background"`. Backgrounding covers most of the ways a person leaves a phone, so this leaks far less than the browser did. It does not cover all of them: iOS auto-lock can be set to Never, and an app left open on a desk then renews forever and bills compute all night.

On the web the same gap billed a live paying account **6.80 hours out of the 7.49 after midnight** on 2026-09-01, against a 40-hour monthly allowance.

## Change

Presence now also requires a touch within `USER_IDLE_TIMEOUT_MS` (10 minutes, the same number the dashboard uses).

React Native has no global input event, so the provider wraps its children in one view whose `onStartShouldSetResponderCapture` / `onMoveShouldSetResponderCapture` record the gesture and then return `false`. It sees every touch and intercepts none.

No client-side agent signal is used. The control plane already refuses to pause a machine whose agent is busy or launching, so going idle mid-run releases the lease and changes nothing.

Unlike the web change there is no `resumeRequired` latch. Opening the app is already a deliberate act, and auto-resume matches how this client behaves today.

## Verification

`AGENTS.md` requires a UI change to be seen, and a root wrapper view is exactly the change that produces a grey screen, so it was run on the simulator (iPhone 17 Pro, UDID `2DDC0F84`, screenshot measured 1206x2622 to confirm the device):

- The app renders normally with the wrapper in place: header, session list, composer, tab bar.
- A synthesised tap at logical (200, 270) navigated into a session, so the capture does not swallow touches.
- `npm run typecheck` in `mobile/`: clean.

## Delivery

This reaches users only through an App Store release. Merging does not ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)