### PR TITLE
fix(opencode): an anonymous box launches the configured free default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent product updates and deployment notes.
 
+## September 5, 2026 - Free OpenCode default really launches (v0.6.45)
+
+- **An anonymous box now launches the configured free OpenCode model.** The
+  picker used to take the first free model that OpenCode's catalog listed,
+  which was still the retired `deepseek-v4-flash-free`. The configured
+  default (`opencode/nemotron-3.5-lightning-free`) now wins whenever the
+  catalog offers it.
+
 ## September 5, 2026 - Update coding agents and refresh models from Settings (v0.6.45)
 
 - **Settings can update a coding agent CLI and refresh its models.** Expand

--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   curateCursorModels,
   curateOpenCodeModels,
   defaultModelForAgent,
+  defaultModelForCatalogItem,
   discoveredModelsOrFallback,
   hasConnectedModelAccount,
   listModelCatalog,
@@ -124,6 +125,24 @@ describe("OpenCode catalog default", () => {
     expect(OPENCODE_MODELS).toContain("opencode/nemotron-3.5-lightning-free");
     expect(MODEL_OPTIONS.opencode.defaultModel).toBe("opencode/nemotron-3.5-lightning-free");
     expect(defaultModelForAgent("opencode")).toBe("opencode/nemotron-3.5-lightning-free");
+  });
+
+  test("an anonymous box launches the configured free default, not the first discovered free model", () => {
+    // models.dev still lists deepseek-v4-flash-free ahead of the working
+    // models, and OpenCode answers every call to it with a server error.
+    const discovered = [
+      "opencode/deepseek-v4-flash-free",
+      "opencode/laguna-s-2.1-free",
+      "opencode/nemotron-3.5-lightning-free",
+      "opencode/claude-opus-4-8",
+    ];
+    expect(defaultModelForCatalogItem("opencode", discovered, false)).toBe(
+      "opencode/nemotron-3.5-lightning-free",
+    );
+    // Without the configured default on offer, the first free entry still wins.
+    expect(defaultModelForCatalogItem("opencode", ["opencode/laguna-s-2.1-free", "opencode/x"], false)).toBe(
+      "opencode/laguna-s-2.1-free",
+    );
   });
 
   test("keeps every cold-fallback model selectable for an anonymous account", () => {

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -709,6 +709,13 @@ export function defaultModelForCatalogItem(
   fullOpenCodeCatalog: boolean,
 ): string {
   if (key === "opencode" && !fullOpenCodeCatalog) {
+    // Discovery lists the free tier in catalog order, and that order put a
+    // model OpenCode had already stopped serving (deepseek-v4-flash-free,
+    // 2026-09-05) in front of every anonymous box. The configured default is
+    // the one model known to answer, so it wins whenever discovery offers it;
+    // the first free entry is only the fallback for a catalog without it.
+    const configured = MODEL_OPTIONS.opencode.defaultModel;
+    if (models.includes(configured)) return configured;
     const free = models.find((model) => /^opencode\/.+-free$/.test(model));
     if (free) return free;
   }


### PR DESCRIPTION
## What
`defaultModelForCatalogItem`: for an anonymous OpenCode box, return `MODEL_OPTIONS.opencode.defaultModel` when discovery offers it; otherwise the first free entry as before. Test added. CHANGELOG entry for v0.6.45.

## Why
Discovery order put the retired `deepseek-v4-flash-free` first (models.dev still lists it), so every anonymous box, including every omg.dev free Computer on v0.6.44, still launched the dead model. Verified by e2e run 2026-09-05T11:13 UTC against a Computer on v0.6.44: `OpenCode turn failed for opencode/deepseek-v4-flash-free`.

## Verification
`bun test src/agent-catalog.test.ts`: 28 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)