### PR TITLE
fix(web): resolve box settings over defaults instead of replacing them

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -218,6 +218,14 @@ export function prefetchChatEngine(): void {
   else setTimeout(run, 1500);
 }
 import {
+  DEFAULT_GLOBAL_SETTINGS,
+  DEFAULT_VIEW_PREFS,
+  resolveGlobalSettings,
+  type GlobalSettings,
+  type ViewPrefs,
+} from "./lib/global-settings";
+export type { GlobalSettings, ViewPrefs };
+import {
   DEFAULT_SCHED_TZ,
   DEFAULT_SIMPLE,
   buildCron,
@@ -1106,76 +1114,6 @@ type ModelCatalogItem = {
   configured?: boolean;
 };
 
-type GlobalSettings = {
-  timeZone: string;
-  // Cap on total LIVE agents, idle included (0 = unlimited).
-  maxLiveAgents: number;
-  // Per-bot cap on self-scheduled routines. Always >= 1 — unlike
-  // maxLiveAgents, 0-as-unlimited is not offered here.
-  maxBotSchedules: number;
-  botAutoCompactionEnabled: boolean;
-  botCompactionThresholdPercent: number;
-  // Whether this box offers the Computer Use MCP to agents. Off by default;
-  // see the MCP servers section in SettingsView.
-  computerMcpEnabled: boolean;
-  transcriptView: TranscriptView;
-  // The update the "What's new" drawer's Skip button last dismissed. See
-  // UpdateProvider in components/update-drawer.tsx.
-  skippedUpdateVersion: string;
-  // Standing instructions appended to the launch envelope of every new
-  // session. "" means nothing extra is sent.
-  customInstructions: string;
-  // Default coding agent + model for a new session when this browser has no
-  // saved choice. "" = host default / catalog default.
-  defaultAgent: string;
-  defaultModel: string;
-  // Box-wide view switches. All true by default. See ViewPrefsContext.
-  showSidebarAgentIcons: boolean;
-  showSessionAgentIcons: boolean;
-  showComposerModels: boolean;
-  // Off: no agent choice in the composer; every new session uses defaultAgent.
-  showComposerAgents: boolean;
-  showBots: boolean;
-  showSchedules: boolean;
-  // Off hides the floating worktree diff bar in a session's chat.
-  showSessionDiffBar: boolean;
-  // Off hides the Fast pill in the composer; new sessions launch without
-  // fast mode.
-  showComposerFastMode: boolean;
-};
-
-/**
- * The box-wide view preferences, read by the pieces of UI they switch: the
- * rail rows, session headers, the composer's model list, and the surface
- * toggle. One context so a deep, memoised row does not need seven props
- * threaded through it. A role system may later decide these per viewer; the
- * consumers only ever read the resolved booleans.
- */
-type ViewPrefs = Pick<
-  GlobalSettings,
-  | "defaultAgent"
-  | "defaultModel"
-  | "showSidebarAgentIcons"
-  | "showSessionAgentIcons"
-  | "showComposerModels"
-  | "showComposerAgents"
-  | "showBots"
-  | "showSchedules"
-  | "showSessionDiffBar"
-  | "showComposerFastMode"
->;
-const DEFAULT_VIEW_PREFS: ViewPrefs = {
-  defaultAgent: "",
-  defaultModel: "",
-  showSidebarAgentIcons: true,
-  showSessionAgentIcons: true,
-  showComposerModels: true,
-  showComposerAgents: true,
-  showBots: true,
-  showSchedules: true,
-  showSessionDiffBar: true,
-  showComposerFastMode: true,
-};
 const ViewPrefsContext = createContext<ViewPrefs>(DEFAULT_VIEW_PREFS);
 
 
@@ -1294,7 +1232,8 @@ type BootstrapPayload = {
   agents?: Agent[] | null;
   codingAgents?: CodingAgentInfo[] | null;
   models?: ModelCatalogItem[] | null;
-  settings?: GlobalSettings | null;
+  // Partial on purpose: an older box omits the fields it does not know.
+  settings?: Partial<GlobalSettings> | null;
   sessions?: Session[] | null;
   sessionPins?: string[] | null;
   conversations?: ProductConversation[] | null;
@@ -6101,18 +6040,7 @@ export function App() {
     [bots],
   );
   const [managedComputer, setManagedComputer] = useState(false);
-  const [settings, setSettings] = useState<GlobalSettings>({
-    timeZone: DEFAULT_SCHED_TZ,
-    maxLiveAgents: 16,
-    maxBotSchedules: 5,
-    botAutoCompactionEnabled: true,
-    computerMcpEnabled: false,
-    botCompactionThresholdPercent: 78,
-    transcriptView: "full",
-    skippedUpdateVersion: "",
-    customInstructions: "",
-    ...DEFAULT_VIEW_PREFS,
-  });
+  const [settings, setSettings] = useState<GlobalSettings>(DEFAULT_GLOBAL_SETTINGS);
   const [schedTz, setSchedTz] = useState<string>(DEFAULT_SCHED_TZ);
   const [findings, setFindings] = useState<AutoFinding[]>([]);
   const [autoTriageBusy, setAutoTriageBusy] = useState(false);
@@ -6411,18 +6339,11 @@ export function App() {
     setManagedComputer(!!payload.computer);
     setCodingAgents(payload.codingAgents ?? []);
     setModelCatalog(buildAgentModelCatalog(payload.models));
-    setSettings(payload.settings ?? {
-      timeZone: payload.auto?.tz ?? DEFAULT_SCHED_TZ,
-      maxLiveAgents: 16,
-      maxBotSchedules: 5,
-      botAutoCompactionEnabled: true,
-      computerMcpEnabled: false,
-        botCompactionThresholdPercent: 78,
-      transcriptView: "full",
-      skippedUpdateVersion: "",
-      customInstructions: "",
-      ...DEFAULT_VIEW_PREFS,
-    });
+    // The scheduler's zone stands in for timeZone only when the box sends no
+    // settings of its own.
+    setSettings(
+      resolveGlobalSettings({ timeZone: payload.auto?.tz, ...payload.settings }),
+    );
     // Guard sessions to [] — it feeds `allLiveSessions`/`liveSessions` which
     // call `.filter()` unconditionally on render, so a malformed/empty payload
     // must degrade to an empty live view rather than crash.
@@ -7881,13 +7802,14 @@ export function App() {
   }
 
   const updateSettings = useCallback(async (patch: Partial<GlobalSettings>) => {
-    const payload = await api<{ settings: GlobalSettings }>("/api/settings", {
+    const payload = await api<{ settings: Partial<GlobalSettings> }>("/api/settings", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
-    setSettings(payload.settings);
-    setSchedTz(payload.settings.timeZone);
+    const next = resolveGlobalSettings(payload.settings);
+    setSettings(next);
+    setSchedTz(next.timeZone);
   }, []);
   // A hidden surface is not a destination. Land on Chat if the URL, a
   // shortcut, or a stale menu still names Bots or Schedules while it is off.

--- a/web/src/lib/global-settings.test.ts
+++ b/web/src/lib/global-settings.test.ts
@@ -1,0 +1,64 @@
+// A Computer can run an older omg.dev build than the UI the dashboard embeds.
+// Its /api/bootstrap answer then omits fields this build renders, and the
+// Settings page crashed on `customInstructions.trim()` when the answer
+// replaced the defaults wholesale.
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_GLOBAL_SETTINGS,
+  resolveGlobalSettings,
+  type GlobalSettings,
+} from "./global-settings";
+
+describe("resolveGlobalSettings", () => {
+  test("an older box that sends no customInstructions still resolves a string", () => {
+    const older: Partial<GlobalSettings> = {
+      timeZone: "Asia/Hong_Kong",
+      maxLiveAgents: 4,
+      transcriptView: "full",
+    };
+
+    const settings = resolveGlobalSettings(older);
+
+    expect(settings.customInstructions).toBe("");
+    expect(settings.customInstructions.trim()).toBe("");
+    expect(settings.timeZone).toBe("Asia/Hong_Kong");
+    expect(settings.maxLiveAgents).toBe(4);
+    expect(settings.showComposerFastMode).toBe(true);
+  });
+
+  test("a null or absent answer resolves to the defaults", () => {
+    expect(resolveGlobalSettings(null)).toEqual(DEFAULT_GLOBAL_SETTINGS);
+    expect(resolveGlobalSettings(undefined)).toEqual(DEFAULT_GLOBAL_SETTINGS);
+  });
+
+  test("a stored null field takes the default instead of overwriting it", () => {
+    const settings = resolveGlobalSettings({
+      customInstructions: null,
+      defaultAgent: null,
+    } as unknown as Partial<GlobalSettings>);
+
+    expect(settings.customInstructions).toBe("");
+    expect(settings.defaultAgent).toBe("");
+  });
+
+  test("every sent value wins, including a deliberate empty string and false", () => {
+    const settings = resolveGlobalSettings({
+      customInstructions: "Always run the tests.",
+      skippedUpdateVersion: "",
+      showBots: false,
+      maxLiveAgents: 0,
+    });
+
+    expect(settings.customInstructions).toBe("Always run the tests.");
+    expect(settings.skippedUpdateVersion).toBe("");
+    expect(settings.showBots).toBe(false);
+    expect(settings.maxLiveAgents).toBe(0);
+  });
+
+  test("the resolved object carries every key the UI renders", () => {
+    expect(Object.keys(resolveGlobalSettings({})).sort()).toEqual(
+      Object.keys(DEFAULT_GLOBAL_SETTINGS).sort(),
+    );
+  });
+});

--- a/web/src/lib/global-settings.ts
+++ b/web/src/lib/global-settings.ts
@@ -1,0 +1,114 @@
+// The box-wide settings the local runtime owns and the Settings view edits.
+//
+// They live outside App so the resolver below can be read and tested on its
+// own, and so one module owns both the shape and its defaults.
+import { DEFAULT_SCHED_TZ } from "../cron";
+import type { TranscriptView } from "./transcript-view";
+
+export type GlobalSettings = {
+  timeZone: string;
+  // Cap on total LIVE agents, idle included (0 = unlimited).
+  maxLiveAgents: number;
+  // Per-bot cap on self-scheduled routines. Always >= 1 — unlike
+  // maxLiveAgents, 0-as-unlimited is not offered here.
+  maxBotSchedules: number;
+  botAutoCompactionEnabled: boolean;
+  botCompactionThresholdPercent: number;
+  // Whether this box offers the Computer Use MCP to agents. Off by default;
+  // see the MCP servers section in SettingsView.
+  computerMcpEnabled: boolean;
+  transcriptView: TranscriptView;
+  // The update the "What's new" drawer's Skip button last dismissed. See
+  // UpdateProvider in components/update-drawer.tsx.
+  skippedUpdateVersion: string;
+  // Standing instructions appended to the launch envelope of every new
+  // session. "" means nothing extra is sent.
+  customInstructions: string;
+  // Default coding agent + model for a new session when this browser has no
+  // saved choice. "" = host default / catalog default.
+  defaultAgent: string;
+  defaultModel: string;
+  // Box-wide view switches. All true by default. See ViewPrefsContext.
+  showSidebarAgentIcons: boolean;
+  showSessionAgentIcons: boolean;
+  showComposerModels: boolean;
+  // Off: no agent choice in the composer; every new session uses defaultAgent.
+  showComposerAgents: boolean;
+  showBots: boolean;
+  showSchedules: boolean;
+  // Off hides the floating worktree diff bar in a session's chat.
+  showSessionDiffBar: boolean;
+  // Off hides the Fast pill in the composer; new sessions launch without
+  // fast mode.
+  showComposerFastMode: boolean;
+};
+
+/**
+ * The box-wide view preferences, read by the pieces of UI they switch: the
+ * rail rows, session headers, the composer's model list, and the surface
+ * toggle. One context so a deep, memoised row does not need seven props
+ * threaded through it. A role system may later decide these per viewer; the
+ * consumers only ever read the resolved booleans.
+ */
+export type ViewPrefs = Pick<
+  GlobalSettings,
+  | "defaultAgent"
+  | "defaultModel"
+  | "showSidebarAgentIcons"
+  | "showSessionAgentIcons"
+  | "showComposerModels"
+  | "showComposerAgents"
+  | "showBots"
+  | "showSchedules"
+  | "showSessionDiffBar"
+  | "showComposerFastMode"
+>;
+export const DEFAULT_VIEW_PREFS: ViewPrefs = {
+  defaultAgent: "",
+  defaultModel: "",
+  showSidebarAgentIcons: true,
+  showSessionAgentIcons: true,
+  showComposerModels: true,
+  showComposerAgents: true,
+  showBots: true,
+  showSchedules: true,
+  showSessionDiffBar: true,
+  showComposerFastMode: true,
+};
+
+/**
+ * Every GlobalSettings field with the value to use when the box does not send
+ * one.
+ *
+ * A Computer can run an older omg.dev build than the UI that the dashboard
+ * embeds, so its /api/bootstrap answer can omit a field this build renders.
+ * Replacing the whole object with that answer used to leave newer fields
+ * undefined, and `settings.customInstructions.trim()` crashed the Settings
+ * page for those boxes. resolveGlobalSettings is the one owner of that merge,
+ * so every consumer reads a complete object and none of them needs its own
+ * fallback.
+ */
+export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
+  timeZone: DEFAULT_SCHED_TZ,
+  maxLiveAgents: 16,
+  maxBotSchedules: 5,
+  botAutoCompactionEnabled: true,
+  botCompactionThresholdPercent: 78,
+  computerMcpEnabled: false,
+  transcriptView: "full",
+  skippedUpdateVersion: "",
+  customInstructions: "",
+  ...DEFAULT_VIEW_PREFS,
+};
+
+/** Resolve a settings answer of any age into a complete GlobalSettings. */
+export function resolveGlobalSettings(
+  input: Partial<GlobalSettings> | null | undefined,
+): GlobalSettings {
+  const sent = Object.fromEntries(
+    // A missing field arrives as an absent key from an older build and as
+    // `null` from a box that stored one, and both mean "use the default".
+    Object.entries(input ?? {}).filter(([, value]) => value !== undefined && value !== null),
+  ) as Partial<GlobalSettings>;
+  return { ...DEFAULT_GLOBAL_SETTINGS, ...sent };
+}


### PR DESCRIPTION
## Problem

`/settings` crashed on app.omg.dev with `TypeError: Cannot read properties of undefined (reading 'trim')`. Three reports on 2026-09-03, in two different dashboard builds, so this is not new.

The crashing frame in the shipped `embedded-*.js` is `CustomInstructionsRow`, which reads `value.trim()`.

`App.tsx` took the server's settings answer wholesale:

- `/api/bootstrap`: `setSettings(payload.settings ?? {defaults})`
- `POST /api/settings`: `setSettings(payload.settings)`

A Computer running an older omg.dev build than the UI the dashboard embeds sends a settings object without `customInstructions`. That object replaced the defaults entirely, so the field arrived `undefined` and the Settings page crashed.

## Change

`GlobalSettings`, its defaults, `ViewPrefs` and the new `resolveGlobalSettings` move to `web/src/lib/global-settings.ts`. Both writers pass the server answer through the resolver, which merges it over the defaults:

- an absent or `null` field takes the default
- every sent value wins, including `""`, `false` and `0`

One owner now guarantees a complete settings object, so no consumer needs its own fallback. This also removes the two duplicated default literals that had already drifted apart in `App.tsx`.

## Verification

- `bun test web/src/lib/global-settings.test.ts`: 5 new tests pass, including the exact skew case
- `bun test web/src/views/custom-instructions-page.test.tsx`: 12 pass
- `cd web && bun x tsc --noEmit`: clean
- `bun run test`: 3327 pass, 2 fail. Both failures (`mobile-plan-specs`, `mobile-secondary-pages`) fail the same way on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)