### PR TITLE
feat(web): film mode blur, dark mode + direct pages in the ⋮ menu, Live pill on settings sub-pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -404,6 +404,7 @@ import { haptic } from "@/lib/haptics";
 import { feedback } from "@/lib/feedback";
 import { useUiFeedbackPrefs, setUiFeedbackPrefs } from "@/lib/ui-feedback-prefs";
 import { useNavigationPrefs, setNavigationPrefs } from "@/lib/navigation-prefs";
+import { useFilmMode, setFilmMode } from "@/lib/film-mode";
 import { subscribeSelectionChange } from "./lib/selection-change";
 import { useProjectListPrefs, setProjectListPrefs } from "@/lib/project-list-prefs";
 import { useSendMorph } from "@/lib/use-send-morph";
@@ -13828,7 +13829,7 @@ const RailRow = memo(function RailRow({
           <>
             <span className="flex min-w-0 flex-1 flex-col gap-0.5">
               <span className="flex items-baseline gap-1.5">
-                <span className="min-w-0 flex-1 truncate text-base font-semibold leading-tight">
+                <span className="lfg-film-blur min-w-0 flex-1 truncate text-base font-semibold leading-tight">
                   {title}
                 </span>
                 {titleBadge}
@@ -16078,7 +16079,7 @@ function SessionTitleLine({ title }: { title: string }) {
       <div
         ref={lineRef}
         className={cn(
-          "text-[17px] font-semibold leading-tight whitespace-nowrap",
+          "lfg-film-blur text-[17px] font-semibold leading-tight whitespace-nowrap",
           marquee ? "lfg-marquee inline-block" : "overflow-hidden text-ellipsis",
         )}
         style={
@@ -18004,7 +18005,7 @@ const onTouchStart = (e: ReactTouchEvent) => {
                   "cursor-text rounded-md hover:bg-muted/50",
               )}
             >
-              <div className="flex min-w-0 flex-1 flex-col">
+              <div className="lfg-film-blur flex min-w-0 flex-1 flex-col">
                 <div className="truncate text-[15px] font-semibold leading-tight">
                   {headerBot ? headerBot.name : titleForSession(session)}
                 </div>
@@ -28224,6 +28225,7 @@ function MoreView({
 }) {
   const uiFeedback = useUiFeedbackPrefs();
   const navigationPrefs = useNavigationPrefs();
+  const filmMode = useFilmMode();
 
   return (
     <div className="mx-auto max-w-xl space-y-8 pb-10" data-lfg-page-column>
@@ -28367,6 +28369,26 @@ function MoreView({
               checked={navigationPrefs.swipeBetweenChats}
               onCheckedChange={(v) => setNavigationPrefs({ swipeBetweenChats: v })}
               aria-label="Toggle swipe between chats"
+            />
+          </div>
+          {/* Film mode: blur titles, previews, messages and terminals on this
+              browser only, so the screen can be recorded without leaking what
+              the agents are doing. A presentation switch, never a setting the
+              server knows about. */}
+          <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+            <div className="flex items-center gap-3">
+              <span className="flex size-7 items-center justify-center rounded-[7px] bg-primary text-white">
+                <EyeOff className="size-4" />
+              </span>
+              <span className="flex min-w-0 flex-col">
+                <span className="text-sm font-medium">Film mode</span>
+                <span className="text-xs text-muted-foreground">Blur titles and output for recording</span>
+              </span>
+            </div>
+            <Switch
+              checked={filmMode}
+              onCheckedChange={(v) => setFilmMode(v)}
+              aria-label="Toggle film mode"
             />
           </div>
         </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10009,7 +10009,7 @@ function PagesMenu({
     tab === "artifacts" ||
     tab === "computer" ||
     tab === "board" ||
-    (showSettings && tab === "settings");
+    (showSettings && (tab === "settings" || tab === "usage" || tab === "storage"));
   const value = known || extraTabs.some((t) => t.id === tab) ? tab : "live";
   // Controlled so a selection dismisses the menu. Radio items don't close on
   // their own — correct for a filter, wrong here: the selection navigates, and
@@ -10082,6 +10082,16 @@ function PagesMenu({
               <DropdownMenuRadioItem value="settings">
                 <Settings className="size-5 shrink-0 text-muted-foreground" />
                 Settings
+              </DropdownMenuRadioItem>
+              {/* Two Settings sub-pages Sam opens often enough that the
+                  detour through Settings cost more than it was worth. */}
+              <DropdownMenuRadioItem value="usage">
+                <Gauge className="size-5 shrink-0 text-muted-foreground" />
+                Usage limits
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="storage">
+                <HardDrive className="size-5 shrink-0 text-muted-foreground" />
+                Storage & performance
               </DropdownMenuRadioItem>
             </>
           ) : null}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8802,6 +8802,20 @@ export function App() {
                 </span>
               </button>
             )}
+            {/* Settings sub-pages (Usage, Storage, More, …) sit two taps from
+                the chats: back to Settings, back to Live. The Pages menu now
+                opens them directly, so the way home should be direct too — a
+                second pill in the same island jumps straight to Live. */}
+            {!embedded && !isPrimarySurfaceTab(tab) && tab !== "settings" && tab !== "notifications" && tab !== "artifacts" && tab !== "board" ? (
+              <button
+                type="button"
+                onClick={() => setTab("live")}
+                aria-label="Back to Live"
+                className="flex h-8 items-center rounded-full border-l border-border/60 pl-3 pr-3 text-[13px] font-medium tracking-[-0.01em] text-muted-foreground transition-colors duration-200 ease-out hover:text-foreground active:scale-[0.96]"
+              >
+                Live
+              </button>
+            ) : null}
           </div>
         </NavIsland>
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10114,9 +10114,36 @@ function PagesMenu({
             one tap from anywhere. A toggle, not a page — the menu stays open
             so the blur is visible behind it. */}
         <DropdownMenuSeparator />
+        <PagesMenuDarkModeItem />
         <PagesMenuFilmModeItem />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function PagesMenuDarkModeItem() {
+  // Same source of truth as the App-level `dark` state: the class on <html>,
+  // re-read on the theme change event so a toggle elsewhere updates this row.
+  const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
+  useEffect(() => {
+    const sync = () => setDark(document.documentElement.classList.contains("dark"));
+    window.addEventListener(THEME_CHANGE_EVENT, sync);
+    return () => window.removeEventListener(THEME_CHANGE_EVENT, sync);
+  }, []);
+  return (
+    <DropdownMenuItem
+      closeOnClick={false}
+      onClick={() => setThemePreference(!document.documentElement.classList.contains("dark"))}
+      aria-label="Toggle dark mode"
+    >
+      {dark ? (
+        <Moon className="size-5 shrink-0 text-muted-foreground" />
+      ) : (
+        <Sun className="size-5 shrink-0 text-muted-foreground" />
+      )}
+      <span className="flex-1">Dark mode</span>
+      <Switch checked={dark} tabIndex={-1} aria-hidden="true" className="pointer-events-none" />
+    </DropdownMenuItem>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10109,8 +10109,34 @@ function PagesMenu({
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>
+        {/* Film mode lives here as well as under More: it is the switch you
+            flip right before you start recording the screen, so it has to be
+            one tap from anywhere. A toggle, not a page — the menu stays open
+            so the blur is visible behind it. */}
+        <DropdownMenuSeparator />
+        <PagesMenuFilmModeItem />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function PagesMenuFilmModeItem() {
+  const filmMode = useFilmMode();
+  return (
+    <DropdownMenuItem
+      closeOnClick={false}
+      onClick={() => setFilmMode(!filmMode)}
+      aria-label="Toggle film mode"
+    >
+      <EyeOff className="size-5 shrink-0 text-muted-foreground" />
+      <span className="flex-1">Film mode</span>
+      <Switch
+        checked={filmMode}
+        tabIndex={-1}
+        aria-hidden="true"
+        className="pointer-events-none"
+      />
+    </DropdownMenuItem>
   );
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -2920,3 +2920,21 @@ html[data-lfg-embed="true"].lfg-keyboard-open {
     animation: none;
   }
 }
+
+/* ------------------------------------------------------------------
+ * Film mode (More → Film mode). Everything that names a session or
+ * shows what it produced gets blurred so the app can be filmed; the
+ * chrome — icons, counts, tabs, buttons — stays sharp so the video
+ * still reads as the app. Opt-in per element with .lfg-film-blur, plus
+ * the few structural hooks that already exist (rail preview, message
+ * bubbles, composer, terminal).
+ * ------------------------------------------------------------------ */
+html.lfg-film .lfg-film-blur,
+html.lfg-film .rail-preview,
+html.lfg-film .msg,
+html.lfg-film [data-composer-sid],
+html.lfg-film .xterm {
+  filter: blur(7px);
+  user-select: none;
+  -webkit-user-select: none;
+}

--- a/web/src/lib/film-mode.ts
+++ b/web/src/lib/film-mode.ts
@@ -1,0 +1,61 @@
+import { useSyncExternalStore } from "react";
+
+// Browser-local "film mode": blur every session title, preview, message and
+// terminal so the screen can be filmed without leaking what the agents are
+// working on. Pure presentation — nothing leaves the browser, and the server
+// never learns the switch exists. The class lives on <html> so plain CSS does
+// the blurring and no component has to re-render for it.
+
+const STORAGE_KEY = "lfg_film_mode";
+const HTML_CLASS = "lfg-film";
+
+let cache: boolean | null = null;
+const listeners = new Set<(on: boolean) => void>();
+
+function read(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function paint(on: boolean): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle(HTML_CLASS, on);
+}
+
+export function getFilmMode(): boolean {
+  if (cache === null) cache = read();
+  return cache;
+}
+
+export function setFilmMode(on: boolean): void {
+  cache = on;
+  try {
+    if (on) window.localStorage.setItem(STORAGE_KEY, "1");
+    else window.localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+  paint(on);
+  for (const listener of listeners) listener(on);
+}
+
+export function subscribeFilmMode(listener: (on: boolean) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useFilmMode(): boolean {
+  return useSyncExternalStore(subscribeFilmMode, getFilmMode, getFilmMode);
+}
+
+if (typeof window !== "undefined") {
+  paint(getFilmMode());
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    cache = read();
+    paint(cache);
+    for (const listener of listeners) listener(cache);
+  });
+}


### PR DESCRIPTION
Five small web-only changes around the Pages menu (⋮) and the Settings sub-pages. No server changes.

## Film mode (blur for screen recording)

A browser-local switch that blurs everything that names a session or shows what it produced — rail titles and previews, the session header title, every message bubble (including tool output), the composer and the terminal — while icons, counters, times, tabs and buttons stay sharp so a recording still reads as the app. Meant for filming the dashboard with a phone without leaking what the agents are working on.

- `web/src/lib/film-mode.ts`: `localStorage` flag (`lfg_film_mode`), toggles class `lfg-film` on `<html>`; `useFilmMode()` via `useSyncExternalStore`, same shape as `navigation-prefs.ts`.
- `index.css`: one rule under `html.lfg-film` (`filter: blur(7px)`) on `.lfg-film-blur`, `.rail-preview`, `.msg`, `[data-composer-sid]`, `.xterm`.
- Reachable from the Pages menu (one tap before you start recording; the menu stays open so the blur is visible behind it) and from More → This device, next to Dark mode.

## Pages menu

- **Dark mode** toggle in the menu, reading the `<html>` class and `THEME_CHANGE_EVENT` like the App-level state, so the row stays in sync with the switch under More.
- **Usage limits** and **Storage & performance** as direct radio items under Settings (gated on `showSettings`, same as Settings itself). Both tabs count as "known" so the current-page marker works.

## Settings sub-pages: direct way back to Live

On Usage, Storage, More etc. the mobile/tablet header showed only `‹ Settings`, so getting back to the chats took two taps. A second `Live` pill in the same island jumps straight there. Not shown when embedded (the host owns that chrome) or on pages that already had a Live back button.

## Verification

- `vite build` green on top of `main`; no `web/src` type errors (`tsc` on this checkout only reports the pre-existing `packages/client` resolution errors that are unrelated to `web/`).
- Exercised live on a self-hosted v0.6.40 install: film mode on/off from the menu and from More, dark mode from the menu, Usage limits and Storage links open the right pages, the Live pill returns to the chat list on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
