### PR TITLE
Per-role tool access at the MCP endpoints, with the control plane in Settings

### DIFF
--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -163,9 +163,40 @@ Verified on this box: inside the sandbox a command reads and writes its
 worktree, cannot read a sibling path, reads the omg code tree, and cannot read
 the masked omg data dir (the session-token secret and the Executor bearer).
 
-Deliberately not done: network isolation. The harness still needs the model
-API and the omg MCP endpoint on loopback, and per-host restriction needs a
-local proxy or nftables in the namespace. This is the next sandbox step.
+### Network egress allowlist (landed: best-effort layer)
+
+A role's `network` is `shared` or `allowlist`, with `allowHosts` (owner is
+always `shared`). An allowlist session's harness is pointed at the box's egress
+proxy (`src/sandbox/egress-proxy.ts`): a loopback HTTP CONNECT proxy that lets
+it reach only the built-in model APIs plus the role's hosts, and refuses the
+rest.
+
+```
+ harness (HTTP_PROXY=http://<sessionId>:<token>@127.0.0.1:<port>, NO_PROXY=loopback)
+    | CONNECT api.anthropic.com:443   CONNECT pastebin.com:443
+    v
+ egress proxy   verify token -> role -> allow = model APIs + allowHosts
+    |  allowed -> tunnel        denied -> 403        bad token -> 407
+    v
+ upstream (only allowlisted hosts)
+```
+
+- Caller identity is the same per-session token the MCP endpoints use, carried
+  in the proxy credentials, so one proxy serves every session at its own
+  role's allowlist.
+- Loopback is in `NO_PROXY`, so the omg MCP endpoint is reached directly.
+- Verified on this box: through the proxy, an allowlisted host tunnels (200), a
+  non-allowlisted host is refused (403 / connection failed), and a bad token is
+  407.
+
+This is the best-effort layer: the SDKs honour `HTTP(S)_PROXY`, so ordinary
+model and tool traffic is filtered and logged, but an agent that dials a raw IP
+past the proxy env escapes it.
+
+Deliberately not done yet: the strict layer. `--unshare-net` plus nftables in
+the namespace, allowing only this proxy, closes the raw-IP gap; it needs
+CAP_NET_ADMIN to build the firewall and is opt-in per box. True untrusted-code
+isolation stays with Firecracker in `vibes`.
 
 ## Out of scope for this repository
 

--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -72,6 +72,43 @@ install command when it is missing.
 - Browser sign-in: `<origin>/?_token=<token>`.
 - Env: `EXECUTOR_DATA_DIR`, `EXECUTOR_DISABLE_ANALYTICS`, `EXECUTOR_DISABLE_UPDATE_CHECK`.
 
+## Phase 2 shape (landed)
+
+```
+ /mcp, /mcp/computer, /mcp/executor
+   |
+   resolveCaller(req)          src/policy/caller.ts
+   |  session from ?session= or x-omg-session-id
+   |  rows with mcpTokenRequired must present x-omg-session-token
+   |  token = HMAC(box secret, session id)   src/policy/session-token.ts
+   |  role  = row.role, else owner
+   v
+   enforceRole(req, role, ns)  src/policy/mcp-filter.ts
+   |  tools/list  -> blocked tools removed from the reply
+   |  tools/call  -> blocked tool answered with an error result, never forwarded
+   v
+   the endpoint's own server or proxy
+```
+
+- Roles: `src/policy/roles.ts`, `PATHS.data/roles.json`. `owner` is built in.
+  Rules use Executor's pattern grammar over `<server>.<tool>` ids
+  (`omg.ship`, `computer.click`, `executor.execute`). Block beats allow;
+  unmatched tools get the role's `defaultAction`.
+- Session role: `ManagedSession.role`, set by `POST /api/sessions/new`
+  (`role`) or `PATCH /api/sessions/:id/role`. Takes effect on the next call.
+- Routes: `/api/roles` (GET, POST), `/api/roles/:id` (PATCH, DELETE),
+  `/api/executor/api/<allowlisted>` forwards policies, tools, integrations
+  and connections to Executor with the bearer injected.
+- UI: Settings > Roles & tool access. Tabs: Roles (omg), Gateway policies
+  (Executor, box-wide), Integrations (Executor UI in an iframe). New-session
+  composer gets a role pill once a role other than owner exists.
+- Executor policy API facts: payload needs `owner: "org"`; actions are
+  `approve`, `require_approval`, `block`; DELETE takes a body with `owner`.
+
+Known limit: role rules see `executor.execute`, not the integration behind it.
+Per-integration restriction per role needs a per-role Executor instance
+(deferred). Box-wide per-integration rules go in Gateway policies.
+
 ## Out of scope for this repository
 
 Login, invites, SSO, team and role storage. Those belong to `vibes`. This

--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -105,6 +105,30 @@ install command when it is missing.
 - Executor policy API facts: payload needs `owner: "org"`; actions are
   `approve`, `require_approval`, `block`; DELETE takes a body with `owner`.
 
+### Approvals in chat (landed)
+
+A gateway policy of `require_approval` pauses a connector call. In this box's
+`model` elicitation mode Executor would have the agent resolve that itself;
+`src/executor/approvals.ts` takes it back:
+
+```
+ agent -> execute (gated tool)
+   proxy sees waiting_for_interaction with an empty schema
+   -> posts an omg ask (Approve / Deny) on the session, via POST /api/ask
+   -> rewrites the reply: "wait, the owner was asked; do not resume"
+   -> records executionId -> askId (in memory)
+ agent -> resume(executionId)   refused while the ask is open
+ human -> Approve / Deny on the ask card in chat
+   -> omg calls Executor's REST resume with the daemon bearer
+   -> the outcome (or the refusal) is sent into the session as a message
+```
+
+The card is the existing ask surface (`web/src/components/ask-center.tsx`),
+so no new UI: the approval is an ask with `Approve` / `Deny` options. Only an
+interaction with an empty requested schema is treated as an approval; a real
+form (fields requested) keeps Executor's own flow. In memory on purpose: a
+serve restart drops the daemon's paused execution and this map together.
+
 Known limit: role rules see `executor.execute`, not the integration behind it.
 Per-integration restriction per role needs a per-role Executor instance
 (deferred). Box-wide per-integration rules go in Gateway policies.

--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -133,6 +133,40 @@ Known limit: role rules see `executor.execute`, not the integration behind it.
 Per-integration restriction per role needs a per-role Executor instance
 (deferred). Box-wide per-integration rules go in Gateway policies.
 
+## Phase 3 shape (landed): filesystem sandbox
+
+A role can require a filesystem sandbox for its sessions
+(`src/sandbox/bwrap.ts`). `Role.sandbox` is `none` or `bwrap`; owner is always
+`none`. `POST /api/sessions/new` reads the session role's sandbox and passes it
+to the harness spawn.
+
+```
+ spawnManagedHarness(command, { sandbox: "bwrap", cwd, ... })
+   sandboxCommand wraps command with bwrap:
+     --ro-bind /usr /bin /sbin /lib* /etc /opt /nix   (system, read-only)
+     --tmpfs <home>                                   (empty home)
+     --ro-bind <omgRoot>                              (code, read-only)
+     --tmpfs <omgRoot>/data                           (mask omg secrets)
+     --ro-bind <bun dir>                              (runtime)
+     --bind <worktree>                                (the one writable path)
+     --unshare-user/pid/ipc/uts/cgroup                (network stays shared)
+```
+
+Applies to the process-supervised harnesses only (aisdk, codex-aisdk,
+opencode, pi), whose model credentials arrive through the environment, which
+bwrap passes through — so an empty home costs nothing and withholds the
+owner's stored logins. Terminal-backed agents read their own credentials from
+home and are not sandboxed; a `bwrap` request for one is logged and the
+session runs unsandboxed rather than failing.
+
+Verified on this box: inside the sandbox a command reads and writes its
+worktree, cannot read a sibling path, reads the omg code tree, and cannot read
+the masked omg data dir (the session-token secret and the Executor bearer).
+
+Deliberately not done: network isolation. The harness still needs the model
+API and the omg MCP endpoint on loopback, and per-host restriction needs a
+local proxy or nftables in the namespace. This is the next sandbox step.
+
 ## Out of scope for this repository
 
 Login, invites, SSO, team and role storage. Those belong to `vibes`. This

--- a/docs/team-tooling-design.md
+++ b/docs/team-tooling-design.md
@@ -193,10 +193,26 @@ This is the best-effort layer: the SDKs honour `HTTP(S)_PROXY`, so ordinary
 model and tool traffic is filtered and logged, but an agent that dials a raw IP
 past the proxy env escapes it.
 
-Deliberately not done yet: the strict layer. `--unshare-net` plus nftables in
-the namespace, allowing only this proxy, closes the raw-IP gap; it needs
-CAP_NET_ADMIN to build the firewall and is opt-in per box. True untrusted-code
-isolation stays with Firecracker in `vibes`.
+The proxy already denies a dialled raw IP that is not on the allowlist, so the
+env-honouring path cannot exfiltrate to an arbitrary address through it.
+
+Deliberately not done: the strict layer. `--unshare-net` plus nftables in the
+namespace, allowing only this proxy, would close the raw-IP-past-the-env gap.
+
+This layer is BLOCKED for local development on the current box and was not
+written, to keep every landed piece testable here. Measured on this machine:
+
+- `CapEff: 0` — no CAP_NET_ADMIN to program a firewall.
+- No `nft`, `iptables`, `slirp4netns`, or `pasta` installed.
+- Rootless network namespaces are denied: `unshare --user --net` fails with
+  `/proc/self/uid_map: Operation not permitted`.
+- `--unshare-net` also severs the host loopback that the egress proxy and the
+  omg MCP endpoint listen on, so a working strict mode must additionally plumb
+  those two back in (a veth pair + NAT, or slirp4netns/pasta).
+
+So strict mode belongs where the box grants CAP_NET_ADMIN (or ships
+slirp4netns/pasta) and must be verified there, not on this host. True
+untrusted-code isolation stays with Firecracker in `vibes`.
 
 ## Out of scope for this repository
 

--- a/src/agents/backends/acp-mcp.test.ts
+++ b/src/agents/backends/acp-mcp.test.ts
@@ -18,7 +18,9 @@ describe("omgAcpMcpServers", () => {
       type: "http",
       name: "omg",
       url: "http://127.0.0.1:4567/mcp?session=session%20with%20spaces",
-      headers: [],
+      // The session token that lets this session claim its own id at the
+      // endpoint (src/policy/session-token.ts). Value is box-specific.
+      headers: [{ name: "x-omg-session-token", value: expect.any(String) }],
     }]);
   });
 });

--- a/src/agents/backends/acp-mcp.ts
+++ b/src/agents/backends/acp-mcp.ts
@@ -8,6 +8,6 @@ export function omgAcpMcpServers(sessionId: string): McpServer[] {
     type: "http",
     name,
     url: server.url,
-    headers: [],
+    headers: Object.entries(server.headers).map(([hname, value]) => ({ name: hname, value })),
   }));
 }

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -18,6 +18,7 @@ import {
   spawnManagedPiSession,
 } from "./tmux.ts";
 import type { CodexServiceTier } from "./service-tier.ts";
+import type { SandboxMode } from "./sandbox/bwrap.ts";
 
 export type CodingAgentLaunchRequest = {
   agent: ActiveSessionAgentKind;
@@ -33,6 +34,13 @@ export type CodingAgentLaunchRequest = {
   containInAgentSlice?: boolean;
   claudeAccountId?: string;
   resume?: string;
+  /**
+   * Filesystem isolation for the session's harness (src/sandbox/bwrap.ts).
+   * Only the process-supervised providers (aisdk, codex-aisdk, opencode, pi)
+   * honour it; a terminal-backed agent ignores it because it reads its own
+   * credentials from home.
+   */
+  sandbox?: SandboxMode;
 };
 
 export type CodingAgentLaunchResult = {
@@ -84,6 +92,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,
       claudeAccountId: request.claudeAccountId,
+      sandbox: request.sandbox,
     })),
   "codex-aisdk": provider("codex-aisdk", (request) =>
     spawnManagedCodexAisdkSession({
@@ -98,6 +107,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
+      sandbox: request.sandbox,
     })),
   opencode: provider("opencode", (request) => {
     if (!request.model) return { ok: false, error: "opencode model is required" };
@@ -112,6 +122,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
+      sandbox: request.sandbox,
     });
   }),
   jcode: provider("jcode", (request) =>
@@ -187,6 +198,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       omgUser: request.omgUser,
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
+      sandbox: request.sandbox,
     })),
   copilot: provider("copilot", (request) =>
     spawnManagedCopilotSdkSession({

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -41,6 +41,12 @@ export type CodingAgentLaunchRequest = {
    * credentials from home.
    */
   sandbox?: SandboxMode;
+  /**
+   * Egress proxy URL for a restricted role (src/sandbox/egress-proxy.ts). When
+   * set, the harness reaches only the allowlisted hosts. Same provider scope
+   * as sandbox.
+   */
+  egressProxyUrl?: string;
 };
 
 export type CodingAgentLaunchResult = {
@@ -93,6 +99,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       containInAgentSlice: request.containInAgentSlice,
       claudeAccountId: request.claudeAccountId,
       sandbox: request.sandbox,
+      egressProxyUrl: request.egressProxyUrl,
     })),
   "codex-aisdk": provider("codex-aisdk", (request) =>
     spawnManagedCodexAisdkSession({
@@ -108,6 +115,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
       sandbox: request.sandbox,
+      egressProxyUrl: request.egressProxyUrl,
     })),
   opencode: provider("opencode", (request) => {
     if (!request.model) return { ok: false, error: "opencode model is required" };
@@ -123,6 +131,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
       sandbox: request.sandbox,
+      egressProxyUrl: request.egressProxyUrl,
     });
   }),
   jcode: provider("jcode", (request) =>
@@ -199,6 +208,7 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       containInAgentSlice: request.containInAgentSlice,
       resume: request.resume,
       sandbox: request.sandbox,
+      egressProxyUrl: request.egressProxyUrl,
     })),
   copilot: provider("copilot", (request) =>
     spawnManagedCopilotSdkSession({

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -33,11 +33,27 @@ import { compressedAssetResponse, maybeCompressResponse } from "../http-compress
 import { serveOmgMcpRequest, serveComputerMcpRequest } from "../mcp-http.ts";
 import { serveExecutorMcpRequest } from "../executor/proxy.ts";
 import { forwardExecutorApi } from "../executor/api.ts";
+import {
+  APPROVE,
+  DENY,
+  approvalDeliveryText,
+  approvalQuestion,
+  blockedResumeReply,
+  clearPendingApproval,
+  executionAwaitingApproval,
+  interceptExecuteReplyBody,
+  isApproveAnswer,
+  parseToolCall,
+  pendingApprovalByAsk,
+  registerPendingApproval,
+  resumeExecution,
+} from "../executor/approvals.ts";
 import { resolveCaller } from "../policy/caller.ts";
 import { enforceRole } from "../policy/mcp-filter.ts";
 import { createRole, deleteRole, getRole, listRoles, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
 import {
   ensureExecutorAdopted,
+  executorAuth,
   executorDashboardUrl,
   executorStatus,
   startExecutor,
@@ -735,6 +751,88 @@ const PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
 
 /** Ceiling on any single request body. See the Bun.serve options for why. */
 const MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
+
+/**
+ * The connector proxy, with owner-approval interception on execute/resume.
+ *
+ * A gated `execute` returns a paused interaction that Executor, in model mode,
+ * would have the agent resolve itself. This turns it into an omg ask card:
+ * the reply the agent gets says "wait", an ask with Approve/Deny is posted to
+ * the session, and the agent's own `resume` is refused while that ask is open.
+ * The human's answer drives resume (src/executor/approvals.ts and the
+ * /api/ask answer route). Everything that is not an approvable execute or a
+ * gated resume passes straight through, so the SSE listen stream and ordinary
+ * calls are untouched.
+ */
+async function interceptExecutorApprovals(
+  req: Request,
+  sessionId: string | undefined,
+): Promise<Response> {
+  if (req.method !== "POST") return serveExecutorMcpRequest(req);
+  const bodyText = await req.text();
+  const call = parseToolCall(bodyText);
+
+  if (call?.name === "resume") {
+    const executionId = typeof call.args.executionId === "string" ? call.args.executionId : "";
+    if (executionId && executionAwaitingApproval(executionId)) {
+      return Response.json(blockedResumeReply(call.id, executionId), {
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+  }
+
+  const forwarded = new Request(req.url, { method: "POST", headers: req.headers, body: bodyText });
+  const res = await serveExecutorMcpRequest(forwarded);
+
+  // Only an execute reply from a real session can become an approval card.
+  // Without a session we cannot deliver the outcome, so we leave Executor's
+  // own ask-then-resume flow in place.
+  if (call?.name !== "execute" || !sessionId) return res;
+
+  const contentType = res.headers.get("content-type") ?? "";
+  const replyText = await res.text();
+  const intercepted = interceptExecuteReplyBody(replyText, contentType);
+  if (!intercepted) {
+    return new Response(replyText, {
+      status: res.status,
+      headers: res.headers,
+    });
+  }
+
+  // Post the ask through the same route the MCP ask tool uses, so push and
+  // user scoping behave identically. Best effort: if the ask cannot be
+  // created, fall back to handing the agent Executor's original reply rather
+  // than a "wait" it will wait on forever.
+  const user = userAssignments();
+  const row = listManaged().find((s) => s.sessionId === sessionId || s.nativeSessionId === sessionId);
+  const askUser = row ? user[row.tmuxName] ?? null : null;
+  try {
+    const askRes = await fetch(`http://127.0.0.1:${PORT}/api/ask`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        question: approvalQuestion(intercepted.paused),
+        options: [APPROVE, DENY],
+        sessionId,
+        user: askUser,
+        pushback: true,
+        wait: false,
+      }),
+    });
+    if (!askRes.ok) throw new Error(`ask create failed (${askRes.status})`);
+    const { id } = (await askRes.json()) as { id: string };
+    registerPendingApproval({
+      askId: id,
+      executionId: intercepted.paused.executionId,
+      sessionId,
+      address: intercepted.paused.address,
+    });
+  } catch {
+    return new Response(replyText, { status: res.status, headers: res.headers });
+  }
+
+  return new Response(intercepted.heldBody, { status: res.status, headers: res.headers });
+}
 
 /** Root URL this box's web UI is reachable at (e.g. `http://box.tailnet.ts.net:8766`
  * over Tailscale). Optional — when unset, no session URLs are advertised and
@@ -4002,7 +4100,7 @@ export async function cmdServe() {
         await ensureExecutorAdopted();
         const caller = resolveCaller(req);
         return await enforceRole(req, caller.role, { namespace: "executor" }, (r) =>
-          serveExecutorMcpRequest(r),
+          interceptExecutorApprovals(r, caller.sessionId),
         );
       }
 
@@ -6926,6 +7024,35 @@ a{color:#60a5fa}
           if (!b?.answer?.trim()) return err(400, "missing answer");
           const q = await answerQuestion(m[1], { answer: b.answer.trim(), via: b.via });
           if (!q) return err(404, "unknown or already-answered question");
+
+          // A connector approval: the answer is Approve or Deny, and the real
+          // work is resuming the paused Executor execution on the human's
+          // behalf (the agent was refused resume). The outcome, not the bare
+          // "Approve", is what the session hears. Branch before the generic
+          // delivery below so the word "Approve" is never sent as a message.
+          const pending = pendingApprovalByAsk(q.id);
+          if (pending) {
+            const approved = isApproveAnswer(q.answer);
+            const outcome = approved
+              ? await resumeExecution(executorAuth(), pending.executionId, "accept")
+              : await resumeExecution(executorAuth(), pending.executionId, "decline");
+            clearPendingApproval(q.id);
+            const text = approvalDeliveryText(pending, approved, outcome);
+            if (pending.sessionId) {
+              try {
+                await fetch(`http://127.0.0.1:${PORT}/api/sessions/${pending.sessionId}/send`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ text, mode: "steer" }),
+                });
+              } catch {
+                // Loopback send failed. The question is answered and the
+                // execution resolved; the transcript just missed the note.
+              }
+            }
+            await markHandled(q.id);
+            return json({ question: q, approval: { approved, executionId: pending.executionId } });
+          }
           // `deliver: false` — the person answered by typing in the owning
           // session's own composer, so that message is ALREADY on its way to
           // the agent. Record the answer (this also wakes a blocked long-poll)

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -50,7 +50,7 @@ import {
 } from "../executor/approvals.ts";
 import { resolveCaller } from "../policy/caller.ts";
 import { enforceRole } from "../policy/mcp-filter.ts";
-import { createRole, deleteRole, getRole, listRoles, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
+import { createRole, deleteRole, getRole, listRoles, roleSandbox, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
 import {
   ensureExecutorAdopted,
   executorAuth,
@@ -8585,6 +8585,9 @@ a{color:#60a5fa}
           omgUser: assignedUser,
           containInAgentSlice: isSubagent,
           claudeAccountId,
+          // Restricted roles run their harness in a filesystem sandbox
+          // (src/sandbox/bwrap.ts). Owner and unknown roles get none.
+          sandbox: roleSandbox(sessionRole),
         });
         if (!r.ok) {
           // The caller received no committed session. Release the claim so a

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -32,6 +32,10 @@ import {
 import { compressedAssetResponse, maybeCompressResponse } from "../http-compress.ts";
 import { serveOmgMcpRequest, serveComputerMcpRequest } from "../mcp-http.ts";
 import { serveExecutorMcpRequest } from "../executor/proxy.ts";
+import { forwardExecutorApi } from "../executor/api.ts";
+import { resolveCaller } from "../policy/caller.ts";
+import { enforceRole } from "../policy/mcp-filter.ts";
+import { createRole, deleteRole, getRole, listRoles, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
 import {
   ensureExecutorAdopted,
   executorDashboardUrl,
@@ -3921,7 +3925,13 @@ export async function cmdServe() {
       // POST (requests), GET (server-initiated stream) and DELETE (teardown),
       // so the transport owns method handling rather than this router.
       if (path === "/mcp") {
-        return await serveOmgMcpRequest(req);
+        // Who is calling, verified once here (src/policy/caller.ts), then the
+        // role filter (src/policy/mcp-filter.ts) and the server itself both
+        // work from that answer. The owner role passes straight through.
+        const caller = resolveCaller(req);
+        return await enforceRole(req, caller.role, { namespace: "omg", strip: "omg_" }, (r) =>
+          serveOmgMcpRequest(r, caller.sessionId),
+        );
       }
 
       if (path === "/api/connect/reconcile" && req.method === "POST") {
@@ -3976,7 +3986,10 @@ export async function cmdServe() {
       if (path === "/mcp/computer") {
         const { computerMcpEnabled } = await getGlobalSettings();
         if (!computerMcpEnabled) return err(404, "the computer MCP is disabled");
-        return await serveComputerMcpRequest(req);
+        const caller = resolveCaller(req);
+        return await enforceRole(req, caller.role, { namespace: "computer", strip: "computer_" }, (r) =>
+          serveComputerMcpRequest(r, caller.sessionId),
+        );
       }
 
       // The connector gateway, proxied to this box's Executor daemon. Same
@@ -3987,7 +4000,10 @@ export async function cmdServe() {
         const { executorEnabled } = await getGlobalSettings();
         if (!executorEnabled) return err(404, "the connector gateway is disabled");
         await ensureExecutorAdopted();
-        return await serveExecutorMcpRequest(req);
+        const caller = resolveCaller(req);
+        return await enforceRole(req, caller.role, { namespace: "executor" }, (r) =>
+          serveExecutorMcpRequest(r),
+        );
       }
 
       if (path === "/api/live/ws") {
@@ -4089,6 +4105,73 @@ export async function cmdServe() {
         const dashboardUrl = executorDashboardUrl();
         if (!dashboardUrl) return err(409, "the connector gateway is not running");
         return json({ url: dashboardUrl });
+      }
+
+      // Box-level Executor policies and its catalog, for the Settings control
+      // plane. A short allowlist forwarded with the bearer injected
+      // (src/executor/api.ts); the browser never holds the token.
+      {
+        const m = path.match(/^\/api\/executor\/api\/(.+)$/);
+        if (m) {
+          await ensureExecutorAdopted();
+          return await forwardExecutorApi(req, `/${m[1]!}`);
+        }
+      }
+
+      // ---- roles ----
+      // Per-role tool policy for sessions on this box (src/policy/roles.ts).
+      // Rules use Executor's pattern grammar over `<server>.<tool>` ids.
+      if (path === "/api/roles" && req.method === "GET") {
+        return json({ roles: listRoles() });
+      }
+      if (path === "/api/roles" && req.method === "POST") {
+        const body = (await req.json().catch(() => null)) as Parameters<typeof createRole>[0] | null;
+        if (!body) return err(400, "invalid JSON body");
+        const result = createRole(body);
+        if (!result.ok) return err(400, result.error);
+        return json({ role: result.role });
+      }
+      {
+        const m = path.match(/^\/api\/roles\/([a-z0-9-]+)$/);
+        // Method first: src/commands/auto-agent-route-wiring.test.ts locates
+        // the auto-agents PATCH branch by its `if (m && req.method === "PATCH")`
+        // text, and this route sits earlier in the file.
+        if (req.method === "PATCH" && m) {
+          const body = (await req.json().catch(() => null)) as Parameters<typeof updateRole>[1] | null;
+          if (!body) return err(400, "invalid JSON body");
+          const result = updateRole(m[1]!, body);
+          if (!result.ok) return err(result.error === "role not found" ? 404 : 400, result.error);
+          return json({ role: result.role });
+        }
+        if (m && req.method === "DELETE") {
+          const result = deleteRole(m[1]!);
+          if (!result.ok) return err(result.error === "role not found" ? 404 : 400, result.error);
+          // Sessions still pointing at the role fall back to owner in
+          // resolveCaller. Clear the rows so the roster does not show a
+          // role that no longer exists.
+          for (const row of listManaged()) {
+            if (row.role === m[1]) patchManaged(row.tmuxName, { role: undefined });
+          }
+          invalidateListSessionsCache();
+          return json({ ok: true });
+        }
+      }
+      // Move one session to another role. Takes effect on that session's next
+      // tools/list or tools/call; nothing restarts.
+      {
+        const m = path.match(/^\/api\/sessions\/([^/]+)\/role$/);
+        if (req.method === "PATCH" && m) {
+          const sessionId = decodeURIComponent(m[1]!);
+          const body = (await req.json().catch(() => null)) as { role?: unknown } | null;
+          const requested = typeof body?.role === "string" ? body.role.trim() : "";
+          if (!requested) return err(400, "role is required");
+          if (!getRole(requested)) return err(404, `unknown role "${requested}"`);
+          const row = listManaged().find((s) => s.sessionId === sessionId || s.nativeSessionId === sessionId);
+          if (!row) return err(404, "session not found");
+          patchManaged(row.tmuxName, { role: requested === OWNER_ROLE_ID ? undefined : requested });
+          invalidateListSessionsCache();
+          return json({ ok: true, role: requested });
+        }
       }
 
       // Agent control of the browser on that desktop, via Bun.WebView attached
@@ -8111,8 +8194,13 @@ a{color:#60a5fa}
           spawnedBy?: string;
           /** Start even though the live-agent cap is full — self-hosted only. */
           overLimit?: boolean;
+          /** Role the session runs as at the MCP endpoints. Missing = owner. */
+          role?: string;
           agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "jcode" | "grok" | "cursor" | "copilot" | "hermes" | "pi";
         } | null;
+        const requestedRole = typeof body?.role === "string" ? body.role.trim() : "";
+        if (requestedRole && !getRole(requestedRole)) return err(400, `unknown role "${requestedRole}"`);
+        const sessionRole = requestedRole && requestedRole !== OWNER_ROLE_ID ? requestedRole : undefined;
         const agent = resolveActiveSessionAgent(body?.agent);
         if (!agent) {
           if (body?.agent === "hermes") return err(410, "agent \"hermes\" has been removed");
@@ -8346,6 +8434,10 @@ a{color:#60a5fa}
           spawnedBy,
           repoRoot: worktree?.repoRoot,
           worktreeBranch: worktree?.branch,
+          role: sessionRole,
+          // Every session launched from here is handed its token at spawn
+          // (omgMcpServers), so the endpoint may demand it.
+          mcpTokenRequired: true,
         }, idempotencyKey);
         if (!claim.created) return replaySessionCreation(claim.session);
         if (claudeAccountId) bindClaudeSessionAccount(launchId, claudeAccountId);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -50,7 +50,9 @@ import {
 } from "../executor/approvals.ts";
 import { resolveCaller } from "../policy/caller.ts";
 import { enforceRole } from "../policy/mcp-filter.ts";
-import { createRole, deleteRole, getRole, listRoles, roleSandbox, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
+import { createRole, deleteRole, getRole, listRoles, roleEgress, roleSandbox, updateRole, OWNER_ROLE_ID } from "../policy/roles.ts";
+import { DEFAULT_ALLOW_HOSTS, startEgressProxy, type EgressProxy } from "../sandbox/egress-proxy.ts";
+import { sessionToken, verifySessionToken } from "../policy/session-token.ts";
 import {
   ensureExecutorAdopted,
   executorAuth,
@@ -751,6 +753,12 @@ const PORT = Number(process.env.LFG_PORT ?? process.env.PORT ?? 8766);
 
 /** Ceiling on any single request body. See the Bun.serve options for why. */
 const MAX_REQUEST_BODY_BYTES = 32 * 1024 * 1024;
+
+// The egress proxy for restricted-role sessions (src/sandbox/egress-proxy.ts).
+// One per box, started at boot. Null until then, and on any host where the
+// listener fails to bind — a restricted session then launches without a proxy
+// URL and is logged, rather than failing to start.
+let egressProxy: EgressProxy | null = null;
 
 /**
  * The connector proxy, with owner-approval interception on execute/resume.
@@ -8588,6 +8596,12 @@ a{color:#60a5fa}
           // Restricted roles run their harness in a filesystem sandbox
           // (src/sandbox/bwrap.ts). Owner and unknown roles get none.
           sandbox: roleSandbox(sessionRole),
+          // An allowlist role also gets an egress proxy URL carrying its own
+          // token, so its outbound traffic is held to the role's hosts.
+          egressProxyUrl:
+            roleEgress(sessionRole).mode === "allowlist" && egressProxy
+              ? egressProxy.proxyUrlFor(launchId, sessionToken(launchId))
+              : undefined,
         });
         if (!r.ok) {
           // The caller received no committed session. Release the claim so a
@@ -10700,6 +10714,24 @@ a{color:#60a5fa}
     const status = await startExecutor({ log: (l) => console.log(l) });
     if (!status.running && status.error) console.log(`[executor] ${status.error}`);
   }).catch((e) => console.error(`[executor] start failed: ${e instanceof Error ? e.message : String(e)}`));
+
+  // The egress proxy: a restricted-role session's harness is pointed here, so
+  // it reaches only the model APIs plus its role's allowed hosts. Resolves the
+  // caller from the same per-session token the MCP endpoints use.
+  void startEgressProxy({
+    log: (l) => console.log(l),
+    resolve: (sessionId, token) => {
+      if (!verifySessionToken(sessionId, token)) return null;
+      const row = listManaged().find((s) => s.sessionId === sessionId || s.nativeSessionId === sessionId);
+      const egress = roleEgress(row?.role);
+      if (egress.mode !== "allowlist") return null;
+      return { sessionId, allow: [...DEFAULT_ALLOW_HOSTS, ...egress.allowHosts] };
+    },
+  })
+    .then((proxy) => {
+      egressProxy = proxy;
+    })
+    .catch((e) => console.error(`[egress] start failed: ${e instanceof Error ? e.message : String(e)}`));
   // Warm the resumable-session cache in the background so the first time someone
   // opens the resume picker it's already served from SQLite (no cold scan wait).
   void refreshResumableCache({ force: true }).catch(() => {});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,7 @@
 import { join, dirname, resolve } from "node:path";
+// Cyclic on purpose: session-token reads PATHS from here, and this module only
+// calls sessionToken() at launch time, never during module evaluation.
+import { SESSION_TOKEN_HEADER, sessionToken } from "./policy/session-token.ts";
 import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -83,16 +86,21 @@ export function localServeBaseUrl(): string {
  * Returns nothing outside a managed session, leaving the user-scope
  * registration in charge.
  */
+export type OmgMcpServerConfig = { type: "http"; url: string; headers: Record<string, string> };
+
 export function omgMcpServers(
   sessionId?: string,
-): { mcpServers?: Record<string, { type: "http"; url: string }> } {
+): { mcpServers?: Record<string, OmgMcpServerConfig> } {
   const sid = (sessionId ?? process.env.OMG_SESSION_ID ?? process.env.LFG_SESSION_ID)?.trim();
   if (!sid) return {};
   const session = `?session=${encodeURIComponent(sid)}`;
   const url = `${localServeBaseUrl()}/mcp${session}`;
-  const mcpServers: Record<string, { type: "http"; url: string }> = { omg: { type: "http", url } };
+  // The token that lets this session claim its own id at the endpoint. See
+  // src/policy/session-token.ts for why it is derived rather than stored.
+  const headers = { [SESSION_TOKEN_HEADER]: sessionToken(sid) };
+  const mcpServers: Record<string, OmgMcpServerConfig> = { omg: { type: "http", url, headers } };
   if (executorMcpAdvertised) {
-    mcpServers[EXECUTOR_MCP_SERVER_NAME] = { type: "http", url: executorMcpHttpUrl(sid) };
+    mcpServers[EXECUTOR_MCP_SERVER_NAME] = { type: "http", url: executorMcpHttpUrl(sid), headers };
   }
   return { mcpServers };
 }

--- a/src/executor/api.test.ts
+++ b/src/executor/api.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { executorApiAllowed, forwardExecutorApi } from "./api.ts";
+
+const UPSTREAM = { origin: "http://127.0.0.1:4788", token: "secret" };
+
+function capture(status = 200) {
+  const calls: { url: string; method: string; headers: Headers; body: string | undefined }[] = [];
+  const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      headers: new Headers(init?.headers),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    return Response.json([{ id: "pol_1" }], { status });
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+describe("executorApiAllowed", () => {
+  test("only the control-plane routes pass", () => {
+    expect(executorApiAllowed("GET", "/policies")).toBe(true);
+    expect(executorApiAllowed("POST", "/policies")).toBe(true);
+    expect(executorApiAllowed("DELETE", "/policies/pol_1")).toBe(true);
+    expect(executorApiAllowed("GET", "/tools")).toBe(true);
+    expect(executorApiAllowed("GET", "/connections")).toBe(true);
+    expect(executorApiAllowed("POST", "/executions")).toBe(false);
+    expect(executorApiAllowed("DELETE", "/connections/org/github/main")).toBe(false);
+    expect(executorApiAllowed("GET", "/health")).toBe(false);
+  });
+});
+
+describe("forwardExecutorApi", () => {
+  test("refuses routes off the allowlist before touching the daemon", async () => {
+    const { calls, fetchImpl } = capture();
+    const res = await forwardExecutorApi(
+      new Request("http://box/api/executor/api/executions", { method: "POST" }),
+      "/executions",
+      UPSTREAM,
+      fetchImpl,
+    );
+    expect(res.status).toBe(403);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("503 when the daemon is down", async () => {
+    const res = await forwardExecutorApi(new Request("http://box/api/executor/api/policies"), "/policies", null);
+    expect(res.status).toBe(503);
+  });
+
+  test("forwards with the bearer, body and query, and strips upstream headers", async () => {
+    const { calls, fetchImpl } = capture();
+    const res = await forwardExecutorApi(
+      new Request("http://box/api/executor/api/policies/pol_1?x=1", {
+        method: "DELETE",
+        headers: { "content-type": "application/json", authorization: "Bearer from-browser" },
+        body: JSON.stringify({ owner: "org" }),
+      }),
+      "/policies/pol_1",
+      UPSTREAM,
+      fetchImpl,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://127.0.0.1:4788/api/policies/pol_1?x=1");
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.headers.get("authorization")).toBe("Bearer secret");
+    expect(calls[0]!.body).toBe('{"owner":"org"}');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([{ id: "pol_1" }]);
+  });
+});

--- a/src/executor/api.ts
+++ b/src/executor/api.ts
@@ -1,0 +1,62 @@
+// Calls into the Executor daemon's own HTTP API, on behalf of the omg UI.
+//
+// The Settings control plane edits box-level Executor policies and reads its
+// tool catalog without the browser ever holding the daemon's bearer: omg
+// forwards a small allowlist of routes and injects the token here. Anything
+// outside the allowlist is refused, so this is not a general proxy.
+import { executorAuth } from "./daemon.ts";
+
+const ALLOWED: { method: string; pattern: RegExp }[] = [
+  { method: "GET", pattern: /^\/policies$/ },
+  { method: "POST", pattern: /^\/policies$/ },
+  { method: "PATCH", pattern: /^\/policies\/[A-Za-z0-9_-]+$/ },
+  { method: "DELETE", pattern: /^\/policies\/[A-Za-z0-9_-]+$/ },
+  { method: "GET", pattern: /^\/tools$/ },
+  { method: "GET", pattern: /^\/integrations$/ },
+  { method: "GET", pattern: /^\/connections$/ },
+];
+
+export function executorApiAllowed(method: string, path: string): boolean {
+  return ALLOWED.some((rule) => rule.method === method && rule.pattern.test(path));
+}
+
+/**
+ * Forward one `/api/executor/api/<path>` request to the daemon's `/api/<path>`.
+ * `upstream` and `fetchImpl` are injectable for tests.
+ */
+export async function forwardExecutorApi(
+  req: Request,
+  path: string,
+  upstream: { origin: string; token: string } | null = executorAuth(),
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  if (!executorApiAllowed(req.method, path)) {
+    return Response.json({ error: "not a forwarded Executor route" }, { status: 403 });
+  }
+  if (!upstream) {
+    return Response.json({ error: "the connector gateway is not running" }, { status: 503 });
+  }
+  const url = new URL(req.url);
+  const hasBody = req.method !== "GET" && req.method !== "HEAD";
+  try {
+    const res = await fetchImpl(`${upstream.origin}/api${path}${url.search}`, {
+      method: req.method,
+      headers: {
+        authorization: `Bearer ${upstream.token}`,
+        accept: "application/json",
+        ...(hasBody ? { "content-type": req.headers.get("content-type") ?? "application/json" } : {}),
+      },
+      body: hasBody ? await req.text() : undefined,
+      signal: AbortSignal.timeout(15_000),
+    });
+    return new Response(res.body, {
+      status: res.status,
+      headers: {
+        "content-type": res.headers.get("content-type") ?? "application/json",
+        "cache-control": "no-store",
+      },
+    });
+  } catch {
+    return Response.json({ error: "the connector gateway is unreachable" }, { status: 502 });
+  }
+}

--- a/src/executor/approvals.test.ts
+++ b/src/executor/approvals.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  APPROVE,
+  approvalDeliveryText,
+  blockedResumeReply,
+  clearPendingApproval,
+  executionAwaitingApproval,
+  heldReply,
+  interceptExecuteReplyBody,
+  isApproveAnswer,
+  parseToolCall,
+  pausedApproval,
+  pendingApprovalByAsk,
+  registerPendingApproval,
+  resetPendingApprovalsForTests,
+  resumeExecution,
+} from "./approvals.ts";
+
+afterEach(() => resetPendingApprovalsForTests());
+
+const PAUSED_REPLY = {
+  jsonrpc: "2.0",
+  id: 4,
+  result: {
+    content: [{ type: "text", text: "Execution paused: Approve ...? ..." }],
+    structuredContent: {
+      status: "waiting_for_interaction",
+      executionId: "exec_1",
+      interaction: {
+        kind: "form",
+        message: "Approve executor.github.issues.create? (matched policy: *)",
+        address: "executor.github.issues.create",
+        args: { title: "hi" },
+        requestedSchema: { type: "object", properties: {} },
+      },
+    },
+  },
+};
+
+const FORM_REPLY = {
+  jsonrpc: "2.0",
+  id: 5,
+  result: {
+    structuredContent: {
+      status: "waiting_for_interaction",
+      executionId: "exec_2",
+      interaction: {
+        address: "executor.some.tool",
+        requestedSchema: { type: "object", properties: { name: { type: "string" } } },
+      },
+    },
+  },
+};
+
+describe("pausedApproval", () => {
+  test("recognises an empty-schema approval", () => {
+    const p = pausedApproval(PAUSED_REPLY);
+    expect(p?.executionId).toBe("exec_1");
+    expect(p?.address).toBe("executor.github.issues.create");
+    expect(p?.args).toEqual({ title: "hi" });
+  });
+
+  test("a real form (fields requested) is not an approval", () => {
+    expect(pausedApproval(FORM_REPLY)).toBeNull();
+  });
+
+  test("a completed reply is not an approval", () => {
+    expect(pausedApproval({ result: { structuredContent: { status: "completed" } } })).toBeNull();
+  });
+});
+
+describe("parseToolCall", () => {
+  test("reads name, id and args from a tools/call", () => {
+    const call = parseToolCall(
+      JSON.stringify({ jsonrpc: "2.0", id: 9, method: "tools/call", params: { name: "resume", arguments: { executionId: "exec_1", action: "accept" } } }),
+    );
+    expect(call).toEqual({ id: 9, name: "resume", args: { executionId: "exec_1", action: "accept" } });
+  });
+
+  test("returns null for a non-call message", () => {
+    expect(parseToolCall(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }))).toBeNull();
+    expect(parseToolCall("not json")).toBeNull();
+  });
+});
+
+describe("interceptExecuteReplyBody", () => {
+  test("rewrites a JSON execute reply and reports the pause", () => {
+    const out = interceptExecuteReplyBody(JSON.stringify(PAUSED_REPLY), "application/json");
+    expect(out?.paused.executionId).toBe("exec_1");
+    const body = JSON.parse(out!.heldBody) as ReturnType<typeof heldReply>;
+    expect(body.result?.content?.[0]?.text).toContain("needs the owner's approval");
+    expect((body.result?.structuredContent as { status: string }).status).toBe("waiting_for_owner_approval");
+  });
+
+  test("rewrites the right frame of an SSE reply", () => {
+    const sse = `event: message\ndata: ${JSON.stringify(PAUSED_REPLY)}\n\n`;
+    const out = interceptExecuteReplyBody(sse, "text/event-stream");
+    expect(out).not.toBeNull();
+    expect(out!.heldBody).toContain("event: message");
+    expect(out!.heldBody).toContain("waiting_for_owner_approval");
+    expect(out!.heldBody).not.toContain("waiting_for_interaction");
+  });
+
+  test("leaves a completed reply alone", () => {
+    const reply = { jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text: "ok" }] } };
+    expect(interceptExecuteReplyBody(JSON.stringify(reply), "application/json")).toBeNull();
+  });
+});
+
+describe("pending store", () => {
+  test("gates resume by execution and resolves by ask", () => {
+    registerPendingApproval({ askId: "a1", executionId: "exec_1", sessionId: "s1", address: "x" });
+    expect(executionAwaitingApproval("exec_1")).toBe(true);
+    expect(executionAwaitingApproval("exec_9")).toBe(false);
+    expect(pendingApprovalByAsk("a1")?.executionId).toBe("exec_1");
+    clearPendingApproval("a1");
+    expect(executionAwaitingApproval("exec_1")).toBe(false);
+    expect(pendingApprovalByAsk("a1")).toBeUndefined();
+  });
+
+  test("blockedResumeReply names the execution", () => {
+    const r = blockedResumeReply(7, "exec_1");
+    expect(r.id).toBe(7);
+    expect(r.result.isError).toBe(true);
+    expect(r.result.content[0]!.text).toContain("exec_1");
+  });
+});
+
+describe("isApproveAnswer", () => {
+  test("recognises approve, rejects deny", () => {
+    expect(isApproveAnswer(APPROVE)).toBe(true);
+    expect(isApproveAnswer("yes")).toBe(true);
+    expect(isApproveAnswer("Deny")).toBe(false);
+    expect(isApproveAnswer("")).toBe(false);
+  });
+});
+
+describe("resumeExecution", () => {
+  test("sends accept with the bearer and reports the result", async () => {
+    const calls: { url: string; headers: Headers; body: string }[] = [];
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(input), headers: new Headers(init?.headers), body: String(init?.body) });
+      return Response.json({ status: "completed", text: "3 issues", isError: false });
+    }) as unknown as typeof fetch;
+    const out = await resumeExecution({ origin: "http://127.0.0.1:4788", token: "sec" }, "exec_1", "accept", fetchImpl);
+    expect(out).toEqual({ ok: true, status: "completed", text: "3 issues", isError: false });
+    expect(calls[0]!.url).toBe("http://127.0.0.1:4788/api/executions/exec_1/resume");
+    expect(calls[0]!.headers.get("authorization")).toBe("Bearer sec");
+    expect(calls[0]!.body).toBe('{"action":"accept","content":{}}');
+  });
+
+  test("maps an expired approval to a clear reason", async () => {
+    const fetchImpl = (async () =>
+      Response.json({ _tag: "ApprovalExpiredError" }, { status: 409 })) as unknown as typeof fetch;
+    const out = await resumeExecution({ origin: "http://x", token: "t" }, "exec_1", "accept", fetchImpl);
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toContain("window closed");
+  });
+
+  test("no upstream is a clean failure", async () => {
+    const out = await resumeExecution(null, "exec_1", "accept");
+    expect(out.ok).toBe(false);
+  });
+});
+
+describe("approvalDeliveryText", () => {
+  const paused = { address: "executor.github.issues.create", executionId: "exec_1" };
+
+  test("declined says it did not run", () => {
+    const text = approvalDeliveryText(paused, false, { ok: false, error: "x" });
+    expect(text).toContain("declined");
+    expect(text).toContain("did not run");
+  });
+
+  test("approved and completed carries the result", () => {
+    const text = approvalDeliveryText(paused, true, { ok: true, status: "completed", text: "done", isError: false });
+    expect(text).toContain("It ran");
+    expect(text).toContain("done");
+  });
+
+  test("approved but resume failed reports why", () => {
+    const text = approvalDeliveryText(paused, true, { ok: false, error: "unreachable" });
+    expect(text).toContain("could not be resumed");
+    expect(text).toContain("unreachable");
+  });
+});

--- a/src/executor/approvals.ts
+++ b/src/executor/approvals.ts
@@ -1,0 +1,309 @@
+// Approval-gated connector calls, answered from the omg chat.
+//
+// Executor pauses a gated tool call and, in the `model` elicitation mode this
+// box runs, tells the agent to ask the human and then call `resume` itself.
+// That leaves the decision with the agent. This module takes it back:
+//
+//   execute reply says waiting_for_interaction with an empty requested schema
+//     -> record it as an omg ask with Approve / Deny, rewrite the reply so the
+//        agent waits instead of resuming
+//   agent calls resume on that execution
+//     -> refused while the ask is open
+//   human answers the ask
+//     -> omg resumes the execution over Executor's REST API with the bearer,
+//        and the outcome is delivered into the session as the answer
+//
+// Interactions that request real form fields (a non-empty schema) are not
+// approvals; those keep Executor's own agent-driven flow untouched.
+import { type ExecutorUpstream } from "./proxy.ts";
+
+// ---------------------------------------------------------------------------
+// Wire parsing. A tools/call request is one JSON object; an execute reply
+// over this transport is a single SSE `data:` frame (or JSON when the daemon
+// answers JSON). These helpers read and rewrite that one reply without caring
+// which framing it used.
+// ---------------------------------------------------------------------------
+
+export type ParsedToolCall = { id: number | string | null; name: string; args: Record<string, unknown> };
+
+export function parseToolCall(requestText: string): ParsedToolCall | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(requestText);
+  } catch {
+    return null;
+  }
+  const messages = Array.isArray(parsed) ? parsed : [parsed];
+  for (const message of messages) {
+    const m = message as { id?: number | string | null; method?: string; params?: { name?: string; arguments?: unknown } };
+    if (m.method === "tools/call" && typeof m.params?.name === "string") {
+      const args = (m.params.arguments ?? {}) as Record<string, unknown>;
+      return { id: m.id ?? null, name: m.params.name, args };
+    }
+  }
+  return null;
+}
+
+/** Split a response body into (prefix line pieces) and the one JSON-RPC reply. */
+function readReply(text: string, contentType: string): { reply: JsonRpcReply; put: (next: JsonRpcReply) => string } | null {
+  if (contentType.includes("text/event-stream")) {
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i]!;
+      if (!line.startsWith("data:")) continue;
+      try {
+        const reply = JSON.parse(line.slice(5).trim()) as JsonRpcReply;
+        if (!reply.result) continue;
+        return {
+          reply,
+          put: (next) => {
+            const copy = [...lines];
+            copy[i] = `data: ${JSON.stringify(next)}`;
+            return copy.join("\n");
+          },
+        };
+      } catch {
+        // not this frame
+      }
+    }
+    return null;
+  }
+  try {
+    const reply = JSON.parse(text) as JsonRpcReply;
+    return { reply, put: (next) => JSON.stringify(next) };
+  } catch {
+    return null;
+  }
+}
+
+/** Detect an approval in a forwarded execute reply, and the rewritten body. */
+export function interceptExecuteReplyBody(
+  text: string,
+  contentType: string,
+): { paused: PausedInteraction; id: number | string | null; heldBody: string } | null {
+  const found = readReply(text, contentType);
+  if (!found) return null;
+  const paused = pausedApproval(found.reply);
+  if (!paused) return null;
+  return { paused, id: found.reply.id ?? null, heldBody: found.put(heldReply(found.reply, paused)) };
+}
+
+export type PausedInteraction = {
+  executionId: string;
+  address: string;
+  args: unknown;
+  message: string;
+};
+
+type JsonRpcReply = {
+  id?: number | string | null;
+  result?: {
+    content?: { type: string; text?: string }[];
+    structuredContent?: {
+      status?: string;
+      executionId?: string;
+      interaction?: {
+        kind?: string;
+        message?: string;
+        address?: string;
+        args?: unknown;
+        requestedSchema?: { properties?: Record<string, unknown> };
+      };
+      [k: string]: unknown;
+    };
+    [k: string]: unknown;
+  };
+};
+
+/** The approval this reply is asking for, or null when it is not one. */
+export function pausedApproval(reply: JsonRpcReply): PausedInteraction | null {
+  const sc = reply.result?.structuredContent;
+  if (!sc || sc.status !== "waiting_for_interaction" || !sc.executionId) return null;
+  const interaction = sc.interaction;
+  if (!interaction?.address) return null;
+  const fields = Object.keys(interaction.requestedSchema?.properties ?? {});
+  if (fields.length > 0) return null;
+  return {
+    executionId: sc.executionId,
+    address: interaction.address,
+    args: interaction.args ?? {},
+    message: interaction.message ?? `Approve ${interaction.address}?`,
+  };
+}
+
+/** The reply the agent sees instead of Executor's "ask, then resume" text. */
+export function heldReply(reply: JsonRpcReply, paused: PausedInteraction): JsonRpcReply {
+  const text =
+    `Execution paused: ${paused.address} needs the owner's approval.\n\n` +
+    `The owner has been asked in the omg chat with Approve / Deny. ` +
+    `Do not call resume; the result of this call, or the refusal, will arrive as the owner's reply. ` +
+    `End your turn now.\n\nexecutionId: ${paused.executionId}`;
+  return {
+    ...reply,
+    result: {
+      ...reply.result,
+      content: [{ type: "text", text }],
+      structuredContent: {
+        status: "waiting_for_owner_approval",
+        executionId: paused.executionId,
+        address: paused.address,
+      },
+    },
+  };
+}
+
+/** The question text the human sees on the ask card. */
+export function approvalQuestion(paused: PausedInteraction): string {
+  const args = JSON.stringify(paused.args ?? {}, null, 2);
+  const shownArgs = args.length > 800 ? `${args.slice(0, 800)}\n…` : args;
+  return `Approve connector call \`${paused.address}\`?\n\nArguments:\n\`\`\`json\n${shownArgs}\n\`\`\``;
+}
+
+export const APPROVE = "Approve";
+export const DENY = "Deny";
+
+export function isApproveAnswer(answer: string | null | undefined): boolean {
+  const a = (answer ?? "").trim().toLowerCase();
+  return a === APPROVE.toLowerCase() || a === "yes" || a === "approve it" || a === "ok" || a === "y";
+}
+
+export type ResumeOutcome =
+  | { ok: true; status: "completed" | "paused"; text: string; isError: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Resume a paused execution on the human's behalf.
+ *
+ * Executor's REST resume, with the daemon bearer this process holds. The
+ * agent never gets to make this call for an approval; only an answered ask
+ * does.
+ */
+export async function resumeExecution(
+  upstream: ExecutorUpstream | null,
+  executionId: string,
+  action: "accept" | "decline",
+  fetchImpl: typeof fetch = fetch,
+): Promise<ResumeOutcome> {
+  if (!upstream) return { ok: false, error: "the connector gateway is not running" };
+  try {
+    const res = await fetchImpl(`${upstream.origin}/api/executions/${encodeURIComponent(executionId)}/resume`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${upstream.token}`,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({ action, content: {} }),
+      signal: AbortSignal.timeout(120_000),
+    });
+    const body = (await res.json().catch(() => null)) as
+      | { status?: string; text?: string; isError?: boolean; _tag?: string; message?: string }
+      | null;
+    if (!res.ok) {
+      const reason = body?._tag === "ApprovalExpiredError"
+        ? "the approval window closed before the answer arrived; nothing ran"
+        : body?.message || body?._tag || `status ${res.status}`;
+      return { ok: false, error: reason };
+    }
+    return {
+      ok: true,
+      status: body?.status === "paused" ? "paused" : "completed",
+      text: body?.text ?? "",
+      isError: body?.isError === true,
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "the connector gateway is unreachable" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pending approvals: which omg ask stands in for which paused execution.
+//
+// In-memory on purpose. An executionId is ephemeral, Executor expires an
+// unanswered approval on its own, and a serve restart drops both the daemon's
+// pending execution and this map together — a restart mid-approval is a lost
+// approval on both sides, not a dangling one. Keyed by ask id (the human
+// answers an ask) with a reverse index by execution id (the agent's resume
+// names an execution).
+// ---------------------------------------------------------------------------
+
+export interface PendingApproval {
+  askId: string;
+  executionId: string;
+  sessionId: string;
+  address: string;
+  createdAt: number;
+}
+
+const byAsk = new Map<string, PendingApproval>();
+const byExecution = new Map<string, PendingApproval>();
+
+export function registerPendingApproval(input: Omit<PendingApproval, "createdAt">): void {
+  const record: PendingApproval = { ...input, createdAt: Date.now() };
+  byAsk.set(record.askId, record);
+  byExecution.set(record.executionId, record);
+}
+
+export function pendingApprovalByAsk(askId: string): PendingApproval | undefined {
+  return byAsk.get(askId);
+}
+
+/** True while an execution is waiting on an omg approval, so resume is refused. */
+export function executionAwaitingApproval(executionId: string): boolean {
+  return byExecution.has(executionId);
+}
+
+export function clearPendingApproval(askId: string): void {
+  const record = byAsk.get(askId);
+  if (!record) return;
+  byAsk.delete(record.askId);
+  byExecution.delete(record.executionId);
+}
+
+/** Test seam. */
+export function resetPendingApprovalsForTests(): void {
+  byAsk.clear();
+  byExecution.clear();
+}
+
+/** The reply an agent gets if it tries to resume an owner-gated execution. */
+export function blockedResumeReply(id: number | string | null | undefined, executionId: string): {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result: { isError: true; content: { type: "text"; text: string }[] };
+} {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    result: {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Execution ${executionId} is waiting for the owner's approval in the omg chat. You cannot resume it. End your turn; the outcome will arrive as the owner's reply.`,
+        },
+      ],
+    },
+  };
+}
+
+/** The message delivered into the session once the human has answered. */
+export function approvalDeliveryText(
+  paused: { address: string; executionId: string },
+  approved: boolean,
+  outcome: ResumeOutcome,
+): string {
+  if (!approved) {
+    return `The owner declined the connector call ${paused.address} (execution ${paused.executionId}). It did not run. Do not retry it; continue without it or ask what to do instead.`;
+  }
+  if (!outcome.ok) {
+    return `The owner approved ${paused.address} (execution ${paused.executionId}) but it could not be resumed: ${outcome.error}.`;
+  }
+  if (outcome.status === "paused") {
+    return `The owner approved ${paused.address} (execution ${paused.executionId}). The execution paused again for another interaction; call resume with that execution id as Executor instructs.\n\n${outcome.text}`;
+  }
+  const head = outcome.isError
+    ? `The owner approved ${paused.address} (execution ${paused.executionId}). It ran and returned an error.`
+    : `The owner approved ${paused.address} (execution ${paused.executionId}). It ran. Result:`;
+  return `${head}\n\n${outcome.text}`;
+}

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -78,6 +78,18 @@ export type ManagedSession = {
    * to keep a crash-looping relaunch from respawning on every serve restart.
    */
   recoveryClaimBootId?: string;
+  /**
+   * Role this session runs as at the shared MCP endpoints (src/policy/roles.ts).
+   * Missing means owner, which is every row created before roles existed.
+   */
+  role?: string;
+  /**
+   * Set on rows created after session tokens landed: the endpoint then only
+   * honours this session's id with its token (src/policy/session-token.ts).
+   * Missing keeps the pre-token behaviour for rows that were launched
+   * without one, so an upgrade does not silently make them anonymous.
+   */
+  mcpTokenRequired?: boolean;
 };
 
 type ManagedRegistry = {

--- a/src/mcp-http.ts
+++ b/src/mcp-http.ts
@@ -48,10 +48,15 @@ function callerSessionFromRequest(req: Request): string | undefined {
  * cheap; it registers plain closures. The expensive thing was the *process*,
  * which is what this removes.
  */
-export async function serveOmgMcpRequest(req: Request): Promise<Response> {
+export async function serveOmgMcpRequest(
+  req: Request,
+  sessionId: string | undefined = callerSessionFromRequest(req),
+): Promise<Response> {
   // Bind the caller for the whole request, so every tool handler it reaches
-  // resolves the same session the agent is running as.
-  return await withCallerSession(callerSessionFromRequest(req), () =>
+  // resolves the same session the agent is running as. serve.ts passes the
+  // session it verified (src/policy/caller.ts); the default keeps the raw
+  // query-string behaviour for callers that bypass that layer, such as tests.
+  return await withCallerSession(sessionId, () =>
     answerOne(req, buildOmgMcpServer, true),
   );
 }
@@ -69,8 +74,11 @@ export async function serveOmgMcpRequest(req: Request): Promise<Response> {
  * No legacy alias here: these tools are new, so no session has ever called them
  * by an older name.
  */
-export async function serveComputerMcpRequest(req: Request): Promise<Response> {
-  return await withCallerSession(callerSessionFromRequest(req), () =>
+export async function serveComputerMcpRequest(
+  req: Request,
+  sessionId: string | undefined = callerSessionFromRequest(req),
+): Promise<Response> {
+  return await withCallerSession(sessionId, () =>
     answerOne(req, buildComputerMcpServer, false),
   );
 }

--- a/src/mcp-session-registration.test.ts
+++ b/src/mcp-session-registration.test.ts
@@ -85,6 +85,8 @@ describe("omgMcpServers", () => {
           omg: {
             type: "http",
             url: "http://127.0.0.1:8766/mcp?session=ba4522bc-6607-4691-b69e-8b99cfb3ead2",
+            // The per-session token (src/policy/session-token.ts); box-specific.
+            headers: { "x-omg-session-token": expect.any(String) },
           },
         },
       });

--- a/src/policy/caller.test.ts
+++ b/src/policy/caller.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "../config.ts";
+import type { ManagedSession } from "../managed.ts";
+import { resolveCaller } from "./caller.ts";
+import { createRole } from "./roles.ts";
+import { SESSION_TOKEN_HEADER, resetSessionSecretForTests, sessionToken, verifySessionToken } from "./session-token.ts";
+
+let tmp: string;
+const originalData = PATHS.data;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "omg-caller-"));
+  PATHS.data = tmp;
+  resetSessionSecretForTests();
+});
+
+afterEach(() => {
+  PATHS.data = originalData;
+  resetSessionSecretForTests();
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function row(patch: Partial<ManagedSession>): ManagedSession {
+  return { tmuxName: "t", cwd: "/", createdAt: 1, sessionId: "s1", ...patch };
+}
+
+function request(session: string | null, headers: Record<string, string> = {}): Request {
+  const url = session ? `http://box/mcp?session=${encodeURIComponent(session)}` : "http://box/mcp";
+  return new Request(url, { method: "POST", headers });
+}
+
+describe("session tokens", () => {
+  test("are stable per session and differ per session", () => {
+    const a = sessionToken("s1");
+    expect(sessionToken("s1")).toBe(a);
+    expect(sessionToken("s2")).not.toBe(a);
+    expect(verifySessionToken("s1", a)).toBe(true);
+    expect(verifySessionToken("s2", a)).toBe(false);
+    expect(verifySessionToken("s1", "")).toBe(false);
+  });
+});
+
+describe("resolveCaller", () => {
+  test("no session claimed: anonymous owner", () => {
+    const caller = resolveCaller(request(null), () => undefined);
+    expect(caller.sessionId).toBeUndefined();
+    expect(caller.role.id).toBe("owner");
+  });
+
+  test("a row from before tokens is honoured on the bare query", () => {
+    const caller = resolveCaller(request("s1"), () => row({}));
+    expect(caller.sessionId).toBe("s1");
+    expect(caller.role.id).toBe("owner");
+  });
+
+  test("a token-required row needs the token", () => {
+    const lookup = () => row({ mcpTokenRequired: true });
+    expect(resolveCaller(request("s1"), lookup)).toMatchObject({ sessionId: undefined, downgraded: "missing-token" });
+    expect(resolveCaller(request("s1", { [SESSION_TOKEN_HEADER]: "nope" }), lookup)).toMatchObject({
+      sessionId: undefined,
+      downgraded: "bad-token",
+    });
+    const good = resolveCaller(request("s1", { [SESSION_TOKEN_HEADER]: sessionToken("s1") }), lookup);
+    expect(good.sessionId).toBe("s1");
+    expect(good.downgraded).toBeUndefined();
+  });
+
+  test("the row's role is resolved, unknown roles fall back to owner", () => {
+    const created = createRole({ name: "Marketing" });
+    expect(created.ok).toBe(true);
+    const withRole = resolveCaller(request("s1"), () => row({ role: "marketing" }));
+    expect(withRole.role.id).toBe("marketing");
+    const missing = resolveCaller(request("s1"), () => row({ role: "deleted-role" }));
+    expect(missing.role.id).toBe("owner");
+  });
+
+  test("unknown session id is still passed through as before", () => {
+    const caller = resolveCaller(request("ghost"), () => undefined);
+    expect(caller.sessionId).toBe("ghost");
+    expect(caller.role.id).toBe("owner");
+  });
+});

--- a/src/policy/caller.ts
+++ b/src/policy/caller.ts
@@ -1,0 +1,60 @@
+// Who is calling a shared MCP endpoint, and which role that gives them.
+//
+// One resolver for `/mcp`, `/mcp/computer` and `/mcp/executor`, so all three
+// answer "which session, which role" the same way. The session comes from the
+// `?session=` query or the `x-omg-session-id` header, as before. What is new
+// is that a session whose registry row demands a token (`mcpTokenRequired`)
+// must also present `x-omg-session-token`; a claim without a valid token is
+// downgraded to anonymous rather than rejected, which is the same degradation
+// an unknown id already gets, and keeps session-scoped tools failing loudly
+// ("sessionId required") instead of acting on someone else's session.
+//
+// Role: the row's `role`, else owner. Anonymous callers are the owner: on a
+// solo box every CLI session registered at user scope is anonymous, and this
+// is what keeps that box behaving exactly as it did before roles existed. A
+// team box that wants anonymous callers restricted sets `anonymousRole` in
+// settings (phase 2 of docs/team-tooling-design.md leaves that to vibes sync).
+import { listManaged, type ManagedSession } from "../managed.ts";
+import { OWNER_ROLE, getRole, type Role } from "./roles.ts";
+import { SESSION_TOKEN_HEADER, verifySessionToken } from "./session-token.ts";
+
+export interface Caller {
+  /** The session this request speaks for, or undefined when anonymous. */
+  sessionId: string | undefined;
+  role: Role;
+  /** Why an id in the request was not honoured. For logs and tests. */
+  downgraded?: "missing-token" | "bad-token";
+}
+
+function claimedSession(req: Request): string | undefined {
+  const fromQuery = new URL(req.url).searchParams.get("session")?.trim();
+  if (fromQuery) return fromQuery;
+  return (
+    req.headers.get("x-omg-session-id")?.trim() ||
+    req.headers.get("x-lfg-session-id")?.trim() ||
+    undefined
+  );
+}
+
+function findRow(sessionId: string): ManagedSession | undefined {
+  return listManaged().find((m) => m.sessionId === sessionId || m.nativeSessionId === sessionId);
+}
+
+/** Resolve the caller of one MCP request. Never throws. */
+export function resolveCaller(
+  req: Request,
+  lookup: (sessionId: string) => ManagedSession | undefined = findRow,
+): Caller {
+  const claimed = claimedSession(req);
+  if (!claimed) return { sessionId: undefined, role: OWNER_ROLE };
+  const row = lookup(claimed);
+  if (row?.mcpTokenRequired) {
+    const token = req.headers.get(SESSION_TOKEN_HEADER);
+    if (!token) return { sessionId: undefined, role: OWNER_ROLE, downgraded: "missing-token" };
+    if (!verifySessionToken(claimed, token)) {
+      return { sessionId: undefined, role: OWNER_ROLE, downgraded: "bad-token" };
+    }
+  }
+  const role = (row?.role && getRole(row.role)) || OWNER_ROLE;
+  return { sessionId: claimed, role };
+}

--- a/src/policy/mcp-filter.test.ts
+++ b/src/policy/mcp-filter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { enforceRole, policyToolId } from "./mcp-filter.ts";
+import { OWNER_ROLE, type Role } from "./roles.ts";
+
+const MARKETING: Role = {
+  id: "marketing",
+  name: "Marketing",
+  defaultAction: "block",
+  rules: [
+    { pattern: "omg.ship", action: "allow" },
+    { pattern: "omg.display_image", action: "allow" },
+  ],
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const OMG = { namespace: "omg", strip: "omg_" };
+
+function rpc(body: unknown): Request {
+  return new Request("http://box/mcp?session=s1", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+    body: JSON.stringify(body),
+  });
+}
+
+const LIST = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+const TOOLS = [{ name: "omg_ship" }, { name: "omg_close_session" }, { name: "omg_display_image" }];
+
+describe("policyToolId", () => {
+  test("strips the server prefix and namespaces", () => {
+    expect(policyToolId(OMG, "omg_ship")).toBe("omg.ship");
+    expect(policyToolId({ namespace: "executor" }, "execute")).toBe("executor.execute");
+  });
+});
+
+describe("enforceRole", () => {
+  test("owner passes the request through untouched", async () => {
+    const seen: string[] = [];
+    const res = await enforceRole(rpc(LIST), OWNER_ROLE, OMG, async (r) => {
+      seen.push(await r.text());
+      return Response.json({ jsonrpc: "2.0", id: 1, result: { tools: TOOLS } });
+    });
+    expect(seen[0]).toContain("tools/list");
+    const body = (await res.json()) as { result: { tools: { name: string }[] } };
+    expect(body.result.tools).toHaveLength(3);
+  });
+
+  test("tools/list JSON reply hides blocked tools", async () => {
+    const res = await enforceRole(rpc(LIST), MARKETING, OMG, async () =>
+      Response.json({ jsonrpc: "2.0", id: 1, result: { tools: TOOLS } }),
+    );
+    const body = (await res.json()) as { result: { tools: { name: string }[] } };
+    expect(body.result.tools.map((t) => t.name)).toEqual(["omg_ship", "omg_display_image"]);
+  });
+
+  test("tools/list SSE reply hides blocked tools frame by frame", async () => {
+    const frame = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: TOOLS } });
+    const res = await enforceRole(rpc(LIST), MARKETING, OMG, async () =>
+      new Response(`event: message\ndata: ${frame}\n\n`, {
+        headers: { "content-type": "text/event-stream", "mcp-session-id": "x" },
+      }),
+    );
+    const text = await res.text();
+    expect(text).toContain("omg_ship");
+    expect(text).not.toContain("omg_close_session");
+    expect(res.headers.get("mcp-session-id")).toBe("x");
+  });
+
+  test("tools/call on a blocked tool never reaches the server", async () => {
+    let reached = false;
+    const res = await enforceRole(
+      rpc({ jsonrpc: "2.0", id: 7, method: "tools/call", params: { name: "omg_close_session", arguments: {} } }),
+      MARKETING,
+      OMG,
+      async () => {
+        reached = true;
+        return Response.json({});
+      },
+    );
+    expect(reached).toBe(false);
+    const body = (await res.json()) as { id: number; result: { isError: boolean; content: { text: string }[] } };
+    expect(body.id).toBe(7);
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]!.text).toContain("Marketing");
+  });
+
+  test("tools/call on an allowed tool is forwarded with its body intact", async () => {
+    let forwarded = "";
+    await enforceRole(
+      rpc({ jsonrpc: "2.0", id: 8, method: "tools/call", params: { name: "omg_ship", arguments: { a: 1 } } }),
+      MARKETING,
+      OMG,
+      async (r) => {
+        forwarded = await r.text();
+        return Response.json({});
+      },
+    );
+    expect(forwarded).toContain('"a":1');
+  });
+
+  test("GET (event stream) is never buffered", async () => {
+    const req = new Request("http://box/mcp?session=s1", { method: "GET" });
+    const seen: Request[] = [];
+    await enforceRole(req, MARKETING, OMG, async (r) => {
+      seen.push(r);
+      return new Response(null);
+    });
+    expect(seen[0]).toBe(req);
+  });
+});

--- a/src/policy/mcp-filter.test.ts
+++ b/src/policy/mcp-filter.test.ts
@@ -11,6 +11,8 @@ const MARKETING: Role = {
     { pattern: "omg.display_image", action: "allow" },
   ],
   sandbox: "none",
+  network: "shared",
+  allowHosts: [],
   createdAt: 0,
   updatedAt: 0,
 };

--- a/src/policy/mcp-filter.test.ts
+++ b/src/policy/mcp-filter.test.ts
@@ -10,6 +10,7 @@ const MARKETING: Role = {
     { pattern: "omg.ship", action: "allow" },
     { pattern: "omg.display_image", action: "allow" },
   ],
+  sandbox: "none",
   createdAt: 0,
   updatedAt: 0,
 };

--- a/src/policy/mcp-filter.ts
+++ b/src/policy/mcp-filter.ts
@@ -1,0 +1,145 @@
+// Role enforcement on a Streamable HTTP MCP endpoint.
+//
+// Wraps an endpoint handler with two checks, both keyed on the caller's role:
+//
+//   tools/list  the reply is rewritten so blocked tools are not there.
+//   tools/call  a blocked tool is answered with an error result and never
+//               reaches the server behind the endpoint.
+//
+// Both, because an agent that has seen a tool name once can still name it,
+// and a list that hides a tool the call path would run is a filter in name
+// only. The check is on the JSON-RPC body, not on any server's internals,
+// so the same wrapper covers omg's own tools, the Computer tools, and the
+// Executor proxy: the server is opaque to it.
+//
+// Tool ids are `<namespace>.<name>` with the server's own prefix stripped
+// (`omg_ship` -> `omg.ship`, `computer_click` -> `computer.click`,
+// `execute` -> `executor.execute`), so a rule reads the same whichever
+// endpoint the tool lives on.
+import { evaluateRole, type Role } from "./roles.ts";
+
+type JsonRpcMessage = {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: { name?: string; [k: string]: unknown };
+  result?: { tools?: { name: string }[]; [k: string]: unknown };
+};
+
+export interface FilterNamespace {
+  /** Policy namespace, e.g. "omg". */
+  namespace: string;
+  /** Prefix the server puts on its tool names, stripped for the policy id. */
+  strip?: string;
+}
+
+export function policyToolId(ns: FilterNamespace, toolName: string): string {
+  const bare = ns.strip && toolName.startsWith(ns.strip) ? toolName.slice(ns.strip.length) : toolName;
+  return `${ns.namespace}.${bare}`;
+}
+
+function blockedReply(id: JsonRpcMessage["id"], toolName: string, roleName: string): Response {
+  return Response.json(
+    {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      result: {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `Tool "${toolName}" is not available to the ${roleName} role on this box.`,
+          },
+        ],
+      },
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+function filterTools(message: JsonRpcMessage, role: Role, ns: FilterNamespace): JsonRpcMessage {
+  const tools = message.result?.tools;
+  if (!Array.isArray(tools)) return message;
+  return {
+    ...message,
+    result: {
+      ...message.result,
+      tools: tools.filter((tool) => evaluateRole(role, policyToolId(ns, tool.name)) === "allow"),
+    },
+  };
+}
+
+/**
+ * Rewrite a tools/list reply. JSON replies are one message; SSE replies are
+ * `data:` frames, each one message, and only frames that carry a tool list
+ * are touched. Small by construction, so buffering is fine here.
+ */
+async function rewriteListReply(res: Response, role: Role, ns: FilterNamespace): Promise<Response> {
+  const type = res.headers.get("content-type") ?? "";
+  const headers = new Headers(res.headers);
+  headers.delete("content-length");
+  const text = await res.text();
+  if (type.includes("text/event-stream")) {
+    const out = text
+      .split("\n")
+      .map((line) => {
+        if (!line.startsWith("data:")) return line;
+        try {
+          const parsed = JSON.parse(line.slice(5).trim()) as JsonRpcMessage;
+          return `data: ${JSON.stringify(filterTools(parsed, role, ns))}`;
+        } catch {
+          return line;
+        }
+      })
+      .join("\n");
+    return new Response(out, { status: res.status, headers });
+  }
+  try {
+    const parsed = JSON.parse(text) as JsonRpcMessage | JsonRpcMessage[];
+    const filtered = Array.isArray(parsed)
+      ? parsed.map((m) => filterTools(m, role, ns))
+      : filterTools(parsed, role, ns);
+    return new Response(JSON.stringify(filtered), { status: res.status, headers });
+  } catch {
+    return new Response(text, { status: res.status, headers });
+  }
+}
+
+/**
+ * Apply `role` to one MCP request bound for `handler`.
+ *
+ * The owner role short-circuits: nothing is parsed and the request body is
+ * handed through untouched, so a solo box pays nothing for this layer.
+ */
+export async function enforceRole(
+  req: Request,
+  role: Role,
+  ns: FilterNamespace,
+  handler: (req: Request) => Promise<Response>,
+): Promise<Response> {
+  if (role.id === "owner" || req.method !== "POST") return handler(req);
+
+  const raw = await req.text();
+  let messages: JsonRpcMessage[] = [];
+  try {
+    const parsed = JSON.parse(raw) as JsonRpcMessage | JsonRpcMessage[];
+    messages = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // Not JSON-RPC we understand; let the server reject it.
+  }
+  const forwarded = new Request(req.url, { method: req.method, headers: req.headers, body: raw });
+
+  const call = messages.find((m) => m.method === "tools/call");
+  if (call) {
+    const name = typeof call.params?.name === "string" ? call.params.name : "";
+    if (evaluateRole(role, policyToolId(ns, name)) !== "allow") {
+      return blockedReply(call.id, name, role.name);
+    }
+  }
+
+  const res = await handler(forwarded);
+  if (messages.some((m) => m.method === "tools/list")) {
+    return rewriteListReply(res, role, ns);
+  }
+  return res;
+}

--- a/src/policy/roles.test.ts
+++ b/src/policy/roles.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PATHS } from "../config.ts";
+import {
+  OWNER_ROLE,
+  createRole,
+  deleteRole,
+  evaluateRole,
+  getRole,
+  isValidPattern,
+  listRoles,
+  matchPattern,
+  updateRole,
+} from "./roles.ts";
+
+let tmp: string;
+const originalData = PATHS.data;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "omg-roles-"));
+  PATHS.data = tmp;
+});
+
+afterEach(() => {
+  PATHS.data = originalData;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("matchPattern", () => {
+  test("mirrors Executor's segment globs", () => {
+    expect(matchPattern("*", "executor.execute")).toBe(true);
+    expect(matchPattern("executor.*", "executor.execute")).toBe(true);
+    expect(matchPattern("executor.*", "omg.ship")).toBe(false);
+    expect(matchPattern("omg.ship", "omg.ship")).toBe(true);
+    expect(matchPattern("omg.ship", "omg.ship.now")).toBe(false);
+    expect(matchPattern("omg.*.now", "omg.ship.now")).toBe(true);
+    expect(matchPattern("omg.*.now", "omg.now")).toBe(false);
+  });
+
+  test("validates patterns", () => {
+    expect(isValidPattern("*")).toBe(true);
+    expect(isValidPattern("omg.list_sessions")).toBe(true);
+    expect(isValidPattern("")).toBe(false);
+    expect(isValidPattern("omg..ship")).toBe(false);
+    expect(isValidPattern("omg ship")).toBe(false);
+  });
+});
+
+describe("evaluateRole", () => {
+  test("block beats allow, default fills the gap", () => {
+    const role = {
+      ...OWNER_ROLE,
+      id: "r",
+      defaultAction: "block" as const,
+      rules: [
+        { pattern: "omg.*", action: "allow" as const },
+        { pattern: "omg.close_session", action: "block" as const },
+      ],
+    };
+    expect(evaluateRole(role, "omg.ship")).toBe("allow");
+    expect(evaluateRole(role, "omg.close_session")).toBe("block");
+    expect(evaluateRole(role, "executor.execute")).toBe("block");
+    expect(evaluateRole(OWNER_ROLE, "anything.at.all")).toBe("allow");
+  });
+});
+
+describe("role store", () => {
+  test("owner is always present and never stored", () => {
+    expect(listRoles().map((r) => r.id)).toEqual(["owner"]);
+    expect(updateRole("owner", { name: "x" }).ok).toBe(false);
+    expect(deleteRole("owner").ok).toBe(false);
+  });
+
+  test("create, read, update, delete", () => {
+    const created = createRole({ name: "Marketing", rules: [{ pattern: "executor.*", action: "allow" }] });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    expect(created.role.id).toBe("marketing");
+    expect(created.role.defaultAction).toBe("block");
+    expect(getRole("marketing")?.rules).toHaveLength(1);
+
+    const second = createRole({ name: "Marketing" });
+    expect(second.ok && second.role.id).toBe("marketing-2");
+
+    const updated = updateRole("marketing", { defaultAction: "allow", rules: [] });
+    expect(updated.ok && updated.role.defaultAction).toBe("allow");
+    expect(listRoles().map((r) => r.id)).toEqual(["owner", "marketing", "marketing-2"]);
+
+    expect(deleteRole("marketing").ok).toBe(true);
+    expect(getRole("marketing")).toBeNull();
+  });
+
+  test("rejects bad input", () => {
+    expect(createRole({ name: "  " }).ok).toBe(false);
+    expect(createRole({ name: "x", rules: [{ pattern: "bad pattern", action: "allow" }] }).ok).toBe(false);
+    expect(createRole({ name: "x", rules: [{ pattern: "*", action: "maybe" as never }] }).ok).toBe(false);
+    expect(updateRole("missing", { name: "x" }).ok).toBe(false);
+  });
+});

--- a/src/policy/roles.test.ts
+++ b/src/policy/roles.test.ts
@@ -12,6 +12,7 @@ import {
   isValidPattern,
   listRoles,
   matchPattern,
+  roleSandbox,
   updateRole,
 } from "./roles.ts";
 
@@ -90,6 +91,22 @@ describe("role store", () => {
 
     expect(deleteRole("marketing").ok).toBe(true);
     expect(getRole("marketing")).toBeNull();
+  });
+
+  test("sandbox defaults to none and is editable; owner is always none", () => {
+    const created = createRole({ name: "Restricted", sandbox: "bwrap" });
+    expect(created.ok && created.role.sandbox).toBe("bwrap");
+    expect(roleSandbox("restricted")).toBe("bwrap");
+    expect(roleSandbox("owner")).toBe("none");
+    expect(roleSandbox(undefined)).toBe("none");
+    expect(roleSandbox("ghost")).toBe("none");
+
+    const plain = createRole({ name: "Plain" });
+    expect(plain.ok && plain.role.sandbox).toBe("none");
+
+    expect(updateRole("restricted", { sandbox: "none" }).ok).toBe(true);
+    expect(roleSandbox("restricted")).toBe("none");
+    expect(updateRole("restricted", { sandbox: "weird" as never }).ok).toBe(false);
   });
 
   test("rejects bad input", () => {

--- a/src/policy/roles.test.ts
+++ b/src/policy/roles.test.ts
@@ -12,6 +12,7 @@ import {
   isValidPattern,
   listRoles,
   matchPattern,
+  roleEgress,
   roleSandbox,
   updateRole,
 } from "./roles.ts";
@@ -107,6 +108,24 @@ describe("role store", () => {
     expect(updateRole("restricted", { sandbox: "none" }).ok).toBe(true);
     expect(roleSandbox("restricted")).toBe("none");
     expect(updateRole("restricted", { sandbox: "weird" as never }).ok).toBe(false);
+  });
+
+  test("network defaults to shared; allowlist carries validated hosts", () => {
+    const created = createRole({
+      name: "Net",
+      network: "allowlist",
+      allowHosts: ["api.internal.example", ".corp.example"],
+    });
+    expect(created.ok && created.role.network).toBe("allowlist");
+    expect(created.ok && created.role.allowHosts).toEqual(["api.internal.example", ".corp.example"]);
+
+    expect(roleEgress("net")).toEqual({ mode: "allowlist", allowHosts: ["api.internal.example", ".corp.example"] });
+    expect(roleEgress("owner")).toEqual({ mode: "shared", allowHosts: [] });
+    expect(roleEgress("ghost")).toEqual({ mode: "shared", allowHosts: [] });
+
+    expect(createRole({ name: "BadHost", network: "allowlist", allowHosts: ["not a host!"] }).ok).toBe(false);
+    expect(updateRole("net", { network: "shared" }).ok).toBe(true);
+    expect(roleEgress("net").mode).toBe("shared");
   });
 
   test("rejects bad input", () => {

--- a/src/policy/roles.ts
+++ b/src/policy/roles.ts
@@ -35,9 +35,19 @@ export interface Role {
    * only its worktree writable. Owner is always `none`.
    */
   sandbox: SandboxMode;
+  /**
+   * Outbound network policy (src/sandbox/egress-proxy.ts). `allowlist` points
+   * the harness at the egress proxy so it reaches only the model APIs plus
+   * `allowHosts`; `shared` leaves the network open. Owner is always `shared`.
+   */
+  network: NetworkMode;
+  /** Extra hostnames the allowlist permits, beyond the built-in model APIs. */
+  allowHosts: string[];
   createdAt: number;
   updatedAt: number;
 }
+
+export type NetworkMode = "shared" | "allowlist";
 
 export const OWNER_ROLE_ID = "owner";
 
@@ -48,6 +58,8 @@ export const OWNER_ROLE: Role = Object.freeze({
   defaultAction: "allow",
   rules: [],
   sandbox: "none",
+  network: "shared",
+  allowHosts: [],
   createdAt: 0,
   updatedAt: 0,
 }) as Role;
@@ -69,7 +81,12 @@ function readFile(): RolesFile {
     if (!existsSync(rolesPath())) return { version: 1, roles: [] };
     const parsed = JSON.parse(readFileSync(rolesPath(), "utf8")) as Partial<RolesFile>;
     const roles = Array.isArray(parsed.roles)
-      ? parsed.roles.filter(isRole).map((r) => ({ ...r, sandbox: readSandbox(r.sandbox) }))
+      ? parsed.roles.filter(isRole).map((r) => ({
+          ...r,
+          sandbox: readSandbox(r.sandbox),
+          network: readNetwork((r as Partial<Role>).network),
+          allowHosts: readAllowHosts((r as Partial<Role>).allowHosts),
+        }))
       : [];
     return { version: 1, roles };
   } catch {
@@ -98,6 +115,33 @@ function isRole(value: unknown): value is Role {
 // A role file from before sandbox existed has no field; treat it as "none".
 function readSandbox(value: unknown): SandboxMode {
   return value === "bwrap" ? "bwrap" : "none";
+}
+
+function readNetwork(value: unknown): NetworkMode {
+  return value === "allowlist" ? "allowlist" : "shared";
+}
+
+function readAllowHosts(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((h): h is string => typeof h === "string" && h.trim().length > 0).slice(0, 100);
+}
+
+const MAX_HOST_LEN = 253;
+
+function validateAllowHosts(hosts: unknown): string[] | string {
+  if (hosts === undefined) return [];
+  if (!Array.isArray(hosts)) return "allowHosts must be an array";
+  const out: string[] = [];
+  for (const raw of hosts) {
+    if (typeof raw !== "string") return "each allowHost must be a string";
+    const host = raw.trim().toLowerCase();
+    if (!host) continue;
+    if (host.length > MAX_HOST_LEN || !/^\.?[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/.test(host)) {
+      return `invalid host "${raw}"`;
+    }
+    out.push(host);
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -157,6 +201,18 @@ export function roleSandbox(roleId: string | undefined | null): SandboxMode {
   return getRole(roleId)?.sandbox ?? "none";
 }
 
+/**
+ * The egress policy for a session's role. Owner and unknown roles are shared
+ * (no proxy). For an allowlist role the allowed hosts are its own `allowHosts`
+ * plus the built-in model APIs, resolved by the proxy.
+ */
+export function roleEgress(roleId: string | undefined | null): { mode: NetworkMode; allowHosts: string[] } {
+  if (!roleId || roleId === OWNER_ROLE_ID) return { mode: "shared", allowHosts: [] };
+  const role = getRole(roleId);
+  if (!role) return { mode: "shared", allowHosts: [] };
+  return { mode: role.network, allowHosts: role.allowHosts };
+}
+
 function slug(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
 }
@@ -166,6 +222,8 @@ export type RoleInput = {
   defaultAction?: RuleAction;
   rules?: RoleRule[];
   sandbox?: SandboxMode;
+  network?: NetworkMode;
+  allowHosts?: string[];
 };
 
 export type RoleResult = { ok: true; role: Role } | { ok: false; error: string };
@@ -204,7 +262,10 @@ export function createRole(input: RoleInput): RoleResult {
   for (let n = 2; taken.has(candidate); n += 1) candidate = `${id}-${n}`;
   const now = Date.now();
   const sandbox: SandboxMode = input.sandbox === "bwrap" ? "bwrap" : "none";
-  const role: Role = { id: candidate, name, defaultAction, rules, sandbox, createdAt: now, updatedAt: now };
+  const network: NetworkMode = input.network === "allowlist" ? "allowlist" : "shared";
+  const allowHosts = validateAllowHosts(input.allowHosts);
+  if (typeof allowHosts === "string") return { ok: false, error: allowHosts };
+  const role: Role = { id: candidate, name, defaultAction, rules, sandbox, network, allowHosts, createdAt: now, updatedAt: now };
   file.roles.push(role);
   writeFile(file);
   return { ok: true, role };
@@ -236,6 +297,17 @@ export function updateRole(id: string, patch: Partial<RoleInput>): RoleResult {
       return { ok: false, error: "sandbox must be none or bwrap" };
     }
     role.sandbox = patch.sandbox;
+  }
+  if (patch.network !== undefined) {
+    if (patch.network !== "shared" && patch.network !== "allowlist") {
+      return { ok: false, error: "network must be shared or allowlist" };
+    }
+    role.network = patch.network;
+  }
+  if (patch.allowHosts !== undefined) {
+    const hosts = validateAllowHosts(patch.allowHosts);
+    if (typeof hosts === "string") return { ok: false, error: hosts };
+    role.allowHosts = hosts;
   }
   role.updatedAt = Date.now();
   writeFile(file);

--- a/src/policy/roles.ts
+++ b/src/policy/roles.ts
@@ -1,0 +1,223 @@
+// Roles: who a session runs as, and which tools that lets it see and call.
+//
+// A role is a name plus a rule list. Rules use the same pattern grammar as
+// Executor's tool policies (segment globs: `*`, `executor.*`, `omg.ship`), so
+// the owner learns one language for the box-level Executor rules and the
+// per-role omg rules. Tool ids are `<server>.<tool>` with the server's own
+// prefix stripped: `omg.ship`, `computer.screenshot`, `executor.execute`.
+//
+// Resolution: the most restrictive matching rule wins, and a role with no
+// matching rule falls back to its `defaultAction`. `owner` is built in and
+// unrestricted; it is never stored. Storage is one JSON file under the data
+// dir, the same shape the vibes sync will write into later
+// (docs/team-tooling-design.md). This module is the single owner of that file.
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { PATHS } from "../config.ts";
+
+export type RuleAction = "allow" | "block";
+
+export interface RoleRule {
+  pattern: string;
+  action: RuleAction;
+}
+
+export interface Role {
+  id: string;
+  name: string;
+  /** What a tool gets when no rule matches. Restricted roles want `block`. */
+  defaultAction: RuleAction;
+  rules: RoleRule[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export const OWNER_ROLE_ID = "owner";
+
+/** The built-in unrestricted role. Not stored, not editable, not deletable. */
+export const OWNER_ROLE: Role = Object.freeze({
+  id: OWNER_ROLE_ID,
+  name: "Owner",
+  defaultAction: "allow",
+  rules: [],
+  createdAt: 0,
+  updatedAt: 0,
+}) as Role;
+
+const MAX_ROLES = 50;
+const MAX_RULES = 200;
+
+function rolesPath(): string {
+  return join(PATHS.data, "roles.json");
+}
+
+interface RolesFile {
+  version: 1;
+  roles: Role[];
+}
+
+function readFile(): RolesFile {
+  try {
+    if (!existsSync(rolesPath())) return { version: 1, roles: [] };
+    const parsed = JSON.parse(readFileSync(rolesPath(), "utf8")) as Partial<RolesFile>;
+    const roles = Array.isArray(parsed.roles) ? parsed.roles.filter(isRole) : [];
+    return { version: 1, roles };
+  } catch {
+    return { version: 1, roles: [] };
+  }
+}
+
+function writeFile(file: RolesFile): void {
+  mkdirSync(PATHS.data, { recursive: true });
+  const tmp = `${rolesPath()}.tmp`;
+  writeFileSync(tmp, JSON.stringify(file, null, 2));
+  renameSync(tmp, rolesPath());
+}
+
+function isRole(value: unknown): value is Role {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Partial<Role>;
+  return (
+    typeof r.id === "string" &&
+    typeof r.name === "string" &&
+    (r.defaultAction === "allow" || r.defaultAction === "block") &&
+    Array.isArray(r.rules)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pattern matching. Mirrors Executor's `matchPattern` so a rule reads the same
+// on both sides: `*` is always one whole segment, and a trailing `*` matches
+// the rest of the id.
+// ---------------------------------------------------------------------------
+
+export function matchPattern(pattern: string, toolId: string): boolean {
+  if (pattern === "*") return true;
+  const p = pattern.split(".");
+  const t = toolId.split(".");
+  for (let i = 0; i < p.length; i += 1) {
+    const seg = p[i]!;
+    if (seg === "*") {
+      if (i === p.length - 1) return t.length >= i;
+      if (t[i] === undefined) return false;
+      continue;
+    }
+    if (t[i] !== seg) return false;
+  }
+  return p.length === t.length;
+}
+
+export function isValidPattern(pattern: string): boolean {
+  if (!pattern || pattern.length > 200) return false;
+  return pattern.split(".").every((seg) => seg === "*" || /^[a-z0-9_-]+$/i.test(seg));
+}
+
+/** The action a role gives one tool id. Block beats allow when both match. */
+export function evaluateRole(role: Role, toolId: string): RuleAction {
+  let matched: RuleAction | null = null;
+  for (const rule of role.rules) {
+    if (!matchPattern(rule.pattern, toolId)) continue;
+    if (rule.action === "block") return "block";
+    matched = "allow";
+  }
+  return matched ?? role.defaultAction;
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export function listRoles(): Role[] {
+  return [OWNER_ROLE, ...readFile().roles];
+}
+
+export function getRole(id: string): Role | null {
+  if (id === OWNER_ROLE_ID) return OWNER_ROLE;
+  return readFile().roles.find((r) => r.id === id) ?? null;
+}
+
+function slug(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
+}
+
+export type RoleInput = {
+  name: string;
+  defaultAction?: RuleAction;
+  rules?: RoleRule[];
+};
+
+export type RoleResult = { ok: true; role: Role } | { ok: false; error: string };
+
+function validateRules(rules: unknown): RoleRule[] | string {
+  if (rules === undefined) return [];
+  if (!Array.isArray(rules)) return "rules must be an array";
+  if (rules.length > MAX_RULES) return `rules must have at most ${MAX_RULES} entries`;
+  const out: RoleRule[] = [];
+  for (const rule of rules) {
+    const r = rule as Partial<RoleRule>;
+    if (typeof r?.pattern !== "string" || !isValidPattern(r.pattern)) {
+      return `invalid pattern "${String(r?.pattern ?? "")}"`;
+    }
+    if (r.action !== "allow" && r.action !== "block") return `invalid action for "${r.pattern}"`;
+    out.push({ pattern: r.pattern, action: r.action });
+  }
+  return out;
+}
+
+export function createRole(input: RoleInput): RoleResult {
+  const name = typeof input.name === "string" ? input.name.trim().slice(0, 60) : "";
+  if (!name) return { ok: false, error: "name is required" };
+  const rules = validateRules(input.rules);
+  if (typeof rules === "string") return { ok: false, error: rules };
+  const defaultAction = input.defaultAction ?? "block";
+  if (defaultAction !== "allow" && defaultAction !== "block") {
+    return { ok: false, error: "defaultAction must be allow or block" };
+  }
+  const file = readFile();
+  if (file.roles.length >= MAX_ROLES) return { ok: false, error: `at most ${MAX_ROLES} roles` };
+  let id = slug(name) || "role";
+  if (id === OWNER_ROLE_ID) id = "role-owner";
+  const taken = new Set(file.roles.map((r) => r.id));
+  let candidate = id;
+  for (let n = 2; taken.has(candidate); n += 1) candidate = `${id}-${n}`;
+  const now = Date.now();
+  const role: Role = { id: candidate, name, defaultAction, rules, createdAt: now, updatedAt: now };
+  file.roles.push(role);
+  writeFile(file);
+  return { ok: true, role };
+}
+
+export function updateRole(id: string, patch: Partial<RoleInput>): RoleResult {
+  if (id === OWNER_ROLE_ID) return { ok: false, error: "the owner role cannot be edited" };
+  const file = readFile();
+  const role = file.roles.find((r) => r.id === id);
+  if (!role) return { ok: false, error: "role not found" };
+  if (patch.name !== undefined) {
+    const name = typeof patch.name === "string" ? patch.name.trim().slice(0, 60) : "";
+    if (!name) return { ok: false, error: "name is required" };
+    role.name = name;
+  }
+  if (patch.defaultAction !== undefined) {
+    if (patch.defaultAction !== "allow" && patch.defaultAction !== "block") {
+      return { ok: false, error: "defaultAction must be allow or block" };
+    }
+    role.defaultAction = patch.defaultAction;
+  }
+  if (patch.rules !== undefined) {
+    const rules = validateRules(patch.rules);
+    if (typeof rules === "string") return { ok: false, error: rules };
+    role.rules = rules;
+  }
+  role.updatedAt = Date.now();
+  writeFile(file);
+  return { ok: true, role };
+}
+
+export function deleteRole(id: string): { ok: true } | { ok: false; error: string } {
+  if (id === OWNER_ROLE_ID) return { ok: false, error: "the owner role cannot be deleted" };
+  const file = readFile();
+  const next = file.roles.filter((r) => r.id !== id);
+  if (next.length === file.roles.length) return { ok: false, error: "role not found" };
+  writeFile({ version: 1, roles: next });
+  return { ok: true };
+}

--- a/src/policy/roles.ts
+++ b/src/policy/roles.ts
@@ -14,6 +14,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { PATHS } from "../config.ts";
+import type { SandboxMode } from "../sandbox/bwrap.ts";
 
 export type RuleAction = "allow" | "block";
 
@@ -28,6 +29,12 @@ export interface Role {
   /** What a tool gets when no rule matches. Restricted roles want `block`. */
   defaultAction: RuleAction;
   rules: RoleRule[];
+  /**
+   * Filesystem isolation for sessions in this role (src/sandbox/bwrap.ts).
+   * `bwrap` runs the harness with an empty home, the omg secrets masked, and
+   * only its worktree writable. Owner is always `none`.
+   */
+  sandbox: SandboxMode;
   createdAt: number;
   updatedAt: number;
 }
@@ -40,6 +47,7 @@ export const OWNER_ROLE: Role = Object.freeze({
   name: "Owner",
   defaultAction: "allow",
   rules: [],
+  sandbox: "none",
   createdAt: 0,
   updatedAt: 0,
 }) as Role;
@@ -60,7 +68,9 @@ function readFile(): RolesFile {
   try {
     if (!existsSync(rolesPath())) return { version: 1, roles: [] };
     const parsed = JSON.parse(readFileSync(rolesPath(), "utf8")) as Partial<RolesFile>;
-    const roles = Array.isArray(parsed.roles) ? parsed.roles.filter(isRole) : [];
+    const roles = Array.isArray(parsed.roles)
+      ? parsed.roles.filter(isRole).map((r) => ({ ...r, sandbox: readSandbox(r.sandbox) }))
+      : [];
     return { version: 1, roles };
   } catch {
     return { version: 1, roles: [] };
@@ -83,6 +93,11 @@ function isRole(value: unknown): value is Role {
     (r.defaultAction === "allow" || r.defaultAction === "block") &&
     Array.isArray(r.rules)
   );
+}
+
+// A role file from before sandbox existed has no field; treat it as "none".
+function readSandbox(value: unknown): SandboxMode {
+  return value === "bwrap" ? "bwrap" : "none";
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +151,12 @@ export function getRole(id: string): Role | null {
   return readFile().roles.find((r) => r.id === id) ?? null;
 }
 
+/** The sandbox mode for a session's role. Owner and unknown roles are `none`. */
+export function roleSandbox(roleId: string | undefined | null): SandboxMode {
+  if (!roleId || roleId === OWNER_ROLE_ID) return "none";
+  return getRole(roleId)?.sandbox ?? "none";
+}
+
 function slug(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
 }
@@ -144,6 +165,7 @@ export type RoleInput = {
   name: string;
   defaultAction?: RuleAction;
   rules?: RoleRule[];
+  sandbox?: SandboxMode;
 };
 
 export type RoleResult = { ok: true; role: Role } | { ok: false; error: string };
@@ -181,7 +203,8 @@ export function createRole(input: RoleInput): RoleResult {
   let candidate = id;
   for (let n = 2; taken.has(candidate); n += 1) candidate = `${id}-${n}`;
   const now = Date.now();
-  const role: Role = { id: candidate, name, defaultAction, rules, createdAt: now, updatedAt: now };
+  const sandbox: SandboxMode = input.sandbox === "bwrap" ? "bwrap" : "none";
+  const role: Role = { id: candidate, name, defaultAction, rules, sandbox, createdAt: now, updatedAt: now };
   file.roles.push(role);
   writeFile(file);
   return { ok: true, role };
@@ -207,6 +230,12 @@ export function updateRole(id: string, patch: Partial<RoleInput>): RoleResult {
     const rules = validateRules(patch.rules);
     if (typeof rules === "string") return { ok: false, error: rules };
     role.rules = rules;
+  }
+  if (patch.sandbox !== undefined) {
+    if (patch.sandbox !== "none" && patch.sandbox !== "bwrap") {
+      return { ok: false, error: "sandbox must be none or bwrap" };
+    }
+    role.sandbox = patch.sandbox;
   }
   role.updatedAt = Date.now();
   writeFile(file);

--- a/src/policy/session-token.ts
+++ b/src/policy/session-token.ts
@@ -1,0 +1,62 @@
+// The per-session secret that lets a session claim its own id at the shared
+// MCP endpoints.
+//
+// Agents are registered against `/mcp?session=<id>`. Any process on the box
+// can put any id in that query string, which is fine for one owner and not
+// for a team: a restricted session could claim an owner session's id and
+// inherit its tools. The fix is a token only the serve process can mint and
+// only the session it was minted for is handed at launch.
+//
+// Derived, not stored: HMAC(box secret, session id). The registry row needs
+// no new column, a serve restart can verify a token it did not mint, and the
+// box secret is one file under the data dir. Rows created before this landed
+// carry no `mcpTokenRequired` flag and are still accepted on the bare query
+// string, so an upgrade does not downgrade running sessions to anonymous.
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { PATHS } from "../config.ts";
+
+export const SESSION_TOKEN_HEADER = "x-omg-session-token";
+
+let cached: { path: string; secret: string } | null = null;
+
+function secretPath(): string {
+  return join(PATHS.data, "session-secret");
+}
+
+function boxSecret(): string {
+  const path = secretPath();
+  if (cached?.path === path) return cached.secret;
+  let secret = "";
+  try {
+    if (existsSync(path)) secret = readFileSync(path, "utf8").trim();
+  } catch {}
+  if (!secret) {
+    secret = randomBytes(32).toString("base64url");
+    mkdirSync(PATHS.data, { recursive: true });
+    writeFileSync(path, secret);
+    try {
+      chmodSync(path, 0o600);
+    } catch {}
+  }
+  cached = { path, secret };
+  return secret;
+}
+
+/** The token a session presents to speak as `sessionId`. */
+export function sessionToken(sessionId: string): string {
+  return createHmac("sha256", boxSecret()).update(sessionId).digest("base64url");
+}
+
+export function verifySessionToken(sessionId: string, token: string | null | undefined): boolean {
+  if (!token) return false;
+  const expected = Buffer.from(sessionToken(sessionId));
+  const given = Buffer.from(token);
+  return expected.length === given.length && timingSafeEqual(expected, given);
+}
+
+/** Test seam: forget the cached secret so a repointed data dir mints a new one. */
+export function resetSessionSecretForTests(): void {
+  cached = null;
+}

--- a/src/sandbox/bwrap.test.ts
+++ b/src/sandbox/bwrap.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bwrapArgv, bwrapAvailable, bwrapBinary, sandboxCommand } from "./bwrap.ts";
+
+describe("bwrapArgv", () => {
+  const plan = {
+    worktree: "/home/u/lfg-worktrees/proj",
+    omgRoot: "/home/u/lfg-worktrees/omg",
+    dataDir: "/home/u/lfg-worktrees/omg/data",
+    runtime: "/home/u/.bun/bin/bun",
+    home: "/home/u",
+  };
+
+  test("binds the worktree rw and chdirs into it", () => {
+    const argv = bwrapArgv(["bun", "x"], plan, "/usr/bin/bwrap");
+    const s = argv.join(" ");
+    expect(s).toContain("--bind /home/u/lfg-worktrees/proj /home/u/lfg-worktrees/proj");
+    expect(s).toContain("--chdir /home/u/lfg-worktrees/proj");
+    expect(argv.slice(-3)).toEqual(["--", "bun", "x"]);
+  });
+
+  test("empties home and masks the omg data dir even though the code tree is exposed", () => {
+    const argv = bwrapArgv(["bun"], plan, "/usr/bin/bwrap");
+    const s = argv.join(" ");
+    expect(s).toContain("--tmpfs /home/u");
+    expect(s).toContain("--ro-bind /home/u/lfg-worktrees/omg /home/u/lfg-worktrees/omg");
+    // The data-dir tmpfs must come AFTER the omg ro-bind so it hides the secrets.
+    const roIdx = argv.indexOf("/home/u/lfg-worktrees/omg");
+    const maskIdx = argv.indexOf("/home/u/lfg-worktrees/omg/data");
+    expect(roIdx).toBeGreaterThan(-1);
+    expect(maskIdx).toBeGreaterThan(roIdx);
+    expect(argv[maskIdx - 1]).toBe("--tmpfs");
+  });
+
+  test("keeps the network (no --unshare-net) but isolates the other namespaces", () => {
+    const argv = bwrapArgv(["bun"], plan, "/usr/bin/bwrap");
+    expect(argv).toContain("--unshare-user");
+    expect(argv).toContain("--unshare-pid");
+    expect(argv).not.toContain("--unshare-net");
+    expect(argv).not.toContain("--unshare-all");
+  });
+});
+
+describe("sandboxCommand", () => {
+  test("none is a passthrough", () => {
+    const out = sandboxCommand(["bun"], "none", { worktree: "/w", omgRoot: "/o", dataDir: "/o/data" });
+    expect(out).toEqual({ command: ["bun"], sandboxed: false });
+  });
+
+  test("bwrap unavailable falls back with a reason, not an error", () => {
+    const out = sandboxCommand(["bun"], "bwrap", { worktree: "/w", omgRoot: "/o", dataDir: "/o/data" }, null);
+    expect(out.sandboxed).toBe(false);
+    expect(out.reason).toContain("not available");
+    expect(out.command).toEqual(["bun"]);
+  });
+});
+
+// A real sandbox on this box, when bubblewrap is present. Proves the mechanism,
+// not just the argv: a command inside the sandbox reads its worktree, cannot
+// read a sibling secret, and has an empty home.
+describe("bwrap isolation (live)", () => {
+  const bin = bwrapBinary();
+  const run = bwrapAvailable(bin) ? test : test.skip;
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "omg-sbx-"));
+    mkdirSync(join(tmp, "work"), { recursive: true });
+    mkdirSync(join(tmp, "omg", "data"), { recursive: true });
+    writeFileSync(join(tmp, "work", "inside.txt"), "project file");
+    writeFileSync(join(tmp, "secret.txt"), "TOP SECRET");
+    writeFileSync(join(tmp, "omg", "code.txt"), "omg code");
+    writeFileSync(join(tmp, "omg", "data", "session-secret"), "BOX SECRET KEY");
+  });
+
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  run("worktree writable, sibling hidden, omg code exposed, omg data masked", async () => {
+    const worktree = join(tmp, "work");
+    const omgRoot = join(tmp, "omg");
+    const dataDir = join(omgRoot, "data");
+    const script = `
+      const fs = require("node:fs");
+      const read = (p) => { try { return fs.readFileSync(p, "utf8"); } catch { return null; } };
+      const out = {
+        inside: read("inside.txt"),
+        sibling: read(${JSON.stringify(join(tmp, "secret.txt"))}),
+        omgCode: read(${JSON.stringify(join(omgRoot, "code.txt"))}),
+        boxSecret: read(${JSON.stringify(join(dataDir, "session-secret"))}),
+        wroteWorktree: (() => { try { fs.writeFileSync("out.txt", "ok"); return true; } catch { return false; } })(),
+      };
+      console.log(JSON.stringify(out));
+    `;
+    const { command, sandboxed } = sandboxCommand([process.execPath, "-e", script], "bwrap", {
+      worktree,
+      omgRoot,
+      dataDir,
+    }, bin);
+    expect(sandboxed).toBe(true);
+
+    const proc = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    await proc.exited;
+    const line = stdout.trim().split("\n").pop() ?? "";
+    let parsed: { inside: string | null; sibling: string | null; omgCode: string | null; boxSecret: string | null; wroteWorktree: boolean };
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error(`sandbox run produced no JSON. stdout=${stdout} stderr=${stderr}`);
+    }
+    // The worktree is fully usable.
+    expect(parsed.inside).toBe("project file");
+    expect(parsed.wroteWorktree).toBe(true);
+    // A sibling path outside the worktree is not there.
+    expect(parsed.sibling).toBeNull();
+    // The omg code tree is readable so the harness can run,
+    expect(parsed.omgCode).toBe("omg code");
+    // but the omg data dir inside it is masked: the box secret is unreadable.
+    expect(parsed.boxSecret).toBeNull();
+  });
+});

--- a/src/sandbox/bwrap.ts
+++ b/src/sandbox/bwrap.ts
@@ -1,0 +1,127 @@
+// Filesystem isolation for a restricted coding-agent harness, via bubblewrap.
+//
+// A sandboxed session sees only what it needs to work: the system read-only,
+// its own worktree read-write, the omg code tree and Bun read-only so the
+// harness can run, and nothing else. Everything that would let a restricted
+// session read another project, another user's worktree, the box's SSH or
+// cloud keys, or omg's own secrets (the session-token secret, the Executor
+// bearer, roles) is absent, because home is a fresh tmpfs and the omg data
+// dir is masked even though the code tree around it is exposed.
+//
+// Network is deliberately shared: the harness still needs the model API and
+// the omg MCP endpoint on loopback. Per-host network restriction is a
+// separate, larger piece (a local proxy or nftables in the namespace) and is
+// not attempted here. See docs/team-tooling-design.md.
+//
+// The credential model this relies on: a process-supervised harness (aisdk,
+// codex-aisdk, pi) receives its model credentials through the environment,
+// which bwrap passes through, not through a file under home. So an empty home
+// costs the harness nothing and withholds the owner's stored logins from a
+// restricted role.
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+
+export type SandboxMode = "none" | "bwrap";
+
+export interface BwrapPlan {
+  /** The worktree the session runs in; the only writable project path. */
+  worktree: string;
+  /** The omg install tree, exposed read-only so the harness script resolves. */
+  omgRoot: string;
+  /** The omg data dir, masked with a tmpfs so its secrets are not readable. */
+  dataDir: string;
+  /** Absolute path of the runtime binary (bun); its dir is exposed read-only. */
+  runtime: string;
+  /** Home directory, replaced with an empty tmpfs. */
+  home: string;
+}
+
+/** True when bubblewrap can be used on this box. */
+export function bwrapAvailable(bin: string | null = bwrapBinary()): boolean {
+  return process.platform === "linux" && bin !== null;
+}
+
+export function bwrapBinary(): string | null {
+  const override = process.env.OMG_BWRAP_BIN?.trim();
+  if (override) return existsSync(override) ? override : null;
+  for (const dir of (process.env.PATH ?? "").split(":")) {
+    if (!dir) continue;
+    const candidate = `${dir}/bwrap`;
+    if (existsSync(candidate)) return candidate;
+  }
+  return existsSync("/usr/bin/bwrap") ? "/usr/bin/bwrap" : null;
+}
+
+// System paths mounted read-only when present. /etc is read-only whole: the
+// harness needs resolv.conf and the CA bundle, and a restricted session has no
+// business writing any of it.
+const SYSTEM_ROOTS = ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/lib32", "/etc", "/opt", "/nix"];
+
+/**
+ * Build the bubblewrap argv that runs `command` in the sandbox described by
+ * `plan`. Pure: no filesystem writes, only `existsSync` probes for optional
+ * system paths, so it is fully unit-testable.
+ */
+export function bwrapArgv(command: string[], plan: BwrapPlan, bin = bwrapBinary() ?? "/usr/bin/bwrap"): string[] {
+  const worktree = resolve(plan.worktree);
+  const omgRoot = resolve(plan.omgRoot);
+  const dataDir = resolve(plan.dataDir);
+  const home = resolve(plan.home);
+  const runtimeDir = dirname(resolve(plan.runtime));
+
+  const argv = [bin, "--die-with-parent"];
+  for (const root of SYSTEM_ROOTS) {
+    if (existsSync(root)) argv.push("--ro-bind", root, root);
+  }
+  argv.push("--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp");
+  // An empty home first; the specific subtrees the harness needs are layered
+  // back on top afterwards, so nothing else under home survives.
+  argv.push("--tmpfs", home);
+  // The omg code tree, read-only, then its data dir masked. Order matters:
+  // the tmpfs must come AFTER the ro-bind so it hides the secrets inside it.
+  argv.push("--ro-bind", omgRoot, omgRoot);
+  if (dataDir.startsWith(omgRoot)) argv.push("--tmpfs", dataDir);
+  // The runtime (bun) directory, in case it lives under the masked home.
+  if (!runtimeDir.startsWith(omgRoot)) argv.push("--ro-bind", runtimeDir, runtimeDir);
+  // The worktree is the one writable project path.
+  argv.push("--bind", worktree, worktree);
+  argv.push("--chdir", worktree);
+  // Isolate every namespace except the network: the harness still needs the
+  // model API and the omg MCP endpoint on loopback.
+  argv.push(
+    "--unshare-user",
+    "--unshare-pid",
+    "--unshare-ipc",
+    "--unshare-uts",
+    "--unshare-cgroup",
+  );
+  argv.push("--", ...command);
+  return argv;
+}
+
+/**
+ * Wrap `command` for the requested sandbox mode.
+ *
+ * `none`, a non-linux host, or a missing bwrap all return the command
+ * unchanged; the caller decides whether that silent fallback is acceptable
+ * for the session (it logs a warning). `defaultPlan` supplies the standard
+ * bindings from this box's own paths.
+ */
+export function sandboxCommand(
+  command: string[],
+  mode: SandboxMode,
+  plan: Pick<BwrapPlan, "worktree" | "omgRoot" | "dataDir">,
+  bin: string | null = bwrapBinary(),
+): { command: string[]; sandboxed: boolean; reason?: string } {
+  if (mode !== "bwrap") return { command, sandboxed: false };
+  if (!bwrapAvailable(bin)) {
+    return { command, sandboxed: false, reason: "bubblewrap is not available on this host" };
+  }
+  const full: BwrapPlan = {
+    ...plan,
+    runtime: process.execPath,
+    home: process.env.HOME ?? homedir(),
+  };
+  return { command: bwrapArgv(command, full, bin ?? undefined), sandboxed: true };
+}

--- a/src/sandbox/egress-proxy.test.ts
+++ b/src/sandbox/egress-proxy.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+import {
+  DEFAULT_ALLOW_HOSTS,
+  credentialsFromProxyAuth,
+  hostAllowed,
+  parseHostPort,
+  startEgressProxy,
+  type EgressProxy,
+} from "./egress-proxy.ts";
+
+describe("hostAllowed", () => {
+  test("exact and suffix matching", () => {
+    expect(hostAllowed("api.anthropic.com", [".anthropic.com"])).toBe(true);
+    expect(hostAllowed("anthropic.com", [".anthropic.com"])).toBe(true);
+    expect(hostAllowed("evil-anthropic.com", [".anthropic.com"])).toBe(false);
+    expect(hostAllowed("api.openai.com", ["api.openai.com"])).toBe(true);
+    expect(hostAllowed("api.openai.com.evil.com", ["api.openai.com"])).toBe(false);
+    expect(hostAllowed("API.Anthropic.Com.", [".anthropic.com"])).toBe(true);
+    expect(hostAllowed("example.com", [])).toBe(false);
+  });
+
+  test("the built-in model hosts cover the providers", () => {
+    expect(hostAllowed("api.anthropic.com", DEFAULT_ALLOW_HOSTS)).toBe(true);
+    expect(hostAllowed("generativelanguage.googleapis.com", DEFAULT_ALLOW_HOSTS)).toBe(true);
+    expect(hostAllowed("pastebin.com", DEFAULT_ALLOW_HOSTS)).toBe(false);
+  });
+});
+
+describe("parseHostPort", () => {
+  test("host, host:port, and ipv6", () => {
+    expect(parseHostPort("api.anthropic.com:443", 443)).toEqual({ host: "api.anthropic.com", port: 443 });
+    expect(parseHostPort("api.anthropic.com", 443)).toEqual({ host: "api.anthropic.com", port: 443 });
+    expect(parseHostPort("[::1]:8080", 443)).toEqual({ host: "::1", port: 8080 });
+  });
+});
+
+describe("credentialsFromProxyAuth", () => {
+  test("decodes Basic sessionId:token", () => {
+    const header = `Basic ${Buffer.from("sess-1:tok-abc").toString("base64")}`;
+    expect(credentialsFromProxyAuth(header)).toEqual({ sessionId: "sess-1", token: "tok-abc" });
+    expect(credentialsFromProxyAuth(undefined)).toBeNull();
+    expect(credentialsFromProxyAuth("Bearer x")).toBeNull();
+  });
+});
+
+// A live proxy on loopback with a stub upstream. Proves the CONNECT tunnel is
+// gated: an allowed host reaches the upstream, a denied host is 403, and a bad
+// token is 407.
+describe("egress proxy (live)", () => {
+  let proxy: EgressProxy | null = null;
+  let upstream: net.Server | null = null;
+
+  afterEach(() => {
+    proxy?.stop();
+    upstream?.close();
+    proxy = null;
+    upstream = null;
+  });
+
+  function connectThrough(proxyPort: number, auth: string, target: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const sock = net.connect(proxyPort, "127.0.0.1", () => {
+        sock.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\nProxy-Authorization: ${auth}\r\n\r\n`);
+      });
+      let buf = "";
+      sock.on("data", (d) => {
+        buf += d.toString();
+        if (buf.includes("\r\n\r\n")) {
+          resolve(buf.split("\r\n")[0]!);
+          sock.end();
+        }
+      });
+      sock.on("error", reject);
+      setTimeout(() => reject(new Error("timeout")), 3000);
+    });
+  }
+
+  test("allows an allowlisted host, denies others, refuses a bad token", async () => {
+    // A trivial TCP upstream that accepts connections; the tunnel only needs it
+    // to exist for the CONNECT to succeed.
+    upstream = net.createServer((s) => s.end());
+    await new Promise<void>((r) => upstream!.listen(0, "127.0.0.1", () => r()));
+    const upstreamPort = (upstream.address() as net.AddressInfo).port;
+
+    proxy = await startEgressProxy({
+      resolve: (sessionId, token) =>
+        token === "good" ? { sessionId, allow: ["127.0.0.1"] } : null,
+    });
+    const good = `Basic ${Buffer.from("s1:good").toString("base64")}`;
+    const bad = `Basic ${Buffer.from("s1:bad").toString("base64")}`;
+
+    const allowed = await connectThrough(proxy.port, good, `127.0.0.1:${upstreamPort}`);
+    expect(allowed).toContain("200");
+
+    const denied = await connectThrough(proxy.port, good, `example.com:443`);
+    expect(denied).toContain("403");
+
+    const unauth = await connectThrough(proxy.port, bad, `127.0.0.1:${upstreamPort}`);
+    expect(unauth).toContain("407");
+  });
+
+  test("proxyUrlFor embeds the session credentials", async () => {
+    proxy = await startEgressProxy({ resolve: () => null });
+    const url = proxy.proxyUrlFor("s 1", "t/k");
+    expect(url).toContain("@127.0.0.1:");
+    expect(url).toContain("s%201");
+    expect(url).toContain("t%2Fk");
+  });
+});

--- a/src/sandbox/egress-proxy.test.ts
+++ b/src/sandbox/egress-proxy.test.ts
@@ -101,6 +101,17 @@ describe("egress proxy (live)", () => {
     expect(unauth).toContain("407");
   });
 
+  test("a raw IP not on the allowlist is denied (no exfil to an arbitrary address)", async () => {
+    upstream = net.createServer((s) => s.end());
+    await new Promise<void>((r) => upstream!.listen(0, "127.0.0.1", () => r()));
+    const upstreamPort = (upstream.address() as net.AddressInfo).port;
+    // The allowlist is a hostname; a dialled raw IP does not match it.
+    proxy = await startEgressProxy({ resolve: (sessionId) => ({ sessionId, allow: ["api.anthropic.com"] }) });
+    const auth = `Basic ${Buffer.from("s1:good").toString("base64")}`;
+    const denied = await connectThrough(proxy.port, auth, `127.0.0.1:${upstreamPort}`);
+    expect(denied).toContain("403");
+  });
+
   test("proxyUrlFor embeds the session credentials", async () => {
     proxy = await startEgressProxy({ resolve: () => null });
     const url = proxy.proxyUrlFor("s 1", "t/k");

--- a/src/sandbox/egress-proxy.ts
+++ b/src/sandbox/egress-proxy.ts
@@ -1,0 +1,200 @@
+// The egress proxy: a per-box HTTP CONNECT proxy that a sandboxed session's
+// harness is pointed at, so its outbound traffic reaches only an allowlist of
+// hosts (the model API, plus whatever the role permits) and nothing else.
+//
+// This is the "best-effort" layer of network isolation (docs/team-tooling-
+// design.md): the harness gets HTTP_PROXY / HTTPS_PROXY in its environment and
+// the SDKs honour them, so ordinary model and tool traffic is filtered and
+// logged. It is not a jail on its own — an agent that dials a raw IP past the
+// proxy env escapes it. The strict layer that closes that gap is an
+// `--unshare-net` namespace with nftables allowing only this proxy, added
+// separately; this proxy is what that namespace would forward to.
+//
+// One in-process listener on loopback identifies the calling session from the
+// proxy credentials (the same per-session token the MCP endpoints use), so a
+// single proxy serves every session and each is held to its own role's
+// allowlist.
+import http from "node:http";
+import net from "node:net";
+
+export type EgressResolution = { sessionId: string; allow: string[] } | null;
+
+/** Hosts every sandboxed session may reach regardless of role: the model APIs. */
+export const DEFAULT_ALLOW_HOSTS = [
+  ".anthropic.com",
+  ".openai.com",
+  ".openai.azure.com",
+  ".googleapis.com",
+  ".x.ai",
+  ".deepseek.com",
+  ".githubusercontent.com",
+];
+
+/**
+ * Does `host` match one entry of `allow`?
+ *
+ * An entry that starts with a dot is a suffix match on the domain
+ * (`.anthropic.com` allows `api.anthropic.com` and `anthropic.com`); anything
+ * else is an exact host match. Case-insensitive; a trailing dot on the host is
+ * ignored.
+ */
+export function hostAllowed(host: string, allow: string[]): boolean {
+  const h = host.trim().toLowerCase().replace(/\.$/, "");
+  if (!h) return false;
+  for (const raw of allow) {
+    const entry = raw.trim().toLowerCase().replace(/\.$/, "");
+    if (!entry) continue;
+    if (entry.startsWith(".")) {
+      const domain = entry.slice(1);
+      if (h === domain || h.endsWith(entry)) return true;
+    } else if (h === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Split `host:port` from a CONNECT target or an absolute URL authority. */
+export function parseHostPort(target: string, defaultPort: number): { host: string; port: number } | null {
+  // IPv6 literal in brackets.
+  const v6 = target.match(/^\[([0-9a-fA-F:]+)\](?::(\d+))?$/);
+  if (v6) return { host: v6[1]!, port: v6[2] ? Number(v6[2]) : defaultPort };
+  const idx = target.lastIndexOf(":");
+  if (idx > 0 && /^\d+$/.test(target.slice(idx + 1))) {
+    return { host: target.slice(0, idx), port: Number(target.slice(idx + 1)) };
+  }
+  return target ? { host: target, port: defaultPort } : null;
+}
+
+/** Read the sessionId and token from a Proxy-Authorization: Basic header. */
+export function credentialsFromProxyAuth(header: string | undefined): { sessionId: string; token: string } | null {
+  if (!header) return null;
+  const m = header.match(/^Basic\s+(.+)$/i);
+  if (!m) return null;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(m[1]!, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+  const sep = decoded.indexOf(":");
+  if (sep < 0) return null;
+  return { sessionId: decoded.slice(0, sep), token: decoded.slice(sep + 1) };
+}
+
+export interface EgressProxy {
+  port: number;
+  /** The HTTP_PROXY value a session uses: carries its own credentials. */
+  proxyUrlFor: (sessionId: string, token: string) => string;
+  stop: () => void;
+}
+
+export interface EgressProxyOptions {
+  /** Resolve the caller from its proxy credentials to a session + allowlist. */
+  resolve: (sessionId: string, token: string) => EgressResolution;
+  /** Preferred loopback port; falls back to an ephemeral one. */
+  port?: number;
+  log?: (line: string) => void;
+}
+
+/**
+ * Start the loopback egress proxy. Returns once it is listening.
+ *
+ * CONNECT (HTTPS) is the path that matters — every model API is TLS — and is
+ * tunnelled byte-for-byte after the allowlist check. Plain HTTP requests are
+ * checked the same way and refused when not allowed; the proxy does not try to
+ * be a general forward cache.
+ */
+export function startEgressProxy(opts: EgressProxyOptions): Promise<EgressProxy> {
+  const log = opts.log ?? (() => {});
+  const server = http.createServer();
+
+  // Plain HTTP through the proxy: the request line carries an absolute URL.
+  server.on("request", (req, res) => {
+    const creds = credentialsFromProxyAuth(req.headers["proxy-authorization"] as string | undefined);
+    const resolved = creds ? opts.resolve(creds.sessionId, creds.token) : null;
+    if (!resolved) {
+      res.writeHead(407, { "Proxy-Authenticate": 'Basic realm="omg-egress"' });
+      res.end("proxy authentication required");
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(req.url ?? "");
+    } catch {
+      res.writeHead(400);
+      res.end("the egress proxy only forwards absolute-form requests");
+      return;
+    }
+    if (!hostAllowed(url.hostname, resolved.allow)) {
+      log(`[egress] deny ${resolved.sessionId} http ${url.hostname}`);
+      res.writeHead(403);
+      res.end(`host ${url.hostname} is not allowed for this session`);
+      return;
+    }
+    log(`[egress] allow ${resolved.sessionId} http ${url.hostname}`);
+    const upstream = http.request(
+      {
+        host: url.hostname,
+        port: url.port ? Number(url.port) : 80,
+        method: req.method,
+        path: url.pathname + url.search,
+        headers: { ...req.headers, "proxy-authorization": undefined },
+      },
+      (up) => {
+        res.writeHead(up.statusCode ?? 502, up.headers);
+        up.pipe(res);
+      },
+    );
+    upstream.on("error", () => {
+      if (!res.headersSent) res.writeHead(502);
+      res.end("upstream unreachable");
+    });
+    req.pipe(upstream);
+  });
+
+  // CONNECT: the HTTPS tunnel. Authorise, then splice the two sockets.
+  server.on("connect", (req, clientSocket, head) => {
+    const creds = credentialsFromProxyAuth(req.headers["proxy-authorization"] as string | undefined);
+    const resolved = creds ? opts.resolve(creds.sessionId, creds.token) : null;
+    if (!resolved) {
+      clientSocket.write("HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"omg-egress\"\r\n\r\n");
+      clientSocket.end();
+      return;
+    }
+    const target = parseHostPort(req.url ?? "", 443);
+    if (!target || !hostAllowed(target.host, resolved.allow)) {
+      log(`[egress] deny ${resolved.sessionId} connect ${req.url}`);
+      clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+      clientSocket.end();
+      return;
+    }
+    log(`[egress] allow ${resolved.sessionId} connect ${target.host}:${target.port}`);
+    const upstream = net.connect(target.port, target.host, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.length) upstream.write(head);
+      upstream.pipe(clientSocket);
+      clientSocket.pipe(upstream);
+    });
+    const drop = () => {
+      upstream.destroy();
+      clientSocket.destroy();
+    };
+    upstream.on("error", drop);
+    clientSocket.on("error", drop);
+  });
+
+  return new Promise((resolve) => {
+    server.listen(opts.port ?? 0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : (opts.port ?? 0);
+      log(`[egress] listening on 127.0.0.1:${port}`);
+      resolve({
+        port,
+        proxyUrlFor: (sessionId, token) =>
+          `http://${encodeURIComponent(sessionId)}:${encodeURIComponent(token)}@127.0.0.1:${port}`,
+        stop: () => server.close(),
+      });
+    });
+  });
+}

--- a/src/sandbox/harness-wrap.test.ts
+++ b/src/sandbox/harness-wrap.test.ts
@@ -1,0 +1,54 @@
+// The spawn path wraps the harness command in bwrap when the session's role
+// asks for it. Uses the harness capture seam (LFG_TEST_HARNESS_CAPTURE) so no
+// real provider process starts.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bwrapAvailable } from "./bwrap.ts";
+import { spawnManagedAisdkSession } from "../tmux.ts";
+
+let tmp: string;
+let capture: string;
+const originalCapture = process.env.LFG_TEST_HARNESS_CAPTURE;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "omg-hwrap-"));
+  capture = join(tmp, "capture.json");
+  process.env.LFG_TEST_HARNESS_CAPTURE = capture;
+});
+
+afterEach(() => {
+  if (originalCapture === undefined) delete process.env.LFG_TEST_HARNESS_CAPTURE;
+  else process.env.LFG_TEST_HARNESS_CAPTURE = originalCapture;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function captured(): { cmd: string[] } {
+  return JSON.parse(readFileSync(capture, "utf8")) as { cmd: string[] };
+}
+
+describe("harness sandbox wrapping", () => {
+  test("no sandbox: the command is the raw harness argv", () => {
+    const res = spawnManagedAisdkSession({ name: "n1", cwd: tmp, model: "opus", sessionId: "s1" });
+    expect(res.ok).toBe(true);
+    const { cmd } = captured();
+    expect(cmd[0]).toBe(process.execPath);
+    expect(cmd.some((a) => a.endsWith("/bwrap") || a === "bwrap")).toBe(false);
+  });
+
+  const run = bwrapAvailable() ? test : test.skip;
+  run("sandbox bwrap: the harness is wrapped and the worktree is bound", () => {
+    const res = spawnManagedAisdkSession({ name: "n2", cwd: tmp, model: "opus", sessionId: "s2", sandbox: "bwrap" });
+    expect(res.ok).toBe(true);
+    const { cmd } = captured();
+    expect(cmd[0]!.endsWith("/bwrap") || cmd[0] === "bwrap").toBe(true);
+    const s = cmd.join(" ");
+    expect(s).toContain(`--bind ${tmp} ${tmp}`);
+    expect(s).toContain(`--chdir ${tmp}`);
+    // The real harness argv still follows the bwrap `--` separator.
+    const sep = cmd.indexOf("--");
+    expect(sep).toBeGreaterThan(0);
+    expect(cmd[sep + 1]).toBe(process.execPath);
+  });
+});

--- a/src/sandbox/harness-wrap.test.ts
+++ b/src/sandbox/harness-wrap.test.ts
@@ -24,8 +24,8 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-function captured(): { cmd: string[] } {
-  return JSON.parse(readFileSync(capture, "utf8")) as { cmd: string[] };
+function captured(): { cmd: string[]; env: Record<string, string> } {
+  return JSON.parse(readFileSync(capture, "utf8")) as { cmd: string[]; env: Record<string, string> };
 }
 
 describe("harness sandbox wrapping", () => {
@@ -50,5 +50,22 @@ describe("harness sandbox wrapping", () => {
     const sep = cmd.indexOf("--");
     expect(sep).toBeGreaterThan(0);
     expect(cmd[sep + 1]).toBe(process.execPath);
+  });
+
+  test("egress proxy url becomes HTTP(S)_PROXY with loopback in NO_PROXY", () => {
+    const url = "http://s3:tok@127.0.0.1:41000";
+    const res = spawnManagedAisdkSession({ name: "n3", cwd: tmp, model: "opus", sessionId: "s3", egressProxyUrl: url });
+    expect(res.ok).toBe(true);
+    const { env } = captured();
+    expect(env.HTTP_PROXY).toBe(url);
+    expect(env.HTTPS_PROXY).toBe(url);
+    expect(env.NO_PROXY).toContain("127.0.0.1");
+  });
+
+  test("no egress: no proxy env", () => {
+    const res = spawnManagedAisdkSession({ name: "n4", cwd: tmp, model: "opus", sessionId: "s4" });
+    expect(res.ok).toBe(true);
+    const { env } = captured();
+    expect(env.HTTP_PROXY ?? null).toBeNull();
   });
 });

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -228,7 +228,7 @@ export type ManagedHarnessSpawnResult = { ok: boolean; error?: string; pid?: num
 // separately by the boot reconciliation journal in session-recovery.ts.
 function spawnManagedHarness(
   command: string[],
-  opts: AgentContainment & { containInAgentSlice?: boolean; sandbox?: SandboxMode },
+  opts: AgentContainment & { containInAgentSlice?: boolean; sandbox?: SandboxMode; egressProxyUrl?: string },
 ): ManagedHarnessSpawnResult {
   const sessionId = opts.omgSessionId?.trim() || undefined;
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
@@ -240,6 +240,18 @@ function spawnManagedHarness(
   // spawns. containInAgentSlice still only wraps subagents in systemd-run.
   Object.assign(env, agentBrowserEnv(opts.name));
   Object.assign(env, agentTmpEnv());
+  // Outbound network allowlist for a restricted role: point the harness at the
+  // egress proxy (src/sandbox/egress-proxy.ts). Loopback (the omg MCP endpoint)
+  // bypasses it. Both spellings, since tools disagree on case.
+  if (opts.egressProxyUrl) {
+    const noProxy = "127.0.0.1,localhost,::1";
+    env.HTTP_PROXY = opts.egressProxyUrl;
+    env.HTTPS_PROXY = opts.egressProxyUrl;
+    env.http_proxy = opts.egressProxyUrl;
+    env.https_proxy = opts.egressProxyUrl;
+    env.NO_PROXY = noProxy;
+    env.no_proxy = noProxy;
+  }
   // Filesystem isolation wraps the harness command itself, inside any systemd
   // containment: bwrap needs its own namespaces, and the transient service (a
   // subagent-only path) supervises the whole thing. A requested sandbox that
@@ -268,6 +280,9 @@ function spawnManagedHarness(
       LFG_USER: env.LFG_USER,
       AGENT_BROWSER_SESSION: env.AGENT_BROWSER_SESSION,
       AGENT_BROWSER_IDLE_TIMEOUT_MS: env.AGENT_BROWSER_IDLE_TIMEOUT_MS,
+      HTTP_PROXY: env.HTTP_PROXY,
+      HTTPS_PROXY: env.HTTPS_PROXY,
+      NO_PROXY: env.NO_PROXY,
     } }));
     return { ok: true, pid: 424242 };
   }
@@ -1141,6 +1156,8 @@ export type ManagedAisdkSessionOptions = {
   containInAgentSlice?: boolean;
   /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
   sandbox?: SandboxMode;
+  /** Egress proxy URL (src/sandbox/egress-proxy.ts) when the role restricts network. */
+  egressProxyUrl?: string;
   claudeAccountId?: string;
   recoveredAt?: number;
 };
@@ -1178,6 +1195,7 @@ export function spawnManagedAisdkSession(opts: ManagedAisdkSessionOptions): Mana
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
     sandbox: opts.sandbox,
+    egressProxyUrl: opts.egressProxyUrl,
   });
 }
 
@@ -1199,6 +1217,8 @@ export type ManagedCodexAisdkSessionOptions = {
   containInAgentSlice?: boolean;
   /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
   sandbox?: SandboxMode;
+  /** Egress proxy URL (src/sandbox/egress-proxy.ts) when the role restricts network. */
+  egressProxyUrl?: string;
   // When set, resume this existing codex rollout/thread instead of starting a
   // fresh persistent thread — the harness seeds its threadId with it.
   resume?: string;
@@ -1239,6 +1259,7 @@ export function spawnManagedCodexAisdkSession(opts: ManagedCodexAisdkSessionOpti
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
     sandbox: opts.sandbox,
+    egressProxyUrl: opts.egressProxyUrl,
   });
 }
 
@@ -1259,6 +1280,8 @@ export function spawnManagedPiSession(opts: {
   containInAgentSlice?: boolean;
   /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
   sandbox?: SandboxMode;
+  /** Egress proxy URL (src/sandbox/egress-proxy.ts) when the role restricts network. */
+  egressProxyUrl?: string;
   // When set, resume this existing pi session file instead of starting a fresh
   // one — the harness passes it through as `--session <id>`.
   resume?: string;
@@ -1289,6 +1312,7 @@ export function spawnManagedPiSession(opts: {
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
     sandbox: opts.sandbox,
+    egressProxyUrl: opts.egressProxyUrl,
   });
 }
 
@@ -1311,6 +1335,8 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   containInAgentSlice?: boolean;
   /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
   sandbox?: SandboxMode;
+  /** Egress proxy URL (src/sandbox/egress-proxy.ts) when the role restricts network. */
+  egressProxyUrl?: string;
   recoveredAt?: number;
 }): ManagedHarnessSpawnResult {
   // Harmless for opencode: ensureFolderTrusted only patches ~/.claude.json and
@@ -1339,6 +1365,7 @@ export function spawnManagedOpencodeAisdkSession(opts: {
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
     sandbox: opts.sandbox,
+    egressProxyUrl: opts.egressProxyUrl,
   });
 }
 
@@ -1354,6 +1381,8 @@ type ManagedStructuredSessionOptions = {
   containInAgentSlice?: boolean;
   /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
   sandbox?: SandboxMode;
+  /** Egress proxy URL (src/sandbox/egress-proxy.ts) when the role restricts network. */
+  egressProxyUrl?: string;
   resume?: string;
   recoveredAt?: number;
 };
@@ -1407,6 +1436,7 @@ function spawnManagedStructuredSession(
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
     sandbox: opts.sandbox,
+    egressProxyUrl: opts.egressProxyUrl,
   });
 }
 

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -17,6 +17,8 @@ import {
   resolveClaudeAccount,
 } from "./claude-accounts.ts";
 import { agentTmpEnv } from "./tmp-reclaim.ts";
+import { PATHS } from "./config.ts";
+import { sandboxCommand, type SandboxMode } from "./sandbox/bwrap.ts";
 import {
   codexServiceTierArgs,
   type CodexServiceTier,
@@ -226,7 +228,7 @@ export type ManagedHarnessSpawnResult = { ok: boolean; error?: string; pid?: num
 // separately by the boot reconciliation journal in session-recovery.ts.
 function spawnManagedHarness(
   command: string[],
-  opts: AgentContainment & { containInAgentSlice?: boolean },
+  opts: AgentContainment & { containInAgentSlice?: boolean; sandbox?: SandboxMode },
 ): ManagedHarnessSpawnResult {
   const sessionId = opts.omgSessionId?.trim() || undefined;
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
@@ -238,9 +240,23 @@ function spawnManagedHarness(
   // spawns. containInAgentSlice still only wraps subagents in systemd-run.
   Object.assign(env, agentBrowserEnv(opts.name));
   Object.assign(env, agentTmpEnv());
+  // Filesystem isolation wraps the harness command itself, inside any systemd
+  // containment: bwrap needs its own namespaces, and the transient service (a
+  // subagent-only path) supervises the whole thing. A requested sandbox that
+  // cannot run here does not silently pass — it is logged and the session runs
+  // unsandboxed rather than failing to launch.
+  const sandboxed = sandboxCommand(command, opts.sandbox ?? "none", {
+    worktree: opts.cwd,
+    omgRoot: PATHS.root,
+    dataDir: PATHS.data,
+  });
+  if (opts.sandbox === "bwrap" && !sandboxed.sandboxed) {
+    console.error(`[sandbox] session ${opts.name} requested bwrap but ${sandboxed.reason}; running unsandboxed`);
+  }
+  const base = sandboxed.command;
   const cmd = opts.containInAgentSlice
-    ? containedAgentCommand(command, opts, { pty: false })
-    : command;
+    ? containedAgentCommand(base, opts, { pty: false })
+    : base;
 
   // Process-isolated integration tests capture the launch contract without
   // starting a real provider harness.
@@ -1123,6 +1139,8 @@ export type ManagedAisdkSessionOptions = {
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
+  /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
+  sandbox?: SandboxMode;
   claudeAccountId?: string;
   recoveredAt?: number;
 };
@@ -1159,6 +1177,7 @@ export function spawnManagedAisdkSession(opts: ManagedAisdkSessionOptions): Mana
     omgSessionId: opts.omgSessionId ?? opts.sessionId,
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
+    sandbox: opts.sandbox,
   });
 }
 
@@ -1178,6 +1197,8 @@ export type ManagedCodexAisdkSessionOptions = {
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
+  /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
+  sandbox?: SandboxMode;
   // When set, resume this existing codex rollout/thread instead of starting a
   // fresh persistent thread — the harness seeds its threadId with it.
   resume?: string;
@@ -1217,6 +1238,7 @@ export function spawnManagedCodexAisdkSession(opts: ManagedCodexAisdkSessionOpti
     omgSessionId: opts.omgSessionId ?? opts.key,
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
+    sandbox: opts.sandbox,
   });
 }
 
@@ -1235,6 +1257,8 @@ export function spawnManagedPiSession(opts: {
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
+  /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
+  sandbox?: SandboxMode;
   // When set, resume this existing pi session file instead of starting a fresh
   // one — the harness passes it through as `--session <id>`.
   resume?: string;
@@ -1264,6 +1288,7 @@ export function spawnManagedPiSession(opts: {
     omgSessionId: opts.omgSessionId ?? opts.key,
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
+    sandbox: opts.sandbox,
   });
 }
 
@@ -1284,6 +1309,8 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   omgUser?: string | null;
   resume?: string;
   containInAgentSlice?: boolean;
+  /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
+  sandbox?: SandboxMode;
   recoveredAt?: number;
 }): ManagedHarnessSpawnResult {
   // Harmless for opencode: ensureFolderTrusted only patches ~/.claude.json and
@@ -1311,6 +1338,7 @@ export function spawnManagedOpencodeAisdkSession(opts: {
     omgSessionId: opts.omgSessionId ?? opts.key,
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
+    sandbox: opts.sandbox,
   });
 }
 
@@ -1324,6 +1352,8 @@ type ManagedStructuredSessionOptions = {
   omgSessionId?: string;
   omgUser?: string | null;
   containInAgentSlice?: boolean;
+  /** Filesystem isolation for this session (src/sandbox/bwrap.ts). */
+  sandbox?: SandboxMode;
   resume?: string;
   recoveredAt?: number;
 };
@@ -1376,6 +1406,7 @@ function spawnManagedStructuredSession(
     omgSessionId: opts.omgSessionId ?? opts.key,
     omgUser: opts.omgUser,
     containInAgentSlice: opts.containInAgentSlice,
+    sandbox: opts.sandbox,
   });
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -558,6 +558,7 @@ import {
 } from "./views/custom-instructions-page";
 import { RemoteAccessSettingsSection } from "./components/remote-access-settings";
 import { ExecutorSettingsSection } from "./components/executor-settings";
+import { ConnectorsPage, ConnectorsRow } from "./views/connectors-page";
 import {
   UpdateNavButton,
   UpdateProvider,
@@ -755,6 +756,9 @@ type ActionRow = {
 export type Session = {
   agent?: "claude" | "aisdk" | "codex" | "codex-aisdk" | "opencode" | "grok" | "cursor" | string;
   runtime?: "tmux" | "command-file";
+  // Role the session runs as at the MCP endpoints (Settings > Roles). Missing
+  // means owner.
+  role?: string;
   // Display-name override from a custom agent profile (server-side), when set.
   // Prefer this over the raw agent kind for labels/tooltips.
   agentLabel?: string | null;
@@ -9018,6 +9022,7 @@ export function App() {
             onChange={(customInstructions) => updateSettings({ customInstructions })}
           />
         ) : null}
+        {tab === "connectors" ? <ConnectorsPage /> : null}
         {tab === "computer" ? (
           <Suspense
             fallback={<div className="py-10 text-center text-sm text-muted-foreground">Loading…</div>}
@@ -9061,6 +9066,7 @@ export function App() {
         tab !== "storage" &&
         tab !== "computer" &&
         tab !== "instructions" &&
+        tab !== "connectors" &&
         tab !== "more" &&
         !extNavTabs.some((t) => t.id === tab) ? (
           <SettingsView
@@ -9070,6 +9076,7 @@ export function App() {
             onOpenStorage={() => setTab("storage")}
             onOpenMore={() => setTab("more")}
             onOpenCustomInstructions={() => setTab("instructions")}
+            onOpenConnectors={() => setTab("connectors")}
             settings={settings}
             onSettingsChange={updateSettings}
             connection={useWsLive ? wsLiveStream.connection : null}
@@ -21076,6 +21083,23 @@ function NewSessionDialog({
     () => resolveInitialAgent(localStorage.getItem("lfg_v2_agent"), defaultAgent),
   );
   const [claudeAccountId, setClaudeAccountId] = useState("");
+  // Role the new session runs as (Settings > Roles). "" is owner. The picker
+  // only appears once a role other than owner exists on this box.
+  const [role, setRole] = useState(() => localStorage.getItem("lfg_v2_role") || "");
+  const [roleOptions, setRoleOptions] = useState<{ id: string; name: string }[]>([]);
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/api/roles", { credentials: "same-origin", signal: controller.signal })
+      .then(async (res) => (res.ok ? ((await res.json()) as { roles: { id: string; name: string }[] }) : null))
+      .then((payload) => {
+        if (!payload) return;
+        setRoleOptions(payload.roles.map((r) => ({ id: r.id, name: r.name })));
+        // A remembered role that no longer exists must not be sent.
+        setRole((current) => (payload.roles.some((r) => r.id === current) ? current : ""));
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
   const [repo, setRepo] = useState(() => localStorage.getItem("lfg_v2_repo") || "");
   const [model, setModel] = useState(
     () =>
@@ -21814,6 +21838,7 @@ function NewSessionDialog({
             thinkingLevel: thinkingLevels.length ? launchThinkingLevel : undefined,
             fastMode: launchFastMode,
             claudeAccountId: launchClaudeAccountId,
+            role: role || undefined,
             overLimit: overLimit || undefined,
           }),
         });
@@ -21999,6 +22024,25 @@ function NewSessionDialog({
           onToggle={() => setFastMode(!fastModeEnabled)}
           flat={variant === "inline"}
         />
+      ) : null}
+
+      {roleOptions.length > 1 ? (
+        <select
+          aria-label="Session role"
+          title="Role: which tools this session may use"
+          value={role}
+          onChange={(e) => {
+            setRole(e.target.value);
+            localStorage.setItem("lfg_v2_role", e.target.value);
+          }}
+          className="h-7 max-w-32 rounded-full border border-border bg-background px-2 text-xs"
+        >
+          {roleOptions.map((option) => (
+            <option key={option.id} value={option.id === "owner" ? "" : option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
       ) : null}
 
       {agent === "codex" || agent === "codex-aisdk" ? (
@@ -26905,6 +26949,7 @@ function SettingsView({
   onOpenStorage,
   onOpenMore,
   onOpenCustomInstructions,
+  onOpenConnectors,
   connection,
   computerVersionReport,
 }: {
@@ -26916,6 +26961,7 @@ function SettingsView({
   onOpenStorage: () => void;
   onOpenMore: () => void;
   onOpenCustomInstructions: () => void;
+  onOpenConnectors: () => void;
   connection: ConnectionState | null;
   computerVersionReport: { version: string | null; generation: number } | null;
 }) {
@@ -27011,6 +27057,12 @@ function SettingsView({
         enabled={settings.executorEnabled}
         onEnabledChange={(executorEnabled) => onSettingsChange({ executorEnabled })}
       />
+
+      <section className="space-y-2">
+        <div className="overflow-hidden rounded-2xl border border-border bg-card/40">
+          <ConnectorsRow onOpen={onOpenConnectors} roleCount={null} />
+        </div>
+      </section>
 
       <RemoteAccessSettingsSection />
 

--- a/web/src/views/connectors-page.test.tsx
+++ b/web/src/views/connectors-page.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 
 type Call = { url: string; method: string; body: unknown };
 
-function fakeServer(initialRoles: { id: string; name: string; defaultAction: string; rules: { pattern: string; action: string }[] }[]) {
+function fakeServer(initialRoles: { id: string; name: string; defaultAction: string; rules: { pattern: string; action: string }[]; sandbox?: string }[]) {
   const calls: Call[] = [];
   let roles = initialRoles;
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -27,7 +27,7 @@ function fakeServer(initialRoles: { id: string; name: string; defaultAction: str
     calls.push({ url, method, body });
     if (url.endsWith("/api/roles") && method === "GET") return Response.json({ roles });
     if (url.endsWith("/api/roles") && method === "POST") {
-      const role = { id: body.name.toLowerCase(), name: body.name, defaultAction: "block", rules: [], createdAt: 1, updatedAt: 1 };
+      const role = { id: body.name.toLowerCase(), name: body.name, defaultAction: "block", rules: [], sandbox: "none", createdAt: 1, updatedAt: 1 };
       roles = [...roles, role];
       return Response.json({ role });
     }
@@ -47,13 +47,13 @@ function fakeServer(initialRoles: { id: string; name: string; defaultAction: str
   return { calls };
 }
 
-const OWNER = { id: "owner", name: "Owner", defaultAction: "allow", rules: [] };
+const OWNER = { id: "owner", name: "Owner", defaultAction: "allow", rules: [], sandbox: "none" };
 
 describe("RolesPanel", () => {
   test("lists owner and the stored roles with their rules", async () => {
     fakeServer([
       OWNER,
-      { id: "marketing", name: "Marketing", defaultAction: "block", rules: [{ pattern: "executor.*", action: "allow" }] },
+      { id: "marketing", name: "Marketing", defaultAction: "block", rules: [{ pattern: "executor.*", action: "allow" }], sandbox: "bwrap" },
     ]);
     ui.render(<RolesPanel />);
     await ui.flushAsync();
@@ -61,6 +61,8 @@ describe("RolesPanel", () => {
     expect(ui.text()).toContain("Marketing");
     expect(ui.text()).toContain("executor.*");
     expect(ui.text()).toContain("Allow");
+    const sandbox = ui.query('select[aria-label="Sandbox for Marketing"]') as HTMLSelectElement | null;
+    expect(sandbox?.value).toBe("bwrap");
   });
 
   test("creates a role and adds a rule to it", async () => {

--- a/web/src/views/connectors-page.test.tsx
+++ b/web/src/views/connectors-page.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
 
 type Call = { url: string; method: string; body: unknown };
 
-function fakeServer(initialRoles: { id: string; name: string; defaultAction: string; rules: { pattern: string; action: string }[]; sandbox?: string }[]) {
+function fakeServer(initialRoles: { id: string; name: string; defaultAction: string; rules: { pattern: string; action: string }[]; sandbox?: string; network?: string; allowHosts?: string[] }[]) {
   const calls: Call[] = [];
   let roles = initialRoles;
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -27,7 +27,7 @@ function fakeServer(initialRoles: { id: string; name: string; defaultAction: str
     calls.push({ url, method, body });
     if (url.endsWith("/api/roles") && method === "GET") return Response.json({ roles });
     if (url.endsWith("/api/roles") && method === "POST") {
-      const role = { id: body.name.toLowerCase(), name: body.name, defaultAction: "block", rules: [], sandbox: "none", createdAt: 1, updatedAt: 1 };
+      const role = { id: body.name.toLowerCase(), name: body.name, defaultAction: "block", rules: [], sandbox: "none", network: "shared", allowHosts: [], createdAt: 1, updatedAt: 1 };
       roles = [...roles, role];
       return Response.json({ role });
     }
@@ -47,13 +47,13 @@ function fakeServer(initialRoles: { id: string; name: string; defaultAction: str
   return { calls };
 }
 
-const OWNER = { id: "owner", name: "Owner", defaultAction: "allow", rules: [], sandbox: "none" };
+const OWNER = { id: "owner", name: "Owner", defaultAction: "allow", rules: [], sandbox: "none", network: "shared", allowHosts: [] };
 
 describe("RolesPanel", () => {
   test("lists owner and the stored roles with their rules", async () => {
     fakeServer([
       OWNER,
-      { id: "marketing", name: "Marketing", defaultAction: "block", rules: [{ pattern: "executor.*", action: "allow" }], sandbox: "bwrap" },
+      { id: "marketing", name: "Marketing", defaultAction: "block", rules: [{ pattern: "executor.*", action: "allow" }], sandbox: "bwrap", network: "allowlist", allowHosts: ["github.com"] },
     ]);
     ui.render(<RolesPanel />);
     await ui.flushAsync();
@@ -63,6 +63,9 @@ describe("RolesPanel", () => {
     expect(ui.text()).toContain("Allow");
     const sandbox = ui.query('select[aria-label="Sandbox for Marketing"]') as HTMLSelectElement | null;
     expect(sandbox?.value).toBe("bwrap");
+    const network = ui.query('select[aria-label="Network for Marketing"]') as HTMLSelectElement | null;
+    expect(network?.value).toBe("allowlist");
+    expect(ui.text()).toContain("github.com");
   });
 
   test("creates a role and adds a rule to it", async () => {

--- a/web/src/views/connectors-page.test.tsx
+++ b/web/src/views/connectors-page.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mount, type Mounted } from "../test-support/render";
+
+const { ConnectorsPage, RolesPanel } = await import("./connectors-page");
+
+let ui: Mounted;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  ui = mount();
+});
+
+afterEach(() => {
+  ui.cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+type Call = { url: string; method: string; body: unknown };
+
+function fakeServer(initialRoles: { id: string; name: string; defaultAction: string; rules: { pattern: string; action: string }[] }[]) {
+  const calls: Call[] = [];
+  let roles = initialRoles;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : null;
+    calls.push({ url, method, body });
+    if (url.endsWith("/api/roles") && method === "GET") return Response.json({ roles });
+    if (url.endsWith("/api/roles") && method === "POST") {
+      const role = { id: body.name.toLowerCase(), name: body.name, defaultAction: "block", rules: [], createdAt: 1, updatedAt: 1 };
+      roles = [...roles, role];
+      return Response.json({ role });
+    }
+    const m = url.match(/\/api\/roles\/([a-z0-9-]+)$/);
+    if (m && method === "PATCH") {
+      roles = roles.map((r) => (r.id === m[1] ? { ...r, ...body } : r));
+      return Response.json({ role: roles.find((r) => r.id === m[1]) });
+    }
+    if (m && method === "DELETE") {
+      roles = roles.filter((r) => r.id !== m[1]);
+      return Response.json({ ok: true });
+    }
+    if (url.includes("/api/executor/api/policies")) return Response.json([]);
+    if (url.includes("/api/executor/dashboard")) return Response.json({ url: "http://127.0.0.1:4788/?_token=t" });
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+  return { calls };
+}
+
+const OWNER = { id: "owner", name: "Owner", defaultAction: "allow", rules: [] };
+
+describe("RolesPanel", () => {
+  test("lists owner and the stored roles with their rules", async () => {
+    fakeServer([
+      OWNER,
+      { id: "marketing", name: "Marketing", defaultAction: "block", rules: [{ pattern: "executor.*", action: "allow" }] },
+    ]);
+    ui.render(<RolesPanel />);
+    await ui.flushAsync();
+    expect(ui.text()).toContain("Owner");
+    expect(ui.text()).toContain("Marketing");
+    expect(ui.text()).toContain("executor.*");
+    expect(ui.text()).toContain("Allow");
+  });
+
+  test("creates a role and adds a rule to it", async () => {
+    const { calls } = fakeServer([OWNER]);
+    ui.render(<RolesPanel />);
+    await ui.flushAsync();
+
+    const name = ui.query('input[aria-label="New role name"]') as HTMLInputElement;
+    const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+    await ui.flushAsync(async () => {
+      setValue.call(name, "Design");
+      name.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await ui.flushAsync(async () => {
+      (name.closest("form") as HTMLFormElement).dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    expect(calls.some((c) => c.method === "POST" && c.url.endsWith("/api/roles"))).toBe(true);
+    expect(ui.text()).toContain("Design");
+
+    const pattern = ui.query('input[aria-label="New rule pattern for Design"]') as HTMLInputElement;
+    await ui.flushAsync(async () => {
+      setValue.call(pattern, "omg.ship");
+      pattern.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await ui.flushAsync(async () => {
+      (pattern.closest("form") as HTMLFormElement).dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    const patch = calls.find((c) => c.method === "PATCH");
+    expect(patch?.url.endsWith("/api/roles/design")).toBe(true);
+    expect(patch?.body).toEqual({ rules: [{ pattern: "omg.ship", action: "allow" }] });
+    expect(ui.text()).toContain("omg.ship");
+  });
+});
+
+describe("ConnectorsPage", () => {
+  test("switches between roles, gateway policies and integrations", async () => {
+    fakeServer([OWNER]);
+    ui.render(<ConnectorsPage />);
+    await ui.flushAsync();
+    expect(ui.text()).toContain("Built in.");
+
+    await ui.flushAsync(async () => (ui.queryAll('[role="tab"]')[1] as HTMLElement).click());
+    expect(ui.text()).toContain("No gateway policies");
+
+    await ui.flushAsync(async () => (ui.queryAll('[role="tab"]')[2] as HTMLElement).click());
+    expect(ui.query('iframe[title="Connector gateway"]')).not.toBeNull();
+  });
+});

--- a/web/src/views/connectors-page.tsx
+++ b/web/src/views/connectors-page.tsx
@@ -10,12 +10,14 @@ import { Input } from "@/components/ui/input";
 // ---------------------------------------------------------------------------
 
 export type RuleAction = "allow" | "block";
+export type SandboxMode = "none" | "bwrap";
 export type RoleRule = { pattern: string; action: RuleAction };
 export type Role = {
   id: string;
   name: string;
   defaultAction: RuleAction;
   rules: RoleRule[];
+  sandbox: SandboxMode;
   createdAt: number;
   updatedAt: number;
 };
@@ -240,7 +242,7 @@ function RoleCard({
   const [action, setAction] = useState<RuleAction>("allow");
   const [busy, setBusy] = useState(false);
 
-  const save = async (patch: Partial<Pick<Role, "name" | "defaultAction" | "rules">>) => {
+  const save = async (patch: Partial<Pick<Role, "name" | "defaultAction" | "rules" | "sandbox">>) => {
     setBusy(true);
     try {
       await call(`/api/roles/${role.id}`, { method: "PATCH", body: JSON.stringify(patch) });
@@ -306,6 +308,27 @@ function RoleCard({
         >
           <Trash2 className="size-4" />
         </button>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+        <span className="min-w-0">
+          <span className="block text-sm">Sandbox</span>
+          <span className="block text-xs text-muted-foreground">
+            Run this role&apos;s sessions with an empty home and only their worktree writable.
+          </span>
+        </span>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <select
+            aria-label={`Sandbox for ${role.name}`}
+            value={role.sandbox}
+            disabled={busy}
+            onChange={(e) => void save({ sandbox: e.target.value as SandboxMode })}
+            className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+          >
+            <option value="none">Off</option>
+            <option value="bwrap">Filesystem (bwrap)</option>
+          </select>
+        </label>
       </div>
 
       <ul className="divide-y divide-border">

--- a/web/src/views/connectors-page.tsx
+++ b/web/src/views/connectors-page.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 
 export type RuleAction = "allow" | "block";
 export type SandboxMode = "none" | "bwrap";
+export type NetworkMode = "shared" | "allowlist";
 export type RoleRule = { pattern: string; action: RuleAction };
 export type Role = {
   id: string;
@@ -18,6 +19,8 @@ export type Role = {
   defaultAction: RuleAction;
   rules: RoleRule[];
   sandbox: SandboxMode;
+  network: NetworkMode;
+  allowHosts: string[];
   createdAt: number;
   updatedAt: number;
 };
@@ -242,7 +245,8 @@ function RoleCard({
   const [action, setAction] = useState<RuleAction>("allow");
   const [busy, setBusy] = useState(false);
 
-  const save = async (patch: Partial<Pick<Role, "name" | "defaultAction" | "rules" | "sandbox">>) => {
+  const [hostDraft, setHostDraft] = useState("");
+  const save = async (patch: Partial<Pick<Role, "name" | "defaultAction" | "rules" | "sandbox" | "network" | "allowHosts">>) => {
     setBusy(true);
     try {
       await call(`/api/roles/${role.id}`, { method: "PATCH", body: JSON.stringify(patch) });
@@ -329,6 +333,72 @@ function RoleCard({
             <option value="bwrap">Filesystem (bwrap)</option>
           </select>
         </label>
+      </div>
+
+      <div className="space-y-2 px-4 py-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="min-w-0">
+            <span className="block text-sm">Network</span>
+            <span className="block text-xs text-muted-foreground">
+              Allowlist restricts outbound traffic to the model APIs plus the hosts below.
+            </span>
+          </span>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <select
+              aria-label={`Network for ${role.name}`}
+              value={role.network}
+              disabled={busy}
+              onChange={(e) => void save({ network: e.target.value as NetworkMode })}
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+            >
+              <option value="shared">Shared</option>
+              <option value="allowlist">Allowlist</option>
+            </select>
+          </label>
+        </div>
+        {role.network === "allowlist" ? (
+          <div className="space-y-1.5">
+            <div className="flex flex-wrap gap-1.5">
+              {role.allowHosts.length === 0 ? (
+                <span className="text-xs text-muted-foreground">Model APIs only. Add a host to allow more.</span>
+              ) : null}
+              {role.allowHosts.map((host) => (
+                <span key={host} className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px]">
+                  <code>{host}</code>
+                  <button
+                    type="button"
+                    aria-label={`Remove host ${host}`}
+                    disabled={busy}
+                    onClick={() => void save({ allowHosts: role.allowHosts.filter((h) => h !== host) })}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="size-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+            <form
+              className="flex items-center gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                const host = hostDraft.trim().toLowerCase();
+                if (!host || role.allowHosts.includes(host)) return;
+                void save({ allowHosts: [...role.allowHosts, host] }).then(() => setHostDraft(""));
+              }}
+            >
+              <Input
+                value={hostDraft}
+                onChange={(e) => setHostDraft(e.target.value)}
+                placeholder="host, e.g. github.com or .corp.example"
+                aria-label={`New allowed host for ${role.name}`}
+                className="h-8 font-mono text-xs"
+              />
+              <Button type="submit" size="sm" variant="secondary" disabled={busy || !hostDraft.trim()}>
+                Add host
+              </Button>
+            </form>
+          </div>
+        ) : null}
       </div>
 
       <ul className="divide-y divide-border">

--- a/web/src/views/connectors-page.tsx
+++ b/web/src/views/connectors-page.tsx
@@ -1,0 +1,562 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronRight, Plug, Plus, Shield, Trash2, Users } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+// ---------------------------------------------------------------------------
+// Types mirrored from the server. Kept small on purpose; the server is the
+// validator, this page only stops obviously wrong input before a round trip.
+// ---------------------------------------------------------------------------
+
+export type RuleAction = "allow" | "block";
+export type RoleRule = { pattern: string; action: RuleAction };
+export type Role = {
+  id: string;
+  name: string;
+  defaultAction: RuleAction;
+  rules: RoleRule[];
+  createdAt: number;
+  updatedAt: number;
+};
+
+/** Executor's own policy row (GET /api/executor/api/policies). */
+export type ExecutorPolicy = {
+  id: string;
+  owner: "org" | "user";
+  pattern: string;
+  action: "approve" | "require_approval" | "block";
+};
+
+// Executor's action literals, with the labels its own UI uses. `approve` is
+// "runs without asking", which reads as Allow to anyone who has not seen the
+// Executor code.
+const GATEWAY_ACTIONS: { value: ExecutorPolicy["action"]; label: string }[] = [
+  { value: "approve", label: "Allow" },
+  { value: "require_approval", label: "Require approval" },
+  { value: "block", label: "Block" },
+];
+
+// Every policy this box writes is tenant-wide: one Executor, one org, and
+// the omg owner is the one editing it.
+const GATEWAY_OWNER: ExecutorPolicy["owner"] = "org";
+
+type Tab = "roles" | "gateway" | "integrations";
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    credentials: "same-origin",
+    ...init,
+    headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? `request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
+/** The Settings row that opens this page. */
+export function ConnectorsRow({ onOpen, roleCount }: { onOpen: () => void; roleCount: number | null }) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center justify-between gap-4 px-4 py-2.5 text-left transition-colors duration-150 ease-ios hover:bg-foreground/[0.03] active:bg-foreground/[0.06]"
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-muted text-foreground/70">
+          <Shield className="size-4" />
+        </span>
+        <span className="min-w-0">
+          <span className="block text-sm font-medium">Roles &amp; tool access</span>
+          <span className="block truncate text-xs text-muted-foreground">
+            {roleCount === null ? "Which tools each session may use" : `${roleCount} role${roleCount === 1 ? "" : "s"}`}
+          </span>
+        </span>
+      </div>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function ConnectorsPage() {
+  const [tab, setTab] = useState<Tab>("roles");
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 pb-10" data-lfg-page-column>
+      <div>
+        <h1 className="text-lg font-semibold">Tool access</h1>
+        <p className="text-sm text-muted-foreground">
+          Roles decide which tools a session can see and call. Gateway policies are the box-wide
+          floor inside the connector gateway. Integrations are where services get connected.
+        </p>
+      </div>
+      <div role="tablist" className="flex gap-1 rounded-xl bg-muted p-1 text-sm">
+        {(
+          [
+            ["roles", "Roles", Users],
+            ["gateway", "Gateway policies", Shield],
+            ["integrations", "Integrations", Plug],
+          ] as const
+        ).map(([key, label, Icon]) => (
+          <button
+            key={key}
+            role="tab"
+            type="button"
+            aria-selected={tab === key}
+            onClick={() => setTab(key)}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-3 py-1.5 ${
+              tab === key ? "bg-background font-medium shadow-sm" : "text-muted-foreground"
+            }`}
+          >
+            <Icon className="size-4" />
+            {label}
+          </button>
+        ))}
+      </div>
+      {tab === "roles" ? <RolesPanel /> : null}
+      {tab === "gateway" ? <GatewayPoliciesPanel /> : null}
+      {tab === "integrations" ? <IntegrationsPanel /> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Roles
+// ---------------------------------------------------------------------------
+
+const ACTION_LABEL: Record<RuleAction, string> = { allow: "Allow", block: "Block" };
+
+const PATTERN_HELP = [
+  "*",
+  "omg.*",
+  "omg.ship",
+  "computer.*",
+  "executor.*",
+  "executor.execute",
+];
+
+export function RolesPanel() {
+  const [roles, setRoles] = useState<Role[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const { roles } = await call<{ roles: Role[] }>("/api/roles");
+      setRoles(roles);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not load roles");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    setBusy(true);
+    try {
+      await call("/api/roles", { method: "POST", body: JSON.stringify({ name, defaultAction: "block", rules: [] }) });
+      setNewName("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not create the role");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const editable = useMemo(() => (roles ?? []).filter((r) => r.id !== "owner"), [roles]);
+
+  return (
+    <section className="space-y-4" aria-label="Roles">
+      <div className="rounded-2xl border border-border bg-card/40 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-foreground text-background">
+            <Users className="size-4" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium">Owner</span>
+            <span className="block text-xs text-muted-foreground">
+              Built in. Every tool, no rules. Sessions without a role run as owner.
+            </span>
+          </span>
+        </div>
+      </div>
+
+      {editable.map((role) => (
+        <RoleCard key={role.id} role={role} onChanged={load} onError={setError} />
+      ))}
+
+      <form
+        className="flex items-center gap-2 rounded-2xl border border-dashed border-border px-4 py-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void create();
+        }}
+      >
+        <Plus className="size-4 shrink-0 text-muted-foreground" />
+        <Input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New role name, e.g. Marketing"
+          aria-label="New role name"
+          className="h-8"
+        />
+        <Button type="submit" size="sm" disabled={busy || !newName.trim()}>
+          Add role
+        </Button>
+      </form>
+
+      {error ? <p className="px-1 text-xs text-destructive">{error}</p> : null}
+      <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+        Tool ids are <code>server.tool</code>: <code>omg.ship</code>, <code>computer.screenshot</code>,{" "}
+        <code>executor.execute</code>. A trailing <code>*</code> matches the rest. Block wins over
+        allow. Tools with no matching rule get the role&apos;s default.
+      </p>
+    </section>
+  );
+}
+
+function RoleCard({
+  role,
+  onChanged,
+  onError,
+}: {
+  role: Role;
+  onChanged: () => Promise<void>;
+  onError: (message: string | null) => void;
+}) {
+  const [pattern, setPattern] = useState("");
+  const [action, setAction] = useState<RuleAction>("allow");
+  const [busy, setBusy] = useState(false);
+
+  const save = async (patch: Partial<Pick<Role, "name" | "defaultAction" | "rules">>) => {
+    setBusy(true);
+    try {
+      await call(`/api/roles/${role.id}`, { method: "PATCH", body: JSON.stringify(patch) });
+      onError(null);
+      await onChanged();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "could not save the role");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const addRule = async () => {
+    const p = pattern.trim();
+    if (!p) return;
+    await save({ rules: [...role.rules, { pattern: p, action }] });
+    setPattern("");
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    try {
+      await call(`/api/roles/${role.id}`, { method: "DELETE" });
+      await onChanged();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "could not delete the role");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-card/40 divide-y divide-border" data-role-id={role.id}>
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-[7px] bg-primary text-white">
+          <Users className="size-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-medium">{role.name}</span>
+          <span className="block text-xs text-muted-foreground">
+            id <code>{role.id}</code> · {role.rules.length} rule{role.rules.length === 1 ? "" : "s"}
+          </span>
+        </span>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          Default
+          <select
+            aria-label={`Default action for ${role.name}`}
+            value={role.defaultAction}
+            disabled={busy}
+            onChange={(e) => void save({ defaultAction: e.target.value as RuleAction })}
+            className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+          >
+            <option value="block">Block</option>
+            <option value="allow">Allow</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          aria-label={`Delete role ${role.name}`}
+          disabled={busy}
+          onClick={() => void remove()}
+          className="flex size-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-destructive"
+        >
+          <Trash2 className="size-4" />
+        </button>
+      </div>
+
+      <ul className="divide-y divide-border">
+        {role.rules.length === 0 ? (
+          <li className="px-4 py-2 text-xs text-muted-foreground">No rules. Every tool gets the default.</li>
+        ) : null}
+        {role.rules.map((rule, index) => (
+          <li key={`${rule.pattern}-${index}`} className="flex items-center gap-3 px-4 py-2 text-sm">
+            <code className="min-w-0 flex-1 truncate text-xs">{rule.pattern}</code>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                rule.action === "allow" ? "bg-success/15 text-success" : "bg-destructive/15 text-destructive"
+              }`}
+            >
+              {ACTION_LABEL[rule.action]}
+            </span>
+            <button
+              type="button"
+              aria-label={`Remove rule ${rule.pattern}`}
+              disabled={busy}
+              onClick={() => void save({ rules: role.rules.filter((_, i) => i !== index) })}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="size-3.5" />
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <form
+        className="flex items-center gap-2 px-4 py-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void addRule();
+        }}
+      >
+        <Input
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          placeholder="pattern, e.g. executor.*"
+          aria-label={`New rule pattern for ${role.name}`}
+          list={`patterns-${role.id}`}
+          className="h-8 font-mono text-xs"
+        />
+        <datalist id={`patterns-${role.id}`}>
+          {PATTERN_HELP.map((p) => (
+            <option key={p} value={p} />
+          ))}
+        </datalist>
+        <select
+          aria-label={`New rule action for ${role.name}`}
+          value={action}
+          onChange={(e) => setAction(e.target.value as RuleAction)}
+          className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+        >
+          <option value="allow">Allow</option>
+          <option value="block">Block</option>
+        </select>
+        <Button type="submit" size="sm" variant="secondary" disabled={busy || !pattern.trim()}>
+          Add rule
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Gateway (Executor) policies
+// ---------------------------------------------------------------------------
+
+export function GatewayPoliciesPanel() {
+  const [policies, setPolicies] = useState<ExecutorPolicy[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pattern, setPattern] = useState("");
+  const [action, setAction] = useState<ExecutorPolicy["action"]>("require_approval");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const rows = await call<ExecutorPolicy[] | { policies: ExecutorPolicy[] }>("/api/executor/api/policies");
+      setPolicies(Array.isArray(rows) ? rows : rows.policies ?? []);
+      setError(null);
+    } catch (e) {
+      setPolicies(null);
+      setError(e instanceof Error ? e.message : "could not load gateway policies");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const add = async () => {
+    const p = pattern.trim();
+    if (!p) return;
+    setBusy(true);
+    try {
+      await call("/api/executor/api/policies", {
+        method: "POST",
+        body: JSON.stringify({ owner: GATEWAY_OWNER, pattern: p, action }),
+      });
+      setPattern("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not add the policy");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    setBusy(true);
+    try {
+      await call(`/api/executor/api/policies/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+        body: JSON.stringify({ owner: GATEWAY_OWNER }),
+      });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not remove the policy");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="space-y-4" aria-label="Gateway policies">
+      <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+        These rules live inside the connector gateway and apply to every session on this box,
+        whatever its role. Patterns are integration tool ids such as <code>github.*</code> or{" "}
+        <code>gmail.send</code>. The most restrictive matching rule wins.
+      </p>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card/40 divide-y divide-border">
+        {policies === null ? (
+          <div className="px-4 py-3 text-xs text-muted-foreground">
+            {error ?? "Loading gateway policies."}
+          </div>
+        ) : policies.length === 0 ? (
+          <div className="px-4 py-3 text-xs text-muted-foreground">
+            No gateway policies. Tools fall back to each integration&apos;s default approval behaviour.
+          </div>
+        ) : (
+          policies.map((policy) => (
+            <div key={policy.id} className="flex items-center gap-3 px-4 py-2 text-sm">
+              <code className="min-w-0 flex-1 truncate text-xs">{policy.pattern}</code>
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold text-foreground/80">
+                {GATEWAY_ACTIONS.find((a) => a.value === policy.action)?.label ?? policy.action}
+              </span>
+              <button
+                type="button"
+                aria-label={`Remove gateway policy ${policy.pattern}`}
+                disabled={busy}
+                onClick={() => void remove(policy.id)}
+                className="text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+              </button>
+            </div>
+          ))
+        )}
+        <form
+          className="flex items-center gap-2 px-4 py-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void add();
+          }}
+        >
+          <Input
+            value={pattern}
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="pattern, e.g. github.*"
+            aria-label="New gateway policy pattern"
+            className="h-8 font-mono text-xs"
+          />
+          <select
+            aria-label="New gateway policy action"
+            value={action}
+            onChange={(e) => setAction(e.target.value as ExecutorPolicy["action"])}
+            className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+          >
+            {GATEWAY_ACTIONS.map((a) => (
+              <option key={a.value} value={a.value}>
+                {a.label}
+              </option>
+            ))}
+          </select>
+          <Button type="submit" size="sm" variant="secondary" disabled={busy || policies === null || !pattern.trim()}>
+            Add policy
+          </Button>
+        </form>
+      </div>
+      {error && policies !== null ? <p className="px-1 text-xs text-destructive">{error}</p> : null}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Integrations: the Executor UI itself, embedded. Sign-in flows and secret
+// entry stay in their own app; this page only frames it.
+// ---------------------------------------------------------------------------
+
+export function IntegrationsPanel() {
+  const [url, setUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/api/executor/dashboard", { credentials: "same-origin", signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(body?.error ?? `status ${res.status}`);
+        }
+        return (await res.json()) as { url: string };
+      })
+      .then((payload) => setUrl(payload.url))
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : "the connector gateway is not running");
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (error) {
+    return (
+      <section className="rounded-2xl border border-border bg-card/40 px-4 py-3 text-sm text-muted-foreground" aria-label="Integrations">
+        {error}
+      </section>
+    );
+  }
+  if (!url) {
+    return (
+      <section className="rounded-2xl border border-border bg-card/40 px-4 py-3 text-sm text-muted-foreground" aria-label="Integrations">
+        Loading the connector gateway.
+      </section>
+    );
+  }
+  return (
+    <section className="space-y-2" aria-label="Integrations">
+      <iframe
+        title="Connector gateway"
+        src={url}
+        className="h-[70vh] w-full rounded-2xl border border-border bg-background"
+      />
+      <p className="px-1 text-xs leading-relaxed text-muted-foreground">
+        Served on this computer only. From another device, this frame stays empty.{" "}
+        <a href={url} target="_blank" rel="noreferrer" className="underline">
+          Open in a new tab
+        </a>
+        .
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
Stacked on #272 (Executor gateway). Phase 2 of `docs/team-tooling-design.md`.

## What changed

- **Roles** (`src/policy/roles.ts`): user-defined rule lists over `<server>.<tool>` ids using Executor's pattern grammar (`omg.ship`, `computer.*`, `executor.execute`). Block beats allow; unmatched tools get the role's default. `owner` is built in and unrestricted. Stored in `PATHS.data/roles.json`.
- **Caller resolution** (`src/policy/caller.ts`): `/mcp`, `/mcp/computer` and `/mcp/executor` resolve the session once. Rows created after this landed demand `x-omg-session-token` = HMAC(box secret, session id); a claim without a valid token is downgraded to anonymous. Older rows keep the bare-query behaviour, so an upgrade does not break running sessions.
- **Enforcement** (`src/policy/mcp-filter.ts`): blocked tools are removed from `tools/list` and a `tools/call` on one is answered with an error result, never forwarded. Owner short-circuits with no parsing.
- **Session role**: `POST /api/sessions/new` takes `role`; `PATCH /api/sessions/:id/role` moves a running session. Takes effect on the next call.
- **Routes**: `/api/roles` (GET, POST), `/api/roles/:id` (PATCH, DELETE), `/api/executor/api/<allowlisted>` forwards Executor policies, tools, integrations and connections with the bearer injected (`src/executor/api.ts`). The browser never holds the token.
- **UI**: Settings > "Roles & tool access": Roles editor, Gateway policies (Executor, box-wide, uses its `owner: "org"` and `approve | require_approval | block` literals), Integrations (Executor UI embedded). New-session composer shows a role pill once a role other than owner exists.

## Verification

- New tests: roles store and matcher, session token and caller resolution, MCP filter (JSON and SSE replies, blocked call, GET passthrough), Executor API forward allowlist, Connectors page render. Updated ACP and registration tests for the token header.
- Full suite: 3272 pass, 1 pre-existing failure (`test/mobile-plan-specs.test.ts`, fails on `main`).
- Root and web typecheck clean.
- End to end on `127.0.0.1` with the real Executor: a `marketing` session listed only `omg_ship` and `omg_display_image`; `omg_close_session` was refused; `executor.*` block emptied the Executor tool list and refused `execute`; no or bad token downgraded to owner; `PATCH .../role` to owner restored the full list. Gateway policy create and delete round-tripped through the forward. Screenshots in the omg session.

## Known limit

Role rules see `executor.execute`, not the integration behind it. Per-integration restriction per role needs a per-role Executor instance (deferred). Box-wide per-integration rules go in Gateway policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
