### PR TITLE
fix: show standing instructions in the omg.dev instructions chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Recent product updates and deployment notes.
 
+## September 2, 2026 - Custom instructions show in the inspect chip (v0.6.36)
+
+- **The omg.dev instructions chip now shows your standing rules.** Custom
+  instructions already went to the agent. The chip only showed the runtime
+  contract, so they looked missing. Open the chip on an existing session and
+  they are there. No new session is needed.
+
 ## September 2, 2026 - Claude Fable 5.1 for the SDK Claude agent too (v0.6.35)
 
 - **The picker has two agents named "claude".** One is the Claude CLI harness.

--- a/mobile/src/omg/omg-prompt-envelope.ts
+++ b/mobile/src/omg/omg-prompt-envelope.ts
@@ -58,7 +58,11 @@ export function parseOmgPromptEnvelope(text: string): OmgPromptEnvelope | null {
 
   const headerLine = text.slice(0, headerEnd);
   const version = headerLine.match(/\(capability version ([^)]+)\)/)?.[1] ?? null;
-  const instructions = text.slice(headerEnd + 1, contractEnd).trim();
+  // Keep in lockstep with web/src/lib/omg-prompt-envelope.ts: standing
+  // instructions ride after the END marker and belong in the inspect chip.
+  const contractBody = text.slice(headerEnd + 1, contractEnd).trim();
+  const standing = text.slice(contractEnd + endMarker.length, taskMarker).trim();
+  const instructions = standing ? `${contractBody}\n\n${standing}` : contractBody;
   const task = text.slice(taskMarker + USER_TASK.length).replace(/^\s*\n?/, "").trim();
 
   if (!instructions || !task) return null;

--- a/test/mobile-omg-prompt-envelope.test.ts
+++ b/test/mobile-omg-prompt-envelope.test.ts
@@ -77,4 +77,31 @@ describe("the phone splits the omg.dev launch envelope off a user message", () =
       parseOnWeb("Just a normal follow-up"),
     );
   });
+
+  test("includes standing instructions in the inspect chip, not the task", () => {
+    const withStanding = [
+      "=== omg.dev RUNTIME CONTRACT (capability version 2026-08-21.1) ===",
+      "- Narrate progress.",
+      "=== END omg.dev RUNTIME CONTRACT ===",
+      "",
+      "=== USER STANDING INSTRUCTIONS ===",
+      "Always reply in points.",
+      "=== END USER STANDING INSTRUCTIONS ===",
+      "",
+      "=== USER TASK ===",
+      "Make the first message easy to read.",
+    ].join("\n");
+    expect(parseOmgPromptEnvelope(withStanding)).toEqual({
+      instructions: [
+        "- Narrate progress.",
+        "",
+        "=== USER STANDING INSTRUCTIONS ===",
+        "Always reply in points.",
+        "=== END USER STANDING INSTRUCTIONS ===",
+      ].join("\n"),
+      task: "Make the first message easy to read.",
+      version: "2026-08-21.1",
+    });
+    expect(parseOmgPromptEnvelope(withStanding)).toEqual(parseOnWeb(withStanding));
+  });
 });

--- a/test/omg-prompt-envelope.test.ts
+++ b/test/omg-prompt-envelope.test.ts
@@ -68,4 +68,33 @@ describe("parseOmgPromptEnvelope", () => {
     expect(parseOmgPromptEnvelope("Just a normal follow-up")).toBeNull();
     expect(parseOmgPromptEnvelope("=== LFG RUNTIME CONTRACT ===\nNo closing marker")).toBeNull();
   });
+
+  test("includes standing instructions in the inspect chip, not the task", () => {
+    expect(
+      parseOmgPromptEnvelope(
+        [
+          "=== omg.dev RUNTIME CONTRACT (capability version 2026-08-21.1) ===",
+          "- Narrate progress.",
+          "=== END omg.dev RUNTIME CONTRACT ===",
+          "",
+          "=== USER STANDING INSTRUCTIONS ===",
+          "Always reply in points.",
+          "=== END USER STANDING INSTRUCTIONS ===",
+          "",
+          "=== USER TASK ===",
+          "Make the first message easy to read.",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      instructions: [
+        "- Narrate progress.",
+        "",
+        "=== USER STANDING INSTRUCTIONS ===",
+        "Always reply in points.",
+        "=== END USER STANDING INSTRUCTIONS ===",
+      ].join("\n"),
+      task: "Make the first message easy to read.",
+      version: "2026-08-21.1",
+    });
+  });
 });

--- a/web/src/lib/omg-prompt-envelope.test.ts
+++ b/web/src/lib/omg-prompt-envelope.test.ts
@@ -27,4 +27,30 @@ describe("parseOmgPromptEnvelope", () => {
   test("does not parse prose that quotes a contract", () => {
     expect(parseOmgPromptEnvelope(`Please inspect this: ${contract}`)).toBeNull();
   });
+
+  test("includes standing instructions in the inspect chip, not the task", () => {
+    const withStanding = [
+      "=== omg.dev RUNTIME CONTRACT (capability version 2026-08-21.1) ===",
+      "- Use the omg.dev tools.",
+      "=== END omg.dev RUNTIME CONTRACT ===",
+      "",
+      "=== USER STANDING INSTRUCTIONS ===",
+      "Always reply in points.",
+      "=== END USER STANDING INSTRUCTIONS ===",
+      "",
+      "=== USER TASK ===",
+      "Fix the status",
+    ].join("\n");
+    expect(parseOmgPromptEnvelope(withStanding)).toEqual({
+      instructions: [
+        "- Use the omg.dev tools.",
+        "",
+        "=== USER STANDING INSTRUCTIONS ===",
+        "Always reply in points.",
+        "=== END USER STANDING INSTRUCTIONS ===",
+      ].join("\n"),
+      task: "Fix the status",
+      version: "2026-08-21.1",
+    });
+  });
 });

--- a/web/src/lib/omg-prompt-envelope.ts
+++ b/web/src/lib/omg-prompt-envelope.ts
@@ -58,7 +58,12 @@ export function parseOmgPromptEnvelope(text: string): OmgPromptEnvelope | null {
 
   const headerLine = envelope.slice(0, headerEnd);
   const version = headerLine.match(/\(capability version ([^)]+)\)/)?.[1] ?? null;
-  const instructions = envelope.slice(headerEnd + 1, contractEnd).trim();
+  // The contract body is the chip's original content. Standing instructions
+  // (and any other preamble) sit after the END marker and before USER TASK —
+  // they are sent to the agent, so they belong in the inspect chip too.
+  const contractBody = envelope.slice(headerEnd + 1, contractEnd).trim();
+  const standing = envelope.slice(contractEnd + endMarker.length, taskMarker).trim();
+  const instructions = standing ? `${contractBody}\n\n${standing}` : contractBody;
   const task = envelope.slice(taskMarker + USER_TASK.length).replace(/^\s*\n?/, "").trim();
 
   if (!instructions || !task) return null;


### PR DESCRIPTION
## Summary
- Custom instructions already went to the agent. The inspect chip only showed the runtime-contract body, so they looked missing.
- The chip now includes the standing-instructions block. Existing sessions show it after a UI refresh.

## Test plan
- [x] `bun test` on the envelope parsers (web, mobile, lockstep)
- [ ] Open an existing session, tap **omg.dev instructions**, confirm standing rules appear
- [ ] Confirm the task bubble still shows only the user ask


Made with [Cursor](https://cursor.com)