### PR TITLE
feat(mobile): plan cards in onboarding, replay from Settings

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -27,6 +27,10 @@ on:
         options:
           - production
           - preview
+          # Unsigned dev client for the iOS Simulator. Native modules cannot
+          # ship over the air, so every native dependency change needs one of
+          # these before the change can be looked at. Never submit this.
+          - simulator
       submit:
         description: "Submit to App Store Connect after a successful build"
         default: false
@@ -107,7 +111,7 @@ jobs:
       # Connect. Keeping them apart means a submit failure does not read as a
       # build failure, and a build can be produced without being submitted.
       - name: Submit to App Store Connect
-        if: ${{ inputs.submit }}
+        if: ${{ inputs.submit && inputs.profile != 'simulator' }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -11,7 +11,13 @@ import Reanimated, {
 } from "react-native-reanimated";
 
 import { AiConsentScreen, useAiDataConsent } from "../src/omg/ai-consent";
-import { IntroScreen, SetupScreen, useIntro, useOnboarding } from "../src/omg/onboarding";
+import {
+  IntroScreen,
+  SetupScreen,
+  rosterFromReadiness,
+  useIntro,
+  useOnboarding,
+} from "../src/omg/onboarding";
 import { BrandMark } from "../src/omg/brand-mark";
 import { LaunchScreen } from "../src/omg/launch";
 import { useLucideFont } from "../src/omg/lucide";
@@ -416,21 +422,11 @@ function RootNavigator() {
      * real answer, not an error, so the screen says "starting up" instead of
      * drawing an empty list that reads as "no agents exist".
      */
-    const roster =
-      readiness?.status === "ready"
-        ? readiness.roster.agents
-            .filter((a) => a.visible !== false)
-            .map((a) => ({
-              key: a.key,
-              label: a.label,
-              connected: a.status?.accountConnected === true,
-            }))
-        : [];
-    const waking = readiness === null || readiness.status === "connecting" || readiness.status === "waking";
+    const { agents, waking } = rosterFromReadiness(readiness);
     return (
       <>
         <StatusBar style={isDark ? "light" : "dark"} />
-        <SetupScreen onDone={onboarding.complete} agents={roster} waking={waking} />
+        <SetupScreen onDone={onboarding.complete} agents={agents} waking={waking} />
       </>
     );
   }
@@ -594,6 +590,9 @@ function RootNavigator() {
               disabling a gesture iOS users reach for reflexively. */}
           <Stack.Screen name="bots/new" options={{ headerShown: false, gestureEnabled: false }} />
           <Stack.Screen name="bots/[id]/edit" options={{ headerShown: false }} />
+          {/* Replay of the welcome flow, from Settings. The screens draw their
+              own chrome (dots, Skip), so no system header. */}
+          <Stack.Screen name="onboarding" options={{ headerShown: false }} />
           {/* In-app purchase. Pushed from the blocked cloud computer and from
               Settings — the two places someone learns they need to pay. It is
               a normal pushed screen rather than a modal so the back gesture

--- a/mobile/app/onboarding.tsx
+++ b/mobile/app/onboarding.tsx
@@ -1,0 +1,44 @@
+/**
+ * Replay of the welcome flow, from Settings.
+ *
+ * First run shows these screens as GATES in _layout.tsx, not routes, so they
+ * cannot be deep-linked into by accident. Replay is the opposite case: someone
+ * signed in asked to see them again, so a plain route is right. Nothing here
+ * writes the onboarding flags; a replay is a look, not a re-run of setup.
+ *
+ * The intro's last button reads "Continue" rather than "Sign in", and both
+ * the intro's exits lead to the setup steps. Setup's exits pop back to
+ * Settings.
+ */
+
+import { useCallback, useState } from "react";
+import { useRouter } from "expo-router";
+import { StatusBar } from "expo-status-bar";
+
+import { IntroScreen, SetupScreen, rosterFromReadiness } from "../src/omg/onboarding";
+import { useOmg } from "../src/omg/provider";
+import { useTheme } from "../src/omg/theme";
+
+export default function OnboardingReplayScreen() {
+  const router = useRouter();
+  const { isDark } = useTheme();
+  const { readiness } = useOmg();
+  const [phase, setPhase] = useState<"intro" | "setup">("intro");
+  const { agents, waking } = rosterFromReadiness(readiness);
+
+  const done = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace("/settings");
+  }, [router]);
+
+  return (
+    <>
+      <StatusBar style={isDark ? "light" : "dark"} />
+      {phase === "intro" ? (
+        <IntroScreen finalLabel="Continue" onSignIn={() => setPhase("setup")} />
+      ) : (
+        <SetupScreen onDone={done} agents={agents} waking={waking} />
+      )}
+    </>
+  );
+}

--- a/mobile/app/plan.tsx
+++ b/mobile/app/plan.tsx
@@ -38,10 +38,11 @@ import * as Haptics from "expo-haptics";
 import { useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { EmptyState, Icon, PrimaryButton, SectionLabel, Separator } from "../src/components";
+import { EmptyState, PrimaryButton, SectionLabel } from "../src/components";
 import { PressableScale } from "../src/omg/motion";
 import { Text } from "../src/omg/text";
 import { useTheme } from "../src/omg/theme";
+import { TierCard } from "../src/omg/tier-card";
 import { useToast } from "../src/omg/toast";
 import { useOmg } from "../src/omg/provider";
 import {
@@ -52,15 +53,7 @@ import {
   type Entitlement,
   type PurchaseAccount,
 } from "../src/omg/billing";
-import {
-  FALLBACK_TIERS,
-  formatComputeHours,
-  formatMachine,
-  formatParallelAgents,
-  labelForPlan,
-  sleepsBetweenTasks,
-  type TierSpecs,
-} from "../src/omg/plan-specs";
+import { FALLBACK_TIERS, labelForPlan } from "../src/omg/plan-specs";
 import {
   connectStore,
   fetchTiers,
@@ -483,194 +476,6 @@ function LegalLinks() {
  * card taller than its neighbours and break the column of numbers that makes
  * five tiers comparable at a glance.
  */
-function SpecRow({
-  label,
-  value,
-  emphasis = false,
-  ...glyph
-}: {
-  label: string;
-  value: string;
-  /** The number this tier is really sold on. */
-  emphasis?: boolean;
-} & ({ ios: "clock"; android: "schedule" } | { ios: "cpu"; android: "memory" } | { ios: "internaldrive"; android: "storage" } | { ios: "bolt.fill"; android: "bolt" })) {
-  const { colors, type, space } = useTheme();
-  return (
-    <View style={{ flexDirection: "row", alignItems: "center", gap: space.md, paddingVertical: 5 }}>
-      <Icon
-        {...glyph}
-        size={15}
-        weight={emphasis ? "semibold" : "regular"}
-        color={emphasis ? colors.text : colors.textMuted}
-      />
-      <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted, flexShrink: 1 }}>
-        {label}
-      </Text>
-      <Text
-        style={{
-          ...type.footnote,
-          color: colors.text,
-          fontWeight: emphasis ? "600" : "500",
-          marginLeft: "auto",
-          flexShrink: 0,
-        }}
-      >
-        {value}
-      </Text>
-    </View>
-  );
-}
-
-/**
- * One tier, as something you can read rather than only price-compare.
- *
- * ── Why a list of cards and not the dashboard's slider ──────────────────────
- *
- * The dashboard shows ONE rung at a time and makes moving between them the
- * whole interaction: a slider, ticks, a spring onto each detent. That works
- * because a mouse is bad at direct selection and good at scrubbing, and because
- * the overlay owns the entire viewport.
- *
- * Neither holds here. The equivalent of "move between the rungs" that a thumb
- * already does perfectly is SCROLL — the vertical scroll IS this screen's
- * slider, and it costs nothing to learn. Reproducing a drag control would also
- * have meant five tiers hidden behind a gesture nobody was told about, on the
- * one screen where hiding what someone is buying is the actual complaint.
- *
- * So: same vocabulary as the web ("Compute time", "Machine", "Disk", "agents in
- * parallel", the same formatters), same facts, different control. All five are
- * visible and comparable without touching anything, which a slider cannot do.
- *
- * ── The card makes no claim it was not handed ──────────────────────────────
- *
- * `specs` is null whenever the server did not describe this tier, and then the
- * card is deliberately just a name and Apple's price. That is the honest
- * degradation and it is the reason the numbers left the bundle: a stale spec
- * would still render beautifully.
- */
-function TierCard({
-  product,
-  current,
-  purchasing,
-  disabled,
-  onPress,
-}: {
-  product: StoreProduct;
-  current: boolean;
-  purchasing: boolean;
-  disabled: boolean;
-  onPress: () => void;
-}) {
-  const { colors, radius, type, space } = useTheme();
-  const specs: TierSpecs | null = product.specs;
-  const sleeps = specs ? sleepsBetweenTasks(specs) : null;
-
-  return (
-    <PressableScale
-      onPress={onPress}
-      disabled={disabled}
-      accessibilityRole="button"
-      // One label for the whole card. VoiceOver reading eight separate nodes
-      // per tier, five times over, is how a screen becomes unusable while
-      // technically being accessible.
-      accessibilityLabel={[
-        product.label,
-        current ? "current plan" : product.displayPrice + " per month",
-        specs
-          ? `${formatParallelAgents(specs.parallelAgents)}, ${formatComputeHours(specs.computeHours)} of compute time, ${formatMachine(specs)}, ${specs.diskGb} GB disk${sleeps ? ", always on, never sleeps" : ""}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join(". ")}
-      scale={0.98}
-      style={({ pressed }) => ({
-        backgroundColor: pressed && !disabled ? colors.cardPressed : colors.card,
-        borderRadius: radius.lg,
-        marginHorizontal: space.lg,
-        marginBottom: space.md,
-        padding: space.lg,
-        gap: specs ? space.md : 0,
-        // The current plan is outlined rather than dimmed. Dimming it would
-        // hide the specs of the machine someone actually has, which is the one
-        // tier they have the most reason to re-read.
-        borderWidth: current ? 1.5 : 0,
-        borderColor: current ? colors.primary : "transparent",
-        // Only a card you cannot buy fades, and the current plan is not one of
-        // those — it is disabled because it is already yours.
-        opacity: disabled && !current ? 0.5 : 1,
-      })}
-    >
-      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: space.md }}>
-        <View style={{ flex: 1, gap: 2 }}>
-          <Text style={{ ...type.headline, color: colors.text }}>{product.label}</Text>
-          {specs ? (
-            /* The dashboard's hero number, demoted to a subtitle. It is still
-               the headline fact — the thing the ladder is really sold on — but
-               five 40pt numbers down a scroll is five heroes and therefore
-               none. */
-            <Text style={{ ...type.subhead, color: colors.textSecondary }}>
-              {formatParallelAgents(specs.parallelAgents)}
-            </Text>
-          ) : null}
-        </View>
-        <View style={{ alignItems: "flex-end", gap: 1 }}>
-          {purchasing ? (
-            <ActivityIndicator color={colors.textMuted} />
-          ) : (
-            <>
-              {/* Apple's string, verbatim. Never composed here — it is a
-                  different currency in every storefront. */}
-              <Text style={{ ...type.headline, color: colors.text }}>{product.displayPrice}</Text>
-              {current ? (
-                <View style={{ flexDirection: "row", alignItems: "center", gap: 3 }}>
-                  <Icon ios="checkmark" android="check" size={11} weight="semibold" color={colors.primary} />
-                  <Text style={{ ...type.caption, color: colors.primary }}>Current plan</Text>
-                </View>
-              ) : (
-                <Text style={{ ...type.caption, color: colors.textMuted }}>per month</Text>
-              )}
-            </>
-          )}
-        </View>
-      </View>
-
-      {specs ? (
-        <>
-          <Separator />
-          <View>
-            {/* Compute time carries the emphasis, matching the dashboard: it is
-                the allowance that actually runs out, and the one people are
-                surprised by. */}
-            <SpecRow
-              ios="clock"
-              android="schedule"
-              label="Compute time"
-              value={formatComputeHours(specs.computeHours)}
-              emphasis
-            />
-            <SpecRow ios="cpu" android="memory" label="Machine" value={formatMachine(specs)} />
-            <SpecRow
-              ios="internaldrive"
-              android="storage"
-              label="Disk"
-              value={`${specs.diskGb} GB`}
-            />
-            {sleeps ? (
-              <SpecRow
-                ios="bolt.fill"
-                android="bolt"
-                label="Sleeps between tasks"
-                value={sleeps}
-                emphasis
-              />
-            ) : null}
-          </View>
-        </>
-      ) : null}
-    </PressableScale>
-  );
-}
-
 /**
  * Apple has the money, omg has not confirmed yet.
  *

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -389,6 +389,20 @@ export default function SettingsScreen() {
         These open omg.dev in your browser.
       </Text>
 
+      <SectionLabel>Help</SectionLabel>
+      <Card>
+        <Row onPress={() => router.push("/onboarding")}>
+          <Text style={{ ...type.callout, color: colors.text, flex: 1 }}>Replay the welcome tour</Text>
+          <Icon
+            ios="chevron.right"
+            android="chevron_right"
+            size={13}
+            weight="semibold"
+            color={colors.textMuted}
+          />
+        </Row>
+      </Card>
+
       <View style={{ marginTop: space.xl }}>
         <Card>
           <Row onPress={confirmSignOut}>

--- a/mobile/src/omg/onboarding.tsx
+++ b/mobile/src/omg/onboarding.tsx
@@ -811,6 +811,9 @@ export function SetupScreen({
     router.push("/plan");
   }, [onDone, router]);
 
+  /** The plan step is showing the ladder, so layout gives it the room. */
+  const cards = step === 1 && products !== null && products.length > 0;
+
   return (
     <View style={{ flex: 1, backgroundColor: colors.bg }}>
       <View
@@ -829,8 +832,53 @@ export function SetupScreen({
         </Pressable>
       </View>
 
-      <View style={{ flex: 1 }} />
-      <View style={{ paddingHorizontal: space.xl, alignItems: "center", width: "100%" }}>
+      {/*
+       * The plan step with cards is the one tall step: it is a ScrollView that
+       * is a DIRECT child of the root column, so flex:1 bounds it between the
+       * header row and the buttons and the ladder scrolls inside that. Nested
+       * flex columns with alignItems:center did not bound it; the list stayed
+       * at its content height and clipped.
+       */}
+      {cards ? (
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingTop: space.xl, paddingBottom: space.md }}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={{ paddingHorizontal: space.xl, gap: space.md, marginBottom: space.lg }}>
+            <Text style={{ ...type.largeTitle, color: colors.text, textAlign: "center" }}>
+              Pick a Computer
+            </Text>
+            <Text
+              style={{ ...type.body, color: colors.textMuted, textAlign: "center", lineHeight: 24 }}
+            >
+              Plans differ in machine size, included compute time, and how many agents run at once.
+            </Text>
+          </View>
+          {/* The paywall's own cards. A tap opens the paywall on the same
+              list, where the purchase happens; setup is marked done first. */}
+          {(products ?? []).map((product) => (
+            <TierCard
+              key={product.productId}
+              product={product}
+              current={currentPlan === product.plan}
+              purchasing={false}
+              disabled={false}
+              onPress={seePlans}
+            />
+          ))}
+        </ScrollView>
+      ) : (
+        <View style={{ flex: 1 }} />
+      )}
+      <View
+        style={{
+          paddingHorizontal: space.xl,
+          alignItems: "center",
+          width: "100%",
+          ...(cards ? { display: "none" } : {}),
+        }}
+      >
         {step === 0 ? (
           <View style={{ width: "100%", gap: space.xl }}>
             <View style={{ gap: space.md }}>
@@ -861,7 +909,7 @@ export function SetupScreen({
           </View>
         ) : (
           <View style={{ width: "100%", alignItems: "center", gap: space.lg }}>
-            {products && products.length > 0 ? null : <PanelArt key="plan" art="mark" still={still} />}
+            <PanelArt key="plan" art="mark" still={still} />
             <View style={{ gap: space.md }}>
               <Text style={{ ...type.largeTitle, color: colors.text, textAlign: "center" }}>
                 Pick a Computer
@@ -874,32 +922,11 @@ export function SetupScreen({
             </View>
             {products === null ? (
               <ActivityIndicator color={colors.textMuted} style={{ marginTop: space.md }} />
-            ) : products.length > 0 ? (
-              /* The paywall's own cards, one per tier. A tap opens the paywall
-                 on the same list, where the purchase happens; setup is marked
-                 done first (see seePlans). marginHorizontal is the card's own
-                 spacing inside a padded column, so it is cancelled here. */
-              <ScrollView
-                style={{ width: "100%", maxHeight: 360, marginHorizontal: -space.lg }}
-                contentContainerStyle={{ paddingTop: space.sm }}
-                showsVerticalScrollIndicator={false}
-              >
-                {products.map((product) => (
-                  <TierCard
-                    key={product.productId}
-                    product={product}
-                    current={currentPlan === product.plan}
-                    purchasing={false}
-                    disabled={false}
-                    onPress={seePlans}
-                  />
-                ))}
-              </ScrollView>
             ) : null}
           </View>
         )}
       </View>
-      <View style={{ flex: 0.6 }} />
+      {cards ? null : <View style={{ flex: 0.6 }} />}
 
       <View style={{ padding: space.lg, paddingBottom: insets.bottom + space.lg, gap: space.sm }}>
         <BigButton

--- a/mobile/src/omg/onboarding.tsx
+++ b/mobile/src/omg/onboarding.tsx
@@ -42,7 +42,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Image, Linking, Pressable, View } from "react-native";
+import { ActivityIndicator, Image, Linking, Pressable, ScrollView, View } from "react-native";
 import { useRouter } from "expo-router";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -61,6 +61,11 @@ import Reanimated, {
 
 import { Icon } from "../components";
 import { agentIcon } from "./agent-icons";
+import { fetchPurchaseAccount } from "./billing";
+import { FALLBACK_TIERS } from "./plan-specs";
+import type { ComputerReadiness } from "./readiness";
+import { connectStore, fetchTiers, isStoreAvailable, type StoreProduct } from "./store";
+import { TierCard } from "./tier-card";
 import { BrandMark } from "./brand-mark";
 import { useReduceMotionEnabled } from "./motion";
 import { Text } from "./text";
@@ -241,6 +246,33 @@ export function useOnboarding(userId: string | null): {
 /** Test/support hook: forget one account's run so the screen shows again. */
 export async function resetOnboarding(userId: string): Promise<void> {
   await AsyncStorage.removeItem(storageKeyFor(userId));
+}
+
+export type SetupAgent = { key: string; label: string; connected: boolean };
+
+/**
+ * The connect step's input, derived from the Computer's readiness. `waking` is
+ * a real answer rather than an error: the box is provisioning or cold, so the
+ * screen says "starting up" instead of drawing an empty list that reads as
+ * "no agents exist". One derivation, used by the first-run gate and by replay.
+ */
+export function rosterFromReadiness(readiness: ComputerReadiness | null): {
+  agents: SetupAgent[];
+  waking: boolean;
+} {
+  const agents =
+    readiness?.status === "ready"
+      ? readiness.roster.agents
+          .filter((a) => a.visible !== false)
+          .map((a) => ({
+            key: a.key,
+            label: a.label,
+            connected: a.status?.accountConnected === true,
+          }))
+      : [];
+  const waking =
+    readiness === null || readiness.status === "connecting" || readiness.status === "waking";
+  return { agents, waking };
 }
 
 /* ── Animated art, one per panel ───────────────────────────────────────────
@@ -600,7 +632,18 @@ function Dots({ count, index }: { count: number; index: number }) {
  * The intro: three panels then a way in. Pre-auth, so it can only talk about
  * the product — it has no account to reason about yet.
  */
-export function IntroScreen({ onSignIn }: { onSignIn: () => void }) {
+/**
+ * `finalLabel` is "Sign in" on first run, where the last panel leads to the
+ * sign-in field, and "Continue" when replayed from Settings, where there is no
+ * sign-in to lead to.
+ */
+export function IntroScreen({
+  onSignIn,
+  finalLabel = "Sign in",
+}: {
+  onSignIn: () => void;
+  finalLabel?: string;
+}) {
   const { colors, space, type } = useTheme();
   const insets = useSafeAreaInsets();
   const still = useReduceMotionEnabled();
@@ -654,7 +697,7 @@ export function IntroScreen({ onSignIn }: { onSignIn: () => void }) {
       <View style={{ flex: 0.6 }} />
 
       <View style={{ padding: space.lg, paddingBottom: insets.bottom + space.lg }}>
-        <BigButton label={last ? "Sign in" : "Continue"} onPress={next} />
+        <BigButton label={last ? finalLabel : "Continue"} onPress={next} />
       </View>
     </View>
   );
@@ -718,7 +761,7 @@ export function SetupScreen({
   waking,
 }: {
   onDone: () => void;
-  agents: { key: string; label: string; connected: boolean }[];
+  agents: SetupAgent[];
   waking: boolean;
 }) {
   const { colors, space, type } = useTheme();
@@ -726,6 +769,37 @@ export function SetupScreen({
   const router = useRouter();
   const still = useReduceMotionEnabled();
   const [step, setStep] = useState<0 | 1>(0);
+
+  /*
+   * The plan step shows the SAME cards as the paywall, from the same source:
+   * the control plane's catalog, priced by StoreKit. Loading starts on mount so
+   * the cards are usually there by the time the step is reached. A build with
+   * no store, or a failed load, falls back to the text-only step with a link
+   * to the paywall, which has its own retry.
+   */
+  const [products, setProducts] = useState<StoreProduct[] | null>(null);
+  const [currentPlan, setCurrentPlan] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (!isStoreAvailable()) {
+      setProducts([]);
+      return;
+    }
+    (async () => {
+      try {
+        const [, account] = await Promise.all([connectStore(), fetchPurchaseAccount()]);
+        const loaded = await fetchTiers(account.tiers ?? FALLBACK_TIERS);
+        if (cancelled) return;
+        setCurrentPlan(account.plan ?? null);
+        setProducts(loaded);
+      } catch {
+        if (!cancelled) setProducts([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   /*
    * Mark setup done BEFORE pushing the paywall. Backing out of plans lands on
@@ -786,8 +860,8 @@ export function SetupScreen({
             )}
           </View>
         ) : (
-          <View style={{ width: "100%", alignItems: "center", gap: space.xl }}>
-            <PanelArt key="plan" art="mark" still={still} />
+          <View style={{ width: "100%", alignItems: "center", gap: space.lg }}>
+            {products && products.length > 0 ? null : <PanelArt key="plan" art="mark" still={still} />}
             <View style={{ gap: space.md }}>
               <Text style={{ ...type.largeTitle, color: colors.text, textAlign: "center" }}>
                 Pick a Computer
@@ -798,6 +872,30 @@ export function SetupScreen({
                 Plans differ in machine size, included compute time, and how many agents run at once.
               </Text>
             </View>
+            {products === null ? (
+              <ActivityIndicator color={colors.textMuted} style={{ marginTop: space.md }} />
+            ) : products.length > 0 ? (
+              /* The paywall's own cards, one per tier. A tap opens the paywall
+                 on the same list, where the purchase happens; setup is marked
+                 done first (see seePlans). marginHorizontal is the card's own
+                 spacing inside a padded column, so it is cancelled here. */
+              <ScrollView
+                style={{ width: "100%", maxHeight: 360, marginHorizontal: -space.lg }}
+                contentContainerStyle={{ paddingTop: space.sm }}
+                showsVerticalScrollIndicator={false}
+              >
+                {products.map((product) => (
+                  <TierCard
+                    key={product.productId}
+                    product={product}
+                    current={currentPlan === product.plan}
+                    purchasing={false}
+                    disabled={false}
+                    onPress={seePlans}
+                  />
+                ))}
+              </ScrollView>
+            ) : null}
           </View>
         )}
       </View>

--- a/mobile/src/omg/tier-card.tsx
+++ b/mobile/src/omg/tier-card.tsx
@@ -1,0 +1,209 @@
+/**
+ * One subscription tier as a card: name, Apple's price, and the specs the
+ * server handed us. Shared by the paywall (app/plan.tsx) and the plan step of
+ * onboarding, so both show a tier in the same shape. The card is presentation
+ * only; whoever renders it decides what a tap does.
+ */
+
+import { ActivityIndicator, View } from "react-native";
+
+import { Icon, Separator } from "../components";
+import { PressableScale } from "./motion";
+import {
+  formatComputeHours,
+  formatMachine,
+  formatParallelAgents,
+  sleepsBetweenTasks,
+  type TierSpecs,
+} from "./plan-specs";
+import type { StoreProduct } from "./store";
+import { Text } from "./text";
+import { useTheme } from "./theme";
+
+function SpecRow({
+  label,
+  value,
+  emphasis = false,
+  ...glyph
+}: {
+  label: string;
+  value: string;
+  /** The number this tier is really sold on. */
+  emphasis?: boolean;
+} & ({ ios: "clock"; android: "schedule" } | { ios: "cpu"; android: "memory" } | { ios: "internaldrive"; android: "storage" } | { ios: "bolt.fill"; android: "bolt" })) {
+  const { colors, type, space } = useTheme();
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center", gap: space.md, paddingVertical: 5 }}>
+      <Icon
+        {...glyph}
+        size={15}
+        weight={emphasis ? "semibold" : "regular"}
+        color={emphasis ? colors.text : colors.textMuted}
+      />
+      <Text numberOfLines={1} style={{ ...type.footnote, color: colors.textMuted, flexShrink: 1 }}>
+        {label}
+      </Text>
+      <Text
+        style={{
+          ...type.footnote,
+          color: colors.text,
+          fontWeight: emphasis ? "600" : "500",
+          marginLeft: "auto",
+          flexShrink: 0,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * One tier, as something you can read rather than only price-compare.
+ *
+ * ── Why a list of cards and not the dashboard's slider ──────────────────────
+ *
+ * The dashboard shows ONE rung at a time and makes moving between them the
+ * whole interaction: a slider, ticks, a spring onto each detent. That works
+ * because a mouse is bad at direct selection and good at scrubbing, and because
+ * the overlay owns the entire viewport.
+ *
+ * Neither holds here. The equivalent of "move between the rungs" that a thumb
+ * already does perfectly is SCROLL — the vertical scroll IS this screen's
+ * slider, and it costs nothing to learn. Reproducing a drag control would also
+ * have meant five tiers hidden behind a gesture nobody was told about, on the
+ * one screen where hiding what someone is buying is the actual complaint.
+ *
+ * So: same vocabulary as the web ("Compute time", "Machine", "Disk", "agents in
+ * parallel", the same formatters), same facts, different control. All five are
+ * visible and comparable without touching anything, which a slider cannot do.
+ *
+ * ── The card makes no claim it was not handed ──────────────────────────────
+ *
+ * `specs` is null whenever the server did not describe this tier, and then the
+ * card is deliberately just a name and Apple's price. That is the honest
+ * degradation and it is the reason the numbers left the bundle: a stale spec
+ * would still render beautifully.
+ */
+export function TierCard({
+  product,
+  current,
+  purchasing,
+  disabled,
+  onPress,
+}: {
+  product: StoreProduct;
+  current: boolean;
+  purchasing: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  const { colors, radius, type, space } = useTheme();
+  const specs: TierSpecs | null = product.specs;
+  const sleeps = specs ? sleepsBetweenTasks(specs) : null;
+
+  return (
+    <PressableScale
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      // One label for the whole card. VoiceOver reading eight separate nodes
+      // per tier, five times over, is how a screen becomes unusable while
+      // technically being accessible.
+      accessibilityLabel={[
+        product.label,
+        current ? "current plan" : product.displayPrice + " per month",
+        specs
+          ? `${formatParallelAgents(specs.parallelAgents)}, ${formatComputeHours(specs.computeHours)} of compute time, ${formatMachine(specs)}, ${specs.diskGb} GB disk${sleeps ? ", always on, never sleeps" : ""}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(". ")}
+      scale={0.98}
+      style={({ pressed }) => ({
+        backgroundColor: pressed && !disabled ? colors.cardPressed : colors.card,
+        borderRadius: radius.lg,
+        marginHorizontal: space.lg,
+        marginBottom: space.md,
+        padding: space.lg,
+        gap: specs ? space.md : 0,
+        // The current plan is outlined rather than dimmed. Dimming it would
+        // hide the specs of the machine someone actually has, which is the one
+        // tier they have the most reason to re-read.
+        borderWidth: current ? 1.5 : 0,
+        borderColor: current ? colors.primary : "transparent",
+        // Only a card you cannot buy fades, and the current plan is not one of
+        // those — it is disabled because it is already yours.
+        opacity: disabled && !current ? 0.5 : 1,
+      })}
+    >
+      <View style={{ flexDirection: "row", alignItems: "flex-start", gap: space.md }}>
+        <View style={{ flex: 1, gap: 2 }}>
+          <Text style={{ ...type.headline, color: colors.text }}>{product.label}</Text>
+          {specs ? (
+            /* The dashboard's hero number, demoted to a subtitle. It is still
+               the headline fact — the thing the ladder is really sold on — but
+               five 40pt numbers down a scroll is five heroes and therefore
+               none. */
+            <Text style={{ ...type.subhead, color: colors.textSecondary }}>
+              {formatParallelAgents(specs.parallelAgents)}
+            </Text>
+          ) : null}
+        </View>
+        <View style={{ alignItems: "flex-end", gap: 1 }}>
+          {purchasing ? (
+            <ActivityIndicator color={colors.textMuted} />
+          ) : (
+            <>
+              {/* Apple's string, verbatim. Never composed here — it is a
+                  different currency in every storefront. */}
+              <Text style={{ ...type.headline, color: colors.text }}>{product.displayPrice}</Text>
+              {current ? (
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 3 }}>
+                  <Icon ios="checkmark" android="check" size={11} weight="semibold" color={colors.primary} />
+                  <Text style={{ ...type.caption, color: colors.primary }}>Current plan</Text>
+                </View>
+              ) : (
+                <Text style={{ ...type.caption, color: colors.textMuted }}>per month</Text>
+              )}
+            </>
+          )}
+        </View>
+      </View>
+
+      {specs ? (
+        <>
+          <Separator />
+          <View>
+            {/* Compute time carries the emphasis, matching the dashboard: it is
+                the allowance that actually runs out, and the one people are
+                surprised by. */}
+            <SpecRow
+              ios="clock"
+              android="schedule"
+              label="Compute time"
+              value={formatComputeHours(specs.computeHours)}
+              emphasis
+            />
+            <SpecRow ios="cpu" android="memory" label="Machine" value={formatMachine(specs)} />
+            <SpecRow
+              ios="internaldrive"
+              android="storage"
+              label="Disk"
+              value={`${specs.diskGb} GB`}
+            />
+            {sleeps ? (
+              <SpecRow
+                ios="bolt.fill"
+                android="bolt"
+                label="Sleeps between tasks"
+                value={sleeps}
+                emphasis
+              />
+            ) : null}
+          </View>
+        </>
+      ) : null}
+    </PressableScale>
+  );
+}


### PR DESCRIPTION
- Plan step of onboarding shows the paywall's own tier cards (same catalog, StoreKit prices, current plan outlined). `TierCard`/`SpecRow` moved to `src/omg/tier-card.tsx`, used by both screens. Card tap opens the paywall; "Start free" stays.
- Settings > Help > "Replay the welcome tour": route `app/onboarding.tsx` runs intro then setup without touching the first-run flags. Last intro button reads "Continue".
- `rosterFromReadiness()` is the single derivation of the connect step's input.
- `mobile-release.yml` gains a `simulator` profile option for dev-client builds with new native modules.

Verified on the iPhone 17 Pro simulator (dev client build with the Apple/Google modules): intro, connect, plan step with two cards, replay row.

JS only. Can ship as an OTA update to runtime 1.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)