### PR TITLE
fix(release): stage packages/connectors into every runtime bundle

### DIFF
--- a/desktop/scripts/prepare-runtime.sh
+++ b/desktop/scripts/prepare-runtime.sh
@@ -34,6 +34,12 @@ cp -R \
 cp -R web/dist "$RUNTIME_DIR/web/dist"
 find "$RUNTIME_DIR/web/dist" -name '*.map' -delete
 find "$RUNTIME_DIR/src" "$RUNTIME_DIR/scripts" -name '*.test.ts' -delete
+# Same list as scripts/release.sh: workspace packages the server imports from
+# source through tsconfig.json "paths".
+mkdir -p "$RUNTIME_DIR/packages/connectors"
+cp packages/connectors/package.json "$RUNTIME_DIR/packages/connectors/"
+cp -R packages/connectors/src "$RUNTIME_DIR/packages/connectors/src"
+find "$RUNTIME_DIR/packages" -name '*.test.ts' -delete
 
 bun run scripts/prepare-release-manifest.ts "$RUNTIME_DIR/package.json"
 (

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -53,6 +53,17 @@ pkg_dir() {
   printf '%s/node_modules/%s' "$ROOT" "$1"
 }
 
+# stage_runtime_workspace_package <stage-root> <name>
+# Copies packages/<name>/{package.json,src} into the bundle, without tests.
+stage_runtime_workspace_package() {
+  local dest="$1/packages/$2"
+  [ -d "packages/$2/src" ] || die "packages/$2/src missing - cannot stage @omg-dev/$2."
+  mkdir -p "$dest"
+  cp "packages/$2/package.json" "$dest/package.json"
+  cp -r "packages/$2/src" "$dest/src"
+  find "$dest/src" -name '*.test.ts' -delete
+}
+
 rewrite_dep_to_vendor_tarball() {
   local manifest="$1"
   local pkg="$2"
@@ -105,6 +116,12 @@ cp -r \
   .env.example README.md CHANGELOG.md LICENSE SECURITY.md CONTRIBUTING.md \
   "$STAGE/lfg/"
 cp -r web/dist "$STAGE/lfg/web/dist"
+# Workspace packages the server imports from source. tsconfig.json maps each
+# one to packages/<name>/src, and Bun applies that map at runtime, so the
+# package directory has to travel with src/. v0.6.39 moved the connector layer
+# into @omg-dev/connectors without staging it, and `serve` died on the import
+# in every install. Keep this list in sync with tsconfig.json "paths".
+stage_runtime_workspace_package "$STAGE/lfg" connectors
 # Source maps are built with sourcemap: "hidden", so no bundle references them
 # and no browser ever fetches one. They were still 27MB of a 61MB download -
 # 700 files, 117MB unpacked, shipped to every install for a debugging aid that

--- a/test/release-manifest.test.ts
+++ b/test/release-manifest.test.ts
@@ -3,6 +3,23 @@ import { readFileSync } from "node:fs";
 
 import { prepareReleaseManifest } from "../scripts/prepare-release-manifest";
 
+const read = (rel: string) =>
+  readFileSync(new URL(`../${rel}`, import.meta.url), "utf8");
+
+// Every @omg-dev/* alias in tsconfig.json "paths" is a workspace package the
+// server imports from source. Bun resolves those aliases at runtime, so each
+// package directory must be staged into every runtime bundle.
+function sourceWorkspacePackages(): string[] {
+  const tsconfig = JSON.parse(read("tsconfig.json")) as {
+    compilerOptions?: { paths?: Record<string, string[]> };
+  };
+  const paths = tsconfig.compilerOptions?.paths ?? {};
+  return Object.values(paths)
+    .flat()
+    .map((target) => target.match(/^\.\/packages\/([^/]+)\/src\//)?.[1])
+    .filter((name): name is string => Boolean(name));
+}
+
 describe("release bundle manifest", () => {
   test("does not advertise source workspaces that are absent from the bundle", () => {
     const source = {
@@ -29,5 +46,23 @@ describe("release bundle manifest", () => {
     expect(releaseScript).toContain(
       '( cd "$STAGE/lfg" && unset CI && bun install --production --lockfile-only )',
     );
+  });
+
+  test("every source workspace package is staged into the release bundle", () => {
+    const releaseScript = read("scripts/release.sh");
+    const packages = sourceWorkspacePackages();
+    expect(packages).toContain("connectors");
+    for (const name of packages) {
+      expect(releaseScript).toContain(
+        `stage_runtime_workspace_package "$STAGE/lfg" ${name}`,
+      );
+    }
+  });
+
+  test("every source workspace package is staged into the desktop runtime", () => {
+    const runtimeScript = read("desktop/scripts/prepare-runtime.sh");
+    for (const name of sourceWorkspacePackages()) {
+      expect(runtimeScript).toContain(`packages/${name}/src`);
+    }
   });
 });


### PR DESCRIPTION
## What

`scripts/release.sh` and `desktop/scripts/prepare-runtime.sh` now stage `packages/connectors/{package.json,src}` next to `src/`. A test derives the list of source workspace packages from `tsconfig.json` "paths" and fails if any is not staged.

## Why

v0.6.39 moved the connector layer into the `@omg-dev/connectors` workspace package. `src/commands/serve.ts` imports it through the tsconfig `paths` alias, which Bun applies at runtime. The bundles only staged `src/`, so every published bundle since v0.6.39 (source bundle, prebuilt platform bundles, desktop runtime) dies at start:

```
Cannot find package '@omg-dev/connectors' imported from src/commands/serve.ts
```

The hosted `agent-lfg` template baked from that bundle (snapshot `ed980dac2bee`) never opens port 8766. Every `POST /v1/sandboxes` for it burns the 60s readiness timeout and returns 500.

## Verification

- `bun test test/release-manifest.test.ts`: 4 pass.
- Took the shipped v0.6.39 `lfg-bundle.tar.gz`, added `packages/connectors`, ran `bun install --production` and `serve`. It listened and answered HTTP 200.
- Not run locally: a full `release.sh` build. The release workflow does that on tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
