### PR TITLE
fix(opencode): anonymous default is the best free model the box discovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Recent product updates and deployment notes.
 
+## September 5, 2026 - Free OpenCode default follows what the box can use (v0.6.47)
+
+- **The free OpenCode default is the best free model the box actually
+  discovers.** OpenCode advertises a different free set to each box, and the
+  retired `deepseek-v4-flash-free` was still first in that set on a fresh
+  omg.dev Computer. LFG now launches the first known-working free model the
+  box offers, and never offers a retired model.
+
 ## September 5, 2026 - Free OpenCode default really launches (v0.6.46)
 
 - **An anonymous box now launches the configured free OpenCode model.** The

--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -127,6 +127,24 @@ describe("OpenCode catalog default", () => {
     expect(defaultModelForAgent("opencode")).toBe("opencode/nemotron-3.5-lightning-free");
   });
 
+  test("an anonymous box launches the best free model discovery offers, never a retired one", () => {
+    // The set a fresh omg.dev Computer discovered on 2026-09-05. No
+    // nemotron-3.5-lightning-free; the first entry is the retired model.
+    const computer = [
+      "opencode/deepseek-v4-flash-free",
+      "opencode/hy3-free",
+      "opencode/mimo-v2.5-free",
+      "opencode/nemotron-3-ultra-free",
+      "opencode/north-mini-code-free",
+    ];
+    expect(defaultModelForCatalogItem("opencode", computer, false)).toBe("opencode/mimo-v2.5-free");
+    // A retired model is not offered at all.
+    expect(curateOpenCodeModels(computer)).not.toContain("opencode/deepseek-v4-flash-free");
+    expect(curateOpenCodeModels(computer)).toContain("opencode/hy3-free");
+    // A catalog with only unknown free models still launches one of them.
+    expect(defaultModelForCatalogItem("opencode", ["opencode/deepseek-v4-flash-free", "opencode/hy3-free"], false)).toBe("opencode/hy3-free");
+  });
+
   test("an anonymous box launches the configured free default, not the first discovered free model", () => {
     // models.dev still lists deepseek-v4-flash-free ahead of the working
     // models, and OpenCode answers every call to it with a server error.

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -135,6 +135,23 @@ export const PI_MODELS: string[] = [
 // when OpenCode Zen started answering every call to it with
 // `UnknownError: Unexpected server error` and dropped it from `opencode
 // models`. nemotron-3.5-lightning-free is on the live free list and answers.
+// Free OpenCode Zen models known to answer, best first. Discovery on a box
+// returns whatever subset Zen advertises to that box (a fresh omg.dev Computer
+// on 2026-09-05 saw deepseek-v4-flash-free, hy3-free, mimo-v2.5-free,
+// nemotron-3-ultra-free and north-mini-code-free; this machine saw a different
+// set), so the anonymous default is the first of these that discovery offers.
+export const PREFERRED_FREE_OPENCODE_MODELS: readonly string[] = [
+  "opencode/nemotron-3.5-lightning-free",
+  "opencode/mimo-v2.5-free",
+  "opencode/ling-3.0-flash-fin-free",
+  "opencode/nemotron-3-ultra-free",
+];
+// Models Zen still advertises but no longer serves. Never offered, never the
+// default. deepseek-v4-flash-free: every call fails with
+// `UnknownError: Unexpected server error` since 2026-09-05.
+export const RETIRED_OPENCODE_MODELS: ReadonlySet<string> = new Set([
+  "opencode/deepseek-v4-flash-free",
+]);
 export const OPENCODE_MODELS: string[] = [
   "opencode/nemotron-3.5-lightning-free",
   "opencode/laguna-s-2.1-free",
@@ -411,7 +428,7 @@ export function curateOpenCodeModels(
   // OpenCode publishes credential-free models in its live catalog. Keep these
   // dynamic instead of pinning one release in LFG: anonymous installs can then
   // follow provider additions/removals without an LFG release.
-  const free = models.filter((model) => /^opencode\/.+-free$/.test(model));
+  const free = models.filter((model) => /^opencode\/.+-free$/.test(model) && !RETIRED_OPENCODE_MODELS.has(model));
   // ChatGPT subscription models (openai/*, present when opencode is logged in
   // via ChatGPT Plus/Pro OAuth) lead the picker. Mirror the codex harness
   // preference order, then stay future-proof by surfacing the newest release
@@ -710,13 +727,12 @@ export function defaultModelForCatalogItem(
 ): string {
   if (key === "opencode" && !fullOpenCodeCatalog) {
     // Discovery lists the free tier in catalog order, and that order put a
-    // model OpenCode had already stopped serving (deepseek-v4-flash-free,
-    // 2026-09-05) in front of every anonymous box. The configured default is
-    // the one model known to answer, so it wins whenever discovery offers it;
-    // the first free entry is only the fallback for a catalog without it.
-    const configured = MODEL_OPTIONS.opencode.defaultModel;
-    if (models.includes(configured)) return configured;
-    const free = models.find((model) => /^opencode\/.+-free$/.test(model));
+    // retired model in front of every anonymous box. Launch the best free
+    // model discovery offers; the first free entry is only the fallback for
+    // a catalog that carries none of the preferred ones.
+    const preferred = PREFERRED_FREE_OPENCODE_MODELS.find((model) => models.includes(model));
+    if (preferred) return preferred;
+    const free = models.find((model) => /^opencode\/.+-free$/.test(model) && !RETIRED_OPENCODE_MODELS.has(model));
     if (free) return free;
   }
   // Muse: discovery lists the catalog newest release first, and the newest


### PR DESCRIPTION
## What
- `PREFERRED_FREE_OPENCODE_MODELS` (best first: nemotron-3.5-lightning-free, mimo-v2.5-free, ling-3.0-flash-fin-free, nemotron-3-ultra-free). An anonymous box launches the first one discovery offers.
- `RETIRED_OPENCODE_MODELS` (deepseek-v4-flash-free): never curated, never the default.
- CHANGELOG entry for v0.6.47.

## Why
Zen advertises a different free set per box. A fresh omg.dev Computer on v0.6.46 discovered `deepseek-v4-flash-free, hy3-free, mimo-v2.5-free, nemotron-3-ultra-free, north-mini-code-free` (read live from `/api/coding-agents` on sandbox `094bd15d20d6`), so #289's rule never matched and the retired model still launched. Every free Computer's first turn fails with `Unexpected server error`.

## Verification
`bun test src/agent-catalog.test.ts`: 29 pass, including the exact discovered set above resolving to `mimo-v2.5-free` with the retired model absent from the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)