### PR TITLE
feat(mobile): user filter, Pages menu, Schedules screen, web finding cards (1.0.4)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "omg",
     "slug": "lfg-native",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -326,6 +326,7 @@ function RootNavigator() {
             <Stack.Screen name="computers" />
             <Stack.Screen name="settings" />
             <Stack.Screen name="notifications" />
+            <Stack.Screen name="schedules" />
             <Stack.Screen name="plan" />
             <Stack.Screen name="bots/index" />
             <Stack.Screen name="bots/new" />
@@ -571,6 +572,12 @@ function RootNavigator() {
           <Stack.Screen
             name="notifications"
             options={{ title: "Notifications", headerLargeTitle: true }}
+          />
+          {/* The auto agent roster, the web's "Schedules" surface. Reached
+              from the home header's pages menu. */}
+          <Stack.Screen
+            name="schedules"
+            options={{ title: "Schedules", headerLargeTitle: true }}
           />
           {/* Bots roster. `bots/[id]` (bot chat) is a later phase — see
               app/bots/index.tsx's own doc comment for the navigation

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -24,10 +24,10 @@ import type { OmgConnectionStatus } from "@omg-dev/client";
 
 import {
   EmptyState,
+  Icon,
   SESSION_ROW_MARK_X,
   SESSION_ROW_MARK_Y,
   HomeComposer,
-  IconButton,
   PrimaryButton,
   SectionHeader,
   SessionCard,
@@ -48,6 +48,8 @@ import { groupNodesByProject } from "../src/omg/session-groups";
 import { sessionPreview } from "../src/omg/session-preview";
 import { selectHomeAutoFindings, useAutoAgents, type AutoFindingRow } from "../src/omg/auto-agents";
 import { useComputerPicker } from "../src/omg/computer-picker";
+import { UserFilterMenu } from "../src/omg/user-filter-menu";
+import { sessionMatchesUserFilter, useUserFilter, useUserRoster } from "../src/omg/users";
 import { useDictation } from "../src/omg/dictation";
 import { PressableScale } from "../src/omg/motion";
 import { useUsage } from "../src/omg/usage";
@@ -389,6 +391,8 @@ export default function SessionsScreen() {
   } = useAutoAgents();
   const agentPicker = useAgentPicker();
   const projectPicker = useProjectPicker();
+  const rosterUsers = useUserRoster();
+  const [userFilter, setUserFilter] = useUserFilter(rosterUsers);
 
   const [sessions, setSessions] = useState<OmgSession[]>([]);
   /**
@@ -745,8 +749,12 @@ export default function SessionsScreen() {
    * with the same narrow cast already used in app/bots/index.tsx.
    */
   const visibleSessions = useMemo(
-    () => sessions.filter((session) => !(session as BotDrivenSession).botId),
-    [sessions],
+    () =>
+      sessions.filter(
+        (session) =>
+          !(session as BotDrivenSession).botId && sessionMatchesUserFilter(session, userFilter),
+      ),
+    [sessions, userFilter],
   );
 
   /**
@@ -1046,32 +1054,11 @@ export default function SessionsScreen() {
       ],
       headerRight: () => (
         <View style={{ flexDirection: "row", alignItems: "center", gap: space.xs }}>
-          {/* The greeting is the door on the web, but a sentence inside a
-              custom bar item does not reliably take a tap on iOS — verified on
-              the simulator, twice. A bar BUTTON does, so the Notification
-              Center gets one of its own. */}
-          <IconButton
-            ios="bell"
-            android="notifications"
-            accessibilityLabel="Notifications"
-            onPress={() => router.push("/notifications")}
-            size={19}
-            color={colors.textSecondary}
-          />
-          {/* Bots. Same idiom as the bell/computer/gear beside it — a plain
-              bar button pushing a full screen — rather than the web's rail
-              toggle, which this app has no rail to hang. See
-              app/bots/index.tsx for the navigation reasoning. Lucide, not an
-              SF Symbol: `person.and.background.dotted` and friends read as
-              "people," not "a bot," and this app already reaches for Lucide
-              exactly when SF Symbols has no honest equivalent (lucide.tsx). */}
-          <IconButton
-            lucide="bot"
-            accessibilityLabel="Bots"
-            onPress={() => router.push("/bots")}
-            size={19}
-            color={colors.textSecondary}
-          />
+          {/* The web's island, in the web's order: the roster filter first,
+              then the machine, then one overflow menu for the pages. The
+              bell, the bot and the gear used to be three more discs here;
+              they live in the menu now, as the web's PagesMenu keeps them. */}
+          <UserFilterMenu value={userFilter} users={rosterUsers} onChange={setUserFilter} />
           {/* TWO BUTTONS, NOT ONE CHIP.
               The machine name and the gear used to share a single pill, which
               read as one control and made the name look pressable-adjacent
@@ -1105,13 +1092,42 @@ export default function SessionsScreen() {
               </View>
             </View>
           </DropdownMenu>
-          <IconButton
-            lucide="settings"
-            accessibilityLabel="Settings"
-            onPress={() => router.push("/settings")}
-            size={20}
-            color={colors.textSecondary}
-          />
+          {/* Pages. The web's PagesMenu: everything that is a screen rather
+              than a filter, behind one control, so the island stays three
+              wide. Live is this screen and is not listed. */}
+          <DropdownMenu
+            title="Pages"
+            options={[
+              {
+                label: "Notifications",
+                icon: "bell",
+                onPress: () => router.push("/notifications"),
+              },
+              {
+                label: "Bots",
+                icon: "bubble.left.and.bubble.right",
+                onPress: () => router.push("/bots"),
+              },
+              {
+                label: "Schedules",
+                icon: "calendar.badge.clock",
+                onPress: () => router.push("/schedules"),
+              },
+              {
+                label: "Settings",
+                icon: "gearshape",
+                onPress: () => router.push("/settings"),
+              },
+            ]}
+          >
+            <View
+              accessibilityRole="button"
+              accessibilityLabel="Pages"
+              style={{ width: 36, height: 36, alignItems: "center", justifyContent: "center" }}
+            >
+              <Icon ios="ellipsis" android="more_vert" size={20} color={colors.textSecondary} />
+            </View>
+          </DropdownMenu>
         </View>
       ),
     });
@@ -1121,6 +1137,9 @@ export default function SessionsScreen() {
     computerPicker.options,
     machineName,
     currentBinding?.online,
+    userFilter,
+    rosterUsers,
+    setUserFilter,
     firstName,
     working.length,
     colors,

--- a/mobile/app/schedules.tsx
+++ b/mobile/app/schedules.tsx
@@ -1,0 +1,226 @@
+/**
+ * Schedules — the auto agent roster, the web's AutoManageView
+ * (/settings/computer/auto, titled "Schedules").
+ *
+ * One row per agent, in the web's shape: name, an "N open" badge when it has
+ * findings waiting, a spinner while a run is in flight, the schedule in words
+ * ("Every day at 9:00 AM · in 10h"), and a switch that pauses it. Paused rows
+ * dim. The user's own agents come first without a heading; bot-owned ones
+ * are grouped under the bot's name, as the web groups them.
+ *
+ * Tapping a row shows what the list truncates — the prompt preview, the
+ * project and the last run. There is no editor here: creating and rewriting a
+ * schedule stays on the web, the same split the phone already makes for
+ * findings (auto-agents.ts).
+ */
+
+import { useNavigation } from "expo-router";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { ActivityIndicator, RefreshControl, ScrollView, Switch, View } from "react-native";
+
+import { Card, EmptyState, Row, SectionHeader, Separator } from "../src/components";
+import { useAutoAgents, type AutoAgent } from "../src/omg/auto-agents";
+import { useBots } from "../src/omg/bots";
+import { describeCron, nextRunAt } from "../src/omg/cron";
+import { relativeTime } from "../src/omg/format";
+import { Text } from "../src/omg/text";
+import { useTheme } from "../src/omg/theme";
+
+/**
+ * "in 12h", "in 4m", "in 3d" — web/src/App.tsx formatRelativeShort, the
+ * compact tail the Schedules row has room for.
+ */
+export function formatRelativeShort(at: number, now: number = Date.now()): string {
+  const diff = at - now;
+  if (diff < 45_000) return "now";
+  const m = Math.round(diff / 60_000);
+  if (m < 60) return `in ${m}m`;
+  const h = Math.round(diff / 3_600_000);
+  if (h < 48) return `in ${h}h`;
+  return `in ${Math.round(diff / 86_400_000)}d`;
+}
+
+/** The web's compact ScheduleSummary: description plus a short "next" tail. */
+export function scheduleSummary(expr: string, tz: string, now: number = Date.now()): string {
+  const desc = describeCron(expr);
+  const next = nextRunAt(expr, tz, now);
+  return next ? `${desc} · ${formatRelativeShort(next, now)}` : desc;
+}
+
+type Group = { key: string; label?: string; items: AutoAgent[] };
+
+/**
+ * The web's grouping: the user's own rows first, then one group per bot, and
+ * within a group the enabled rows before the paused ones.
+ */
+export function groupAgents(agents: AutoAgent[], botName: (id: string) => string): Group[] {
+  const own: AutoAgent[] = [];
+  const byBot = new Map<string, AutoAgent[]>();
+  for (const a of agents) {
+    if (a.owner?.kind === "bot") {
+      const list = byBot.get(a.owner.botId) ?? [];
+      list.push(a);
+      byBot.set(a.owner.botId, list);
+    } else own.push(a);
+  }
+  const order = (list: AutoAgent[]) =>
+    [...list].sort((a, b) => Number(b.enabled) - Number(a.enabled));
+  const groups: Group[] = [];
+  if (own.length) groups.push({ key: "own", items: order(own) });
+  for (const [botId, items] of byBot) {
+    groups.push({ key: `bot:${botId}`, label: botName(botId), items: order(items) });
+  }
+  return groups;
+}
+
+export default function SchedulesScreen() {
+  const navigation = useNavigation();
+  const { colors, type, space, radius } = useTheme();
+  const { agents, findings, tz, loading, refresh, setAgentEnabled } = useAutoAgents();
+  const { bots } = useBots();
+  const [pulling, setPulling] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  // The relative tail ("in 10h") is derived at render time; a 30s tick is
+  // the clock, as on the web.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: "Schedules", headerLargeTitle: true });
+  }, [navigation]);
+
+  useEffect(() => {
+    if (!loading) setPulling(false);
+  }, [loading]);
+
+  const openByAgent = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const f of findings) counts.set(f.agentId, (counts.get(f.agentId) ?? 0) + 1);
+    return counts;
+  }, [findings]);
+
+  const botName = useCallback(
+    (id: string) => bots.find((bot) => bot.id === id)?.name ?? "Bot",
+    [bots],
+  );
+  const groups = useMemo(() => groupAgents(agents, botName), [agents, botName]);
+
+  const onCount = agents.filter((a) => a.enabled).length;
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={{ paddingBottom: space.xxl, gap: space.md }}
+      contentInsetAdjustmentBehavior="automatic"
+      refreshControl={
+        <RefreshControl
+          refreshing={pulling}
+          onRefresh={() => {
+            setPulling(true);
+            refresh();
+          }}
+          tintColor={colors.textMuted}
+        />
+      }
+    >
+      <Text
+        style={{
+          ...type.footnote,
+          color: colors.textMuted,
+          paddingHorizontal: space.lg,
+          paddingTop: space.xs,
+        }}
+      >
+        {agents.length
+          ? `${onCount} of ${agents.length} on · times in ${tz}`
+          : "Agents that run on a timer and report what they find."}
+      </Text>
+
+      {agents.length === 0 && loading ? null : agents.length === 0 ? (
+        <EmptyState
+          title="No schedules yet"
+          detail="Create one on the web: Schedules, then New."
+        />
+      ) : (
+        groups.map((group) => (
+          <View key={group.key} style={{ gap: space.sm }}>
+            {group.label ? <SectionHeader label={group.label} count={group.items.length} /> : null}
+            <Card>
+              {group.items.map((a, index) => {
+                const open = openByAgent.get(a.id) ?? 0;
+                const isOpen = expanded === a.id;
+                return (
+                  <View key={a.id}>
+                    {index > 0 ? <Separator inset={space.lg} /> : null}
+                    <Row onPress={() => setExpanded((cur) => (cur === a.id ? null : a.id))}>
+                      <View style={{ flex: 1, minWidth: 0, gap: 2, opacity: a.enabled ? 1 : 0.6 }}>
+                        <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
+                          <Text
+                            numberOfLines={1}
+                            style={{ ...type.subhead, color: colors.text, flexShrink: 1 }}
+                          >
+                            {a.name}
+                          </Text>
+                          {open ? (
+                            <View
+                              style={{
+                                borderRadius: radius.pill,
+                                paddingHorizontal: 6,
+                                paddingVertical: 2,
+                                backgroundColor: colors.accentSoft,
+                              }}
+                            >
+                              <Text style={{ ...type.caption, fontSize: 10, color: colors.primary }}>
+                                {open} open
+                              </Text>
+                            </View>
+                          ) : null}
+                          {a.running ? (
+                            <ActivityIndicator size="small" color={colors.primary} />
+                          ) : null}
+                        </View>
+                        <Text
+                          numberOfLines={isOpen ? undefined : 1}
+                          style={{ ...type.footnote, color: colors.textMuted }}
+                        >
+                          {scheduleSummary(a.schedule, tz, now)}
+                        </Text>
+                        {isOpen ? (
+                          <View style={{ gap: 2, paddingTop: space.xs }}>
+                            {a.prompt ? (
+                              <Text style={{ ...type.footnote, color: colors.textSecondary }}>
+                                {a.prompt}
+                              </Text>
+                            ) : null}
+                            <Text style={{ ...type.caption, color: colors.textMuted }}>
+                              {[
+                                a.project ? `Project ${a.project}` : null,
+                                a.lastRunAt ? `Last run ${relativeTime(a.lastRunAt)}` : "Never run",
+                                a.schedule,
+                              ]
+                                .filter(Boolean)
+                                .join(" · ")}
+                            </Text>
+                          </View>
+                        ) : null}
+                      </View>
+                      <Switch
+                        value={a.enabled}
+                        onValueChange={(next) => void setAgentEnabled(a.id, next)}
+                        accessibilityLabel={`${a.enabled ? "Disable" : "Enable"} ${a.name}`}
+                      />
+                    </Row>
+                  </View>
+                );
+              })}
+            </Card>
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}

--- a/mobile/src/omg/auto-agent-card.tsx
+++ b/mobile/src/omg/auto-agent-card.tsx
@@ -45,9 +45,9 @@
 
 import Reanimated from "react-native-reanimated";
 import { type AndroidSymbol, type SFSymbol } from "expo-symbols";
-import { View } from "react-native";
+import { ActivityIndicator, View } from "react-native";
 
-import { AgentAvatar, Icon } from "../components";
+import { Icon } from "../components";
 import { Text } from "./text";
 import { useListItemMotion, PressableScale } from "./motion";
 import { useSwipeToCommit } from "./swipe-row";
@@ -69,15 +69,15 @@ function severityColor(
   }
 }
 
-/** The severity dot. 7pt: reads next to 13pt text without becoming a bullet. */
+/** The severity dot. 8pt, the web's `size-2`. */
 function SeverityDot({ severity }: { severity?: AutoFindingSeverity }) {
   const { colors } = useTheme();
   return (
     <View
       style={{
-        width: 7,
-        height: 7,
-        borderRadius: 3.5,
+        width: 8,
+        height: 8,
+        borderRadius: 4,
         backgroundColor: severityColor(severity, colors),
       }}
     />
@@ -220,81 +220,46 @@ export function AutoFindingCard({
           accessibilityRole="button"
           accessibilityLabel={`${agent?.name ?? "Auto agent"} finding: ${finding.title}`}
           accessibilityState={{ expanded }}
+          /**
+           * The web's AutoFindingCard, line for line: a 12pt-radius card,
+           * 12/10 padding, severity dot + agent name + age on the first
+           * line, the title on the second, indented to the name. No agent
+           * avatar — the web's row has only the dot, and the mark on the
+           * phone made this the one home row with a picture. The age is
+           * `createdAt`, as on the web; `lastSeenAt` made a recurring
+           * finding read "2h" here and "3d" there.
+           */
           style={({ pressed }) => ({
-            flexDirection: "row",
-            gap: space.md,
             marginHorizontal: space.lg,
-            padding: space.md,
-            borderRadius: radius.xl,
+            paddingHorizontal: space.md,
+            paddingVertical: 10,
+            gap: space.xs,
+            borderRadius: radius.lg,
             borderWidth: 1,
-            borderColor: colors.borderStrong,
+            borderColor: colors.borderSoft,
             backgroundColor: pressed ? colors.cardPressed : colors.card,
           })}
         >
-          <AgentAvatar agent={agent?.agent} size={26} plain busy={!!agent?.running} />
-          <View style={{ flex: 1, gap: 3 }}>
-            <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
-              <Text
-                numberOfLines={1}
-                style={{ ...type.headline, color: colors.text, flexShrink: 1 }}
-              >
-                {agent?.name ?? "Auto agent"}
-              </Text>
-              <Text style={{ ...type.caption, color: colors.textMuted, marginLeft: "auto" }}>
-                {relativeTime(finding.lastSeenAt ?? finding.createdAt)}
-              </Text>
-            </View>
-
-            <View style={{ flexDirection: "row", gap: space.sm }}>
-              <View style={{ marginTop: 5 }}>
-                <SeverityDot severity={finding.severity} />
-              </View>
-              {/**
-               * COLLAPSED HEIGHT IS FIXED AT TWO LINES, NOT "UP TO TWO."
-               *
-               * `numberOfLines={2}` alone caps wrapping but does not RESERVE
-               * the space — a one-line title sizes to one line, a two-line
-               * title sizes to two, and which one you get depends on the
-               * text's actual measured width against the row's available
-               * width. That measurement is a SECOND layout pass Yoga has to
-               * run after resolving this row's flex width, which every other
-               * home-list row (SessionCard's `numberOfLines={1}` title and
-               * subtitle, always exactly one line) never needs. This
-               * two-pass convergence is what list-overlap-watch.tsx's
-               * diagnostics caught: when a section above this one grows late
-               * (see the ordering fix in app/index.tsx), Session rows
-               * resettle in one pass and this row needed a second — the
-               * asymmetry that made Auto specifically the one that showed a
-               * transient wrong position rather than Working/Idle/Recent.
-               *
-               * `height: lineHeight * 2` while collapsed makes the box a
-               * CONSTANT regardless of whether the title needs one line or
-               * two — no text measurement required to know this row's
-               * height before Yoga can place it, same one-pass shape as
-               * every other row. Expanded stays auto-sized (`numberOfLines`
-               * already goes to `undefined` there) since a tap is a
-               * deliberate, one-row-at-a-time action, not a burst of many
-               * rows settling at once — the case this addresses.
-               *
-               * THE COST, ON PURPOSE, NOT HIDDEN: a one-line title now
-               * leaves visible blank space below it where a second line
-               * would have gone. That is a real visual change for short
-               * findings, not a free win — Benny should see it before/after
-               * rather than have it decided for him.
-               */}
-              <Text
-                numberOfLines={expanded ? undefined : 2}
-                style={{
-                  ...type.footnote,
-                  color: colors.textSecondary,
-                  flex: 1,
-                  lineHeight: 18,
-                  ...(expanded ? null : { height: 18 * 2 }),
-                }}
-              >
-                {finding.title}
-              </Text>
-            </View>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: space.sm }}>
+            <SeverityDot severity={finding.severity} />
+            <Text
+              numberOfLines={1}
+              style={{ ...type.footnote, fontWeight: "600", color: colors.text, flexShrink: 1 }}
+            >
+              {agent?.name ?? "Auto agent"}
+            </Text>
+            {agent?.running ? <ActivityIndicator size="small" color={colors.primary} /> : null}
+            <Text style={{ ...type.caption, fontSize: 11, color: colors.textMuted, marginLeft: "auto" }}>
+              {relativeTime(finding.createdAt ?? finding.lastSeenAt)}
+            </Text>
+          </View>
+          <View style={{ paddingLeft: 8 + space.sm }}>
+            <Text
+              numberOfLines={expanded ? undefined : 3}
+              style={{ ...type.footnote, color: colors.textMuted, lineHeight: 17 }}
+            >
+              {finding.title}
+            </Text>
 
             {expanded ? (
               <View style={{ gap: space.sm, paddingTop: space.xs }}>

--- a/mobile/src/omg/auto-agents.ts
+++ b/mobile/src/omg/auto-agents.ts
@@ -49,6 +49,8 @@ export type AutoAgent = {
   /** 5-field cron, evaluated by the machine in the payload's `tz`. */
   schedule: string;
   enabled: boolean;
+  /** Who the schedule belongs to. Absent on old rows means the user. */
+  owner?: { kind: "user" } | { kind: "bot"; botId: string };
   cwd?: string;
   /** Backend key — "grok", "codex-aisdk", …; absent on old rows means Claude. */
   agent?: string;
@@ -94,6 +96,14 @@ export type AutoAgentsState = {
    * already resolved a different way (from another device, or the web).
    */
   setFindingStatus: (id: string, status: "dismissed" | "session") => Promise<void>;
+  /**
+   * Flip one schedule on or off — the Schedules row switch, as on the web's
+   * AutoManageView. PATCH /api/auto/agents/:id carries every other field
+   * forward server-side, so this never has to know the untruncated prompt.
+   * Optimistic like setFindingStatus; a failure refetches rather than
+   * guessing at the row's real state.
+   */
+  setAgentEnabled: (id: string, enabled: boolean) => Promise<void>;
 };
 
 /**
@@ -197,7 +207,24 @@ export function useAutoAgents(): AutoAgentsState {
     [client],
   );
 
-  return { agents, findings, tz, loading, refresh, setFindingStatus };
+  const setAgentEnabled = useCallback(
+    async (id: string, enabled: boolean) => {
+      if (!client) return;
+      setAgents((prev) => prev.map((a) => (a.id === id ? { ...a, enabled } : a)));
+      try {
+        await client.transport.request(`/api/auto/agents/${encodeURIComponent(id)}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled }),
+        });
+      } catch {
+        setTick((n) => n + 1);
+      }
+    },
+    [client],
+  );
+
+  return { agents, findings, tz, loading, refresh, setFindingStatus, setAgentEnabled };
 }
 
 const SEVERITY_RANK: Record<string, number> = { high: 0, med: 1, low: 2 };

--- a/mobile/src/omg/config.ts
+++ b/mobile/src/omg/config.ts
@@ -106,6 +106,8 @@ export const STORAGE_KEYS = {
    * would be a 400 at launch discovered only after typing a prompt.
    */
   composerSetup: "omg:mobile:composer-setup",
+  /** The session-list user filter: "__all", "__unassigned", or an email. */
+  userFilter: "omg:mobile:user-filter",
 } as const;
 
 export type ComputerMode = "direct" | "hosted";

--- a/mobile/src/omg/menu.tsx
+++ b/mobile/src/omg/menu.tsx
@@ -152,7 +152,12 @@ function useMenuImageUris(options: MenuOption[]): number {
     void Promise.all(
       pending.map(async (image) => {
         try {
-          const asset = Asset.fromModule(Number(image));
+          // A bundled module resolves through the asset registry; a remote
+          // picture (a roster avatar) is pulled into the cache once, because
+          // SwiftUI's `Image` still wants bytes it can read from disk.
+          const asset = /^https?:\/\//.test(image)
+            ? Asset.fromURI(image)
+            : Asset.fromModule(Number(image));
           const uri = asset.localUri ?? (await asset.downloadAsync()).localUri;
           if (uri) imageUriCache.set(image, uri);
         } catch {
@@ -176,7 +181,7 @@ function collectImages(options: MenuOption[]): string[] {
   const out: string[] = [];
   const walk = (list: MenuOption[]) => {
     for (const option of list) {
-      if (option.image) out.push(String(option.image));
+      if (option.image) out.push(imageKey(option.image));
       if (option.submenu) walk(option.submenu);
     }
   };
@@ -184,8 +189,20 @@ function collectImages(options: MenuOption[]): string[] {
   return out;
 }
 
+/**
+ * The cache key for an image: the module number for a `require()`d asset,
+ * the URL for a `{ uri }` source. `String()` on the object form would give
+ * every remote picture the same "[object Object]" key.
+ */
+function imageKey(image: ImageSourcePropType): string {
+  if (typeof image === "object" && image !== null && !Array.isArray(image) && "uri" in image) {
+    return String(image.uri ?? "");
+  }
+  return String(image);
+}
+
 function uriFor(option: MenuOption): string | undefined {
-  return option.image ? imageUriCache.get(String(option.image)) : undefined;
+  return option.image ? imageUriCache.get(imageKey(option.image)) : undefined;
 }
 
 export function DropdownMenu({

--- a/mobile/src/omg/user-filter-menu.tsx
+++ b/mobile/src/omg/user-filter-menu.tsx
@@ -1,0 +1,95 @@
+/**
+ * The roster filter on the home header — the phone's UserFilterMenu
+ * (web/src/components/user-filter-menu.tsx).
+ *
+ * The trigger wears the selected person's avatar, a person glyph for
+ * "Unassigned", and a globe for everyone, exactly as the web's 24px button
+ * does; the menu is the system one (menu.tsx), with the same three groups:
+ * All users, Unassigned, then one row per roster user. Rows carry the
+ * avatar where the machine serves one the menu can fetch (Gravatar); an
+ * uploaded icon behind the transport's grant falls back to the person glyph
+ * in the row and still shows on the trigger, which draws through RN `Image`.
+ */
+
+import { Image, View } from "react-native";
+
+import { Icon } from "../components";
+import { DropdownMenu, type MenuOption } from "./menu";
+import { useTheme } from "./theme";
+import {
+  ALL_USERS,
+  rosterUserLabel,
+  UNASSIGNED_USERS,
+  useAvatarUri,
+  type RosterUser,
+} from "./users";
+
+const TRIGGER_AVATAR = 24;
+
+export function UserFilterMenu({
+  value,
+  users,
+  onChange,
+}: {
+  value: string;
+  users: RosterUser[];
+  onChange: (next: string) => void;
+}) {
+  const { colors } = useTheme();
+  const active = value !== ALL_USERS;
+  const selected = users.find((user) => user.email === value);
+  const avatarUri = useAvatarUri(selected?.avatar);
+  const tint = active ? colors.primary : colors.textSecondary;
+
+  const options: MenuOption[] = [
+    {
+      label: "All users",
+      icon: "globe",
+      selected: value === ALL_USERS,
+      onPress: () => onChange(ALL_USERS),
+    },
+    {
+      label: "Unassigned",
+      icon: "person.crop.circle.dashed",
+      selected: value === UNASSIGNED_USERS,
+      onPress: () => onChange(UNASSIGNED_USERS),
+    },
+    ...users.map<MenuOption>((user) => ({
+      label: rosterUserLabel(user),
+      ...(user.avatar && /^https?:\/\//i.test(user.avatar)
+        ? { image: { uri: user.avatar } }
+        : { icon: "person.crop.circle" as const }),
+      selected: value === user.email,
+      onPress: () => onChange(user.email),
+    })),
+  ];
+
+  const title = selected ? rosterUserLabel(selected) : active ? "Unassigned" : "All users";
+
+  return (
+    <DropdownMenu title="Filter by user" options={options}>
+      <View
+        accessibilityRole="button"
+        accessibilityLabel={`Filter sessions by user: ${title}. Change`}
+        style={{ width: 36, height: 36, alignItems: "center", justifyContent: "center" }}
+      >
+        {avatarUri ? (
+          <Image
+            source={{ uri: avatarUri }}
+            style={{
+              width: TRIGGER_AVATAR,
+              height: TRIGGER_AVATAR,
+              borderRadius: TRIGGER_AVATAR / 2,
+              borderWidth: 1,
+              borderColor: colors.primary,
+            }}
+          />
+        ) : active ? (
+          <Icon ios="person.crop.circle" android="person" size={20} color={tint} />
+        ) : (
+          <Icon ios="globe" android="public" size={20} color={tint} />
+        )}
+      </View>
+    </DropdownMenu>
+  );
+}

--- a/mobile/src/omg/users.ts
+++ b/mobile/src/omg/users.ts
@@ -1,0 +1,202 @@
+/**
+ * The machine's user roster and the session-list filter built on it — the
+ * phone's copy of web/src/lib/user-filter.ts plus the `/api/users` read the
+ * web does at bootstrap and on window focus.
+ *
+ * A session carries `assignedUser` (an email) or nothing. The roster
+ * (`GET /api/users`) maps each email to a display name and an avatar URL, and
+ * the filter in the header narrows the list to one person, to the unclaimed
+ * pile, or to everyone. Picking a PERSON also keeps every unassigned session —
+ * see sessionMatchesUserFilter for why that inclusion is the whole point.
+ *
+ * The chosen filter is persisted the way the web persists
+ * `lfg_v2_user_filter`, so the list reopens the way it was left. It is NOT
+ * carried into new sessions as an identity: the native app authenticates by
+ * omg account and never sends a roster email (the web's hosted rule,
+ * `userFilterUpdatesStandaloneIdentity`, is false here always).
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+
+import { STORAGE_KEYS } from "./config";
+import { useOmg } from "./provider";
+
+/** Mirrors the `users` rows of GET /api/users (src/users.ts userRoster). */
+export type RosterUser = {
+  email: string;
+  name?: string;
+  /** Absolute (Gravatar) or machine-relative (`/api/avatars/<file>`). */
+  avatar?: string;
+};
+
+export const ALL_USERS = "__all";
+export const UNASSIGNED_USERS = "__unassigned";
+
+/** "ada" for ada@example.com — what the web shows when a name is missing. */
+export function shortUser(email: string): string {
+  return email.split("@")[0]?.trim() || email;
+}
+
+export function rosterUserLabel(user: RosterUser): string {
+  return user.name?.trim() || shortUser(user.email);
+}
+
+/**
+ * Verbatim port of web/src/lib/user-filter.ts. Sessions created from the
+ * phone carry no owner at all, so a person view that dropped unassigned
+ * sessions would hide live work the phone itself started.
+ */
+export function sessionMatchesUserFilter(
+  session: { assignedUser?: string | null },
+  userFilter: string,
+): boolean {
+  if (userFilter === ALL_USERS) return true;
+  if (userFilter === UNASSIGNED_USERS) return !session.assignedUser;
+  return session.assignedUser === userFilter || !session.assignedUser;
+}
+
+export function useUserRoster(): RosterUser[] {
+  const { client, bindingId } = useOmg();
+  const [users, setUsers] = useState<RosterUser[]>([]);
+
+  // A machine switch invalidates the roster: it belongs to the box.
+  useEffect(() => {
+    setUsers([]);
+  }, [bindingId]);
+
+  // On every focus, like the web's window-focus refetch: the avatar URL
+  // carries a rotating cache-buster and a replaced photo should show up.
+  useFocusEffect(
+    useCallback(() => {
+      if (!client) return;
+      let live = true;
+      client.transport
+        .request<{ users?: RosterUser[] }>("/api/users")
+        .then((payload) => {
+          if (live) setUsers(Array.isArray(payload.users) ? payload.users : []);
+        })
+        .catch(() => {
+          // An older machine has no roster endpoint. No filter, not an error.
+          if (live) setUsers([]);
+        });
+      return () => {
+        live = false;
+      };
+    }, [client]),
+  );
+
+  return users;
+}
+
+/**
+ * The persisted filter, reconciled against the roster: a stored email that
+ * has left the roster falls back to everyone rather than filtering the list
+ * down to nothing with no visible reason.
+ */
+export function useUserFilter(users: RosterUser[]): [string, (next: string) => void] {
+  const [value, setValue] = useState(ALL_USERS);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    AsyncStorage.getItem(STORAGE_KEYS.userFilter)
+      .then((stored) => {
+        if (live && stored) setValue(stored);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (live) setLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!loaded || !users.length) return;
+    if (value === ALL_USERS || value === UNASSIGNED_USERS) return;
+    if (users.some((user) => user.email === value)) return;
+    setValue(ALL_USERS);
+    void AsyncStorage.setItem(STORAGE_KEYS.userFilter, ALL_USERS);
+  }, [loaded, users, value]);
+
+  const change = useCallback((next: string) => {
+    setValue(next);
+    void AsyncStorage.setItem(STORAGE_KEYS.userFilter, next);
+  }, []);
+
+  return [value, change];
+}
+
+const avatarUriCache = new Map<string, string>();
+
+function readAsDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("avatar bytes unreadable"));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") resolve(result);
+      else reject(new Error("avatar bytes were not a data URI"));
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * Something an RN `Image` can draw for a roster avatar.
+ *
+ * Gravatar URLs are absolute and public, so they pass through. An uploaded
+ * icon is served from the machine at `/api/avatars/<file>` behind the
+ * transport's grant, so it is fetched through the transport and handed over
+ * as a data URI — the same move remote-image.tsx makes for attachments.
+ */
+export function useAvatarUri(avatar: string | undefined): string | null {
+  const { client } = useOmg();
+  const [uri, setUri] = useState<string | null>(() =>
+    avatar ? (avatarUriCache.get(avatar) ?? (isAbsolute(avatar) ? avatar : null)) : null,
+  );
+
+  useEffect(() => {
+    if (!avatar) {
+      setUri(null);
+      return;
+    }
+    if (isAbsolute(avatar)) {
+      setUri(avatar);
+      return;
+    }
+    const cached = avatarUriCache.get(avatar);
+    if (cached) {
+      setUri(cached);
+      return;
+    }
+    if (!client) {
+      setUri(null);
+      return;
+    }
+    let live = true;
+    void (async () => {
+      try {
+        const response = await client.transport.fetch(avatar);
+        if (!response.ok) throw new Error(`avatar ${response.status}`);
+        const data = await readAsDataUri(await response.blob());
+        avatarUriCache.set(avatar, data);
+        if (live) setUri(data);
+      } catch {
+        if (live) setUri(null);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [avatar, client]);
+
+  return uri;
+}
+
+function isAbsolute(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}


### PR DESCRIPTION
## Summary
- Home header matches the web island: user filter (avatar), computer, then one Pages menu (Notifications, Bots, Schedules, Settings).
- New `/schedules` screen: the web AutoManageView rows (name, N open, running, "Every day at 9:00 AM · in 10h" in the machine tz, on/off switch via `PATCH /api/auto/agents/:id`), grouped by bot.
- Home finding cards follow the web AutoFindingCard: severity dot, agent name, `createdAt` age, indented title, no avatar.
- `DropdownMenu` rows accept `{ uri }` images (roster avatars).
- App version 1.0.4 for a fresh TestFlight build.

## Verification
- `bunx tsc --noEmit`, `bunx expo export --platform ios`, `bun scripts/check-cron-drift.ts` all pass.
- Seen on the iPhone 17 Pro simulator: filter menu with avatars, filtered list, Pages menu, Schedules list, finding cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)