### PR TITLE
fix(mobile): Return sends in the session composer; new sessions follow the project filter

### DIFF
--- a/mobile/app/session/[id].tsx
+++ b/mobile/app/session/[id].tsx
@@ -2000,6 +2000,19 @@ export function SessionScreenBody({
             }
             placeholderTextColor={colors.textMuted}
             multiline
+            /**
+             * RETURN SENDS, on every keyboard. A multiline field's default is
+             * to insert a newline, so an iPad with a hardware keyboard typed
+             * a blank line where the web (and the home composer above)
+             * send. `submitBehavior="submit"` makes Return fire
+             * `onSubmitEditing` instead, for the on-screen key and a
+             * hardware one alike; the send button still handles queueing.
+             */
+            returnKeyType="send"
+            submitBehavior="submit"
+            onSubmitEditing={() => {
+              if (canSend) send("steer");
+            }}
             style={{
               flex: 1,
               maxHeight: 120,

--- a/mobile/src/omg/session-options.ts
+++ b/mobile/src/omg/session-options.ts
@@ -329,6 +329,10 @@ export function useProjectPicker() {
     [bindings, bindingId],
   );
 
+  // Declared before `cwd` because the folder the next session runs in follows
+  // the filter when nothing was picked explicitly (see below).
+  const [filter, setFilter] = useState<string>(ALL_PROJECTS);
+
   /**
    * Resolution order: an explicit pick, else the machine's own default folder,
    * else the box's first project. The machine default comes second rather than
@@ -339,10 +343,17 @@ export function useProjectPicker() {
    */
   const cwd = useMemo(() => {
     if (chosen && repos.some((r) => r.cwd === chosen)) return chosen;
+    // The list's own filter (set from a folder heading, which never touches
+    // `chosen`) also says where the next session runs. Without this, scoping
+    // the list to one repo still launched into the machine's default folder.
+    if (filter !== ALL_PROJECTS) {
+      const scoped = repos.find((r) => projectKey(r) === filter);
+      if (scoped) return scoped.cwd;
+    }
     const fallback = binding?.defaultFolder ?? null;
     if (fallback && repos.some((r) => r.cwd === fallback)) return fallback;
     return repos[0]?.cwd ?? fallback;
-  }, [chosen, repos, binding]);
+  }, [chosen, filter, repos, binding]);
 
   const label = useMemo(() => {
     if (!cwd) return null;
@@ -365,8 +376,6 @@ export function useProjectPicker() {
    * repo it belongs to, which is the whole reason to match on the key rather
    * than on `cwd`.
    */
-  const [filter, setFilter] = useState<string>(ALL_PROJECTS);
-
   // A filter naming a repo this machine no longer lists would hide everything
   // with no way back, so it falls open.
   const activeFilter = useMemo(


### PR DESCRIPTION
## What
- Session composer: `Return` sends on hardware and on-screen keyboards (`submitBehavior="submit"` + `onSubmitEditing`). On iPad with a keyboard, `Return` inserted a newline and nothing sent.
- Home screen: a new session runs in the folder the list is filtered to. Tapping a folder heading only set the filter; the launch still used the machine default folder.

## Verification
- `bun run typecheck` in `mobile/`: pass.
- Not run on a device. OTA follows via `mobile-ota.yml`.
- Native surface unchanged since build 40 (`227020dca`): `mobile/package.json`, `mobile/app.json`, `mobile/app.config.js` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)