### PR TITLE
Executor connector gateway: one daemon per box, /mcp/executor proxy, Settings card

### DIFF
--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -1,0 +1,78 @@
+# Team tooling: Executor, roles, sandbox
+
+Status: phase 1 in progress. Decisions recorded 2026-09-02.
+
+## Goal
+
+One agent-facing tool endpoint per box. Team roles decide which tools a
+session can see and call. Non-owner sessions run in a sandbox. Identity comes
+from omg.dev (`vibes`). Compute, data, and connector credentials stay on the
+box.
+
+## Decisions
+
+| Item | Decision |
+|---|---|
+| Connector gateway | One default [Executor](https://executor.sh) daemon per box, owned by `omg serve`. Not per role. |
+| Executor bind | `127.0.0.1`, data under `PATHS.data/executor`, bearer token minted by omg. |
+| Agent contract | Agents register `/mcp?session=<id>` (omg tools) and `/mcp/executor?session=<id>` (connectors). They never see the Executor token or port. |
+| Identity | `identity.resolve(request) -> { member, role } \| owner`. `local-owner` today, `vibes` JWT verifier later. Solo box = owner, no filter. |
+| Roles | User-defined in vibes. Role = name + policy. Cached on the box, max age 7 days, then deny. |
+| Policy shape | `{ tools: string[], deny: string[], sandbox: "none" \| "bwrap" }`. Globs on tool names. |
+| Enforcement | Filter `tools/list` and reject `tools/call` in the omg proxy. Both. |
+| Session secret | Random token per session, `x-omg-session-token` header. Replaces trust in the bare `?session=` query. |
+| Approval | Stays in the Executor UI. Linked from Settings. |
+| Sandbox | bwrap. Opt-in per session first, then default for non-owner roles. |
+| Dashboard | Settings shows a Connectors card: status, toggle, open dashboard. Opens `<origin>/?_token=<token>` in a new tab. |
+
+## Phases
+
+1. Executor lifecycle, `/mcp/executor` proxy, settings card. This document.
+2. Session secret, identity interface, role policy filter.
+3. bwrap sandbox profile per role.
+
+## Phase 1 shape
+
+```
+ agent CLI
+   |  /mcp?session=<id>            omg tools (existing)
+   |  /mcp/executor?session=<id>   connector tools (new)
+   v
+ omg serve
+   |  injects Authorization: Bearer <token>
+   |  passes mcp-session-id both ways
+   v
+ executor daemon  127.0.0.1:<port>  EXECUTOR_DATA_DIR=PATHS.data/executor
+```
+
+Owner of the daemon: `src/executor/daemon.ts`. Same pattern as
+`src/computer/desktop.ts`: pid and port on disk, adopt a healthy daemon after
+a serve restart, reap a dead one.
+
+Owner of the agent-facing endpoint: `src/executor/proxy.ts`. Transparent
+HTTP proxy. No MCP client in omg, no schema conversion. The role filter in
+phase 2 reads and rewrites the JSON-RPC bodies at this point.
+
+Setting: `executorEnabled`, default `true`. When off, `/mcp/executor` answers
+404, the same as `/mcp/computer` when disabled.
+
+Binary: `executor` on `PATH`. Installed with `npm install -g executor` or
+`bun install -g executor`. The package is about 280 MB unpacked. It is not a
+dependency of this repository. Status reports `installed: false` with the
+install command when it is missing.
+
+## Executor facts verified 2026-09-02 (v1.6.7)
+
+- `executor daemon run --foreground --hostname 127.0.0.1 --port <p> --auth-token <t>`
+- `GET /api/health` returns `ok`.
+- `POST /mcp` without a bearer returns 401. With the bearer it answers
+  Streamable HTTP with `mcp-session-id`.
+- Manifest at `<data>/server-control/server.json` with `pid`, `connection.origin`,
+  `connection.auth.token`.
+- Browser sign-in: `<origin>/?_token=<token>`.
+- Env: `EXECUTOR_DATA_DIR`, `EXECUTOR_DISABLE_ANALYTICS`, `EXECUTOR_DISABLE_UPDATE_CHECK`.
+
+## Out of scope for this repository
+
+Login, invites, SSO, team and role storage. Those belong to `vibes`. This
+repository consumes a signed member token and a role policy.

--- a/src/agents/backends/acp-mcp.ts
+++ b/src/agents/backends/acp-mcp.ts
@@ -1,14 +1,13 @@
 import type { McpServer } from "@agentclientprotocol/sdk";
 import { omgMcpServers } from "../../config.ts";
 
-/** Convert the shared managed-session MCP registration to ACP's wire shape. */
+/** The omg-served MCP endpoints for one session, in ACP's server shape. */
 export function omgAcpMcpServers(sessionId: string): McpServer[] {
-  const server = omgMcpServers(sessionId).mcpServers?.omg;
-  if (!server) return [];
-  return [{
+  const servers = omgMcpServers(sessionId).mcpServers ?? {};
+  return Object.entries(servers).map(([name, server]) => ({
     type: "http",
-    name: "omg",
+    name,
     url: server.url,
     headers: [],
-  }];
+  }));
 }

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { PATHS, localServeBaseUrl } from "./config.ts";
+import { EXECUTOR_MCP_SERVER_NAME, PATHS, executorMcpHttpUrl, localServeBaseUrl } from "./config.ts";
 import { omgCapabilityAccess } from "./omg-capabilities.ts";
 import { githubCliPath } from "./tool-connections.ts";
 import { agentAccountProfile, type AgentAccountProfile } from "./agent-profiles.ts";
@@ -1610,7 +1610,21 @@ async function installClaudeMcp(claude: string): Promise<void> {
       claude, "mcp", "add", "-s", "user", "--transport", "http", MCP_SERVER_NAME, mcpHttpUrl(),
     ], env);
     if (!out.ok) throw new Error(out.text.trim() || "Claude MCP install failed");
+    await installClaudeExecutorMcp(claude, env);
   }
+}
+
+// The connector gateway beside the general server, at user scope. Session-less:
+// one config serves every session, the same as the omg entry. Best effort, so a
+// Claude build that rejects the second registration still keeps the first.
+async function installClaudeExecutorMcp(
+  claude: string,
+  env: Record<string, string | undefined>,
+): Promise<void> {
+  await commandOutputAsync([claude, "mcp", "remove", EXECUTOR_MCP_SERVER_NAME, "-s", "user"], env);
+  await commandOutputAsync([
+    claude, "mcp", "add", "-s", "user", "--transport", "http", EXECUTOR_MCP_SERVER_NAME, executorMcpHttpUrl(),
+  ], env);
 }
 
 /**
@@ -1629,6 +1643,7 @@ export async function registerClaudeMcpForAccount(accountId: string): Promise<bo
   const out = await commandOutputAsync([
     claude, "mcp", "add", "-s", "user", "--transport", "http", MCP_SERVER_NAME, mcpHttpUrl(),
   ], env);
+  if (out.ok) await installClaudeExecutorMcp(claude, env);
   return out.ok;
 }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -31,6 +31,14 @@ import {
 } from "../self-update.ts";
 import { compressedAssetResponse, maybeCompressResponse } from "../http-compress.ts";
 import { serveOmgMcpRequest, serveComputerMcpRequest } from "../mcp-http.ts";
+import { serveExecutorMcpRequest } from "../executor/proxy.ts";
+import {
+  ensureExecutorAdopted,
+  executorDashboardUrl,
+  executorStatus,
+  startExecutor,
+  stopExecutor,
+} from "../executor/daemon.ts";
 import * as pwaBootLog from "../pwa-boot-log.ts";
 import { botRuntimeContract, shortSessionId } from "../omg-capabilities.ts";
 import {
@@ -3971,6 +3979,17 @@ export async function cmdServe() {
         return await serveComputerMcpRequest(req);
       }
 
+      // The connector gateway, proxied to this box's Executor daemon. Same
+      // gate shape as the computer MCP: 404 when the owner turned it off, so
+      // a probing client finds nothing. Adopt first so a serve restart does
+      // not answer 503 for a daemon that is still up.
+      if (path === "/mcp/executor") {
+        const { executorEnabled } = await getGlobalSettings();
+        if (!executorEnabled) return err(404, "the connector gateway is disabled");
+        await ensureExecutorAdopted();
+        return await serveExecutorMcpRequest(req);
+      }
+
       if (path === "/api/live/ws") {
         if (!isLiveWsEnabled()) return err(404, "live websocket disabled");
         // Resolve who this socket speaks for ONCE, here, and never again from
@@ -4037,6 +4056,39 @@ export async function cmdServe() {
       if (path === "/api/computer/stop" && req.method === "POST") {
         await stopDesktop();
         return json(desktopStatus());
+      }
+
+      // ---- connector gateway (Executor) ----
+      // Status is safe to poll. It reports whether the binary is installed so
+      // the Settings card can show the exact install command instead of a
+      // dead switch.
+      if (path === "/api/executor/status" && req.method === "GET") {
+        const { executorEnabled } = await getGlobalSettings();
+        await ensureExecutorAdopted();
+        return json({ enabled: executorEnabled, ...executorStatus() });
+      }
+
+      if (path === "/api/executor/start" && req.method === "POST") {
+        const { executorEnabled } = await getGlobalSettings();
+        if (!executorEnabled) return err(409, "the connector gateway is disabled in settings");
+        return json({ enabled: executorEnabled, ...(await startExecutor({ log: (l) => console.log(l) })) });
+      }
+
+      if (path === "/api/executor/stop" && req.method === "POST") {
+        const { executorEnabled } = await getGlobalSettings();
+        return json({ enabled: executorEnabled, ...(await stopExecutor()) });
+      }
+
+      // The dashboard URL carries the daemon's bearer token, which is how
+      // Executor's own `executor web` signs the browser in. Minted per request
+      // and never rendered until asked for, so the token does not sit in a
+      // status payload every poll fetches. Loopback only: the dashboard is
+      // reachable from a browser on this machine, not through remote access.
+      if (path === "/api/executor/dashboard" && req.method === "GET") {
+        await ensureExecutorAdopted();
+        const dashboardUrl = executorDashboardUrl();
+        if (!dashboardUrl) return err(409, "the connector gateway is not running");
+        return json({ url: dashboardUrl });
       }
 
       // Agent control of the browser on that desktop, via Bun.WebView attached
@@ -4695,6 +4747,11 @@ a{color:#60a5fa}
               return err(400, "computerMcpEnabled must be a boolean");
             patch.computerMcpEnabled = b.computerMcpEnabled;
           }
+          if (b?.executorEnabled !== undefined) {
+            if (typeof b.executorEnabled !== "boolean")
+              return err(400, "executorEnabled must be a boolean");
+            patch.executorEnabled = b.executorEnabled;
+          }
           if (b?.botAutoCompactionEnabled !== undefined) {
             if (typeof b.botAutoCompactionEnabled !== "boolean")
               return err(400, "botAutoCompactionEnabled must be a boolean");
@@ -4732,6 +4789,15 @@ a{color:#60a5fa}
             patch.customInstructions = b.customInstructions;
           }
           const settings = await setGlobalSettings(patch);
+          // The connector gateway follows its switch: off stops the daemon
+          // now rather than leaving it running behind a 404, and on starts it
+          // without waiting for the next boot. Off the response path: a cold
+          // start is seconds.
+          if (patch.executorEnabled === true) {
+            void startExecutor({ log: (l) => console.log(l) }).catch(() => {});
+          } else if (patch.executorEnabled === false) {
+            void stopExecutor().catch(() => {});
+          }
           return json({ settings });
         }
         return err(405, "method not allowed");
@@ -10404,6 +10470,14 @@ a{color:#60a5fa}
   // JSONL files are treated as an import source; live draft deltas stay
   // ephemeral until the provider writes the completed turn.
   startChatIngestMonitor(listSessionsCached);
+  // The connector gateway. Adopts a daemon left running by the previous serve
+  // process, or starts one. Off the boot path: a cold Executor start is
+  // seconds, and nothing at boot needs it.
+  void getGlobalSettings().then(async ({ executorEnabled }) => {
+    if (!executorEnabled) return;
+    const status = await startExecutor({ log: (l) => console.log(l) });
+    if (!status.running && status.error) console.log(`[executor] ${status.error}`);
+  }).catch((e) => console.error(`[executor] start failed: ${e instanceof Error ? e.message : String(e)}`));
   // Warm the resumable-session cache in the background so the first time someone
   // opens the resume picker it's already served from SQLite (no cold scan wait).
   void refreshResumableCache({ force: true }).catch(() => {});

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,8 +88,33 @@ export function omgMcpServers(
 ): { mcpServers?: Record<string, { type: "http"; url: string }> } {
   const sid = (sessionId ?? process.env.OMG_SESSION_ID ?? process.env.LFG_SESSION_ID)?.trim();
   if (!sid) return {};
-  const url = `${localServeBaseUrl()}/mcp?session=${encodeURIComponent(sid)}`;
-  return { mcpServers: { omg: { type: "http", url } } };
+  const session = `?session=${encodeURIComponent(sid)}`;
+  const url = `${localServeBaseUrl()}/mcp${session}`;
+  const mcpServers: Record<string, { type: "http"; url: string }> = { omg: { type: "http", url } };
+  if (executorMcpAdvertised) {
+    mcpServers[EXECUTOR_MCP_SERVER_NAME] = { type: "http", url: executorMcpHttpUrl(sid) };
+  }
+  return { mcpServers };
+}
+
+/** The tool namespace agents see for the connector gateway (`mcp__executor__*`). */
+export const EXECUTOR_MCP_SERVER_NAME = "executor";
+
+/** The omg-served connector endpoint. Session-less for a user-scope registration. */
+export function executorMcpHttpUrl(sessionId?: string): string {
+  const base = `${localServeBaseUrl()}/mcp/executor`;
+  return sessionId ? `${base}?session=${encodeURIComponent(sessionId)}` : base;
+}
+
+// Whether sessions launched from this process are handed the connector
+// endpoint. Owned by src/executor/daemon.ts: set once the daemon answers, and
+// cleared when it stops, so no session is registered against a dead URL. A
+// plain flag rather than a settings read because this function runs on every
+// launch and must stay synchronous and dependency-free.
+let executorMcpAdvertised = false;
+
+export function setExecutorMcpAdvertised(advertised: boolean): void {
+  executorMcpAdvertised = advertised;
 }
 
 function readVersionFromDisk(): string {

--- a/src/executor/daemon.test.ts
+++ b/src/executor/daemon.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS, omgMcpServers } from "../config.ts";
+import {
+  ensureExecutorAdopted,
+  executorAuth,
+  executorDashboardUrl,
+  executorStatus,
+  executorToken,
+  resetExecutorStateForTests,
+  startExecutor,
+  stopExecutor,
+} from "./daemon.ts";
+
+let tmp: string;
+const originalData = PATHS.data;
+const originalPath = process.env.PATH;
+const originalBin = process.env.OMG_EXECUTOR_BIN;
+
+// A stand-in `executor` binary: answers /api/health on the requested port
+// and records its argv, so the daemon owner can be exercised without the
+// real 130 MB binary.
+function fakeExecutor(dir: string, body: string): string {
+  const path = join(dir, "executor");
+  writeFileSync(path, `#!/usr/bin/env bun\n${body}`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+const HEALTHY = `
+const port = Number(process.argv[process.argv.indexOf("--port") + 1]);
+const host = process.argv[process.argv.indexOf("--hostname") + 1];
+require("node:fs").writeFileSync(process.env.EXECUTOR_DATA_DIR + "/argv.json", JSON.stringify({ argv: process.argv.slice(2), env: { EXECUTOR_DATA_DIR: process.env.EXECUTOR_DATA_DIR } }));
+Bun.serve({ port, hostname: host, fetch(req) {
+  const url = new URL(req.url);
+  if (url.pathname === "/api/health") return new Response("ok");
+  return new Response("nope", { status: 404 });
+} });
+setInterval(() => {}, 1000);
+`;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "omg-executor-"));
+  PATHS.data = join(tmp, "data");
+  mkdirSync(PATHS.data, { recursive: true });
+  resetExecutorStateForTests();
+});
+
+afterEach(async () => {
+  await stopExecutor();
+  resetExecutorStateForTests();
+  PATHS.data = originalData;
+  process.env.PATH = originalPath;
+  if (originalBin === undefined) delete process.env.OMG_EXECUTOR_BIN;
+  else process.env.OMG_EXECUTOR_BIN = originalBin;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("executor daemon", () => {
+  test("reports not installed when no binary is on PATH", async () => {
+    process.env.PATH = tmp;
+    delete process.env.OMG_EXECUTOR_BIN;
+    const status = await startExecutor({ log: () => {} });
+    expect(status.installed).toBe(false);
+    expect(status.running).toBe(false);
+    expect(status.error).toContain("npm install -g executor");
+    expect(omgMcpServers("s1").mcpServers?.executor).toBeUndefined();
+  });
+
+  test("mints one stable token", () => {
+    const first = executorToken();
+    expect(first.length).toBeGreaterThan(20);
+    expect(executorToken()).toBe(first);
+  });
+
+  test("starts the binary on loopback with the omg token and data dir, then advertises the endpoint", async () => {
+    process.env.OMG_EXECUTOR_BIN = fakeExecutor(tmp, HEALTHY);
+    const status = await startExecutor({ port: 47901, log: () => {} });
+    expect(status.running).toBe(true);
+    expect(status.origin).toBe("http://127.0.0.1:47901");
+    expect(status.error).toBeNull();
+
+    const seen = JSON.parse(readFileSync(join(PATHS.data, "executor", "argv.json"), "utf8")) as {
+      argv: string[];
+      env: { EXECUTOR_DATA_DIR: string };
+    };
+    expect(seen.argv.slice(0, 3)).toEqual(["daemon", "run", "--foreground"]);
+    expect(seen.argv).toContain("--hostname");
+    expect(seen.argv[seen.argv.indexOf("--hostname") + 1]).toBe("127.0.0.1");
+    expect(seen.argv[seen.argv.indexOf("--auth-token") + 1]).toBe(executorToken());
+    expect(seen.env.EXECUTOR_DATA_DIR).toBe(join(PATHS.data, "executor"));
+
+    expect(executorAuth()).toEqual({ origin: "http://127.0.0.1:47901", token: executorToken() });
+    expect(executorDashboardUrl()).toBe(`http://127.0.0.1:47901/?_token=${encodeURIComponent(executorToken())}`);
+    expect(omgMcpServers("s1").mcpServers?.executor?.url).toContain("/mcp/executor?session=s1");
+
+    const stopped = await stopExecutor();
+    expect(stopped.running).toBe(false);
+    expect(executorAuth()).toBeNull();
+    expect(omgMcpServers("s1").mcpServers?.executor).toBeUndefined();
+  });
+
+  test("a restarted owner adopts the daemon it left running", async () => {
+    process.env.OMG_EXECUTOR_BIN = fakeExecutor(tmp, HEALTHY);
+    const started = await startExecutor({ port: 47902, log: () => {} });
+    expect(started.running).toBe(true);
+    const pid = started.pid;
+
+    // Forget the process without killing it, as a serve restart would.
+    resetExecutorStateForTests();
+    expect(executorStatus().running).toBe(false);
+
+    expect(await ensureExecutorAdopted()).toBe(true);
+    const adopted = executorStatus();
+    expect(adopted.running).toBe(true);
+    expect(adopted.pid).toBe(pid);
+    expect(adopted.origin).toBe("http://127.0.0.1:47902");
+  });
+
+  test("a stale record is reaped rather than adopted", async () => {
+    mkdirSync(join(PATHS.data, "executor"), { recursive: true });
+    writeFileSync(
+      join(PATHS.data, "executor", "omg-daemon.json"),
+      JSON.stringify({ pid: 2_147_483_000, port: 47903, token: "old", startedAt: 1 }),
+    );
+    expect(await ensureExecutorAdopted()).toBe(false);
+    expect(executorStatus().running).toBe(false);
+  });
+
+  test("reports a binary that never answers", async () => {
+    process.env.OMG_EXECUTOR_BIN = fakeExecutor(tmp, "process.exit(3);");
+    const status = await startExecutor({ port: 47904, log: () => {} });
+    expect(status.running).toBe(false);
+    expect(status.error).toContain("exit");
+  });
+});

--- a/src/executor/daemon.ts
+++ b/src/executor/daemon.ts
@@ -1,0 +1,444 @@
+// The Executor connector daemon this box runs, owned by `omg serve`.
+//
+// Executor (https://executor.sh) is the one connector gateway per box: every
+// third-party integration is configured there once, and agents reach all of
+// them through the omg-served `/mcp/executor` endpoint (see ./proxy.ts). The
+// daemon is a separate binary with its own SQLite store, so the serve process
+// only has to start it, find it again after a restart, and know its port and
+// bearer token.
+//
+// Same lifecycle shape as src/computer/desktop.ts: the pid and port go on
+// disk, a restarted serve ADOPTS a daemon that is still healthy instead of
+// killing a process that agents may be mid-call against, and a dead one is
+// reaped before a new start. The daemon therefore survives serve restarts and
+// is stopped only by an explicit stop or by the setting being turned off.
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { join } from "node:path";
+import { PATHS, setExecutorMcpAdvertised } from "../config.ts";
+
+export const DEFAULT_EXECUTOR_PORT = 4788;
+export const EXECUTOR_INSTALL_COMMAND = "npm install -g executor";
+
+// How long a fresh daemon gets to answer /api/health before the start is
+// reported as failed. The binary is ~130 MB and opens a SQLite store, so cold
+// start on a loaded box is seconds, not milliseconds.
+const BOOT_TIMEOUT_MS = 30_000;
+const BOOT_POLL_MS = 250;
+// Unsupervised restarts after an unexpected exit. Bounded so a binary that
+// crashes on boot does not spin forever; the status carries the last error.
+const RESTART_DELAY_MS = 5_000;
+const RESTART_LIMIT = 5;
+
+export function executorDataDir(): string {
+  return join(PATHS.data, "executor");
+}
+
+// Where the running daemon is recorded, so a restarted server can find it.
+function stateFile(): string {
+  return join(executorDataDir(), "omg-daemon.json");
+}
+
+// The bearer token omg mints for the daemon. Kept in its own file so it is
+// stable across daemon restarts: the token is what an adopted daemon still
+// expects, and minting a new one per start would orphan a healthy process.
+function tokenFile(): string {
+  return join(executorDataDir(), "omg-token");
+}
+
+interface PersistedDaemon {
+  pid: number;
+  port: number;
+  token: string;
+  startedAt: number;
+}
+
+interface DaemonState {
+  pid: number;
+  port: number;
+  token: string;
+  startedAt: number;
+  // Present only for a daemon this process spawned. An adopted daemon has a
+  // pid and no handle, and is signalled by pid.
+  child?: ChildProcess;
+}
+
+export interface ExecutorStatus {
+  installed: boolean;
+  binary: string | null;
+  installCommand: string;
+  running: boolean;
+  origin: string | null;
+  pid: number | null;
+  startedAt: number | null;
+  error: string | null;
+}
+
+// Module-level singleton: one box, one daemon.
+let state: DaemonState | null = null;
+let lastError: string | null = null;
+let stopping = false;
+let restarts = 0;
+let restartTimer: ReturnType<typeof setTimeout> | null = null;
+let starting: Promise<ExecutorStatus> | null = null;
+
+function which(bin: string): string | null {
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (!dir) continue;
+    const candidate = `${dir}/${bin}`;
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** The `executor` binary, or null when it is not installed. */
+export function executorBinary(): string | null {
+  const override = process.env.OMG_EXECUTOR_BIN?.trim();
+  if (override) return existsSync(override) ? override : null;
+  return which("executor");
+}
+
+/** The bearer token for this box's daemon, minted on first use. */
+export function executorToken(): string {
+  const path = tokenFile();
+  try {
+    const existing = readFileSync(path, "utf8").trim();
+    if (existing) return existing;
+  } catch {}
+  const token = randomBytes(32).toString("base64url");
+  mkdirSync(executorDataDir(), { recursive: true });
+  writeFileSync(path, token);
+  try {
+    chmodSync(path, 0o600);
+  } catch {}
+  return token;
+}
+
+function writeStateFile(next: DaemonState): void {
+  try {
+    mkdirSync(executorDataDir(), { recursive: true });
+    const record: PersistedDaemon = {
+      pid: next.pid,
+      port: next.port,
+      token: next.token,
+      startedAt: next.startedAt,
+    };
+    writeFileSync(stateFile(), JSON.stringify(record));
+    try {
+      chmodSync(stateFile(), 0o600);
+    } catch {}
+  } catch {
+    // Losing the record only costs adoption on the next boot.
+  }
+}
+
+function clearStateFile(): void {
+  try {
+    rmSync(stateFile(), { force: true });
+  } catch {}
+}
+
+function readStateFile(): PersistedDaemon | null {
+  try {
+    if (!existsSync(stateFile())) return null;
+    const parsed = JSON.parse(readFileSync(stateFile(), "utf8")) as Partial<PersistedDaemon>;
+    if (
+      typeof parsed.pid !== "number" ||
+      typeof parsed.port !== "number" ||
+      typeof parsed.token !== "string"
+    ) {
+      return null;
+    }
+    return {
+      pid: parsed.pid,
+      port: parsed.port,
+      token: parsed.token,
+      startedAt: typeof parsed.startedAt === "number" ? parsed.startedAt : Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function alive(pid: number | undefined): boolean {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killPid(pid: number | undefined, signal: NodeJS.Signals = "SIGTERM"): void {
+  if (!pid) return;
+  try {
+    process.kill(pid, signal);
+  } catch {}
+}
+
+export function executorOriginFor(port: number): string {
+  return `http://127.0.0.1:${port}`;
+}
+
+/** True when the daemon on `port` answers its health probe. */
+export async function executorHealthy(port: number, timeoutMs = 1_000): Promise<boolean> {
+  try {
+    const res = await fetch(`${executorOriginFor(port)}/api/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHealthy(port: number, timeoutMs: number, stillRunning: () => boolean): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!stillRunning()) return false;
+    if (await executorHealthy(port, 800)) return true;
+    await Bun.sleep(BOOT_POLL_MS);
+  }
+  return false;
+}
+
+function portFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(false));
+    probe.listen(port, "127.0.0.1", () => {
+      probe.close(() => resolve(true));
+    });
+  });
+}
+
+// The preferred port, or the next free one above it. Executor's own default
+// is 4788; a user who also runs Executor by hand keeps it, and we move.
+async function pickPort(preferred: number): Promise<number> {
+  for (let port = preferred; port < preferred + 20; port += 1) {
+    if (await portFree(port)) return port;
+  }
+  throw new Error(`no free port between ${preferred} and ${preferred + 19}`);
+}
+
+function setState(next: DaemonState | null): void {
+  state = next;
+  setExecutorMcpAdvertised(next !== null);
+}
+
+/**
+ * Reattach to a daemon this box left running, or clean up its remains.
+ *
+ * Returns true when a healthy daemon was adopted. Idempotent: a live in-memory
+ * state short-circuits, so this is safe to call from every status request.
+ */
+export async function ensureExecutorAdopted(): Promise<boolean> {
+  if (state) return true;
+  const record = readStateFile();
+  if (!record) return false;
+  const healthy = alive(record.pid) && (await executorHealthy(record.port, 1_500));
+  if (!healthy) {
+    killPid(record.pid);
+    await Bun.sleep(300);
+    killPid(record.pid, "SIGKILL");
+    clearStateFile();
+    return false;
+  }
+  setState({ pid: record.pid, port: record.port, token: record.token, startedAt: record.startedAt });
+  return true;
+}
+
+/** The daemon's origin and bearer, or null when it is not running. */
+export function executorAuth(): { origin: string; token: string } | null {
+  if (!state) return null;
+  return { origin: executorOriginFor(state.port), token: state.token };
+}
+
+/** The URL that opens the Executor dashboard already signed in. */
+export function executorDashboardUrl(): string | null {
+  const auth = executorAuth();
+  if (!auth) return null;
+  return `${auth.origin}/?_token=${encodeURIComponent(auth.token)}`;
+}
+
+export function executorStatus(): ExecutorStatus {
+  const binary = executorBinary();
+  return {
+    installed: binary !== null,
+    binary,
+    installCommand: EXECUTOR_INSTALL_COMMAND,
+    running: state !== null,
+    origin: state ? executorOriginFor(state.port) : null,
+    pid: state?.pid ?? null,
+    startedAt: state?.startedAt ?? null,
+    error: lastError,
+  };
+}
+
+function scheduleRestart(log: (line: string) => void): void {
+  if (stopping) return;
+  if (restarts >= RESTART_LIMIT) {
+    lastError = `executor exited ${RESTART_LIMIT} times; not restarting. Check the binary with: executor daemon run --foreground`;
+    log(`[executor] ${lastError}`);
+    return;
+  }
+  restarts += 1;
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    void startExecutor({ log }).catch(() => {});
+  }, RESTART_DELAY_MS);
+}
+
+/**
+ * Start the daemon, or adopt one that is already running.
+ *
+ * Concurrent callers share one start: the settings toggle, the boot hook and a
+ * status poll can all race here, and two spawns would fight over the port.
+ */
+export function startExecutor(opts: { port?: number; log?: (line: string) => void } = {}): Promise<ExecutorStatus> {
+  if (starting) return starting;
+  starting = startExecutorOnce(opts).finally(() => {
+    starting = null;
+  });
+  return starting;
+}
+
+async function startExecutorOnce(opts: { port?: number; log?: (line: string) => void }): Promise<ExecutorStatus> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  stopping = false;
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+  if (await ensureExecutorAdopted()) {
+    lastError = null;
+    return executorStatus();
+  }
+  const binary = executorBinary();
+  if (!binary) {
+    lastError = `executor is not installed. Install it with: ${EXECUTOR_INSTALL_COMMAND}`;
+    return executorStatus();
+  }
+
+  let port: number;
+  try {
+    port = await pickPort(opts.port ?? DEFAULT_EXECUTOR_PORT);
+  } catch (e) {
+    lastError = e instanceof Error ? e.message : String(e);
+    return executorStatus();
+  }
+  const token = executorToken();
+  const dataDir = executorDataDir();
+  mkdirSync(dataDir, { recursive: true });
+
+  const child = spawn(
+    binary,
+    [
+      "daemon", "run", "--foreground",
+      "--hostname", "127.0.0.1",
+      "--port", String(port),
+      "--auth-token", token,
+    ],
+    {
+      env: {
+        ...process.env,
+        EXECUTOR_DATA_DIR: dataDir,
+        EXECUTOR_DISABLE_ANALYTICS: "1",
+        EXECUTOR_DISABLE_UPDATE_CHECK: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+    },
+  );
+  let exited = false;
+  let exitNote = "";
+  const relay = (chunk: Buffer) => {
+    for (const line of chunk.toString().split("\n")) {
+      if (line.trim()) log(`[executor] ${line}`);
+    }
+  };
+  child.stdout?.on("data", relay);
+  child.stderr?.on("data", relay);
+  child.once("error", (e) => {
+    exited = true;
+    exitNote = e.message;
+  });
+  child.once("exit", (code, signal) => {
+    exited = true;
+    exitNote = signal ? `signal ${signal}` : `exit code ${code}`;
+    if (state?.child === child) {
+      setState(null);
+      clearStateFile();
+      if (!stopping) {
+        lastError = `executor stopped unexpectedly (${exitNote})`;
+        log(`[executor] ${lastError}`);
+        scheduleRestart(log);
+      }
+    }
+  });
+
+  const pid = child.pid;
+  if (!pid) {
+    lastError = `failed to spawn executor: ${exitNote || "no pid"}`;
+    return executorStatus();
+  }
+  const next: DaemonState = { pid, port, token, startedAt: Date.now(), child };
+  // Record and advertise only after the daemon answers, so an agent launched
+  // during boot is not handed an endpoint that 503s.
+  const ready = await waitForHealthy(port, BOOT_TIMEOUT_MS, () => !exited);
+  if (!ready) {
+    killPid(pid);
+    await Bun.sleep(300);
+    killPid(pid, "SIGKILL");
+    lastError = exited
+      ? `executor exited during start (${exitNote})`
+      : `executor did not answer on port ${port} within ${BOOT_TIMEOUT_MS / 1000}s`;
+    return executorStatus();
+  }
+  setState(next);
+  writeStateFile(next);
+  lastError = null;
+  restarts = 0;
+  log(`[executor] ready on ${executorOriginFor(port)} (pid ${pid})`);
+  return executorStatus();
+}
+
+/** Stop the daemon. Safe to call when nothing is running. */
+export async function stopExecutor(): Promise<ExecutorStatus> {
+  stopping = true;
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+  const current = state ?? (() => {
+    const record = readStateFile();
+    return record ? { ...record } : null;
+  })();
+  setState(null);
+  clearStateFile();
+  if (current) {
+    killPid(current.pid);
+    const deadline = Date.now() + 3_000;
+    while (alive(current.pid) && Date.now() < deadline) await Bun.sleep(100);
+    if (alive(current.pid)) killPid(current.pid, "SIGKILL");
+  }
+  lastError = null;
+  restarts = 0;
+  return executorStatus();
+}
+
+/** Test seam: forget in-memory state without touching any process. */
+export function resetExecutorStateForTests(): void {
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+  setState(null);
+  lastError = null;
+  stopping = false;
+  restarts = 0;
+  starting = null;
+}

--- a/src/executor/proxy.test.ts
+++ b/src/executor/proxy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { serveExecutorMcpRequest } from "./proxy.ts";
+
+const UPSTREAM = { origin: "http://127.0.0.1:4788", token: "secret-token" };
+
+function capture() {
+  const calls: { url: string; init: RequestInit & { headers: Headers } }[] = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push({ url: String(input), init: { ...init, headers } });
+    return new Response("event: message\ndata: {}\n\n", {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "mcp-session-id": "sess-1",
+        "x-upstream-private": "hidden",
+      },
+    });
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+describe("serveExecutorMcpRequest", () => {
+  test("503 when the daemon is not running", async () => {
+    const res = await serveExecutorMcpRequest(new Request("http://box/mcp/executor", { method: "POST" }), null);
+    expect(res.status).toBe(503);
+  });
+
+  test("forwards to the daemon /mcp with the bearer and MCP headers", async () => {
+    const { calls, fetchImpl } = capture();
+    const req = new Request("http://box/mcp/executor?session=abc", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-session-id": "sess-1",
+        authorization: "Bearer from-the-agent",
+        cookie: "omg=1",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    const res = await serveExecutorMcpRequest(req, UPSTREAM, fetchImpl);
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toBe("http://127.0.0.1:4788/mcp");
+    expect(call.init.method).toBe("POST");
+    expect(call.init.headers.get("authorization")).toBe("Bearer secret-token");
+    expect(call.init.headers.get("mcp-session-id")).toBe("sess-1");
+    expect(call.init.headers.get("accept")).toContain("text/event-stream");
+    expect(call.init.headers.get("cookie")).toBeNull();
+    expect(new TextDecoder().decode(call.init.body as ArrayBuffer)).toContain("tools/list");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("mcp-session-id")).toBe("sess-1");
+    expect(res.headers.get("x-upstream-private")).toBeNull();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.text()).toContain("event: message");
+  });
+
+  test("GET carries no body", async () => {
+    const { calls, fetchImpl } = capture();
+    await serveExecutorMcpRequest(new Request("http://box/mcp/executor", { method: "GET" }), UPSTREAM, fetchImpl);
+    expect(calls[0]!.init.body).toBeUndefined();
+  });
+
+  test("502 when the daemon does not answer", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const res = await serveExecutorMcpRequest(new Request("http://box/mcp/executor", { method: "POST" }), UPSTREAM, fetchImpl);
+    expect(res.status).toBe(502);
+  });
+});

--- a/src/executor/proxy.ts
+++ b/src/executor/proxy.ts
@@ -1,0 +1,78 @@
+// The agent-facing connector endpoint: `/mcp/executor`.
+//
+// A transparent Streamable HTTP proxy in front of the Executor daemon. Agents
+// register this URL and nothing else; the daemon's port and bearer token stay
+// inside the serve process. Passing the daemon's own `/mcp` straight through,
+// rather than re-describing its tools through an MCP client, keeps omg out of
+// the schema business and gives the role filter (phase 2 of
+// docs/team-tooling-design.md) one place to read and rewrite JSON-RPC bodies.
+//
+// Streamable HTTP is stateful: the daemon issues an `mcp-session-id` on
+// initialize and expects it back on every later request, and GET opens a
+// long-lived event stream. Both headers therefore pass in both directions and
+// the response body is streamed, never buffered.
+import { executorAuth } from "./daemon.ts";
+
+// Request headers the daemon needs to see. Everything else, including the
+// agent's own Authorization header if it sent one, is dropped.
+const FORWARD_REQUEST_HEADERS = [
+  "accept",
+  "content-type",
+  "mcp-session-id",
+  "mcp-protocol-version",
+  "last-event-id",
+];
+
+// Response headers the agent needs to see.
+const FORWARD_RESPONSE_HEADERS = ["content-type", "mcp-session-id", "mcp-protocol-version"];
+
+export type ExecutorUpstream = { origin: string; token: string };
+
+/**
+ * Answer one `/mcp/executor` request by forwarding it to the daemon.
+ *
+ * `upstream` is injectable for tests; production callers leave it to the
+ * daemon owner. A missing upstream is a 503, not a 404: the endpoint exists
+ * and is enabled, the process behind it is not up yet.
+ */
+export async function serveExecutorMcpRequest(
+  req: Request,
+  upstream: ExecutorUpstream | null = executorAuth(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  if (!upstream) {
+    return Response.json(
+      { error: "the connector gateway is not running" },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  const headers = new Headers();
+  for (const name of FORWARD_REQUEST_HEADERS) {
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  headers.set("authorization", `Bearer ${upstream.token}`);
+
+  const hasBody = req.method !== "GET" && req.method !== "HEAD";
+  let res: Response;
+  try {
+    res = await fetchImpl(`${upstream.origin}/mcp`, {
+      method: req.method,
+      headers,
+      // JSON-RPC request bodies are small; the long-lived direction is the
+      // response stream, which is passed through below.
+      body: hasBody ? await req.arrayBuffer() : undefined,
+    });
+  } catch {
+    return Response.json(
+      { error: "the connector gateway is unreachable" },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  const out = new Headers({ "Cache-Control": "no-store" });
+  for (const name of FORWARD_RESPONSE_HEADERS) {
+    const value = res.headers.get(name);
+    if (value) out.set(name, value);
+  }
+  return new Response(res.body, { status: res.status, headers: out });
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,6 +32,10 @@ export type GlobalSettings = {
   // screen would offer an agent capabilities it cannot use. Local only -- this
   // never travels to a hosted Computer.
   computerMcpEnabled: boolean;
+  // Run the Executor connector daemon and expose it to agents at
+  // /mcp/executor. On by default: it is the one connector gateway per box
+  // (docs/team-tooling-design.md). Off stops the daemon and answers 404.
+  executorEnabled: boolean;
   // Share of the model's context window at which that rotation fires. Bounded
   // well away from both ends: see sanitizeBotCompactionThreshold for why 40 and
   // 95 are the limits. There is no matching setting for the re-arm mark, which
@@ -133,6 +137,7 @@ function sanitize(input: Partial<GlobalSettings> | null | undefined): GlobalSett
   const botAutoCompactionEnabled = input?.botAutoCompactionEnabled !== false;
   // Note the polarity: unlike bot auto-compaction, this defaults OFF.
   const computerMcpEnabled = input?.computerMcpEnabled === true;
+  const executorEnabled = input?.executorEnabled !== false;
   const botCompactionThresholdPercent = sanitizeBotCompactionThreshold(
     input?.botCompactionThresholdPercent,
   );
@@ -143,6 +148,7 @@ function sanitize(input: Partial<GlobalSettings> | null | undefined): GlobalSett
     transcriptView,
     botAutoCompactionEnabled,
     computerMcpEnabled,
+    executorEnabled,
     botCompactionThresholdPercent,
     skippedUpdateVersion,
     customInstructions,
@@ -247,6 +253,7 @@ export async function setGlobalSettings(patch: Partial<GlobalSettings>): Promise
     write.run("transcriptView", JSON.stringify(next.transcriptView), now);
     write.run("botAutoCompactionEnabled", JSON.stringify(next.botAutoCompactionEnabled), now);
     write.run("computerMcpEnabled", JSON.stringify(next.computerMcpEnabled), now);
+    write.run("executorEnabled", JSON.stringify(next.executorEnabled), now);
     write.run("botCompactionThresholdPercent", JSON.stringify(next.botCompactionThresholdPercent), now);
     write.run("skippedUpdateVersion", JSON.stringify(next.skippedUpdateVersion), now);
     write.run("customInstructions", JSON.stringify(next.customInstructions), now);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -557,6 +557,7 @@ import {
   CustomInstructionsRow,
 } from "./views/custom-instructions-page";
 import { RemoteAccessSettingsSection } from "./components/remote-access-settings";
+import { ExecutorSettingsSection } from "./components/executor-settings";
 import {
   UpdateNavButton,
   UpdateProvider,
@@ -1099,6 +1100,9 @@ type GlobalSettings = {
   // Whether this box offers the Computer Use MCP to agents. Off by default;
   // see the MCP servers section in SettingsView.
   computerMcpEnabled: boolean;
+  // Whether this box runs the connector gateway (Executor) and offers it to
+  // agents at /mcp/executor. On by default; see ExecutorSettingsSection.
+  executorEnabled: boolean;
   transcriptView: TranscriptView;
   // The update the "What's new" drawer's Skip button last dismissed. See
   // UpdateProvider in components/update-drawer.tsx.
@@ -5966,6 +5970,7 @@ export function App() {
     maxBotSchedules: 5,
     botAutoCompactionEnabled: true,
     computerMcpEnabled: false,
+    executorEnabled: true,
     botCompactionThresholdPercent: 78,
     transcriptView: "full",
     skippedUpdateVersion: "",
@@ -6274,6 +6279,7 @@ export function App() {
       maxBotSchedules: 5,
       botAutoCompactionEnabled: true,
       computerMcpEnabled: false,
+      executorEnabled: true,
       botCompactionThresholdPercent: 78,
       transcriptView: "full",
       skippedUpdateVersion: "",
@@ -27000,6 +27006,11 @@ function SettingsView({
           />
         </div>
       </section>
+
+      <ExecutorSettingsSection
+        enabled={settings.executorEnabled}
+        onEnabledChange={(executorEnabled) => onSettingsChange({ executorEnabled })}
+      />
 
       <RemoteAccessSettingsSection />
 

--- a/web/src/components/executor-settings.test.tsx
+++ b/web/src/components/executor-settings.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mount, type Mounted } from "../test-support/render";
+
+const { ExecutorSettingsSection } = await import("./executor-settings");
+
+let ui: Mounted;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  ui = mount();
+});
+
+afterEach(() => {
+  ui.cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+const BASE = {
+  enabled: true,
+  installed: true,
+  binary: "/usr/bin/executor",
+  installCommand: "npm install -g executor",
+  running: true,
+  origin: "http://127.0.0.1:4788",
+  pid: 42,
+  startedAt: 1,
+  error: null,
+};
+
+function respond(status: Record<string, unknown>) {
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.includes("/api/executor/status")) return Response.json(status);
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+describe("ExecutorSettingsSection", () => {
+  test("shows a running gateway with the dashboard button", async () => {
+    respond(BASE);
+    ui.render(<ExecutorSettingsSection enabled onEnabledChange={async () => {}} />);
+    await ui.flushAsync();
+
+    expect(ui.text()).toContain("Connectors");
+    expect(ui.text()).toContain("Running");
+    expect(ui.text()).toContain("http://127.0.0.1:4788");
+    expect(ui.text()).toContain("Open dashboard");
+    expect(ui.text()).not.toContain("npm install -g executor");
+  });
+
+  test("shows the install command when the binary is missing", async () => {
+    respond({ ...BASE, installed: false, binary: null, running: false, origin: null, pid: null });
+    ui.render(<ExecutorSettingsSection enabled onEnabledChange={async () => {}} />);
+    await ui.flushAsync();
+
+    expect(ui.text()).toContain("Not installed");
+    expect(ui.text()).toContain("npm install -g executor");
+    expect(ui.text()).not.toContain("Open dashboard");
+  });
+
+  test("shows off when disabled and reports the toggle", async () => {
+    respond({ ...BASE, enabled: false, running: false, origin: null });
+    const seen: boolean[] = [];
+    ui.render(
+      <ExecutorSettingsSection
+        enabled={false}
+        onEnabledChange={async (next) => {
+          seen.push(next);
+        }}
+      />,
+    );
+    await ui.flushAsync();
+
+    expect(ui.text()).toContain("Off.");
+    const toggle = ui.query('[role="switch"]') as HTMLElement | null;
+    expect(toggle).not.toBeNull();
+    toggle!.click();
+    await ui.flushAsync();
+    expect(seen).toEqual([true]);
+  });
+
+  test("renders nothing on a server without the gateway", async () => {
+    globalThis.fetch = (async () => new Response("nope", { status: 404 })) as typeof fetch;
+    ui.render(<ExecutorSettingsSection enabled onEnabledChange={async () => {}} />);
+    await ui.flushAsync();
+    expect(ui.text()).not.toContain("Connectors");
+  });
+});

--- a/web/src/components/executor-settings.tsx
+++ b/web/src/components/executor-settings.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from "react";
+import { ExternalLink, Plug, TerminalSquare } from "lucide-react";
+
+import { Switch } from "@/components/ui/switch";
+
+/** Mirrors the payload of GET /api/executor/status. */
+export type ExecutorStatusInfo = {
+  enabled: boolean;
+  installed: boolean;
+  binary: string | null;
+  installCommand: string;
+  running: boolean;
+  origin: string | null;
+  pid: number | null;
+  startedAt: number | null;
+  error: string | null;
+};
+
+// Polled while the card is on screen. A start takes seconds and the card
+// should turn from "Starting" to "Running" without a reload.
+const POLL_MS = 5_000;
+
+function describe(status: ExecutorStatusInfo): string {
+  if (!status.enabled) return "Off. Agents cannot reach any connector.";
+  if (!status.installed) return "Not installed on this computer.";
+  if (status.running) return `Running at ${status.origin ?? "127.0.0.1"}. Agents reach it at /mcp/executor.`;
+  if (status.error) return status.error;
+  return "Starting.";
+}
+
+/**
+ * The Settings card for the connector gateway (Executor).
+ *
+ * One switch, one status line, and the dashboard link. Connections, policies
+ * and approvals are edited in Executor's own UI, which opens in a new tab
+ * already signed in; this card does not duplicate any of that.
+ */
+export function ExecutorSettingsSection({
+  enabled,
+  onEnabledChange,
+}: {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => Promise<void>;
+}) {
+  const [status, setStatus] = useState<ExecutorStatusInfo | null>(null);
+  const [opening, setOpening] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const response = await fetch("/api/executor/status", { credentials: "same-origin", signal });
+      if (!response.ok) throw new Error(`status ${response.status}`);
+      setStatus((await response.json()) as ExecutorStatusInfo);
+    } catch {
+      // An older server has no gateway. Leave the card hidden rather than
+      // presenting a switch that cannot do anything.
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void refresh(controller.signal);
+    const timer = window.setInterval(() => void refresh(controller.signal), POLL_MS);
+    return () => {
+      controller.abort();
+      window.clearInterval(timer);
+    };
+  }, [refresh, enabled]);
+
+  const openDashboard = useCallback(async () => {
+    setOpening(true);
+    setOpenError(null);
+    // Open the tab before the await: browsers block window.open once the
+    // click is no longer the current task.
+    const tab = window.open("", "_blank");
+    try {
+      const response = await fetch("/api/executor/dashboard", { credentials: "same-origin" });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `status ${response.status}`);
+      }
+      const { url } = (await response.json()) as { url: string };
+      if (tab) tab.location.href = url;
+      else window.open(url, "_blank", "noopener");
+    } catch (e) {
+      tab?.close();
+      setOpenError(e instanceof Error ? e.message : "could not open the dashboard");
+    } finally {
+      setOpening(false);
+    }
+  }, []);
+
+  if (!status) return null;
+
+  return (
+    <section className="space-y-2" aria-labelledby="connectors-heading">
+      <h2 id="connectors-heading" className="px-4 text-xs font-semibold text-muted-foreground">
+        Connectors
+      </h2>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card/40 divide-y divide-border">
+        <div className="flex items-center justify-between gap-4 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-foreground text-background">
+              <Plug className="size-4" />
+            </span>
+            <span className="min-w-0">
+              <span className="flex items-center gap-2 text-sm font-medium">
+                Connector gateway
+                {status.enabled && status.running ? (
+                  <span className="rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-semibold text-success">
+                    Running
+                  </span>
+                ) : null}
+              </span>
+              <span className="block text-xs text-muted-foreground">{describe(status)}</span>
+            </span>
+          </div>
+          <Switch
+            checked={enabled}
+            onCheckedChange={(next) => void onEnabledChange(next)}
+            aria-label={enabled ? "Disable the connector gateway" : "Enable the connector gateway"}
+          />
+        </div>
+
+        {status.enabled && !status.installed ? (
+          <div className="space-y-2 px-4 py-3">
+            <div className="flex items-center gap-2 rounded-xl border border-border bg-background/50 px-3 py-2">
+              <TerminalSquare className="size-4 shrink-0 text-muted-foreground" />
+              <code className="min-w-0 flex-1 truncate text-xs">{status.installCommand}</code>
+            </div>
+            <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+              Run this once on this computer, then the gateway starts on its own.
+            </p>
+          </div>
+        ) : null}
+
+        {status.enabled && status.running ? (
+          <div className="space-y-2 px-4 py-3">
+            <button
+              type="button"
+              onClick={() => void openDashboard()}
+              disabled={opening}
+              className="flex w-full items-center justify-between gap-4 rounded-xl border border-border bg-background/50 px-3 py-2 text-left text-sm hover:bg-foreground/[0.03] disabled:opacity-60"
+            >
+              <span>
+                <span className="block font-medium">Open dashboard</span>
+                <span className="block text-xs text-muted-foreground">
+                  Add integrations, sign in to services, set per-tool policies and approve calls.
+                </span>
+              </span>
+              <ExternalLink className="size-4 shrink-0 text-muted-foreground" />
+            </button>
+            {openError ? <p className="px-1 text-xs text-destructive">{openError}</p> : null}
+            <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+              The dashboard is served on this computer only. Open it from a browser on this machine.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## What changed

- `omg serve` owns one [Executor](https://executor.sh) daemon per box (`src/executor/daemon.ts`). Loopback only, omg-minted bearer, data in `PATHS.data/executor`. Adopted across serve restarts, reaped when dead, bounded auto-restart.
- New agent endpoint `/mcp/executor` (`src/executor/proxy.ts`): transparent Streamable HTTP proxy that injects the bearer. Agents never see the daemon port or token. 404 when the setting is off, 503 when the daemon is down.
- Sessions get a second MCP server `executor` next to `omg` (`omgMcpServers`, ACP backends). Claude user-scope setup registers it too.
- Setting `executorEnabled`, default on. The switch starts or stops the daemon.
- Routes: `GET /api/executor/status`, `POST /api/executor/start|stop`, `GET /api/executor/dashboard`.
- Settings page: Connectors card with status, switch, install command when the binary is missing, and "Open dashboard" (opens Executor signed in, new tab).
- `docs/team-tooling-design.md`: decisions and phases. Phase 2 (session secret, identity, role policy) and phase 3 (bwrap) are separate PRs.

## Verification

- New tests: daemon lifecycle with a fake binary, proxy header handling, Settings card render. 14 pass.
- Route coverage, config, coding-agents, MCP, ACP, settings suites: 103 pass.
- Full suite: 3250 pass, 1 pre-existing failure in `test/mobile-plan-specs.test.ts` (fails on `main` too).
- Root and web typecheck clean.
- End to end with the real `executor` 1.6.7 binary on `127.0.0.1`: status running, `initialize` and `tools/list` through `/mcp/executor`, dashboard URL issued, switch off gave 404 and stopped the daemon, switch on restarted it. Screenshots in the omg session.

## Notes

- `executor` is not a dependency. Install with `npm install -g executor` (about 280 MB). The card shows the command until it is present.
- The dashboard is loopback only. Not reachable through Tailscale remote access in this PR.
- `/mcp/executor` trusts `?session=` the same way `/mcp` does today. The session secret lands in phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
