### PR TITLE
fix(web): the composer measurement stops moving the transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Recent product updates and deployment notes.
 
+## September 1, 2026 - The transcript holds still while you type (v0.6.32)
+
+- **Typing no longer moves the transcript.** The message box measures itself
+  after every keystroke. That measurement collapsed the box to zero height for
+  one layout pass, which made the transcript above it taller by the full height
+  of the box. The browser then pulled the scroll position to the shorter
+  maximum, and the transcript snapped back to the newest message. This is most
+  visible on a phone, where the message box is a large part of the screen.
+- **The measurement now stays inside the message box.** Nothing above the box
+  moves while it measures. The box still grows and shrinks with your text.
+
 ## September 1, 2026 - The faces move to the right of the header (v0.6.31)
 
 - **The faces are now where the assignee avatar used to be.** They sat under

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14561,10 +14561,42 @@ function SkillTextarea({
   // CSS `field-sizing: content` is still flaky across browsers (and loses to
   // rows/min-height combos), so grow from scrollHeight. max-height in className
   // clamps the box; overflow-y-auto scrolls past the cap.
+  //
+  // THE COLLAPSE MUST NOT ESCAPE THE COMPOSER.
+  //
+  // `height = 0px` followed by a `scrollHeight` read is a forced layout of the
+  // whole document with this field at zero height, and this field is the
+  // bottom of the same flex column the transcript scroller sits in. For that
+  // one layout the scroller is taller by the composer's full height, which is
+  // a large fraction of the visible pane on a phone with the keyboard up.
+  // Measured in Chrome on a 400pt column: the pane went 276 -> 366 -> 276 per
+  // keystroke, and a reader parked inside one composer-height of the bottom
+  // had `scrollTop` clamped to the shorter maximum in the middle of it.
+  //
+  // ChatStream owns transcript scroll position, and it decides what to do from
+  // the pane's height (see its ResizeObserver and follow effect). Handing it a
+  // height that only ever existed inside a measurement is not its bug to
+  // solve, so the measurement is contained here instead: the field's own
+  // wrapper is pinned to the height it already has, the collapse happens
+  // inside that fixed box, and nothing above the composer moves.
   const resizeField = useCallback((el: HTMLTextAreaElement | null = fieldRef.current) => {
     if (!el) return;
+    const box = el.parentElement;
+    const lockedHeight = box ? box.getBoundingClientRect().height : 0;
+    const previousHeight = box?.style.height ?? "";
+    const previousBoxSizing = box?.style.boxSizing ?? "";
+    if (box && lockedHeight > 0) {
+      // Border-box explicitly: the locked figure is a border-box measurement,
+      // and this must not depend on the cascade agreeing.
+      box.style.boxSizing = "border-box";
+      box.style.height = `${lockedHeight}px`;
+    }
     el.style.height = "0px";
     el.style.height = `${el.scrollHeight}px`;
+    if (box && lockedHeight > 0) {
+      box.style.height = previousHeight;
+      box.style.boxSizing = previousBoxSizing;
+    }
     if (onMultilineChange) {
       const style = window.getComputedStyle(el);
       const lineHeight = Number.parseFloat(style.lineHeight);


### PR DESCRIPTION
## What changed

`SkillTextarea.resizeField` measured the composer with `height = "0px"` followed by a `scrollHeight` read. That read forces a layout of the whole document with the field at zero height, and the field is the bottom of the same flex column as the transcript scroller. For that one pass the scroller is taller by the composer's full height. It runs twice per keystroke: once in `onChange`, once in the layout effect keyed on `value`.

`ChatStream` reads the pane height through its `ResizeObserver`, and `viewportHeight` is a dependency of the follow effect, which is the only code that writes `scrollTop`. So a height that only ever existed inside a measurement reached the follow logic.

The field's wrapper is now pinned to the height it already has for the duration of the measurement. The collapse happens inside a fixed box and nothing above the composer moves.

## Evidence

Headless Chrome, 390x400 column, 5-line composer:

```
keystroke, OLD:
   mid-measure: paneClientH=370 paneMax=5630 top=5630.0   <- clamped from 5708
   after:       top=5708.0 paneClientH=272 composerH=112
keystroke, NEW:
   mid-measure: paneClientH=272 paneMax=5728 top=5708.0
   after:       top=5708.0 paneClientH=272 composerH=112
```

Auto-sizing is unchanged: 112 -> 132 on a new line, 132 -> 52 back down to two lines.

## Verification

- `cd web && bun x tsc --noEmit` passes.
- `bun test web/src/lib/transcript-glide.test.ts web/src/lib/transcript-stick.test.ts web/src/chat-height-invariants.test.ts` passes, 36 tests.
- `bun test web/src/components/` passes, 55 tests.

## Risk

Not reproduced on a real phone. Chrome restores the clamped offset once the composer height returns, so on Chrome this is layout thrash rather than a net scroll jump. WebKit does not always restore a clamped offset, which is the reason to believe this is the reported bug on an iPhone. WebKit could not be run in this environment because Playwright's WebKit needs system packages that require sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)