### PR TITLE
chore(mobile): bump app version to 1.0.3

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "omg",
     "slug": "lfg-native",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
Bumps `mobile/app.json` version 1.0.2 -> 1.0.3 for the next App Store submission.

Why a native version and not OTA: the 1.0 listing still says "Sign in with email or iMessage" and lists Starter and Pro. Description and review notes are locked on a released version. Version 1.0.3 now exists in App Store Connect (Prepare for Submission, manual release) with:
- description: iMessage removed, plan list reads "Starter Plus and Personal"
- What's New: onboarding, email-only sign-in
- review notes: iMessage paragraphs removed, 4.8 note rewritten for email OTP, intro screen noted

After merge: run `mobile-release.yml` (profile `production`, submit `true`), then release manually as before.

Note: `runtimeVersion` policy is `appVersion`, so installed 1.0.2 binaries stop receiving OTA updates targeting 1.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)