### PR TITLE
perf(serve): slim /api/bootstrap and compress every asset, not just the precompressed ones

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -200,7 +200,6 @@ import {
   attachRuntimeSession,
   botParticipantId,
   canManageConversation,
-  canReadConversation,
   conversationBotParticipant,
   conversationHumanParticipantId,
   detachRuntimeSession,
@@ -208,7 +207,6 @@ import {
   ensureConversationHuman,
   getConversation,
   leaveConversationParticipant,
-  listConversations,
   replaceConversationPrimaryRuntime,
   upsertConversationParticipant,
   viewerConversationParticipantId,
@@ -1726,6 +1724,10 @@ async function staticAssetResponse(
   if (matchesEtag || notModifiedByDate) {
     return new Response(null, { status: 304, headers });
   }
+  // SVG icons and the manifest are text; the build leaves no precompressed
+  // sibling for them, so this is always the on-the-fly path.
+  const compressed = await compressedAssetResponse(req, filePath, headers);
+  if (compressed) return compressed;
   return new Response(f, { headers });
 }
 
@@ -5257,16 +5259,12 @@ a{color:#60a5fa}
         // local users, not a new trust boundary. A managed caller's trusted
         // header always wins over this regardless (see botViewer).
         const viewer = botViewerFromRequest(req, url.searchParams.get("user"));
-        const conversationsTask = sessionsTask.then(() => {
-          let conversations = listConversations();
-          if (viewer.managed && viewer.identity) {
-            const participantId = conversationHumanParticipantId(viewer.identity);
-            conversations = conversations.filter((conversation) =>
-              canReadConversation(conversation, participantId),
-            );
-          }
-          return conversations;
-        });
+        // No `conversations` here. The full conversation index (every
+        // conversation this box ever held, ~600 KB of JSON on a busy box)
+        // used to ride along on every cold open, and nothing on the client
+        // read it: the roster's unread state comes from /api/bots, and a
+        // transcript loads its own conversation. Dropping it takes the
+        // bootstrap payload from ~630 KB to ~90 KB before compression.
         // Which participant, if any, the *messages* the UI is about to render
         // belong to "me" — see viewerConversationParticipantId.
         const viewerParticipantId = viewerConversationParticipantId(viewer.identity);
@@ -5283,7 +5281,6 @@ a{color:#60a5fa}
           settings: settingsTask,
           sessions: sessionsTask,
           sessionPins: sessionPinsTask,
-          conversations: conversationsTask,
           users: Promise.resolve(userRoster()),
           repos: reposTask,
           autoAgents: listAutoAgents(),
@@ -5304,7 +5301,6 @@ a{color:#60a5fa}
           settings?: GlobalSettings | null;
           sessions?: Awaited<ReturnType<typeof listSessionsCached>> | null;
           sessionPins?: string[] | null;
-          conversations?: Awaited<typeof conversationsTask> | null;
           users?: ReturnType<typeof userRoster> | null;
           repos?: Awaited<ReturnType<typeof listRepos>> | null;
           autoAgents?: Awaited<ReturnType<typeof listAutoAgents>> | null;
@@ -5321,7 +5317,6 @@ a{color:#60a5fa}
               ? withSessionUnread(viewer.identity, boot.sessions.map(sessionListRow))
               : null,
             sessionPins: boot.sessionPins ?? null,
-            conversations: boot.conversations ?? null,
             // Not an authorization signal — never gates what the UI is allowed
             // to show. It only tells the transcript renderer which already-
             // delivered MessageAuthorRef.participantId is "mine", so a shared

--- a/src/http-compress.test.ts
+++ b/src/http-compress.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  compressedAssetResponse,
+  maybeCompressResponse,
+  resetCompressedAssetCache,
+} from "./http-compress.ts";
+
+const dirs: string[] = [];
+function scratch(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omg-compress-"));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  resetCompressedAssetCache();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const BIG = "const x = 1;\n".repeat(400); // ~5 KB, compresses well
+
+describe("compressedAssetResponse", () => {
+  test("prefers the precompressed sibling when one exists", async () => {
+    const dir = scratch();
+    const file = join(dir, "app.js");
+    writeFileSync(file, BIG);
+    writeFileSync(`${file}.br`, "sibling");
+    const res = await compressedAssetResponse(
+      new Request("http://x/assets/app.js", { headers: { "accept-encoding": "gzip, br" } }),
+      file,
+      { "Content-Type": "application/javascript" },
+    );
+    expect(res?.headers.get("content-encoding")).toBe("br");
+    expect(await res?.text()).toBe("sibling");
+  });
+
+  test("compresses on the fly when no sibling shipped, and serves the same bytes back", async () => {
+    const dir = scratch();
+    const file = join(dir, "index.css");
+    writeFileSync(file, BIG);
+    const req = () =>
+      new Request("http://x/assets/index.css", { headers: { "accept-encoding": "br, gzip" } });
+    const res = await compressedAssetResponse(req(), file, { "Content-Type": "text/css" });
+    expect(res).not.toBeNull();
+    expect(res!.headers.get("content-encoding")).toBe("br");
+    expect(res!.headers.get("vary")).toBe("Accept-Encoding");
+    const body = new Uint8Array(await res!.arrayBuffer());
+    expect(body.byteLength).toBeLessThan(BIG.length / 4);
+    expect(Number(res!.headers.get("content-length"))).toBe(body.byteLength);
+    expect(brotliDecompressSync(body).toString()).toBe(BIG);
+    // Second hit is served from the cache: same bytes, no re-encode.
+    const again = await compressedAssetResponse(req(), file, { "Content-Type": "text/css" });
+    expect(new Uint8Array(await again!.arrayBuffer())).toEqual(body);
+  });
+
+  test("falls back to gzip when the client does not accept brotli", async () => {
+    const dir = scratch();
+    const file = join(dir, "chunk.js");
+    writeFileSync(file, BIG);
+    const res = await compressedAssetResponse(
+      new Request("http://x/assets/chunk.js", { headers: { "accept-encoding": "gzip" } }),
+      file,
+      { "Content-Type": "application/javascript" },
+    );
+    expect(res!.headers.get("content-encoding")).toBe("gzip");
+    expect(gunzipSync(new Uint8Array(await res!.arrayBuffer())).toString()).toBe(BIG);
+  });
+
+  test("leaves tiny files, already-compressed formats and clients without accept-encoding alone", async () => {
+    const dir = scratch();
+    const tiny = join(dir, "tiny.js");
+    writeFileSync(tiny, "x");
+    expect(
+      await compressedAssetResponse(
+        new Request("http://x/a", { headers: { "accept-encoding": "br" } }),
+        tiny,
+        {},
+      ),
+    ).toBeNull();
+    const png = join(dir, "img.png");
+    writeFileSync(png, BIG);
+    expect(
+      await compressedAssetResponse(
+        new Request("http://x/a", { headers: { "accept-encoding": "br" } }),
+        png,
+        {},
+      ),
+    ).toBeNull();
+    const big = join(dir, "big.js");
+    writeFileSync(big, BIG);
+    expect(await compressedAssetResponse(new Request("http://x/a"), big, {})).toBeNull();
+  });
+
+  test("a rebuilt file under the same name is not served from the stale cache", async () => {
+    const dir = scratch();
+    const file = join(dir, "dev.js");
+    writeFileSync(file, BIG);
+    const req = () => new Request("http://x/a", { headers: { "accept-encoding": "gzip" } });
+    const first = await compressedAssetResponse(req(), file, {});
+    expect(gunzipSync(new Uint8Array(await first!.arrayBuffer())).toString()).toBe(BIG);
+    // A real rebuild is seconds apart; in a test two writes can land in the
+    // same millisecond, so let the size change carry the key.
+    const NEXT = "const y = 22;\n".repeat(400);
+    writeFileSync(file, NEXT);
+    const second = await compressedAssetResponse(req(), file, {});
+    expect(gunzipSync(new Uint8Array(await second!.arrayBuffer())).toString()).toBe(NEXT);
+  });
+});
+
+describe("maybeCompressResponse", () => {
+  const html = `<!doctype html><html><head></head><body>${"<p>hello</p>".repeat(300)}</body></html>`;
+
+  test("compresses the HTML app shell on / and on SPA fallback routes", async () => {
+    for (const path of ["/", "/sessions/abc"]) {
+      const res = await maybeCompressResponse(
+        new Request(`http://x${path}`, { headers: { "accept-encoding": "br" } }),
+        path,
+        new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } }),
+      );
+      expect(res!.headers.get("content-encoding")).toBe("br");
+      expect(brotliDecompressSync(new Uint8Array(await res!.arrayBuffer())).toString()).toBe(html);
+    }
+  });
+
+  test("still leaves non-HTML, non-API bodies untouched", async () => {
+    const res = await maybeCompressResponse(
+      new Request("http://x/sw.js", { headers: { "accept-encoding": "br" } }),
+      "/sw.js",
+      new Response(BIG, { headers: { "Content-Type": "application/javascript" } }),
+    );
+    expect(res!.headers.get("content-encoding")).toBeNull();
+  });
+
+  test("still compresses JSON under /api/", async () => {
+    const body = JSON.stringify({ rows: Array.from({ length: 200 }, (_, i) => ({ i, name: "session" })) });
+    const res = await maybeCompressResponse(
+      new Request("http://x/api/sessions", { headers: { "accept-encoding": "gzip" } }),
+      "/api/sessions",
+      new Response(body, { headers: { "Content-Type": "application/json" } }),
+    );
+    expect(res!.headers.get("content-encoding")).toBe("gzip");
+  });
+});

--- a/src/http-compress.ts
+++ b/src/http-compress.ts
@@ -76,15 +76,24 @@ function isJsonResponse(response: Response): boolean {
   return /\bapplication\/(?:[^;\s]+\+)?json\b/.test(contentType);
 }
 
+function isHtmlResponse(response: Response): boolean {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  return contentType.startsWith("text/html");
+}
+
 function shouldSkipDynamicCompression(req: Request, path: string, response: Response): boolean {
   if (req.method === "HEAD") return true;
-  if (!path.startsWith("/api/")) return true;
   if (path.startsWith("/api/live/")) return true;
   if (req.headers.has("range")) return true;
   if (req.headers.get("upgrade")) return true;
   if (response.status === 204 || response.status === 304) return true;
   if (response.headers.has("content-encoding")) return true;
   if (response.headers.get("content-type")?.toLowerCase().startsWith("text/event-stream")) return true;
+  // The app shell (`/`, and every SPA route that falls back to it) is HTML
+  // rebuilt per request, so it has no precompressed sibling on disk. It is
+  // ~17 KB raw and ~5 KB compressed, and it is on the critical path of every
+  // cold open — compress it like the JSON under /api/.
+  if (!path.startsWith("/api/")) return !isHtmlResponse(response);
   if (!isJsonResponse(response)) return true;
   return false;
 }
@@ -97,6 +106,53 @@ function responseInit(response: Response, headers: Headers): ResponseInit {
   };
 }
 
+/**
+ * Compressed bodies for assets that shipped WITHOUT a `.br`/`.gz` sibling.
+ *
+ * The Vite build writes one for every asset, but not every deployment serves
+ * the build's output verbatim: an overlay that copies only the raw chunks it
+ * changed, a dev checkout, a CDN sync that skipped dotfiles. Before this the
+ * server then sent the raw bytes — 1.3 MB for the main chunk, 210 KB for the
+ * stylesheet — to a phone on a cell link, on every release. Compressing once
+ * on first request and keeping the result costs a few MB of memory and turns
+ * that cliff back into the ~400 KB / ~30 KB the build intended.
+ *
+ * Keyed by path + size + mtime so a rebuilt file under the same name (dev) is
+ * never served stale. Bounded by total bytes; the assets under /assets/ are
+ * content-hashed and immutable, so eviction is only ever about memory.
+ */
+const FALLBACK_MIN_BYTES = 1024;
+const FALLBACK_MAX_BYTES_PER_FILE = 8 * 1024 * 1024;
+const FALLBACK_CACHE_MAX_BYTES = 48 * 1024 * 1024;
+const fallbackCache = new Map<string, Uint8Array>();
+let fallbackCacheBytes = 0;
+
+function fallbackCompressed(key: string, body: Uint8Array, encoding: CompressionEncoding): Uint8Array {
+  const hit = fallbackCache.get(key);
+  if (hit) {
+    // Refresh recency: Map iterates in insertion order, so re-inserting makes
+    // this the newest entry and the oldest one the eviction candidate.
+    fallbackCache.delete(key);
+    fallbackCache.set(key, hit);
+    return hit;
+  }
+  const compressed = compressBody(body, encoding);
+  while (fallbackCacheBytes + compressed.byteLength > FALLBACK_CACHE_MAX_BYTES && fallbackCache.size) {
+    const oldest = fallbackCache.keys().next().value as string;
+    fallbackCacheBytes -= fallbackCache.get(oldest)?.byteLength ?? 0;
+    fallbackCache.delete(oldest);
+  }
+  fallbackCache.set(key, compressed);
+  fallbackCacheBytes += compressed.byteLength;
+  return compressed;
+}
+
+/** Test seam: forget every on-the-fly compressed asset. */
+export function resetCompressedAssetCache(): void {
+  fallbackCache.clear();
+  fallbackCacheBytes = 0;
+}
+
 export async function compressedAssetResponse(
   req: Request,
   filePath: string,
@@ -104,9 +160,11 @@ export async function compressedAssetResponse(
 ): Promise<Response | null> {
   if (req.method === "HEAD" || req.headers.has("range")) return null;
   if (!isPrecompressedAssetCandidate(filePath)) return null;
+  const encodings = acceptedEncodings(req);
+  if (!encodings.length) return null;
   const headers = new Headers(headersInit);
   addAcceptEncodingVary(headers);
-  for (const encoding of acceptedEncodings(req)) {
+  for (const encoding of encodings) {
     const compressedPath = `${filePath}.${encoding === "br" ? "br" : "gz"}`;
     const file = Bun.file(compressedPath);
     if (!(await file.exists())) continue;
@@ -114,7 +172,18 @@ export async function compressedAssetResponse(
     headers.set("Content-Length", String(file.size));
     return new Response(file, { headers });
   }
-  return null;
+  // No sibling on disk for any accepted encoding: compress the raw file
+  // ourselves, once, with the client's most preferred encoding.
+  const raw = Bun.file(filePath);
+  if (!(await raw.exists())) return null;
+  const size = raw.size;
+  if (size < FALLBACK_MIN_BYTES || size > FALLBACK_MAX_BYTES_PER_FILE) return null;
+  const encoding = encodings[0]!;
+  const key = `${filePath}\u0000${encoding}\u0000${size}\u0000${Math.floor(raw.lastModified)}`;
+  const compressed = fallbackCache.get(key) ?? fallbackCompressed(key, new Uint8Array(await raw.arrayBuffer()), encoding);
+  headers.set("Content-Encoding", encoding);
+  headers.set("Content-Length", String(compressed.byteLength));
+  return new Response(compressed, { headers });
 }
 
 export async function maybeCompressResponse(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1271,7 +1271,6 @@ type BootstrapPayload = {
   settings?: Partial<GlobalSettings> | null;
   sessions?: Session[] | null;
   sessionPins?: string[] | null;
-  conversations?: ProductConversation[] | null;
   /** Which conversation participant, if any, "I" am — see fetchBootstrap. */
   viewer?: { managed: boolean; participantId: string | null } | null;
   users?: User[] | null;


### PR DESCRIPTION
## Why

Opening the web UI on a phone felt sluggish even though the server itself was idle. Profiled with a phone-class emulation (390px viewport, 4× CPU throttle) against a box with ~20 live sessions and ~900 stored conversations:

| | before |
|---|---|
| bytes on a cold open | **1.1 MB** |
| `/api/bootstrap` body | **630 KB** raw (95 KB br), of which **541 KB** is `conversations` |
| main-thread blocked before roster | ~1.0 s (longest task 727 ms) |
| server time for `/api/bootstrap` | 36 ms — not the bottleneck |

## What

1. **`/api/bootstrap` no longer ships `conversations`.** It carried every conversation the box ever held and nothing on the client read it (`payload.conversations` is never touched; the roster's unread state comes from `/api/bots`, a transcript loads its own conversation). The per-request filtering work behind it is gone too. Payload drops from ~630 KB to ~90 KB before compression. The optional field is removed from the client's `BootstrapPayload` type.

2. **Static assets are compressed even without a `.br`/`.gz` sibling.** The build writes siblings, but any deployment that copies raw chunks (overlay, dev checkout, a sync that dropped dotfiles) then served the 1.3 MB main chunk and the 210 KB stylesheet uncompressed on every release. `compressedAssetResponse` now compresses on first request and keeps the result in a bounded in-memory cache (48 MB total, 8 MB per file) keyed by path + size + mtime, so a rebuilt file under the same name is never served stale. SVG icons and the manifest (which never had siblings) take the same path.

3. **The HTML app shell is compressed.** `/` and every SPA fallback route are rebuilt per request and were excluded from dynamic compression: 17 KB → 5 KB.

## Verification

- `src/http-compress.test.ts` (new, 8 tests): sibling-first order, on-the-fly fallback + cache hit, gzip-only client, skip rules (tiny files, image formats, no `Accept-Encoding`), rebuilt-file case, HTML/JSON/other split in the dynamic path.
- Smoke on a scratch data dir with the CSS siblings deleted: `/` → `Content-Encoding: br`, 5413 B; `index-*.css` → br, 208 907 → 29 808 B, decompressed bytes identical to the file; `icon.svg` → br; a client without `Accept-Encoding` still gets the raw 200. `/api/bootstrap` keys: no `conversations`.
- `bun run typecheck` (root) and `tsc --noEmit` (web) clean.
- `bun run test`: 3508 pass; the 7 failures in `test/finding-sheet-page-mode`, `test/mobile-plan-specs`, `test/mobile-secondary-pages`, `test/thinking-level-label` fail identically on pristine `origin/main` (verified via stash).

## Not in this PR

Opening a transcript still costs ~2 s of main thread at 4× throttle. The sourcemapped profile puts that in the transcript renderer, spread thin: react-dom 0.8 s, the pretext/markdown-metrics height model 0.65 s, `marked` 0.24 s, tanstack measurement 0.3 s — no single hotspot. Lowering `CHAT_TAIL_ROWS` did not measurably help and the comment above it argues against it, so that is left for a separate change with its own measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
