### PR TITLE
fix(opencode): default model moves to nemotron-3.5-lightning-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Recent product updates and deployment notes.
 
 ## September 5, 2026 - Mobile chat layout and auto-agent pages (v0.6.44)
 
+- **OpenCode default model is `opencode/nemotron-3.5-lightning-free`.** The
+  previous default, `opencode/deepseek-v4-flash-free`, now fails on
+  OpenCode's side with `Unexpected server error` and is gone from the
+  OpenCode catalog. A new box, and every omg.dev free Computer, picks the
+  working model.
+
 - **Chat messages keep their measured heights during keyboard changes.**
   Opening or closing the mobile keyboard while messages arrive no longer
   leaves rows at estimated heights that can make messages overlap.

--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -32,7 +32,7 @@ const DISCOVERED = [
   "openai/gpt-5.6-sol-pro",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-terra-fast",
-  "opencode/deepseek-v4-flash-free",
+  "opencode/nemotron-3.5-lightning-free",
   "opencode/future-coder-free",
   "opencode-go/kimi-k3",
   "opencode-go/kimi-k2.7-code",
@@ -67,7 +67,7 @@ describe("curateOpenCodeModels", () => {
 
   test("retains every dynamic credential-free OpenCode model", () => {
     const out = curateOpenCodeModels(DISCOVERED);
-    expect(out).toContain("opencode/deepseek-v4-flash-free");
+    expect(out).toContain("opencode/nemotron-3.5-lightning-free");
     expect(out).toContain("opencode/future-coder-free");
   });
 
@@ -121,9 +121,9 @@ describe("OpenCode catalog default", () => {
     // one-entry fallback made new accounts believe a single free model existed.
     expect(OPENCODE_MODELS.length).toBeGreaterThan(1);
     for (const model of OPENCODE_MODELS) expect(model).toMatch(/^opencode\/.+-free$/);
-    expect(OPENCODE_MODELS).toContain("opencode/deepseek-v4-flash-free");
-    expect(MODEL_OPTIONS.opencode.defaultModel).toBe("opencode/deepseek-v4-flash-free");
-    expect(defaultModelForAgent("opencode")).toBe("opencode/deepseek-v4-flash-free");
+    expect(OPENCODE_MODELS).toContain("opencode/nemotron-3.5-lightning-free");
+    expect(MODEL_OPTIONS.opencode.defaultModel).toBe("opencode/nemotron-3.5-lightning-free");
+    expect(defaultModelForAgent("opencode")).toBe("opencode/nemotron-3.5-lightning-free");
   });
 
   test("keeps every cold-fallback model selectable for an anonymous account", () => {
@@ -135,8 +135,8 @@ describe("OpenCode catalog default", () => {
   test("replaces stale fallback providers with successful live discovery", () => {
     expect(discoveredModelsOrFallback(
       ["opencode-go/deepseek-v4-flash"],
-      { ok: true, models: ["opencode/deepseek-v4-flash-free"] },
-    )).toEqual(["opencode/deepseek-v4-flash-free"]);
+      { ok: true, models: ["opencode/nemotron-3.5-lightning-free"] },
+    )).toEqual(["opencode/nemotron-3.5-lightning-free"]);
   });
 
   test("uses the safe fallback only when live discovery is unavailable", () => {
@@ -156,7 +156,7 @@ describe("OpenCode catalog default", () => {
 
   test("shows only credential-free OpenCode models before account setup", () => {
     expect(accessibleModelsForAgent("opencode", DISCOVERED, false, [], true)).toEqual([
-      "opencode/deepseek-v4-flash-free",
+      "opencode/nemotron-3.5-lightning-free",
       "opencode/future-coder-free",
     ]);
   });
@@ -192,7 +192,7 @@ describe("OpenCode catalog default", () => {
 
   test("does not let another agent's account unlock OpenCode's paid providers", () => {
     expect(accessibleModelsForAgent("opencode", DISCOVERED, true, [], false)).toEqual([
-      "opencode/deepseek-v4-flash-free",
+      "opencode/nemotron-3.5-lightning-free",
       "opencode/future-coder-free",
     ]);
   });
@@ -212,7 +212,7 @@ describe("OpenCode catalog default", () => {
       const opencode = listModelCatalog([codingAgent(key, true), codingAgent("opencode", true)]).find(
         (item) => item.key === "opencode",
       );
-      expect(opencode?.defaultModel).toBe("opencode/deepseek-v4-flash-free");
+      expect(opencode?.defaultModel).toBe("opencode/nemotron-3.5-lightning-free");
     },
   );
 

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -113,7 +113,7 @@ export const PI_OPENCODE_MODELS: string[] = [
   "opencode/gpt-5.6-sol",
   "opencode/kimi-k2.7-code",
   "opencode/minimax-m3",
-  "opencode/deepseek-v4-flash-free",
+  "opencode/nemotron-3.5-lightning-free",
 ];
 export const PI_MODELS: string[] = [
   "fable",
@@ -131,8 +131,12 @@ export const PI_MODELS: string[] = [
 // therefore looked like "OpenCode only offers one free model" to every brand
 // new user who opened the picker inside the first refresh window, so seed it
 // with the full credential-free Zen set instead of one representative id.
+// deepseek-v4-flash-free led this list and was the default until 2026-09-05,
+// when OpenCode Zen started answering every call to it with
+// `UnknownError: Unexpected server error` and dropped it from `opencode
+// models`. nemotron-3.5-lightning-free is on the live free list and answers.
 export const OPENCODE_MODELS: string[] = [
-  "opencode/deepseek-v4-flash-free",
+  "opencode/nemotron-3.5-lightning-free",
   "opencode/laguna-s-2.1-free",
   "opencode/ling-3.0-tiny-free",
   "opencode/longcat-2.0-free",
@@ -239,7 +243,7 @@ export const MODEL_OPTIONS: Record<CodingAgentKind, { defaultModel: string; mode
   muse: { defaultModel: "muse-spark-1.2", models: MUSE_MODELS },
   deepseek: { defaultModel: "deepseek-v4-flash", models: DEEPSEEK_MODELS },
   hermes: { defaultModel: "nousresearch/hermes-4-405b", models: HERMES_MODELS },
-  opencode: { defaultModel: "opencode/deepseek-v4-flash-free", models: OPENCODE_MODELS },
+  opencode: { defaultModel: "opencode/nemotron-3.5-lightning-free", models: OPENCODE_MODELS },
   jcode: { defaultModel: "auto", models: JCODE_MODELS },
   pi: { defaultModel: "sonnet", models: PI_MODELS },
   copilot: { defaultModel: "claude-sonnet-4.5", models: COPILOT_MODELS },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1313,7 +1313,7 @@ const CURSOR_MODELS = [
   "cursor-grok-4.6",
 ];
 const OPENCODE_MODELS = [
-  "opencode/deepseek-v4-flash-free",
+  "opencode/nemotron-3.5-lightning-free",
 ];
 // pi resolves the same Claude aliases as claude/aisdk plus one custom proxy
 // model id. Kept in sync with PI_MODELS in src/agent-catalog.ts (the server
@@ -1399,7 +1399,7 @@ const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   fx: "auto",
   muse: "muse-spark-1.2",
   deepseek: "deepseek-v4-flash",
-  opencode: "opencode/deepseek-v4-flash-free",
+  opencode: "opencode/nemotron-3.5-lightning-free",
   jcode: "auto",
   pi: "sonnet",
   copilot: "claude-sonnet-4.5",


### PR DESCRIPTION
## What
OpenCode default and cold-fallback lead: `opencode/deepseek-v4-flash-free` → `opencode/nemotron-3.5-lightning-free`. Same swap in the pi OpenCode list. CHANGELOG entry for v0.6.42.

## Why
Every call to deepseek-v4-flash-free fails on OpenCode's side since 2026-09-05 (`Unexpected server error`, 5 refs across a cloud Computer and the dev box) and `opencode models` dropped it. Every omg.dev free Computer's first message fails with that error (BennyKok/vibes#1641 covers the host side; the composer default comes from here).

## Verification
- `bun test src/agent-catalog.test.ts`: 27 pass.
- `opencode run -m opencode/nemotron-3.5-lightning-free` answers READY in ~8s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)