### PR TITLE
fix(auto): answer the feedback refine at once and let the browser follow it

### DIFF
--- a/src/auto/refine-state.test.ts
+++ b/src/auto/refine-state.test.ts
@@ -1,0 +1,29 @@
+// The in-memory state a feedback-driven rewrite publishes while the refine
+// route has already answered 202 (see store.ts "in-flight refines").
+import { describe, expect, test } from "bun:test";
+import { markRefining, refineStatus, settleRefine } from "./store.ts";
+
+describe("refine state", () => {
+  test("nothing is in flight for an agent nobody asked about", () => {
+    expect(refineStatus("never")).toBeUndefined();
+  });
+
+  test("claiming an agent publishes running; a second claim while running is refused", () => {
+    expect(markRefining("a")).toBe(true);
+    expect(refineStatus("a")?.state).toBe("running");
+    expect(markRefining("a")).toBe(false);
+  });
+
+  test("settling without an error reads done, and frees the agent for the next rewrite", () => {
+    markRefining("b");
+    settleRefine("b");
+    expect(refineStatus("b")?.state).toBe("done");
+    expect(markRefining("b")).toBe(true);
+  });
+
+  test("settling with an error keeps the message for the poll to surface", () => {
+    markRefining("c");
+    settleRefine("c", "refiner produced no output");
+    expect(refineStatus("c")).toMatchObject({ state: "failed", error: "refiner produced no output" });
+  });
+});

--- a/src/auto/store.ts
+++ b/src/auto/store.ts
@@ -356,6 +356,40 @@ export function isRunning(id: string): boolean {
   return inFlight.has(id);
 }
 
+// ---------- in-flight refines (in-memory; serve process only) ----------
+// A feedback-driven rewrite of an agent's instruction (POST .../refine) is a
+// real model call against the agent's repo and routinely runs past a minute —
+// longer than a phone keeps a fetch open (Safari gives up at 60s). So the route
+// answers at once and the browser follows the rewrite through this state on
+// the agent it already polls. Like `inFlight` this is deliberately not
+// persisted: a rewrite can't outlive the process, and a poll that finds no
+// state after a restart is told exactly that.
+export type RefineStatus =
+  | { state: "running"; startedAt: number }
+  | { state: "done"; at: number }
+  | { state: "failed"; at: number; error: string };
+
+const refines = new Map<string, RefineStatus>();
+
+/** Claim the agent for a rewrite. False when one is already in flight — two
+ *  concurrent rewrites of the same instruction would race each other's save. */
+export function markRefining(id: string): boolean {
+  if (refines.get(id)?.state === "running") return false;
+  refines.set(id, { state: "running", startedAt: Date.now() });
+  return true;
+}
+
+export function settleRefine(id: string, error?: string): void {
+  refines.set(
+    id,
+    error === undefined ? { state: "done", at: Date.now() } : { state: "failed", at: Date.now(), error },
+  );
+}
+
+export function refineStatus(id: string): RefineStatus | undefined {
+  return refines.get(id);
+}
+
 // ---------- findings ----------
 
 export async function listFindings(status?: string): Promise<Finding[]> {

--- a/src/commands/auto-agent-route-wiring.test.ts
+++ b/src/commands/auto-agent-route-wiring.test.ts
@@ -219,6 +219,12 @@ describe("POST /api/auto/agents/:id/refine (feedback → rewritten instruction)"
     expect(handler).toContain('if (!current) throw new Error("the agent was deleted while it was being updated")');
   });
 
+  test("a rewrite grounded in a finding dismisses that finding once it has landed", () => {
+    expect(handler).toContain('if (finding && finding.status === "open") {');
+    expect(handler).toContain('await updateFinding(finding.id, { status: "dismissed" })');
+    expect(handler.indexOf("await saveAutoAgent(")).toBeLessThan(handler.indexOf('status: "dismissed"'));
+  });
+
   test("the agent payload carries the refine state for the browser poll", () => {
     expect(SERVE).toContain("refine: refineStatus(a.id)");
   });

--- a/src/commands/auto-agent-route-wiring.test.ts
+++ b/src/commands/auto-agent-route-wiring.test.ts
@@ -219,10 +219,14 @@ describe("POST /api/auto/agents/:id/refine (feedback → rewritten instruction)"
     expect(handler).toContain('if (!current) throw new Error("the agent was deleted while it was being updated")');
   });
 
-  test("a rewrite grounded in a finding dismisses that finding once it has landed", () => {
+  test("a rewrite grounded in a finding marks it read once it has landed — never dismissed", () => {
     expect(handler).toContain('if (finding && finding.status === "open") {');
-    expect(handler).toContain('await updateFinding(finding.id, { status: "dismissed" })');
-    expect(handler.indexOf("await saveAutoAgent(")).toBeLessThan(handler.indexOf('status: "dismissed"'));
+    expect(handler).toContain('await updateFinding(finding.id, { status: "read" })');
+    expect(handler.indexOf("await saveAutoAgent(")).toBeLessThan(handler.indexOf('status: "read"'));
+    // A dismissed title is fed to the next run as "do NOT resurface"; feedback
+    // usually means "handle this properly", so dismissing here muted exactly
+    // the case the owner just retuned the agent for.
+    expect(handler).not.toContain('status: "dismissed"');
   });
 
   test("the agent payload carries the refine state for the browser poll", () => {

--- a/src/commands/auto-agent-route-wiring.test.ts
+++ b/src/commands/auto-agent-route-wiring.test.ts
@@ -190,3 +190,37 @@ describe("caller identity threading", () => {
     expect(SERVE).toContain('req.headers.get("x-omg-caller-session-id")');
   });
 });
+
+// The refine route used to hold the request open for the whole model call —
+// a minute-plus against a real repo — which a phone's fetch timeout threw away
+// while the server finished and saved anyway. These pin that it answers
+// first and does the work after, publishing its progress for the poll.
+describe("POST /api/auto/agents/:id/refine (feedback → rewritten instruction)", () => {
+  const handler = block("/refine$/", 4500);
+
+  test("claims the agent before answering, and refuses a second concurrent rewrite", () => {
+    expect(handler).toContain('if (!markRefining(agent.id)) return err(409');
+  });
+
+  test("answers 202 and carries the rewrite on in the background", () => {
+    expect(handler).toContain("void (async () => {");
+    expect(handler).toContain("return json({ ok: true, agent: withAutoAgentMeta(agent) }, { status: 202 })");
+    // The model call happens inside the detached block, not before the response.
+    expect(handler.indexOf("void (async () => {")).toBeLessThan(handler.indexOf("await refineAutoPrompt("));
+  });
+
+  test("settles the state both ways so the poll can end on success or the real error", () => {
+    expect(handler).toContain("() => settleRefine(agent.id)");
+    expect(handler).toContain("settleRefine(agent.id, msg)");
+  });
+
+  test("saves against the row as it is when the model returns, not the snapshot it started from", () => {
+    expect(handler).toContain("const current = await getAutoAgent(agent.id)");
+    expect(handler).toContain('if (!current) throw new Error("the agent was deleted while it was being updated")');
+  });
+
+  test("the agent payload carries the refine state for the browser poll", () => {
+    expect(SERVE).toContain("refine: refineStatus(a.id)");
+  });
+});
+

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7053,10 +7053,14 @@ a{color:#60a5fa}
             // The finding the owner was looking at is answered by the rewrite:
             // leaving it open under "Auto" reads as "still needs doing" (the
             // very first report of this fix was a screenshot of it still
-            // sitting there). Dismissed, not resolved — that is also what
-            // feeds the runner's "do NOT resurface" list next run.
+            // sitting there). "read", NOT "dismissed": a dismissed title is
+            // fed back to the next run as "do NOT resurface" (runner.ts), and
+            // feedback usually means the opposite — "handle this properly" —
+            // so dismissing it made the retuned agent skip exactly that case
+            // on its very next run. "read" drops it from the open list and
+            // still counts as unresolved, so a real recurrence escalates.
             if (finding && finding.status === "open") {
-              await updateFinding(finding.id, { status: "dismissed" });
+              await updateFinding(finding.id, { status: "read" });
             }
           })().then(
             () => settleRefine(agent.id),

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -7050,6 +7050,14 @@ a{color:#60a5fa}
               tools: current.tools,
             });
             console.log(`[auto] refined ${agent.id} from feedback (${prompt.length} chars)`);
+            // The finding the owner was looking at is answered by the rewrite:
+            // leaving it open under "Auto" reads as "still needs doing" (the
+            // very first report of this fix was a screenshot of it still
+            // sitting there). Dismissed, not resolved — that is also what
+            // feeds the runner's "do NOT resurface" list next run.
+            if (finding && finding.status === "open") {
+              await updateFinding(finding.id, { status: "dismissed" });
+            }
           })().then(
             () => settleRefine(agent.id),
             (e) => {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -97,6 +97,9 @@ import {
   deleteAutoAgentsOwnedByBot,
   countAutoAgentsOwnedByBot,
   isRunning,
+  markRefining,
+  settleRefine,
+  refineStatus,
   listFindings,
   updateFinding,
   dismissAllFindings,
@@ -1131,7 +1134,12 @@ type RepoEntry = Awaited<ReturnType<typeof listRepos>>[number];
 // worktree cwds back to the main checkout, so compute it server-side — the
 // browser cannot read .git files to do this itself.
 function withAutoAgentMeta<T extends { id: string; cwd?: string }>(a: T) {
-  return { ...a, project: projectName(a.cwd || SELF_REPO), running: isRunning(a.id) };
+  return {
+    ...a,
+    project: projectName(a.cwd || SELF_REPO),
+    running: isRunning(a.id),
+    refine: refineStatus(a.id),
+  };
 }
 
 /**
@@ -6973,6 +6981,14 @@ a{color:#60a5fa}
       // agent's own instruction so the correction survives into the next
       // scheduled run. Everything else about the row (schedule, backend, cwd)
       // is carried through untouched.
+      //
+      // The rewrite is a real model call against the agent's repo and
+      // routinely runs past a minute — longer than a phone holds a fetch open
+      // (Safari drops it at 60s, and the server used to finish and save into a
+      // connection nobody was listening on, so the toast said "couldn't
+      // update" over an agent that had in fact changed). So the request is
+      // answered now with 202 and the work carries on here; the browser
+      // follows it through `refine` on the agent it polls anyway.
       {
         const m = path.match(/^\/api\/auto\/agents\/([a-z0-9_-]+)\/refine$/);
         if (m && req.method === "POST") {
@@ -6980,24 +6996,29 @@ a{color:#60a5fa}
             feedback?: string;
             findingId?: string;
           } | null;
-          if (!b?.feedback?.trim()) return err(400, "feedback is required");
+          const feedback = b?.feedback?.trim();
+          if (!feedback) return err(400, "feedback is required");
           const agent = await getAutoAgent(m[1]);
           if (!agent) return err(404, "unknown auto agent");
           // Only ever ground the rewrite in a finding this agent actually
           // produced — an id from another agent would teach it about work it
           // does not do.
-          const findingId = b.findingId?.trim();
+          const findingId = b?.findingId?.trim();
           const finding = findingId
             ? (await listFindings()).find((f) => f.id === findingId && f.agentId === agent.id)
             : undefined;
-          try {
+          // A second tap while one rewrite is in flight would race two saves
+          // of the same instruction; the first one wins.
+          if (!markRefining(agent.id)) return err(409, "this agent is already being updated from feedback");
+          console.log(`[auto] refining ${agent.id} from feedback (${feedback.length} chars)`);
+          void (async () => {
             const { refineAutoPrompt } = await import("../auto/enhance.ts");
             const cwd = await resolveAutoCwd(agent.cwd);
             const prompt = await refineAutoPrompt(
               {
                 name: agent.name,
                 prompt: agent.prompt,
-                feedback: b.feedback,
+                feedback,
                 finding: finding
                   ? {
                       title: finding.title,
@@ -7010,22 +7031,34 @@ a{color:#60a5fa}
               cwd,
               (l) => console.log(l),
             );
-            const saved = await saveAutoAgent({
-              id: agent.id,
-              name: agent.name,
+            // Re-read the row before saving: an edit (schedule, enabled, model)
+            // that landed while the model was thinking must not be clobbered
+            // by the snapshot we started from, and a row deleted meanwhile
+            // must not come back.
+            const current = await getAutoAgent(agent.id);
+            if (!current) throw new Error("the agent was deleted while it was being updated");
+            await saveAutoAgent({
+              id: current.id,
+              name: current.name,
               prompt,
-              schedule: agent.schedule,
-              enabled: agent.enabled,
-              cwd: agent.cwd,
-              agent: agent.agent,
-              model: agent.model,
-              thinkingLevel: agent.thinkingLevel,
-              tools: agent.tools,
+              schedule: current.schedule,
+              enabled: current.enabled,
+              cwd: current.cwd,
+              agent: current.agent,
+              model: current.model,
+              thinkingLevel: current.thinkingLevel,
+              tools: current.tools,
             });
-            return json({ agent: withAutoAgentMeta(saved) });
-          } catch (e) {
-            return err(502, e instanceof Error ? e.message : String(e));
-          }
+            console.log(`[auto] refined ${agent.id} from feedback (${prompt.length} chars)`);
+          })().then(
+            () => settleRefine(agent.id),
+            (e) => {
+              const msg = e instanceof Error ? e.message : String(e);
+              console.error(`[auto] refine of ${agent.id} failed: ${msg}`);
+              settleRefine(agent.id, msg);
+            },
+          );
+          return json({ ok: true, agent: withAutoAgentMeta(agent) }, { status: 202 });
         }
       }
       if (path === "/api/auto/findings" && req.method === "GET") {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -402,6 +402,7 @@ import {
 import { toast } from "@/lib/notify";
 import { haptic } from "@/lib/haptics";
 import { feedback } from "@/lib/feedback";
+import { waitForRefine, type AutoAgentRefine } from "@/lib/auto-refine";
 import { useUiFeedbackPrefs, setUiFeedbackPrefs } from "@/lib/ui-feedback-prefs";
 import { useNavigationPrefs, setNavigationPrefs } from "@/lib/navigation-prefs";
 import { subscribeSelectionChange } from "./lib/selection-change";
@@ -871,6 +872,9 @@ type AutoAgent = {
   thinkingLevel?: string;
   lastRunAt?: number;
   running?: boolean; // mid-run right now (live, from the server poll)
+  // A feedback-driven rewrite of `prompt` in flight or just settled (live,
+  // from the server poll; absent until one has been asked for).
+  refine?: AutoAgentRefine;
   // List responses ship only the first ~200 chars of `prompt` (the row renders
   // it CSS-truncated anyway). When this is true, `prompt` is a preview and the
   // editor must refetch GET /api/auto/agents/:id before editing it.
@@ -7536,16 +7540,28 @@ export function App() {
   // agent's own instruction in place, so the correction is live before the next
   // scheduled run. Fire-and-close under a toast — the rewrite is a real model
   // call against the agent's repo and can take a while; nothing should block on
-  // it, and the sheet has already served its purpose.
+  // it, and the sheet has already served its purpose. The server answers 202
+  // at once and we follow the rewrite through the agent's `refine` state:
+  // holding one fetch open for the whole call is what a phone's 60s timeout
+  // used to cut off, so the toast said "couldn't update" over an agent that
+  // had in fact changed.
   function refineAgentFromFinding(f: AutoFinding, feedbackText: string) {
     const name = agentName(f.agentId);
+    const id = encodeURIComponent(f.agentId);
     setOpenFinding(null);
     toast.promise(
-      api(`/api/auto/agents/${f.agentId}/refine`, {
+      api(`/api/auto/agents/${id}/refine`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ feedback: feedbackText, findingId: f.id }),
-      }).then(() => refreshAuto()),
+      })
+        .then(() => refreshAuto())
+        .then(() =>
+          waitForRefine(() =>
+            api<{ agent: AutoAgent }>(`/api/auto/agents/${id}`).then((r) => r.agent.refine),
+          ),
+        )
+        .then(() => refreshAuto()),
       {
         loading: `Updating ${name}…`,
         success: `${name} updated`,
@@ -25297,6 +25313,11 @@ function AgentReportSheet({
               </span>
               {agent?.running ? (
                 <Loader2 className="size-3.5 shrink-0 animate-spin text-primary" aria-label="Running" />
+              ) : agent?.refine?.state === "running" ? (
+                <Loader2
+                  className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+                  aria-label="Updating from feedback"
+                />
               ) : null}
               {worst ? (
                 <span
@@ -30156,6 +30177,11 @@ function AutoManageView({
                           <span className="truncate text-sm font-medium leading-tight">{a.name}</span>
                           {a.running ? (
                             <Loader2 className="size-3 shrink-0 animate-spin text-primary" aria-label="Running" />
+                          ) : a.refine?.state === "running" ? (
+                            <Loader2
+                              className="size-3 shrink-0 animate-spin text-muted-foreground"
+                              aria-label="Updating from feedback"
+                            />
                           ) : null}
                         </span>
                         <span className="flex min-w-0 items-center text-xs text-muted-foreground">

--- a/web/src/lib/auto-refine.test.ts
+++ b/web/src/lib/auto-refine.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { waitForRefine, type AutoAgentRefine } from "./auto-refine";
+
+function script(states: (AutoAgentRefine | undefined | Error)[]) {
+  let i = 0;
+  const calls: number[] = [];
+  return {
+    calls,
+    fetchStatus: async () => {
+      calls.push(i);
+      const s = states[Math.min(i++, states.length - 1)];
+      if (s instanceof Error) throw s;
+      return s;
+    },
+  };
+}
+
+const noSleep = async () => {};
+
+describe("waitForRefine", () => {
+  test("resolves once the server reports the rewrite done", async () => {
+    const s = script([
+      { state: "running", startedAt: 1 },
+      { state: "running", startedAt: 1 },
+      { state: "done", at: 2 },
+    ]);
+    await waitForRefine(s.fetchStatus, { sleep: noSleep });
+    expect(s.calls.length).toBe(3);
+  });
+
+  test("surfaces the server's error when the rewrite failed", async () => {
+    const s = script([{ state: "running", startedAt: 1 }, { state: "failed", at: 2, error: "refiner produced no output" }]);
+    await expect(waitForRefine(s.fetchStatus, { sleep: noSleep })).rejects.toThrow("refiner produced no output");
+  });
+
+  test("a vanished state (serve restarted) is reported, not spun on", async () => {
+    const s = script([{ state: "running", startedAt: 1 }, undefined]);
+    await expect(waitForRefine(s.fetchStatus, { sleep: noSleep })).rejects.toThrow(/restarted/);
+  });
+
+  test("rides out a few failed polls (phone coming back from the lock screen)", async () => {
+    const s = script([
+      { state: "running", startedAt: 1 },
+      new Error("Load failed"),
+      new Error("Load failed"),
+      { state: "done", at: 2 },
+    ]);
+    await waitForRefine(s.fetchStatus, { sleep: noSleep, retries: 2 });
+    expect(s.calls.length).toBe(4);
+  });
+
+  test("gives up after too many consecutive failed polls", async () => {
+    const s = script([new Error("Load failed")]);
+    await expect(waitForRefine(s.fetchStatus, { sleep: noSleep, retries: 2 })).rejects.toThrow("Load failed");
+    expect(s.calls.length).toBe(3);
+  });
+
+  test("stops waiting after the timeout while still running", async () => {
+    let t = 0;
+    const s = script([{ state: "running", startedAt: 1 }]);
+    await expect(
+      waitForRefine(s.fetchStatus, {
+        sleep: async () => {
+          t += 1000;
+        },
+        now: () => t,
+        timeoutMs: 2500,
+      }),
+    ).rejects.toThrow(/still updating/);
+  });
+});

--- a/web/src/lib/auto-refine.ts
+++ b/web/src/lib/auto-refine.ts
@@ -1,0 +1,57 @@
+// Following a feedback-driven rewrite of an auto agent's instruction to its
+// end. POST /api/auto/agents/:id/refine answers 202 at once — the rewrite is
+// a real model call against the agent's repo and routinely runs past a
+// minute, longer than a phone keeps a fetch open — and publishes its progress
+// as `refine` on the agent. This polls that until it settles, so the toast
+// that says "updated" only says it once the new instruction is on disk.
+
+export type AutoAgentRefine =
+  | { state: "running"; startedAt: number }
+  | { state: "done"; at: number }
+  | { state: "failed"; at: number; error: string };
+
+export const REFINE_POLL_MS = 2000;
+/** Generous: the rewrite inspects the repo with read-only tools first. */
+export const REFINE_WAIT_MS = 15 * 60 * 1000;
+/** Consecutive poll failures tolerated — a phone coming back from the lock
+ *  screen fails one or two fetches before the network is back. */
+export const REFINE_POLL_RETRIES = 5;
+
+export async function waitForRefine(
+  fetchStatus: () => Promise<AutoAgentRefine | undefined>,
+  opts: {
+    intervalMs?: number;
+    timeoutMs?: number;
+    retries?: number;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<void> {
+  const interval = opts.intervalMs ?? REFINE_POLL_MS;
+  const timeout = opts.timeoutMs ?? REFINE_WAIT_MS;
+  const retries = opts.retries ?? REFINE_POLL_RETRIES;
+  const sleep = opts.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = opts.now ?? Date.now;
+  const started = now();
+  let failures = 0;
+  for (;;) {
+    let status: AutoAgentRefine | undefined;
+    try {
+      status = await fetchStatus();
+      failures = 0;
+    } catch (e) {
+      if (++failures > retries) throw e;
+      await sleep(interval);
+      continue;
+    }
+    // No state at all: the serve process restarted (the state is in-memory)
+    // and took the rewrite with it. Say so instead of spinning forever.
+    if (!status) throw new Error("the server restarted before the update finished");
+    if (status.state === "done") return;
+    if (status.state === "failed") throw new Error(status.error || "the rewrite failed");
+    if (now() - started > timeout) {
+      throw new Error("still updating — check the agent again in a bit");
+    }
+    await sleep(interval);
+  }
+}


### PR DESCRIPTION
## What

The **Feedback** action on a finding (`POST /api/auto/agents/:id/refine`) held the HTTP request open for the whole rewrite. That rewrite is a real model call against the agent's repo with read-only tools and routinely takes a minute or more. Phones don't keep a fetch open that long — Safari drops it at 60s — so the toast said *"Couldn't update the agent"* while the server finished the rewrite and saved it into a connection nobody was listening on.

Measured on my box today: refine started 17:07:09, `[runner] ai-sdk done` 17:08:09, `agents.json` written with the new instruction — and the owner saw an error and reported "feedback doesn't work / doesn't update". The old route also never logged start, finish or failure, so there was nothing in the journal to find.

## How

**Server**
- The route claims the agent (`markRefining`, 409 on a second tap while one is in flight), answers **202** immediately and carries the rewrite on in the background.
- Progress is published as `refine` on the agent payload the UI already polls: `running → done | failed { error }` (in-memory, like `running`).
- The save re-reads the row when the model returns, so an edit that landed meanwhile (schedule, enabled, model) is not clobbered and a deleted row does not come back.
- `[auto] refining <id> from feedback` / `refined` / `refine … failed:` in the log.
- A rewrite grounded in a finding **marks that finding read** once it lands — leaving it open under Auto read as "still needs doing" (the first report of this fix was a screenshot of exactly that). Not *dismissed*: a dismissed title is fed to the next run as "do NOT resurface", and feedback usually means "handle this properly" — measured today, dismissing it made the retuned agent skip exactly that customer mail on its next run. "read" stays UNRESOLVED so a real recurrence still escalates.

**Web**
- Post, then follow `refine` on `GET /api/auto/agents/:id` (`waitForRefine`: 2s poll, rides out a few failed polls when the phone comes back from the lock screen, reports a vanished state after a serve restart instead of spinning forever, 15-min cap) and only then say "updated".
- The agent row and the finding sheet show a spinner while the rewrite runs.

## Tests

- `src/auto/refine-state.test.ts` — the in-memory state machine.
- `src/commands/auto-agent-route-wiring.test.ts` — pins that the route claims → answers 202 → refines in the detached block → settles both ways → saves against the re-read row.
- `web/src/lib/auto-refine.test.ts` — done / failed / vanished / transient poll failures / timeout.
- `bun run typecheck` root + web clean; `bun test src/auto src/commands/auto-agent-* test/auto-agent-list-payload.test.ts` 121 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
