### PR TITLE
fix(auto): tell an agent that has acting tools that it may act

### DIFF
--- a/src/auto/runner-system.test.ts
+++ b/src/auto/runner-system.test.ts
@@ -1,0 +1,27 @@
+// The framing ahead of the owner's instruction has to match the tool grant:
+// an agent with Bash/Skill was told it "has read-only tools" and only surfaces
+// notifications, and that framing beat an instruction that said "handle it".
+import { describe, expect, test } from "bun:test";
+import { buildSystem } from "./runner.ts";
+
+describe("buildSystem", () => {
+  test("a read-only agent is framed as read-only and is never told to act", () => {
+    const s = buildSystem([]);
+    expect(s).toContain("You have read-only tools (Read, Grep, Glob, WebSearch, WebFetch)");
+    expect(s).not.toContain("you can ACT");
+    expect(s).toContain('{"findings": []}');
+  });
+
+  test("an agent granted acting tools is told it has them and what to do with finished work", () => {
+    const s = buildSystem(["Bash", "Skill"]);
+    expect(s).toContain("Bash, Skill — so you can ACT");
+    expect(s).toContain('never file "someone should do X"');
+    expect(s).toContain("report it as ONE low-severity finding whose title says what you did");
+    // The output contract is unchanged: still JSON findings only.
+    expect(s).toContain('{"findings": []}');
+  });
+
+  test("granting a tool that is already in the read-only set does not flip the agent into acting mode", () => {
+    expect(buildSystem(["Read", "Grep"])).not.toContain("you can ACT");
+  });
+});

--- a/src/auto/runner.ts
+++ b/src/auto/runner.ts
@@ -34,12 +34,41 @@ import {
  */
 const MAX_FINDINGS_PER_RUN = 5;
 
-const SYSTEM = `You are an autonomous watch agent. Carry out the instruction below.
-
-You have read-only tools (Read, Grep, Glob, WebSearch, WebFetch) — use them to
+/**
+ * The framing every run gets ahead of the owner's instruction.
+ *
+ * It is built per agent, not a constant, because of the tool grant: an agent
+ * given Bash/Skill/Write on top of the read-only set was still told here that
+ * it "has read-only tools" and exists to surface notifications — and that
+ * framing won. A mailbox agent whose instruction said "answer the customer,
+ * don't report it" did one search and filed "customer mail unanswered, someone
+ * should run the flow" run after run, even after the owner retuned it from
+ * feedback. So when the grant includes tools that can act, the framing says
+ * so, and says what to do with work that got done (report it, briefly, as the
+ * one exception to silence — the owner has to be able to see it happened).
+ */
+export function buildSystem(extraTools: readonly string[] = []): string {
+  const acting = extraTools.filter((t) => !READONLY_TOOLS.includes(t));
+  const tools = acting.length
+    ? `You have read-only tools (${READONLY_TOOLS.join(", ")}) and, on top of those,
+${acting.join(", ")} — so you can ACT, not only look. Use the read-only tools to
+gather your own context. If the instruction tells you to handle something
+yourself (send, label, write, run a script, load a skill), then do it, exactly
+within what the instruction allows — never file "someone should do X" for work
+the instruction told you to do. Work you completed is not a problem to surface:
+report it as ONE low-severity finding whose title says what you did, so the
+owner can see it happened. Something you were told to handle but could not is
+a finding of its own, with the reason. Beyond that, decide what, if anything,
+is worth surfacing as a notification right now. Be strict: most runs should
+surface nothing. Only surface something concrete, high-leverage, and actionable
+— never filler.`
+    : `You have read-only tools (${READONLY_TOOLS.join(", ")}) — use them to
 gather your own context. Decide what, if anything, is worth surfacing as a
 notification right now. Be strict: most runs should surface nothing. Only
-surface something concrete, high-leverage, and actionable — never filler.
+surface something concrete, high-leverage, and actionable — never filler.`;
+  return `You are an autonomous watch agent. Carry out the instruction below.
+
+${tools}
 
 Report every INDEPENDENT problem you find, not just the most important one — two
 unrelated problems are two findings. This is not licence to pad: if one thing is
@@ -61,6 +90,7 @@ Each finding must stand alone: its title names one specific problem, and its
 reasoning and suggest refer only to that problem.
 
 Rules: title is one line. At most 4 short reasoning bullets per finding. No essay.`;
+}
 
 function normSeverity(s: unknown): Severity {
   const v = String(s ?? "").toLowerCase();
@@ -437,7 +467,7 @@ async function runAutoAgentInner(
   const mine = (await listFindings()).filter((f) => f.agentId === agent.id);
   const feedback = buildFindingFeedback(mine);
 
-  const prompt = `${SYSTEM}\n\n## Instruction\n${agent.prompt}${feedback}`;
+  const prompt = `${buildSystem(agent.tools ?? [])}\n\n## Instruction\n${agent.prompt}${feedback}`;
   // The agent's base repo (chosen from the repo list in the UI) is where it runs
   // and from which it inherits .claude/settings.json. If it's unset, fall back to
   // the repo root but say so loudly — a missing base means the agent is watching


### PR DESCRIPTION
## What

The runner's framing ahead of the owner's instruction was a constant that always said *"You have read-only tools (Read, Grep, Glob, WebSearch, WebFetch) … surface a notification"* — even for an agent granted `Bash`/`Skill` on top of that set. That framing wins over the instruction.

Measured today on a mailbox agent whose instruction says "answer the customer yourself; reporting is not an outcome": it did one Gmail search and filed *"customer mail unanswered — someone should run the flow"*. Twice. Including right after the owner had retuned it via finding feedback (#283). The owner's feedback was in the instruction; the framing told the agent to ignore it.

## How

`buildSystem(extraTools)` replaces the `SYSTEM` constant. It lists the real grant and, when it includes tools outside the read-only set, adds: do what the instruction tells you to do; never file "someone should do X" for your own work; report completed work as **one low-severity finding whose title says what you did** (the owner has to be able to see it happened — that is the one exception to silence); report what you were told to handle but could not, with the reason.

- The JSON output contract is unchanged.
- A read-only agent gets byte-for-byte the same text as before.
- Granting a tool that is already read-only (`Read`) does not flip the agent into acting mode.

## Tests

`src/auto/runner-system.test.ts` — read-only framing, acting framing, read-only-only grant. `bun test src/auto` 76 pass, `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
