### PR TITLE
feat(sessions): move the header faces to the assignee's old slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent product updates and deployment notes.
 
+## September 1, 2026 - The faces move to the right of the header (v0.6.31)
+
+- **The faces are now where the assignee avatar used to be.** They sat under
+  the session title. They now sit at the right end of the header, next to the
+  model name, which is where people look to see who is on a session.
+- **Tapping them still opens the list.** The list is unchanged. It names each
+  person and says who owns the session.
+
 ## September 1, 2026 - Tap the faces to see who is in the session (v0.6.30)
 
 - **The faces in the header now open a list.** Tap or click them. The list

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17520,15 +17520,6 @@ const onTouchStart = (e: ReactTouchEvent) => {
                     {latest}
                   </div>
                 ) : null}
-                {/* A persistent bot conversation's header shows the bot's own
-                    identity and settings only — never who created or owns it.
-                    SessionParticipantRow's human chip belongs beside each
-                    message that sender actually wrote (see
-                    OtherHumanMessageBubble), not on the card that represents
-                    the bot itself. */}
-                {headerBot ? null : (
-                  <SessionParticipantRow session={session} typingIds={typingIds} />
-                )}
               </div>
             </button>
           )}
@@ -17556,11 +17547,18 @@ const onTouchStart = (e: ReactTouchEvent) => {
             <Pin className="size-3.5" fill="currentColor" />
           </span>
         ) : null}
-        {/* No assignee avatar here. The assignee is a participant, so this
-            header drew them twice: once in the pile under the title and once
-            again on this end of the bar. The pile marks the owner instead. The
-            session MARK keeps its own corner assignee badge, which is a
-            different surface with no roster beside it. */}
+        {/* The faces sit where the assignee avatar used to, because that is
+            where people look for "who is on this". They replace it rather than
+            join it: the assignee is a participant, so keeping both drew the
+            same person twice in one bar. The session MARK keeps its own corner
+            assignee badge — a different surface, with no roster beside it.
+
+            A persistent bot conversation's header shows the bot's own identity
+            and settings only, never who owns it, so headerBot suppresses this
+            (see OtherHumanMessageBubble for where a sender's face belongs). */}
+        {headerBot ? null : (
+          <SessionParticipantRow session={session} typingIds={typingIds} />
+        )}
         {/* A bot-backed card is the authoritative desktop bot conversation.
             Keep its lifecycle menu on the same header instead of exposing the
             regular session menu or a settings-only shortcut. */}

--- a/web/src/components/conversation-presence.test.tsx
+++ b/web/src/components/conversation-presence.test.tsx
@@ -160,12 +160,10 @@ describe("the pile is the only avatar display on the header", () => {
     ui.render(<ConversationParticipantRow participants={[OWNER, BEN]} />);
     const trigger = ui.query("[aria-label^='Conversation participants']")!;
     expect(trigger).not.toBeNull();
-    expect(trigger.getAttribute("role")).toBe("button");
-    expect(trigger.getAttribute("tabindex")).toBe("0");
-    // Never a nested <button>: the card header mounts this inside its own
-    // rename button, and that is invalid HTML.
-    expect(trigger.tagName).toBe("SPAN");
-    expect(trigger.closest("button")).toBeNull();
+    // A real <button>: it lives in the header's own slot now, not inside the
+    // card's rename button, so it needs no role/tabIndex shim.
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger.getAttribute("type")).toBe("button");
   });
 
   test("a member-only roster tints nobody", () => {

--- a/web/src/components/conversation-presence.tsx
+++ b/web/src/components/conversation-presence.tsx
@@ -110,10 +110,11 @@ export function HumanFace({
  * ring (card-coloured, by design) was invisible next to it. The menu says
  * "Owner" and can be read.
  *
- * A `<span role="button">`, not a `<button>`: the session card header nests
- * this inside its own rename button, and a nested <button> is invalid HTML and
- * fights the parent for the click (same reason OwnershipPill does this). The
- * click is stopped from reaching that parent.
+ * It sits in the header slot the standalone assignee avatar used to occupy,
+ * which is why it is a real <button>: it is no longer nested inside the card's
+ * rename button, so it needs neither the role/tabIndex shim nor Base UI's
+ * nativeButton escape hatch. The click still stops propagating, so dropping it
+ * back inside a clickable row cannot silently start a rename.
  *
  * Hidden below two people, so a session you work on alone is unchanged. A bot
  * is not company: one human plus a bot draws nothing, because the bot is named
@@ -134,22 +135,15 @@ export function ConversationParticipantRow({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        // The trigger is a <span role="button"> (see the note above), so Base UI
-        // must be told not to expect native button semantics.
-        nativeButton={false}
         render={
-          <span
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             aria-label={`Conversation participants: ${names}`}
             title={names}
-            className="mt-0.5 flex w-fit max-w-full cursor-pointer items-center overflow-hidden rounded-full outline-none"
+            className="flex w-fit shrink-0 max-w-full cursor-pointer items-center overflow-hidden rounded-full outline-none"
             // stopPropagation ONLY. preventDefault here also cancels Base UI's
             // own trigger action, so the menu never opened.
             onClick={(event) => event.stopPropagation()}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") event.stopPropagation();
-            }}
           >
             {people.slice(0, MAX_FACES).map((participant) => (
               <HumanFace
@@ -164,7 +158,7 @@ export function ConversationParticipantRow({
                 +{people.length - MAX_FACES}
               </span>
             ) : null}
-          </span>
+          </button>
         }
       />
       <DropdownMenuContent align="start" className="min-w-52">


### PR DESCRIPTION
The faces sat under the session title, in the title column. Reported twice that this is the wrong place — the right end of the header is where the standalone `SessionAssigneeAvatar` used to be, and that is where people look for "who is on this". Moved there, next to the model chip.

They **replace** that avatar rather than join it. The assignee is a participant, so keeping both is what drew the same person twice in one bar (v0.6.27).

## The trigger becomes a real `<button>`

It was a `<span role="button">` only because the title column nests inside the card's rename button, where a nested `<button>` is invalid HTML. In the header's own slot that constraint is gone, so the role/tabIndex shim and Base UI's `nativeButton={false}` escape hatch both go with it.

The click still stops propagating, so dropping this back inside a clickable row cannot silently start a rename.

## Verification

Driven in Chrome against the real box:
- trigger is a `BUTTON` at `x=1035` on a 1280px viewport — the right end
- `insideButton=false`
- opens on click, `aria-expanded=true`, menu reads "In this session / angel Owner / benny Member"
- no console errors

Both type checks clean.

## Known-red, not mine

`bun run test` is 3233 pass / 1 fail. The failure is `test/mobile-plan-specs.test.ts` → "iOS sells Starter through Pro, and does not offer Always On" (expects `computer_s20` / `computer_10`). It fails identically with my changes stashed, so it is pre-existing on `main` from in-flight iOS billing work. I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)