### PR TITLE
fix(web): dialog backdrop leaves a bright line at the bottom edge

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -418,13 +418,18 @@ html[data-lfg-embed="true"].lfg-keyboard-open {
   /* iOS can expose a 1px browser-canvas strip at the bottom after the app has
      been idle/backgrounded and its dynamic viewport metrics settle late. Keep a
      tiny fixed bleed painted in the app background so stale dvh rounding cannot
-     show the white canvas beneath bottom-fixed controls. */
+     show the white canvas beneath bottom-fixed controls.
+
+     It paints BELOW everything (negative z-index): only the canvas strip under
+     the <html> box needs covering. A top z-index put this strip above dialog
+     backdrops, so a bright 2px line stayed undimmed along the bottom edge
+     whenever a modal was open. */
   body::after {
     content: "";
     position: fixed;
     inset-inline: 0;
     bottom: -2px;
-    z-index: 2147483647;
+    z-index: -1;
     height: 4px;
     pointer-events: none;
     background: var(--background);


### PR DESCRIPTION
The iOS bottom bleed strip (`body::after` in `web/src/index.css`) used `z-index: 2147483647`, so it painted above every dialog backdrop. In light theme this showed as a bright 2px line along the bottom edge while a modal was open.

Fix: `z-index: -1`. The strip still covers the canvas gap under the `<html>` box (its only job) and is now dimmed with everything else.

Verified in headless Chrome by sampling bottom pixels: old CSS 240 (bright), new CSS 48 (dimmed); the strip still paints below a short html box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)