### PR TITLE
perf: quiet the roster — no re-render on unchanged polls, 30 s poll while the socket is live, bot-unread without transcript subscriptions, delta status frames

### DIFF
--- a/src/live-ws.ts
+++ b/src/live-ws.ts
@@ -393,7 +393,7 @@ export function createLiveWsSupport(opts: {
   const agentRunUnsubs = new Map<string, () => void>();
   const openSockets = new Set<LiveWs>();
   let statusInterval: ReturnType<typeof setInterval> | null = null;
-  let lastStatusSig = "";
+  let lastStatusSigs = new Map<string, string>();
   let statusPublishing = false;
 
   const channelId = (channel: Pick<Channel, "kind" | "key">): string => `${channel.kind}:${channel.key}`;
@@ -617,7 +617,7 @@ export function createLiveWsSupport(opts: {
     if (openSockets.size || !statusInterval) return;
     clearInterval(statusInterval);
     statusInterval = null;
-    lastStatusSig = "";
+    lastStatusSigs = new Map();
   };
 
   const publishStatus = async () => {
@@ -634,17 +634,31 @@ export function createLiveWsSupport(opts: {
       const rows = (await listSessionsCached())
         .filter((s) => s.sessionId)
         .map(slimStatus);
-      const sig = JSON.stringify(rows);
-      const changed = sig !== lastStatusSig;
-      if (changed) {
-        lastStatusSig = sig;
-        const frame = stamp(statusChannel(), { t: "status", rows });
+      // Only the rows that changed since the last broadcast. A busy fleet
+      // changes one or two rows a second (a lastActivityAt, a busy flag), and
+      // sending the whole fleet for each of those cost every open tab ~6 KB
+      // and a full merge pass per tick. Clients patch by sessionId (see
+      // applyLiveStatusRows), so a partial frame is the same protocol; a
+      // socket that just connected still gets the full fleet from
+      // sendStatusBaseline.
+      const nextSigs = new Map<string, string>();
+      const changedRows: typeof rows = [];
+      for (const row of rows) {
+        const sig = JSON.stringify(row);
+        nextSigs.set(row.sessionId!, sig);
+        if (lastStatusSigs.get(row.sessionId!) !== sig) changedRows.push(row);
+      }
+      const changed = changedRows.length > 0 || nextSigs.size !== lastStatusSigs.size;
+      lastStatusSigs = nextSigs;
+      if (changedRows.length) {
+        const frame = stamp(statusChannel(), { t: "status", rows: changedRows });
         for (const ws of openSockets) safeSend(ws, frame);
       }
       evlog("live_status_tick", {
         transport: "ws",
         sessions: rows.length,
         changed,
+        changedRows: changedRows.length,
         durationMs: roundMs(performance.now() - t0),
       });
     } finally {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -120,6 +120,7 @@ import {
   clearBotConversationUnread,
   hasUnreadBotConversation,
   type BotConversationUnread,
+  botConversationActivityKey,
 } from "./lib/bot-unread";
 import { resolveRosterUser } from "./lib/roster-user";
 import {
@@ -4767,6 +4768,21 @@ function removeForcedStreamSid(sid: string): void {
 const SEEDED_SESSION_MAX_AGE_MS = 30_000;
 
 const recentlyCreatedSids = new Set<string>();
+/**
+ * `prev` when `next` serializes to the same JSON, else `next`.
+ *
+ * For the setState calls fed by the periodic REST polls. A poll that finds
+ * nothing changed used to hand React a fresh array anyway, and a fresh array
+ * is a state change: every consumer of `sessions`, `bots`, `autoAgents` and
+ * `findings` re-rendered every five seconds, on every open tab, for nothing.
+ * Returning the previous reference lets React bail out of the update. The
+ * payloads are small (tens of KB) so the stringify is far cheaper than the
+ * render it prevents.
+ */
+function sameJson<T>(prev: T, next: T): T {
+  return JSON.stringify(prev) === JSON.stringify(next) ? prev : next;
+}
+
 function markCreatedSid(sid: string): void {
   recentlyCreatedSids.add(sid);
   window.setTimeout(() => recentlyCreatedSids.delete(sid), 2000);
@@ -6367,9 +6383,9 @@ export function App() {
       `/api/bots?user=${encodeURIComponent(botUnreadIdentity)}`,
       { cache: "no-store" },
     );
-    setBots(payload.bots ?? []);
-    setBotConversations(payload.conversations ?? []);
-    setBotQuota(payload.quota ?? null);
+    setBots((prev) => sameJson(prev, payload.bots ?? []));
+    setBotConversations((prev) => sameJson(prev, payload.conversations ?? []));
+    setBotQuota((prev) => sameJson(prev, payload.quota ?? null));
   }, [botUnreadIdentity]);
 
   const loadCore = useCallback(async () => {
@@ -6512,9 +6528,9 @@ export function App() {
     // render unconditionally (e.g. findings.length in LiveView), so a missing
     // field must degrade to [] rather than crash the live view.
     const findingList = fd.findings ?? [];
-    setAutoAgents(ag.agents ?? []);
+    setAutoAgents((prev) => sameJson(prev, ag.agents ?? []));
     if (ag.tz) setSchedTz(ag.tz);
-    setFindings(findingList);
+    setFindings((prev) => sameJson(prev, findingList));
     if (!seededAuto.current) {
       findingList.forEach((f) => seenFindings.current.add(f.id));
       seededAuto.current = true;
@@ -6623,7 +6639,7 @@ export function App() {
       }
       sessionList.push(entry.session);
     }
-    setSessions(sessionList);
+    setSessions((prev) => sameJson(prev, sessionList));
     // From the server's payload, not from `sessionList`: the seeded and renamed
     // rows spliced in above were built by this client and carry no watermark.
     applyUnreadSessions(payload.sessions ?? []);
@@ -6645,7 +6661,7 @@ export function App() {
     });
     const next = payload.sessionIds ?? [];
     topPinnedRef.current = next;
-    setTopPinned(next);
+    setTopPinned((prev) => sameJson(prev, next));
   }, []);
 
   const toggleTopPin = useCallback((sessionId: string) => {
@@ -6784,16 +6800,34 @@ export function App() {
   // visibilitychange fires on tab switch, window minimise, and phone lock, and
   // returning runs one immediate refresh so the view is never stale-on-arrival
   // while it waits out the rest of an interval.
+  //
+  // While the live socket is up it already pushes every status change the
+  // roster shows (busy, title, last text, model) the second it happens, so
+  // this REST poll is only reconciliation: sessions that appeared or went
+  // away, unread watermarks, pins, schedules, bots. Reconciliation does not
+  // need to run every five seconds — and on a phone each cycle was ~30 KB
+  // plus four state updates. With the socket live the poll runs every 30 s;
+  // a session that appears on the socket first is picked up at once (see
+  // applyLiveStatusRows). The moment the socket is not live the poll is back
+  // to 5 s, which is what the non-socket transports always had.
+  const wsLiveRef = useRef(false);
   useEffect(() => {
     let id: number | null = null;
+    let cyclesSinceTick = 0;
     const tick = () => {
       refreshSessions().catch(() => {});
       refreshSessionPins().catch(() => {});
       refreshAuto().catch(() => {});
       refreshBots().catch(() => {});
     };
+    const cycle = () => {
+      cyclesSinceTick += 1;
+      if (wsLiveRef.current && cyclesSinceTick < 6) return;
+      cyclesSinceTick = 0;
+      tick();
+    };
     const start = () => {
-      if (id === null) id = window.setInterval(tick, 5000);
+      if (id === null) id = window.setInterval(cycle, 5000);
     };
     const stop = () => {
       if (id !== null) {
@@ -6806,6 +6840,7 @@ export function App() {
         stop();
         return;
       }
+      cyclesSinceTick = 0;
       tick();
       start();
     };
@@ -7127,6 +7162,9 @@ export function App() {
   const liveStatusKey = liveStatusIds.join(",");
   const liveTransport = useMemo(() => liveTransportMode(), []);
   const useWsLive = liveTransport === "ws";
+  const unknownSidRefreshAtRef = useRef(0);
+  const refreshSessionsRef = useRef(refreshSessions);
+  refreshSessionsRef.current = refreshSessions;
   const applyLiveStatusRows = useCallback((rows: Array<
     Pick<
       Session,
@@ -7144,6 +7182,20 @@ export function App() {
     if (!rows.length) return;
     const bySid = new Map(rows.map((row) => [row.sessionId, row]));
     setSessions((prev) => {
+      // A row for a session the list has never seen means a session was
+      // created since the last list read (another device, an agent spawning
+      // a child, a schedule firing). The socket cannot supply the full row,
+      // so ask the list for it now instead of waiting out the poll interval.
+      // Throttled: one list read per 5 s at most, so a socket that keeps
+      // reporting a session the list refuses to return (filtered out, mid-
+      // shutdown) costs no more than the old poll did.
+      if (rows.some((row) => row.sessionId && !prev.some((s) => s.sessionId === row.sessionId))) {
+        const now = Date.now();
+        if (now - unknownSidRefreshAtRef.current >= 5000) {
+          unknownSidRefreshAtRef.current = now;
+          window.setTimeout(() => void refreshSessionsRef.current().catch(() => {}), 0);
+        }
+      }
       let changed = false;
       const next = prev.map((session) => {
         const sid = session.sessionId;
@@ -7253,6 +7305,7 @@ export function App() {
     // managed box ignores it in favour of its verified header.
     viewerIdentity: botUnreadIdentity,
   });
+  wsLiveRef.current = useWsLive && wsLiveStream.connection.status === "live";
   const liveStream = useWsLive ? wsLiveStream : sseLiveStream;
 
   // "Somebody ELSE is typing."
@@ -7398,6 +7451,12 @@ export function App() {
   // existing subscriptions instead of replacing all of them.
   const botUnreadViewRef = useRef({ selectedConversationSid, tab });
   botUnreadViewRef.current = { selectedConversationSid, tab };
+  // Passive: hear the messages of a bot conversation that is open (and so
+  // already streaming) to clear its dot the moment a reply lands in view. It
+  // deliberately holds no subscription of its own — subscribing every bot
+  // transcript from the roster pulled each one's full backlog and send queue
+  // (hundreds of KB) on every socket connect, to compute a dot. Arrivals in
+  // conversations that are NOT open are caught below from the fleet status.
   useEffect(() => {
     if (!useWsLive) return;
     const unsubs = botConversationSids.map((sessionId) =>
@@ -7413,11 +7472,29 @@ export function App() {
         });
         if (action === "mark-read") void markBotConversationVisible(sessionId).catch(() => {});
         if (action === "refresh") void refreshBots().catch(() => {});
-      })
+      }, { passive: true })
     );
     return () => unsubs.forEach((unsubscribe) => unsubscribe());
   }, [botConversationSids, markBotConversationVisible, refreshBots, useWsLive, wsLiveStream.subscribeTranscript]);
 
+  // A bot finished a turn, or a line arrived while it was idle: the server
+  // decides whether that is unread, so ask it. Keyed on the status rows the
+  // socket pushes for every session (see botConversationActivityKey), which
+  // is why no per-bot transcript subscription is needed for this.
+  const botActivityKey = useMemo(
+    () => botConversationActivityKey(botConversationSids, sessions),
+    [botConversationSids, sessions],
+  );
+  const botActivitySeenRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!useWsLive) return;
+    if (botActivitySeenRef.current === null || botActivitySeenRef.current === botActivityKey) {
+      botActivitySeenRef.current = botActivityKey;
+      return;
+    }
+    botActivitySeenRef.current = botActivityKey;
+    void refreshBots().catch(() => {});
+  }, [botActivityKey, refreshBots, useWsLive]);
   function toggleTheme() {
     setThemePreference(!document.documentElement.classList.contains("dark"));
   }

--- a/web/src/lib/bot-unread.test.ts
+++ b/web/src/lib/bot-unread.test.ts
@@ -6,6 +6,7 @@ import {
   botRosterRowAriaLabel,
   botUnreadActionForTranscript,
   hasUnreadBotConversation,
+  botConversationActivityKey,
 } from "./bot-unread";
 
 describe("bot conversation unread presentation", () => {
@@ -148,5 +149,43 @@ describe("bot conversation unread presentation", () => {
     expect(
       botRosterRowAriaLabel({ name: "Scout", enabled: true, working: true, unread: false }),
     ).toBe("Scout, working, read conversation");
+  });
+});
+
+describe("botConversationActivityKey", () => {
+  const sids = ["bot-a", "bot-b"];
+  test("holds still while a bot is working, moves when its turn ends", () => {
+    const working = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: true, lastActivityAt: 100 },
+      { sessionId: "bot-b", busy: false, lastActivityAt: 50 },
+    ]);
+    const stillWorking = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: true, lastActivityAt: 130 },
+      { sessionId: "bot-b", busy: false, lastActivityAt: 50 },
+    ]);
+    const done = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: false, lastActivityAt: 140 },
+      { sessionId: "bot-b", busy: false, lastActivityAt: 50 },
+    ]);
+    expect(stillWorking).toBe(working);
+    expect(done).not.toBe(working);
+  });
+  test("moves when a line lands in an idle conversation, ignores unrelated sessions", () => {
+    const before = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: false, lastActivityAt: 100 },
+      { sessionId: "other", busy: true, lastActivityAt: 1 },
+    ]);
+    const unrelated = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: false, lastActivityAt: 100 },
+      { sessionId: "other", busy: false, lastActivityAt: 2 },
+    ]);
+    const arrival = botConversationActivityKey(sids, [
+      { sessionId: "bot-a", busy: false, lastActivityAt: 101 },
+      { sessionId: "other", busy: false, lastActivityAt: 2 },
+    ]);
+    expect(unrelated).toBe(before);
+    expect(arrival).not.toBe(before);
+    // A bot without a session yet is represented, not dropped.
+    expect(before).toContain("bot-b:-");
   });
 });

--- a/web/src/lib/bot-unread.ts
+++ b/web/src/lib/bot-unread.ts
@@ -161,3 +161,30 @@ export function clearBotConversationUnread(
       )
     : conversations;
 }
+
+/**
+ * One string that changes exactly when a watched bot conversation may have
+ * gained an unread message, computed from the fleet status rows the socket
+ * already pushes for every session.
+ *
+ * A bot's turn ends when its session stops being busy; a peer or human line
+ * arrives while it is not busy and moves `lastActivityAt`. While the bot is
+ * still working the key holds still, so a streaming reply does not refetch
+ * the roster once per token. This replaces subscribing to every bot
+ * transcript for the sake of a dot: that pulled each conversation's full
+ * backlog and send queue on every socket (re)connect.
+ */
+export function botConversationActivityKey(
+  sids: readonly string[],
+  sessions: ReadonlyArray<{ sessionId?: string | null; busy?: boolean | null; lastActivityAt?: string | number | null }>,
+): string {
+  const bySid = new Map<string, { busy?: boolean | null; lastActivityAt?: string | number | null }>();
+  for (const session of sessions) if (session.sessionId) bySid.set(session.sessionId, session);
+  return sids
+    .map((sid) => {
+      const row = bySid.get(sid);
+      if (!row) return `${sid}:-`;
+      return row.busy ? `${sid}:busy` : `${sid}:${row.lastActivityAt ?? ""}`;
+    })
+    .join("|");
+}

--- a/web/src/useLiveSocket.ts
+++ b/web/src/useLiveSocket.ts
@@ -131,6 +131,18 @@ export type TranscriptEvent =
 export type TranscriptSubscribe = (
   sid: string,
   listener: (event: TranscriptEvent) => void,
+  options?: {
+    /**
+     * Listen without holding a subscription. The listener hears whatever the
+     * socket already streams for this sid because something else (an open
+     * transcript, an expanded card) subscribed it, and nothing when nothing
+     * did. A plain subscribe pulls the full backlog snapshot and the send
+     * queue the moment it attaches — fine for a transcript that is about to
+     * be shown, hundreds of KB of waste for a watcher that only wants to know
+     * that something new arrived.
+     */
+    passive?: boolean;
+  },
 ) => () => void;
 
 const DRAFT_CATCHUP_MIN_CHARS = 160;
@@ -427,6 +439,13 @@ export function useLiveSocket(
   const lastSeqRef = useRef<Record<string, number>>({});
   const agentRunHandlersRef = useRef<Record<string, AgentRunHandler>>({});
   const transcriptListenersRef = useRef<Record<string, Set<(event: TranscriptEvent) => void>>>({});
+  /** Per sid, how many of the listeners above are passive (see TranscriptSubscribe). */
+  const passiveListenerCountRef = useRef<Record<string, number>>({});
+  /** Sids with at least one listener that wants a subscription of its own. */
+  const activelyListenedSids = () =>
+    Object.entries(transcriptListenersRef.current)
+      .filter(([sid, listeners]) => listeners.size > (passiveListenerCountRef.current[sid] ?? 0))
+      .map(([sid]) => sid);
   const queueBySidRef = useRef<Record<string, QueueMsg[]>>({});
   const seenRef = useRef<Record<string, Set<string>>>({});
   const messagesRef = useRef(messagesBySid);
@@ -994,7 +1013,7 @@ export function useLiveSocket(
   useEffect(() => {
     const expanded = new Set(ids);
     activeTranscriptIdsRef.current = expanded;
-    const active = new Set([...expanded, ...Object.keys(transcriptListenersRef.current)]);
+    const active = new Set([...expanded, ...activelyListenedSids()]);
     const live = new Set(Object.keys(listBusy));
     queueBySidRef.current = Object.fromEntries(
       Object.entries(queueBySidRef.current).filter(([sid]) => live.has(sid)),
@@ -1222,25 +1241,37 @@ export function useLiveSocket(
     };
   }, [enabled, subscribeChannels, unsubscribeChannels]);
 
-  const subscribeTranscript = useCallback<TranscriptSubscribe>((sid, listener) => {
+  const subscribeTranscript = useCallback<TranscriptSubscribe>((sid, listener, options) => {
+    const passive = !!options?.passive;
     const listeners = transcriptListenersRef.current[sid] || (transcriptListenersRef.current[sid] = new Set());
     listeners.add(listener);
+    if (passive) passiveListenerCountRef.current[sid] = (passiveListenerCountRef.current[sid] ?? 0) + 1;
     const queue = queueBySidRef.current[sid];
     if (queue) listener({ type: "queue", queue });
     const channel = transcriptChannel(sid);
     const id = channelId(channel);
-    desiredRef.current.add(sid);
-    desiredChannelsRef.current.set(id, channel);
-    if (enabled && !subscribedChannelsRef.current.has(id) && subscribeChannels([channel])) {
-      subscribedChannelsRef.current.add(id);
-      subscribedRef.current.add(sid);
+    if (!passive) {
+      desiredRef.current.add(sid);
+      desiredChannelsRef.current.set(id, channel);
+      if (enabled && !subscribedChannelsRef.current.has(id) && subscribeChannels([channel])) {
+        subscribedChannelsRef.current.add(id);
+        subscribedRef.current.add(sid);
+      }
     }
     return () => {
       const current = transcriptListenersRef.current[sid];
       if (!current) return;
       current.delete(listener);
-      if (current.size) return;
-      delete transcriptListenersRef.current[sid];
+      if (passive) {
+        const remaining = (passiveListenerCountRef.current[sid] ?? 1) - 1;
+        if (remaining > 0) passiveListenerCountRef.current[sid] = remaining;
+        else delete passiveListenerCountRef.current[sid];
+        if (!current.size) delete transcriptListenersRef.current[sid];
+        return;
+      }
+      // Another listener of our own kind still holds the subscription.
+      if (current.size > (passiveListenerCountRef.current[sid] ?? 0)) return;
+      if (!current.size) delete transcriptListenersRef.current[sid];
       if (activeTranscriptIdsRef.current.has(sid)) return;
       desiredRef.current.delete(sid);
       desiredChannelsRef.current.delete(id);


### PR DESCRIPTION
## Why

Follow-up to #291. With the cold open cheaper, the next thing a phone feels is the roster *while nothing is happening*: constant network and main-thread work in the background. Measured on the roster with nothing open, 390px viewport, 4× CPU throttle, a box with ~20 live sessions and 6 bot conversations, over 60 s:

| | before | after |
|---|---|---|
| REST requests | 96 / 484 KB | 32 / 104 KB |
| websocket | 64 frames / 861 KB | 42 frames / 138 KB (→ ~10 KB with the server change) |
| main thread busy | 1920 ms | 643 ms |

## What

**web**
1. **No re-render on unchanged polls.** The 5 s poll (sessions, pins, schedules, bots) handed React a fresh array each cycle even when nothing changed — a state change for every consumer, every five seconds, on every open tab. `sameJson()` hands back the previous reference when the payload serializes identically, so React bails out.
2. **Poll every 30 s while the socket is live.** The socket already pushes every roster-visible change (busy, title, last text, model) as it happens; the poll is reconciliation. It stays at 5 s when the socket is not live. A session that appears on the socket before the list knows it triggers a list read at once (throttled to one per 5 s), so a session started elsewhere still shows within a second.
3. **Bot-unread without pulling six transcripts.** The roster subscribed to every bot conversation's transcript to compute an unread dot. Each subscription pulls the full backlog snapshot plus the send queue on every socket (re)connect — here ~290 KB of transcript and ~200 KB of queued messages, and again on every reconnect (tab switch, phone lock). The listener is now *passive* (`subscribeTranscript(sid, fn, { passive: true })`: hears an open conversation's stream, holds no subscription), and arrivals in closed conversations are detected from the fleet status rows the socket already sends: a bot leaving `busy`, or `lastActivityAt` moving while idle, asks `/api/bots` whether that is unread. `botConversationActivityKey()` carries that rule with tests.

**server**
4. **Status frames carry only the rows that changed.** The tick compared the whole row set and, on any difference, sent the whole set (~6 KB/s per open tab on a busy fleet). It now keeps one signature per session and sends only moved rows. Clients already patch by `sessionId`; a fresh socket still gets the full fleet from `sendStatusBaseline`.

## Verification

- `web/src/lib/bot-unread.test.ts`: two new tests for the activity key (holds still while working, moves on turn end / idle arrival, ignores unrelated sessions).
- `bun run typecheck` (root) and `tsc --noEmit` (web) clean; `src/live-ws*.test.ts` 31 pass.
- `bun run test`: 3505 pass; the same 8 failures as pristine `origin/main` (`test/finding-sheet-page-mode`, `test/mobile-plan-specs`, `test/mobile-secondary-pages`, `test/thinking-level-label`, and `header-profile.test.tsx` which passes in isolation).
- The before/after table above comes from a Playwright harness that serves the built `web/dist` over a live box and counts REST responses, websocket frames by type and long tasks; the bot snapshots/queue frames are gone from the roster capture, the two remaining polls per minute are the 30 s reconciliation.

## Not in this PR

Opening a transcript is still ~2 s of main thread at 4× throttle, spread over react-dom, the height model and markdown parsing with no single hotspot. Code-splitting is also left out: 418 KB of the 1.29 MB entry chunk is `App.tsx` itself and the secondary pages live inside it, so lazy routes first need the file split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
