### PR TITLE
feat(agents): add the omg agent (OpenCode on omg-funded models)

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -299,3 +299,21 @@ describe("curateCursorModels", () => {
     for (const model of out) expect(model).not.toMatch(/-(fast|xhigh|high|medium|low)$/);
   });
 });
+
+test("omg agent lists the 7 routed models in hosted picker order", async () => {
+  const { OMG_MODELS } = await import("./agent-catalog.ts");
+  expect(OMG_MODELS).toEqual([
+    "omg/deepseek/deepseek-v4-flash-0731",
+    "omg/deepseek/deepseek-v4-pro",
+    "omg/z-ai/glm-5.3-flash",
+    "omg/z-ai/glm-5.2",
+    "omg/qwen/qwen3.7-plus",
+    "omg/qwen/qwen3-coder-next",
+    "omg/minimax/minimax-m3",
+  ]);
+  expect(defaultModelForAgent("omg")).toBe(OMG_MODELS[0]!);
+  expect(modelsForAgent("omg")).toEqual(OMG_MODELS);
+  expect(listModelCatalog().find((item) => item.key === "omg")).toMatchObject({
+    label: "omg agent", models: OMG_MODELS, defaultModel: OMG_MODELS[0], session: true, auto: true,
+  });
+});

--- a/src/agent-catalog.ts
+++ b/src/agent-catalog.ts
@@ -1,3 +1,6 @@
+import { OMG_MODELS } from "./omg-models.ts";
+export { OMG_MODELS } from "./omg-models.ts";
+
 import type { Agent } from "./agents/registry.ts";
 import type { AutoAgent } from "./auto/store.ts";
 import type { CodingAgentInfo, CodingAgentKind } from "./coding-agents.ts";
@@ -176,6 +179,7 @@ export const AUTO_AGENT_BACKENDS = [
   "fx",
   "muse",
   "opencode",
+  "omg",
 ] as const;
 export type AutoAgentBackend = (typeof AUTO_AGENT_BACKENDS)[number];
 const MODEL_CATALOG_KEYS: CodingAgentKind[] = [
@@ -189,6 +193,7 @@ const MODEL_CATALOG_KEYS: CodingAgentKind[] = [
   "muse",
   "deepseek",
   "opencode",
+  "omg",
   "jcode",
   "pi",
   "copilot",
@@ -238,6 +243,7 @@ const LABELS: Record<CodingAgentKind, string> = {
   codex: "codex",
   "codex-aisdk": "codex",
   opencode: "opencode",
+  omg: "omg agent",
   jcode: "jcode",
   grok: "grok",
   cursor: "cursor",
@@ -261,6 +267,7 @@ export const MODEL_OPTIONS: Record<CodingAgentKind, { defaultModel: string; mode
   deepseek: { defaultModel: "deepseek-v4-flash", models: DEEPSEEK_MODELS },
   hermes: { defaultModel: "nousresearch/hermes-4-405b", models: HERMES_MODELS },
   opencode: { defaultModel: "opencode/nemotron-3.5-lightning-free", models: OPENCODE_MODELS },
+  omg: { defaultModel: OMG_MODELS[0]!, models: OMG_MODELS },
   jcode: { defaultModel: "auto", models: JCODE_MODELS },
   pi: { defaultModel: "sonnet", models: PI_MODELS },
   copilot: { defaultModel: "claude-sonnet-4.5", models: COPILOT_MODELS },
@@ -542,6 +549,7 @@ function curateModels(
 }
 
 export function rawModelsForAgent(agent: CodingAgentKind): string[] {
+  if (agent === "omg") return [...OMG_MODELS];
   const fallback = MODEL_OPTIONS[agent]?.models;
   const provider = readModelDiscoveryCacheSync()?.providers?.[agent];
   // A successful harness query is authoritative. Unioning it with the static

--- a/src/agents/backends/opencode-aisdk-session.test.ts
+++ b/src/agents/backends/opencode-aisdk-session.test.ts
@@ -265,3 +265,9 @@ describe("opencode session.error handling", () => {
     expect(sessionErrorText(null)).toBeNull();
   });
 });
+
+test("omg model preserves the nested router id in the OpenCode request", () => {
+  expect(opencodePromptBody("omg/deepseek/deepseek-v4-flash-0731", undefined, "hello").model).toEqual({
+    providerID: "omg", modelID: "deepseek/deepseek-v4-flash-0731",
+  });
+});

--- a/src/agents/backends/opencode-aisdk-session.ts
+++ b/src/agents/backends/opencode-aisdk-session.ts
@@ -1,3 +1,4 @@
+import { ensureOmgProvider } from "../../omg-provider.ts";
 // Headless interactive session harness for the "opencode" agent kind.
 //
 // This is the long-lived process behind a managed opencode session. Like its
@@ -476,6 +477,7 @@ export async function pipeToOpencodeAiSdk(
 ): Promise<string> {
   const model = opts.model ?? "opencode/big-pickle";
   const cwd = opts.cwd ?? process.cwd();
+  if (model.startsWith("omg/")) ensureOmgProvider();
   ensureOpencodeOnPath();
   const { createOpencodeServer, createOpencodeClient } = await import("@opencode-ai/sdk");
 
@@ -539,6 +541,7 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
     process.chdir(cwd);
   } catch {}
 
+  if (model.startsWith("omg/")) ensureOmgProvider();
   ensureOpencodeOnPath();
   const { createOpencodeServer, createOpencodeClient } = await import("@opencode-ai/sdk");
 
@@ -635,7 +638,7 @@ export async function cmdOpencodeAisdkSession(argv: string[]): Promise<void> {
   const bootId = currentBootId();
   writeEntry({
     sessionId: key,
-    agent: "opencode",
+    agent: model.startsWith("omg/") ? "omg" : "opencode",
     threadId: ocSessionId,
     harnessPid: process.pid,
     tmuxName,

--- a/src/aisdk-registry.ts
+++ b/src/aisdk-registry.ts
@@ -74,7 +74,7 @@ export type AisdkEntry = {
   createdAt: number;
   // Which AI-SDK backend this entry drives. Absent on legacy Claude entries —
   // treat a missing value as "claude" so old entries keep working unchanged.
-  agent?: "claude" | "codex" | "opencode" | "pi" | "grok" | "cursor" | "fx" | "muse" | "deepseek" | "copilot" | "jcode";
+  agent?: "claude" | "codex" | "opencode" | "omg" | "pi" | "grok" | "cursor" | "fx" | "muse" | "deepseek" | "copilot" | "jcode";
   // Resume-handle slot, reused by the backends that can't pick their transcript
   // id up front:
   //   - codex: the app-server-assigned thread id, which is ALSO the rollout

--- a/src/auto/runner.ts
+++ b/src/auto/runner.ts
@@ -1,3 +1,4 @@
+import { defaultModelForAgent } from "../agent-catalog.ts";
 // Runs one auto agent: build a prompt from the agent's instruction + the
 // dismiss-feedback block, pipe it to a real headless Claude session with
 // read-only tools, and parse the findings out of the result. Most runs should
@@ -253,13 +254,13 @@ async function runSelectedBackend(
       }),
     );
   }
-  if (backend === "opencode") {
+  if (backend === "opencode" || backend === "omg") {
     onLog(`[auto] opencode run (${prompt.length} chars) in ${cwd} [model: ${agent.model ?? "default"}]`);
     const { pipeToOpencodeAiSdk } = await import("../agents/backends/opencode-aisdk-session.ts");
     return await runInCwd(cwd, () =>
       pipeToOpencodeAiSdk(prompt, onLog, {
         cwd,
-        model: agent.model,
+        model: agent.model ?? defaultModelForAgent(backend),
         thinkingLevel: agent.thinkingLevel,
       }),
     );

--- a/src/auto/store.ts
+++ b/src/auto/store.ts
@@ -21,6 +21,7 @@ export type AutoAgentBackend =
   | "fx"
   | "muse"
   | "opencode"
+  | "omg"
   | "hermes";
 
 /**

--- a/src/chat-ingest.ts
+++ b/src/chat-ingest.ts
@@ -284,7 +284,7 @@ let warmRunning = false;
 // backfills when the in-process indexer has fallen behind or never ran (e.g. a
 // session started before index-at-source shipped, or a best-effort catch-up that
 // dropped). Any residual gap still self-heals via the transcript read path.
-const SELF_INDEXING_AGENTS = new Set<Session["agent"]>(["aisdk", "opencode", "codex-aisdk"]);
+const SELF_INDEXING_AGENTS = new Set<Session["agent"]>(["aisdk", "opencode", "omg", "codex-aisdk"]);
 
 function tailerFor(path: string, sessionId: string): ChatTranscriptTailer {
   let tailer = tailers.get(path);

--- a/src/cloud-account.ts
+++ b/src/cloud-account.ts
@@ -217,13 +217,17 @@ export function safeReturnTo(value: unknown): string {
   return trimmed;
 }
 
+export function cloudApiBaseUrl(): string {
+  return (process.env.OMG_API_URL?.trim() || DEFAULT_CONTROL_PLANE_URL).replace(/\/+$/, "");
+}
+
 export function createCloudAccount(options: CloudAccountOptions = {}): CloudAccount {
   const credentialPath = options.credentialPath ?? CLOUD_CREDENTIALS_PATH;
   const authUrl = (
     options.authUrl ?? (process.env.OMG_AUTH_URL?.trim() || DEFAULT_AUTH_URL)
   ).replace(/\/+$/, "");
   const controlPlaneUrl = (
-    options.controlPlaneUrl ?? (process.env.OMG_API_URL?.trim() || DEFAULT_CONTROL_PLANE_URL)
+    options.controlPlaneUrl ?? cloudApiBaseUrl()
   ).replace(/\/+$/, "");
   const resource = options.resource ?? (process.env.OMG_OAUTH_RESOURCE?.trim() || DEFAULT_RESOURCE);
   const fetchImpl = options.fetch ?? globalThis.fetch;

--- a/src/coding-agent-adapters.test.ts
+++ b/src/coding-agent-adapters.test.ts
@@ -57,6 +57,7 @@ const launchers = {
   codex: spawnManagedCodexSession,
   "codex-aisdk": spawnManagedCodexAisdkSession,
   opencode: spawnManagedOpencodeAisdkSession,
+  omg: spawnManagedOpencodeAisdkSession,
   jcode: spawnManagedJcodeSdkSession,
   grok: spawnManagedGrokAcpSession,
   cursor: spawnManagedCursorAcpSession,
@@ -409,4 +410,27 @@ describe("coding agent adapter contract", () => {
       ],
     });
   });
+});
+
+test("omg accepts its own kind and delegates to the OpenCode launch with the default model", () => {
+  expect(isCodingAgentKind("omg")).toBe(true);
+  expect(resolveActiveSessionAgent("omg")).toBe("omg");
+  expect(CODING_AGENT_LABELS.omg).toBe("omg agent");
+  const opencode = ACTIVE_CODING_AGENT_PROVIDERS.opencode;
+  const original = opencode.launch;
+  let request: Parameters<typeof opencode.launch>[0] | undefined;
+  opencode.launch = (value) => { request = value; return { ok: true }; };
+  try {
+    expect(ACTIVE_CODING_AGENT_PROVIDERS.omg.launch({
+      agent: "omg", name: "test", cwd: "/tmp", sessionId: "test-session",
+    })).toEqual({ ok: true });
+    expect(request?.agent).toBe("omg");
+    expect(request?.model).toBe("omg/deepseek/deepseek-v4-flash-0731");
+  } finally { opencode.launch = original; }
+});
+
+test("omg rejects models outside its managed provider before launch", () => {
+  expect(ACTIVE_CODING_AGENT_PROVIDERS.omg.launch({
+    agent: "omg", name: "test", cwd: "/tmp", sessionId: "test-session", model: "opencode/free",
+  })).toEqual({ ok: false, error: 'unknown omg model "opencode/free"' });
 });

--- a/src/coding-agent-adapters.ts
+++ b/src/coding-agent-adapters.ts
@@ -6,6 +6,7 @@ export type CodingAgentProduct =
   | "claude"
   | "codex"
   | "opencode"
+  | "omg"
   | "jcode"
   | "grok"
   | "cursor"
@@ -106,6 +107,11 @@ export const CODING_AGENT_ADAPTERS = {
     recovery: "durable",
     capabilities: { interrupt: "immediate", questions: true, modelChange: "live", thinkingChange: "none", scheduled: true, toolAccess: "mcp" },
   },
+  omg: {
+    product: "omg", driver: "sdk", transport: "command-file", managedLaunch: true,
+    recovery: "durable",
+    capabilities: { interrupt: "immediate", questions: true, modelChange: "live", thinkingChange: "none", scheduled: true, toolAccess: "mcp" },
+  },
   jcode: {
     product: "jcode", driver: "sdk", transport: "command-file", managedLaunch: true,
     recovery: "durable",
@@ -128,6 +134,7 @@ export const ACTIVE_SESSION_AGENT_KINDS = [
   "aisdk",
   "codex-aisdk",
   "opencode",
+  "omg",
   "jcode",
   "grok",
   "cursor",
@@ -145,6 +152,7 @@ const LEGACY_COMMAND_FILE_AGENT_SET = new Set<string>([
   "aisdk",
   "codex-aisdk",
   "opencode",
+  "omg",
   "pi",
 ]);
 
@@ -161,6 +169,7 @@ export const SESSION_AGENT_KINDS = [
   "codex",
   "codex-aisdk",
   "opencode",
+  "omg",
   "jcode",
   "grok",
   "cursor",
@@ -180,6 +189,7 @@ export const COMMAND_FILE_AGENT_KINDS = [
   "aisdk",
   "codex-aisdk",
   "opencode",
+  "omg",
   "pi",
   "grok",
   "cursor",

--- a/src/coding-agent-provider.ts
+++ b/src/coding-agent-provider.ts
@@ -1,4 +1,4 @@
-import { defaultModelForAgent } from "./agent-catalog.ts";
+import { defaultModelForAgent, OMG_MODELS } from "./agent-catalog.ts";
 import {
   CODING_AGENT_ADAPTERS,
   type ActiveSessionAgentKind,
@@ -119,6 +119,11 @@ export const ACTIVE_CODING_AGENT_PROVIDERS = {
       sandbox: request.sandbox,
       egressProxyUrl: request.egressProxyUrl,
     })),
+  omg: provider("omg", (request): CodingAgentLaunchResult => {
+    const model = request.model ?? defaultModelForAgent("omg");
+    if (!OMG_MODELS.includes(model)) return { ok: false, error: `unknown omg model "${model}"` };
+    return ACTIVE_CODING_AGENT_PROVIDERS.opencode.launch({ ...request, model });
+  }),
   opencode: provider("opencode", (request) => {
     if (!request.model) return { ok: false, error: "opencode model is required" };
     return spawnManagedOpencodeAisdkSession({

--- a/src/coding-agents.ts
+++ b/src/coding-agents.ts
@@ -24,6 +24,7 @@ import {
   startPiOAuthLogin,
   type PiAuthProviderId,
 } from "./pi-auth.ts";
+import { hasOmgProviderAccess } from "./omg-provider.ts";
 import { hasOpenCodeAccountAuth, opencodeAuthProviders } from "./opencode-auth.ts";
 import {
   clearJcodePendingLogin,
@@ -44,6 +45,7 @@ export type CodingAgentKind =
   | "codex"
   | "codex-aisdk"
   | "opencode"
+  | "omg"
   | "jcode"
   | "grok"
   | "cursor"
@@ -222,6 +224,7 @@ export const CODING_AGENT_KINDS: Exclude<CodingAgentKind, "claude" | "hermes">[]
   "muse",
   "deepseek",
   "opencode",
+  "omg",
   "jcode",
   "copilot",
   "pi",
@@ -233,6 +236,7 @@ export const CODING_AGENT_LABELS: Record<CodingAgentKind, string> = {
   codex: "codex",
   "codex-aisdk": "codex",
   opencode: "opencode",
+  omg: "omg agent",
   jcode: "jcode",
   grok: "grok",
   cursor: "cursor",
@@ -813,7 +817,7 @@ function hasMuseAccountAuth(): boolean {
 function installCommandFor(kind: CodingAgentKind): string | null {
   if (kind === "claude" || kind === "aisdk") return "curl -fsSL https://claude.ai/install.sh | bash";
   if (kind === "codex" || kind === "codex-aisdk") return "bun add -g @openai/codex";
-  if (kind === "opencode") return "bun add -g opencode-ai";
+  if (kind === "opencode" || kind === "omg") return "bun add -g opencode-ai";
   if (kind === "jcode") return "curl -fsSL https://jcode.sh/install | bash";
   if (kind === "grok") return "curl -fsSL https://x.ai/cli/install.sh | bash";
   if (kind === "cursor") return "curl -fsSL https://cursor.com/install | bash";
@@ -836,6 +840,7 @@ function loginCommandPartsFor(kind: CodingAgentKind): string[] | null {
   if (kind === "codex" || kind === "codex-aisdk") {
     return [codexPath() ?? "codex", "login", "--device-auth"];
   }
+  if (kind === "omg") return ["omg", "login"];
   if (kind === "opencode") return [opencodePath() ?? "opencode"];
   // Sign-in is the Claude/Codex rows. A quoted `jcode login` argv is a second
   // product the settings page would print the moment the CLI is missing.
@@ -1454,6 +1459,11 @@ async function statusFor(kind: CodingAgentKind): Promise<CodingAgentStatus> {
       "use Login below or set OPENAI_API_KEY",
     );
     instructions.push("Use Login to connect ChatGPT in your browser, or set OPENAI_API_KEY.");
+  } else if (kind === "omg") {
+    accountConnected = hasOmgProviderAccess();
+    addBinary("OpenCode CLI", opencodePath());
+    addAuth("omg account", accountConnected, "Sign in with `omg login` to use the omg agent.");
+    instructions.push("Sign in with `omg login` to use the omg agent.");
   } else if (kind === "opencode") {
     // Auth is deliberately not a `checks` row: OpenCode Zen's free tier needs no
     // credential, so an unauthenticated install is still fully usable and must
@@ -1811,7 +1821,7 @@ export function codingAgentHasInstaller(kind: CodingAgentKind): boolean {
 function setupEnvFor(kind: CodingAgentKind): Record<string, string> | null {
   if (kind === "claude" || kind === "aisdk") return { LFG_INSTALL_CLAUDE: "1" };
   if (kind === "codex" || kind === "codex-aisdk") return { LFG_INSTALL_CODEX: "1" };
-  if (kind === "opencode") return { LFG_INSTALL_OPENCODE: "1" };
+  if (kind === "opencode" || kind === "omg") return { LFG_INSTALL_OPENCODE: "1" };
   if (kind === "jcode") return { LFG_INSTALL_JCODE: "1" };
   if (kind === "grok") return { LFG_INSTALL_GROK: "1" };
   if (kind === "cursor") return { LFG_INSTALL_CURSOR: "1" };

--- a/src/commands/auto-agent-runtime-validation.test.ts
+++ b/src/commands/auto-agent-runtime-validation.test.ts
@@ -90,3 +90,9 @@ describe("thinking level", () => {
     if (!r.ok) expect(r.error).toContain('unknown thinking level "galaxy-brain"');
   });
 });
+
+test("omg schedules accept only the managed router model list", () => {
+  const model = "omg/deepseek/deepseek-v4-flash-0731";
+  expect(ok(resolveAutoAgentRuntime({ agent: "omg", model }))).toMatchObject({ agent: "omg", model });
+  expect(resolveAutoAgentRuntime({ agent: "omg", model: "opencode/free" }).ok).toBe(false);
+});

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1304,8 +1304,8 @@ function persistManagedResume(session: Session): void {
     ? "aisdk"
     : session.agent === "codex-aisdk"
       ? "codex-aisdk"
-      : session.agent === "opencode"
-        ? "opencode"
+      : (session.agent === "opencode" || session.agent === "omg")
+        ? session.agent
         : session.agent === "pi"
           ? "pi"
           : session.runtime === "command-file" &&
@@ -1332,8 +1332,8 @@ function persistManagedResume(session: Session): void {
   const agent =
     backend === "codex-aisdk" || session.agent === "codex"
       ? "codex"
-      : backend === "opencode"
-        ? "opencode"
+      : (backend === "opencode" || backend === "omg")
+        ? backend
         : backend === "pi"
           ? "pi"
           : backend === "grok" || backend === "cursor" || backend === "fx" || backend === "muse" || backend === "copilot" || backend === "jcode"
@@ -2581,14 +2581,14 @@ function validateBotAgent(
 ): { agent: NonNullable<ReturnType<typeof resolveActiveSessionAgent>> } | { error: string } {
   const agent = resolveActiveSessionAgent(agentValue || "aisdk");
   if (!agent) return { error: `unknown coding agent "${agentValue ?? ""}"` };
-  if ((agent === "aisdk" || agent === "grok" || agent === "pi" || agent === "copilot") && model) {
+  if ((agent === "aisdk" || agent === "omg" || agent === "grok" || agent === "pi" || agent === "copilot") && model) {
     const allowed = modelsForAgent(agent);
     if (!allowed.includes(model))
       return { error: `unknown model "${model}" (expected one of ${allowed.join(", ")})` };
   }
   if (agent === "codex-aisdk" && model && !/^[A-Za-z0-9_.:-]{1,80}$/.test(model))
     return { error: "invalid codex model name" };
-  if ((agent === "cursor" || agent === "opencode" || agent === "fx" || agent === "muse") && model && !/^[A-Za-z0-9_.:\/-]{1,120}$/.test(model))
+  if ((agent === "cursor" || agent === "opencode" || agent === "omg" || agent === "fx" || agent === "muse") && model && !/^[A-Za-z0-9_.:\/-]{1,120}$/.test(model))
     return { error: `invalid ${agent} model name` };
   if (agent === "jcode" && model && !/^[A-Za-z0-9_.:\/\-[\],=]{1,160}$/.test(model))
     return { error: "invalid jcode model name" };
@@ -2733,7 +2733,7 @@ async function launchBotSession(
       ? resolvedModel ?? GROK_DEFAULT_MODEL()
       : agent === "cursor" || agent === "jcode" || agent === "copilot" || agent === "fx"
         ? resolvedModel ?? "auto"
-        : agent === "opencode" || agent === "muse"
+        : agent === "opencode" || agent === "omg" || agent === "muse"
           ? resolvedModel ?? defaultModelForAgent(agent)
           : agent === "codex-aisdk"
             ? resolvedModel ?? "gpt-5.5"
@@ -2814,7 +2814,7 @@ async function launchBotSession(
       agent,
       runtime: CODING_AGENT_ADAPTERS[agent].transport,
       sessionId,
-      nativeSessionId: agent === "aisdk" || agent === "opencode" ? sessionId : undefined,
+      nativeSessionId: agent === "aisdk" || agent === "opencode" || agent === "omg" ? sessionId : undefined,
       launchState: "launching",
       model: launchModel,
       thinkingLevel: bot.thinkingLevel,
@@ -3475,8 +3475,8 @@ export function resolveAutoAgentRuntime(
       return { ok: false, status: 400, error: "Claude account is missing or not connected" };
   }
   const model = b.model?.trim() || undefined;
-  if (autoBackend === "aisdk" && model) {
-    const allowed = modelsForAgent("aisdk");
+  if ((autoBackend === "aisdk" || autoBackend === "omg") && model) {
+    const allowed = modelsForAgent(autoBackend);
     if (!allowed.includes(model))
       return {
         ok: false,
@@ -3501,7 +3501,7 @@ export function resolveAutoAgentRuntime(
     return { ok: false, status: 400, error: "invalid fx model name" };
   if (autoBackend === "muse" && model && !/^[A-Za-z0-9_.:\/-]{1,120}$/.test(model))
     return { ok: false, status: 400, error: "invalid muse model name" };
-  if (autoBackend === "opencode" && model && !/^[A-Za-z0-9_.:\/-]{1,80}$/.test(model))
+  if ((autoBackend === "opencode" || autoBackend === "omg") && model && !/^[A-Za-z0-9_.:\/-]{1,80}$/.test(model))
     return { ok: false, status: 400, error: "invalid opencode model name" };
   const thinkingLevel = b.thinkingLevel?.trim() || undefined;
   if (thinkingLevel) {
@@ -8048,7 +8048,7 @@ a{color:#60a5fa}
         const offset = Number(url.searchParams.get("offset")) || 0;
         const search = url.searchParams.get("search")?.trim() || undefined;
         const agentParam = url.searchParams.get("agent")?.trim();
-        const agent = agentParam === "claude" || agentParam === "codex" || agentParam === "opencode" || agentParam === "pi"
+        const agent = agentParam === "claude" || agentParam === "codex" || agentParam === "opencode" || agentParam === "omg" || agentParam === "pi"
           ? agentParam
           : undefined;
         const project = url.searchParams.get("project")?.trim() || undefined;
@@ -8521,7 +8521,7 @@ a{color:#60a5fa}
             thinkingLevel?: string;
             archiveSource?: boolean;
             claudeAccountId?: string;
-            agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "grok" | "cursor" | "hermes" | "pi" | "jcode";
+            agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "omg" | "grok" | "cursor" | "hermes" | "pi" | "jcode";
           } | null;
           // Cached: this read is pure metadata (cwd, project, title, owner) for
           // a session that already exists, so a few seconds of staleness cannot
@@ -8634,7 +8634,7 @@ a{color:#60a5fa}
           overLimit?: boolean;
           /** Role the session runs as at the MCP endpoints. Missing = owner. */
           role?: string;
-          agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "jcode" | "grok" | "cursor" | "copilot" | "hermes" | "pi";
+          agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "omg" | "jcode" | "grok" | "cursor" | "copilot" | "hermes" | "pi";
         } | null;
         const requestedRole = typeof body?.role === "string" ? body.role.trim() : "";
         if (requestedRole && !getRole(requestedRole)) return err(400, `unknown role "${requestedRole}"`);
@@ -8663,13 +8663,13 @@ a{color:#60a5fa}
         // names are provider/catalog driven, so validate shape instead.
         const requestedModel = body?.model?.trim() || undefined;
         const opencodeDefault =
-          agent === "opencode" ? defaultModelForAgent("opencode") : undefined;
+          (agent === "opencode" || agent === "omg") ? defaultModelForAgent(agent) : undefined;
         const model =
-          agent === "opencode" && requestedModel && OPENCODE_DISABLED_MODELS.has(requestedModel)
+          (agent === "opencode" || agent === "omg") && requestedModel && OPENCODE_DISABLED_MODELS.has(requestedModel)
             ? opencodeDefault
             : requestedModel;
-        if (agent === "aisdk" && model) {
-          const allowed = modelsForAgent("aisdk");
+        if ((agent === "aisdk" || agent === "omg") && model) {
+          const allowed = modelsForAgent(agent);
           if (!allowed.includes(model))
             return err(400, `unknown model "${model}" (expected one of ${allowed.join(", ")})`);
         }
@@ -8698,7 +8698,7 @@ a{color:#60a5fa}
         // opencode models are "provider/model" (e.g. anthropic/claude-sonnet-4-6),
         // so the validation shape additionally allows a slash. Catalog-driven, so
         // validate by shape rather than an allowlist.
-        if (agent === "opencode" && model && !/^[A-Za-z0-9_.:\/-]{1,80}$/.test(model))
+        if ((agent === "opencode" || agent === "omg") && model && !/^[A-Za-z0-9_.:\/-]{1,80}$/.test(model))
           return err(400, "invalid opencode model name");
         if (agent === "jcode" && model && !/^[A-Za-z0-9_.:\/\-[\],=]{1,160}$/.test(model))
           return err(400, "invalid jcode model name");
@@ -8837,7 +8837,7 @@ a{color:#60a5fa}
             ? resolvedModel ?? GROK_DEFAULT_MODEL()
             : agent === "cursor"
               ? resolvedModel ?? "auto"
-              : agent === "opencode"
+              : (agent === "opencode" || agent === "omg")
                   ? resolvedModel ?? opencodeDefault
                 : agent === "jcode"
                   ? resolvedModel ?? "auto"
@@ -8859,7 +8859,7 @@ a{color:#60a5fa}
           runtime: CODING_AGENT_ADAPTERS[agent].transport,
           sessionId: launchId,
           nativeSessionId:
-            agent === "aisdk" || agent === "opencode"
+            agent === "aisdk" || agent === "opencode" || agent === "omg"
               ? launchId
               : undefined,
           launchState: "launching",
@@ -9894,7 +9894,9 @@ a{color:#60a5fa}
             if (sess.tmuxName) patchManaged(sess.tmuxName, { model });
             return json({ ok: true, model });
           }
-          if (sess.agent === "opencode") {
+          if (sess.agent === "opencode" || sess.agent === "omg") {
+            if (sess.agent === "omg" && !modelsForAgent("omg").includes(model))
+              return err(400, `unknown omg model "${model}"`);
             if (!/^[A-Za-z0-9_.:\/-]{1,80}$/.test(model))
               return err(400, "invalid opencode model name");
             if (OPENCODE_DISABLED_MODELS.has(model))
@@ -9967,7 +9969,7 @@ a{color:#60a5fa}
           if (!allowed.includes(thinkingLevel))
             return err(400, `unknown thinking level "${thinkingLevel}" for ${sess.agent} (expected one of ${allowed.join(", ")})`);
 
-          if (sess.agent === "aisdk" || sess.agent === "codex-aisdk" || sess.agent === "opencode" || sess.agent === "pi" || (sess.agent === "jcode" && sess.runtime === "command-file")) {
+          if (sess.agent === "aisdk" || sess.agent === "codex-aisdk" || sess.agent === "opencode" || sess.agent === "omg" || sess.agent === "pi" || (sess.agent === "jcode" && sess.runtime === "command-file")) {
             const entry = findAisdkEntryByAnyId(m[1]);
             if (!entry) return err(409, "session control process is unavailable");
             appendAisdkCmd(entry.sessionId, { type: "set_thinking_level", thinkingLevel });

--- a/src/managed.ts
+++ b/src/managed.ts
@@ -32,7 +32,7 @@ export type ManagedSession = {
   tmuxName: string;
   cwd: string;
   createdAt: number;
-  agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "jcode" | "grok" | "cursor" | "fx" | "muse" | "deepseek" | "hermes" | "pi" | "copilot";
+  agent?: "claude" | "codex" | "aisdk" | "codex-aisdk" | "opencode" | "omg" | "jcode" | "grok" | "cursor" | "fx" | "muse" | "deepseek" | "hermes" | "pi" | "copilot";
   /** Explicit runtime for new rows. Missing preserves the legacy kind-based runtime. */
   runtime?: "tmux" | "command-file";
   // Stable id shown to clients for lfg-created sessions. For agents that mint a

--- a/src/omg-models.ts
+++ b/src/omg-models.ts
@@ -1,0 +1,10 @@
+// Shared by the runtime and dashboard. Order is the hosted router picker order.
+export const OMG_MODELS: string[] = [
+  "omg/deepseek/deepseek-v4-flash-0731",
+  "omg/deepseek/deepseek-v4-pro",
+  "omg/z-ai/glm-5.3-flash",
+  "omg/z-ai/glm-5.2",
+  "omg/qwen/qwen3.7-plus",
+  "omg/qwen/qwen3-coder-next",
+  "omg/minimax/minimax-m3",
+];

--- a/src/omg-provider.test.ts
+++ b/src/omg-provider.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { ensureOmgProvider, hasOmgProviderAccess, isHostedOmgSandbox, OMG_SIGN_IN_REQUIRED } from "./omg-provider.ts";
+import { OMG_MODELS } from "./omg-models.ts";
+
+let home: string;
+let apiUrl: string | undefined;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "omg-provider-"));
+  apiUrl = process.env.OMG_API_URL;
+  process.env.OMG_API_URL = "https://api.example.test/";
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (apiUrl === undefined) delete process.env.OMG_API_URL;
+  else process.env.OMG_API_URL = apiUrl;
+});
+const options = () => ({ home, env: {}, guestConfigPath: join(home, "guest.jsonc") });
+function put(path: string, text: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, text);
+}
+function credentials(kind = "api-key", token = "omg_sk_test") {
+  put(join(home, ".omg/credentials.json"), JSON.stringify({ kind, token }));
+}
+const configPath = () => join(home, ".config/opencode/opencode.json");
+
+test("hosted proxy environment is a no-op without credentials", () => {
+  const opts = { ...options(), env: { OMG_AI_URL: "http://169.254.0.1:9090/v1/" } };
+  expect(isHostedOmgSandbox(opts)).toBe(true);
+  expect(hasOmgProviderAccess(opts)).toBe(true);
+  ensureOmgProvider(opts);
+  expect(existsSync(configPath())).toBe(false);
+});
+
+test("guest's existing omg provider is a no-op and stays byte-for-byte intact", () => {
+  const opts = options();
+  const source = '{ // guest managed\n "provider": { "omg": { "options": { "baseURL": "http://169.254.0.1:9090/v1" } } } }';
+  put(opts.guestConfigPath, source);
+  expect(isHostedOmgSandbox(opts)).toBe(true);
+  ensureOmgProvider(opts);
+  expect(readFileSync(opts.guestConfigPath, "utf8")).toBe(source);
+  expect(existsSync(configPath())).toBe(false);
+});
+
+test("an unrelated proxy environment does not count as a hosted sandbox", () => {
+  expect(isHostedOmgSandbox({ ...options(), env: { OMG_AI_URL: "https://external.example" } })).toBe(false);
+});
+
+for (const kind of ["api-key", "oauth", "jwt"]) {
+  test(`local write uses the saved ${kind} token as the SDK Bearer apiKey`, () => {
+    credentials(kind, `test-${kind}-token`);
+    expect(hasOmgProviderAccess(options())).toBe(true);
+    ensureOmgProvider(options());
+    const config = JSON.parse(readFileSync(configPath(), "utf8"));
+    expect(config).toEqual({ provider: { omg: {
+      npm: "@ai-sdk/openai-compatible",
+      name: "omg",
+      options: { baseURL: "https://api.example.test/api/cli/llm/v1", apiKey: `test-${kind}-token` },
+      models: Object.fromEntries(OMG_MODELS.map((model) => {
+        const id = model.slice(4);
+        return [id, { name: id }];
+      })),
+    } } });
+    expect(statSync(configPath()).mode & 0o777).toBe(0o600);
+  });
+}
+
+test("merge preserves other keys, providers, and custom omg options", () => {
+  credentials();
+  put(configPath(), JSON.stringify({ theme: "dark", mcp: { custom: { enabled: true } }, provider: {
+    other: { npm: "other-sdk" }, omg: { options: { timeout: 500, apiKey: "old" }, models: { custom: { name: "Custom" } } },
+  } }));
+  ensureOmgProvider(options());
+  const result = JSON.parse(readFileSync(configPath(), "utf8"));
+  expect(result.theme).toBe("dark");
+  expect(result.mcp).toEqual({ custom: { enabled: true } });
+  expect(result.provider.other).toEqual({ npm: "other-sdk" });
+  expect(result.provider.omg.options).toEqual({ timeout: 500, baseURL: "https://api.example.test/api/cli/llm/v1", apiKey: "omg_sk_test" });
+  expect(result.provider.omg.models.custom).toEqual({ name: "Custom" });
+  const first = readFileSync(configPath(), "utf8");
+  ensureOmgProvider(options());
+  expect(readFileSync(configPath(), "utf8")).toBe(first);
+});
+
+test("prefers existing JSONC, parses comments and trailing commas, honors XDG", () => {
+  credentials();
+  const xdg = join(home, "xdg");
+  const path = join(xdg, "opencode/opencode.jsonc");
+  put(path, '{ // comment\n "theme": "light", "provider": {"other": {}}, }');
+  ensureOmgProvider({ ...options(), env: { XDG_CONFIG_HOME: xdg } });
+  const result = JSON.parse(readFileSync(path, "utf8"));
+  expect(result.theme).toBe("light");
+  expect(result.provider.other).toEqual({});
+  expect(result.provider.omg.options.apiKey).toBe("omg_sk_test");
+  expect(existsSync(join(xdg, "opencode/opencode.json"))).toBe(false);
+});
+
+test("missing credentials fail with the login instruction before writing", () => {
+  expect(hasOmgProviderAccess(options())).toBe(false);
+  expect(() => ensureOmgProvider(options())).toThrow(OMG_SIGN_IN_REQUIRED);
+  expect(existsSync(configPath())).toBe(false);
+});
+
+test("invalid config is not overwritten", () => {
+  credentials();
+  put(configPath(), "{broken");
+  expect(() => ensureOmgProvider(options())).toThrow("Cannot update invalid JSON config:");
+  expect(readFileSync(configPath(), "utf8")).toBe("{broken");
+});

--- a/src/omg-provider.ts
+++ b/src/omg-provider.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { cloudApiBaseUrl, loadCloudCredentials } from "./cloud-account.ts";
+import { OMG_MODELS } from "./omg-models.ts";
+
+const GUEST_PROXY = "http://169.254.0.1:9090";
+export const OMG_SIGN_IN_REQUIRED = "Sign in with `omg login` to use the omg agent.";
+
+type Config = Record<string, any>;
+export type OmgProviderOptions = {
+  home?: string;
+  env?: Record<string, string | undefined>;
+  guestConfigPath?: string;
+};
+
+function readConfig(path: string): Config {
+  if (!existsSync(path)) return {};
+  try {
+    const value = Bun.JSONC.parse(readFileSync(path, "utf8"));
+    if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  } catch {}
+  throw new Error(`Cannot update invalid JSON config: ${path}`);
+}
+
+/** The guest sets OMG_AI_URL; its preinstalled provider is a fallback marker. */
+export function isHostedOmgSandbox(options: OmgProviderOptions = {}): boolean {
+  const env = options.env ?? process.env;
+  if (env.OMG_AI_URL?.trim().replace(/\/+$/, "").replace(/\/v1$/, "") === GUEST_PROXY) return true;
+  const path = options.guestConfigPath ?? "/home/user/.config/opencode/opencode.jsonc";
+  try { return !!readConfig(path).provider?.omg; } catch { return false; }
+}
+
+export function hasOmgProviderAccess(options: OmgProviderOptions = {}): boolean {
+  if (isHostedOmgSandbox(options)) return true;
+  return !!loadCloudCredentials(join(options.home ?? homedir(), ".omg", "credentials.json"));
+}
+
+/** Merge only our provider. JSONC takes precedence over JSON in OpenCode. */
+export function ensureOmgProvider(options: OmgProviderOptions = {}): void {
+  if (isHostedOmgSandbox(options)) return;
+  const home = options.home ?? homedir();
+  const credentials = loadCloudCredentials(join(home, ".omg", "credentials.json"));
+  if (!credentials) throw new Error(OMG_SIGN_IN_REQUIRED);
+  const env = options.env ?? process.env;
+  const dir = join(env.XDG_CONFIG_HOME?.trim() || join(home, ".config"), "opencode");
+  // Match the existing MCP writer's opencode.json path on a new installation.
+  const jsonc = join(dir, "opencode.jsonc");
+  const path = existsSync(jsonc) ? jsonc : join(dir, "opencode.json");
+  const current = readConfig(path);
+  const previous = current.provider?.omg ?? {};
+  // The local CLI holds a control-plane OAuth token. Infra does not accept it, so
+  // the local route goes through the control-plane CLI gate (control-plane/lib/cli.ts).
+  const baseURL = `${cloudApiBaseUrl()}/api/cli/llm/v1`;
+  const next = {
+    ...current,
+    provider: {
+      ...current.provider,
+      omg: {
+        ...previous,
+        npm: "@ai-sdk/openai-compatible",
+        name: "omg",
+        options: { ...previous.options, baseURL, apiKey: credentials.token },
+        models: {
+          ...previous.models,
+          ...Object.fromEntries(OMG_MODELS.map((model) => {
+            const id = model.slice("omg/".length);
+            return [id, { ...previous.models?.[id], name: id }];
+          })),
+        },
+      },
+    },
+  };
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, path);
+  } finally {
+    rmSync(tmp, { force: true });
+  }
+}

--- a/src/resume-cache.ts
+++ b/src/resume-cache.ts
@@ -33,7 +33,7 @@ export type ResumableCacheRow = ResumableSession & {
 export type ResumableBackend =
   | "aisdk"
   | "codex-aisdk"
-  | "opencode"
+  | "opencode" | "omg"
   | "pi"
   | "grok"
   | "cursor"
@@ -212,7 +212,7 @@ function toSession(row: Row): ResumableSession {
     lastUserText: row.last_user_text,
     agent: (
       row.agent === "codex" ||
-      row.agent === "opencode" ||
+      row.agent === "opencode" || row.agent === "omg" ||
       row.agent === "pi" ||
       row.agent === "grok" ||
       row.agent === "cursor" ||

--- a/src/session-recovery.integration.test.ts
+++ b/src/session-recovery.integration.test.ts
@@ -55,6 +55,7 @@ describe("session recovery integration", () => {
       "grok",
       "jcode",
       "muse",
+      "omg",
       "opencode",
       "pi",
     ]);
@@ -71,7 +72,8 @@ describe("session recovery integration", () => {
     const fakeTmux = join(fakeBin, "tmux");
     const fakeHome = join(root, "home");
     mkdirSync(fakeBin, { recursive: true });
-    mkdirSync(fakeHome, { recursive: true });
+    mkdirSync(join(fakeHome, ".omg"), { recursive: true });
+    writeFileSync(join(fakeHome, ".omg/credentials.json"), JSON.stringify({ token: "omg_sk_test", kind: "api-key" }));
     writeFileSync(fakeTmux, [
       "#!/usr/bin/env bun",
       "const capture = process.env.LFG_TEST_TMUX_CAPTURE;",

--- a/src/session-recovery.ts
+++ b/src/session-recovery.ts
@@ -119,7 +119,7 @@ function launchRecovered(
       serviceTier: managed.serviceTier ?? entry.serviceTier ?? undefined,
     });
   }
-  if (entry.agent === "opencode") {
+  if (entry.agent === "opencode" || entry.agent === "omg") {
     if (!entry.threadId) return { ok: false, error: "opencode recovery handle missing" };
     return spawnManagedOpencodeAisdkSession({
       ...common,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -87,6 +87,7 @@ const DIRECT_INDEX_MANAGED_AGENTS = new Set<ManagedSession["agent"]>([
   "aisdk",
   "codex-aisdk",
   "opencode",
+  "omg",
   "pi",
   "grok",
   "cursor",
@@ -626,7 +627,7 @@ export function managedLaunchRow(
             ? `jcode --model ${m.model ?? ""} repl`.trim()
           : agent === "hermes"
           ? `hermes --model ${m.model ?? ""}`.trim()
-          : agent === "opencode"
+          : (agent === "opencode" || agent === "omg")
             ? `lfg opencode-aisdk-session --model ${m.model ?? ""}`.trim()
             : agent === "pi"
               ? `lfg pi-session --model ${m.model ?? ""}`.trim()
@@ -673,7 +674,7 @@ export function managedLaunchRow(
     managed: true,
     assignedUser: assigns[m.tmuxName] ?? null,
     model:
-      agent === "codex" || agent === "codex-aisdk" || agent === "opencode" || agent === "jcode" || agent === "grok" || agent === "cursor" || agent === "deepseek" || agent === "hermes" || agent === "muse"
+      agent === "codex" || agent === "codex-aisdk" || agent === "opencode" || agent === "omg" || agent === "jcode" || agent === "grok" || agent === "cursor" || agent === "deepseek" || agent === "hermes" || agent === "muse"
         ? model
         : modelAlias(model),
     thinkingLevel: m.thinkingLevel ?? null,
@@ -3022,7 +3023,7 @@ export async function listSessions(): Promise<Session[]> {
   // (send/interrupt route through the command file, not the pane).
   for (const e of aisdkEntries) {
     const isCodex = e.agent === "codex";
-    const isOpencode = e.agent === "opencode";
+    const isOpencode = (e.agent === "opencode" || e.agent === "omg");
     const isPi = e.agent === "pi";
     const publicAgent = isCodex ? "codex-aisdk" : (e.agent ?? "claude") === "claude" ? "aisdk" : e.agent!;
     const codexThreadId = isCodex ? (e.threadId ?? null) : null;
@@ -3454,8 +3455,8 @@ export type ResumableSession = {
   // Which engine the session was recorded with. "claude" resumes via the claude
   // CLI (`claude --resume`); "codex" resumes via a codex-aisdk harness keyed to
   // the rollout's threadId. The serve /resume endpoint branches on this.
-  agent: "claude" | "codex" | "opencode" | "pi" | "grok" | "cursor" | "fx" | "muse" | "copilot" | "jcode";
-  backend?: "aisdk" | "codex-aisdk" | "opencode" | "pi" | "grok" | "cursor" | "fx" | "muse" | "copilot" | "jcode";
+  agent: "claude" | "codex" | "opencode" | "omg" | "pi" | "grok" | "cursor" | "fx" | "muse" | "copilot" | "jcode";
+  backend?: "aisdk" | "codex-aisdk" | "opencode" | "omg" | "pi" | "grok" | "cursor" | "fx" | "muse" | "copilot" | "jcode";
   resumeHandle?: string | null;
   model?: string | null;
   thinkingLevel?: string | null;
@@ -3752,8 +3753,8 @@ async function refreshResumableCacheOnce(focusSessionId?: string): Promise<void>
     );
     const backend = m.agent === "codex-aisdk"
       ? "codex-aisdk"
-      : m.agent === "opencode"
-        ? "opencode"
+      : (m.agent === "opencode" || m.agent === "omg")
+        ? m.agent
         : m.agent === "pi"
           ? "pi"
           : m.agent === "grok" || m.agent === "cursor" || m.agent === "copilot" || m.agent === "jcode"
@@ -3761,8 +3762,8 @@ async function refreshResumableCacheOnce(focusSessionId?: string): Promise<void>
             : "aisdk";
     const agent = backend === "codex-aisdk"
       ? "codex"
-      : backend === "opencode"
-        ? "opencode"
+      : (backend === "opencode" || backend === "omg")
+        ? backend
       : backend === "pi"
         ? "pi"
         : backend === "grok" || backend === "cursor" || backend === "copilot" || backend === "jcode"

--- a/src/test-support/recovery-launch-process.ts
+++ b/src/test-support/recovery-launch-process.ts
@@ -45,9 +45,10 @@ const result = await (agent === "claude" || agent === "aisdk"
         key: `key-${resume}`,
         resume,
       })
-    : agent === "opencode"
+    : agent === "opencode" || agent === "omg"
       ? spawnManagedOpencodeAisdkSession({
           ...common,
+          model: agent === "omg" ? "omg/deepseek/deepseek-v4-flash-0731" : common.model,
           key: `key-${resume}`,
           resume,
         })

--- a/src/tmux.ts
+++ b/src/tmux.ts
@@ -1,3 +1,4 @@
+import { ensureOmgProvider } from "./omg-provider.ts";
 // Map a live process to its tmux pane and inject input. Claude Code sessions
 // run inside tmux panes; we discover the `claude` pid via pgrep/proc, walk up
 // its parent chain to the pane's top process, and `send-keys` into that pane.
@@ -1356,6 +1357,11 @@ export function spawnManagedOpencodeAisdkSession(opts: {
   egressProxyUrl?: string;
   recoveredAt?: number;
 }): ManagedHarnessSpawnResult {
+  if (opts.model.startsWith("omg/")) {
+    try { ensureOmgProvider(); } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
   // Harmless for opencode: ensureFolderTrusted only patches ~/.claude.json and
   // is a no-op when that file (or the project entry) is absent. Kept in lockstep
   // with the other AI-SDK spawn helpers.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { OMG_MODELS } from "../../src/omg-models";
 import { useRuntimeLifecycle } from "./lib/runtime-lifecycle";
 import { LiveHeaderContext } from "./components/live-header-context";
 import { activeMachine } from "./lib/machines";
@@ -1360,7 +1361,7 @@ const FX_MODELS = [
 const MUSE_MODELS = ["muse-spark-1.2"];
 const THINKING_LEVELS = ["low", "medium", "high", "xhigh"] as const;
 type ThinkingLevel = string;
-type AutoAgentBackend = "aisdk" | "codex-aisdk" | "grok" | "cursor" | "fx" | "muse" | "opencode";
+type AutoAgentBackend = "omg" | "aisdk" | "codex-aisdk" | "grok" | "cursor" | "fx" | "muse" | "opencode";
 function savedThinkingLevel(): ThinkingLevel {
   const value = localStorage.getItem("lfg_thinking_level");
   return value && (THINKING_LEVELS as readonly string[]).includes(value) ? value : "medium";
@@ -1401,6 +1402,7 @@ const AGENT_MODELS: Record<AgentKind, string[]> = {
   muse: MUSE_MODELS,
   deepseek: DEEPSEEK_MODELS,
   opencode: OPENCODE_MODELS,
+  omg: OMG_MODELS,
   jcode: JCODE_MODELS,
   pi: PI_MODELS_FALLBACK,
   copilot: COPILOT_MODELS,
@@ -1416,6 +1418,7 @@ const AGENT_DEFAULT_MODEL: Record<AgentKind, string> = {
   muse: "muse-spark-1.2",
   deepseek: "deepseek-v4-flash",
   opencode: "opencode/nemotron-3.5-lightning-free",
+  omg: OMG_MODELS[0]!,
   jcode: "auto",
   pi: "sonnet",
   copilot: "claude-sonnet-4.5",
@@ -1435,6 +1438,7 @@ const AGENT_THINKING_LEVELS: Record<AgentKind, string[]> = {
   muse: ["none", "minimal", "low", "medium", "high", "xhigh", "ultra"],
   deepseek: [],
   opencode: [],
+  omg: [],
   jcode: ["low", "medium", "high", "xhigh", "max"],
   // pi's own list, straight from its --thinking help. It has a real "off".
   pi: ["off", "minimal", "low", "medium", "high", "xhigh"],
@@ -16688,6 +16692,7 @@ const LIVE_THINKING_AGENTS = new Set([
   "grok",
   "cursor",
   "opencode",
+  "omg",
   "pi",
 ]);
 
@@ -18134,8 +18139,8 @@ const onTouchStart = (e: ReactTouchEvent) => {
             model mid-conversation is a session action — both belong to the
             session view of this same session, not to the chat. */}
         {!collapsedView && !headerBot && (
-          (session.agent === "claude" || session.agent === "opencode") &&
-          (session.tmuxTarget || session.agent === "opencode") &&
+          (session.agent === "claude" || session.agent === "opencode" || session.agent === "omg") &&
+          (session.tmuxTarget || session.agent === "opencode" || session.agent === "omg") &&
           sid ? (
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -20856,7 +20861,7 @@ export type ResumableSession = {
   title: string;
   lastActivityAt: number | null;
   lastUserText: string | null;
-  agent: "claude" | "codex" | "opencode" | "grok" | "cursor" | "fx" | "muse";
+  agent: "omg" | "claude" | "codex" | "opencode" | "grok" | "cursor" | "fx" | "muse";
   model?: string | null;
 };
 
@@ -22049,10 +22054,10 @@ function NewSessionDialog({
         ? ["fable", "claude-fable-5-1", "opus", "sonnet", "haiku"].includes(model)
           ? model
           : undefined
-        : session.agent === "opencode"
-          ? (catalog.models.opencode ?? AGENT_MODELS.opencode).includes(model)
+        : session.agent === "opencode" || session.agent === "omg"
+          ? (catalog.models[session.agent] ?? AGENT_MODELS[session.agent]).includes(model)
             ? model
-            : defaultModelFor("opencode")
+            : defaultModelFor(session.agent)
         : session.agent === "codex"
           ? (catalog.models["codex-aisdk"] ?? AGENT_MODELS["codex-aisdk"]).includes(model)
             ? model

--- a/web/src/lib/coding-agent-options.test.ts
+++ b/web/src/lib/coding-agent-options.test.ts
@@ -14,3 +14,10 @@ describe("resolveInitialAgent", () => {
     expect(resolveInitialAgent("managed-anthropic", "opencode")).toBe("opencode");
   });
 });
+
+test("omg is selectable and keeps its saved kind", async () => {
+  const { AGENT_CATALOG, configuredAgentOptions } = await import("./coding-agent-options");
+  expect(AGENT_CATALOG.find((item) => item.key === "omg")).toEqual({ key: "omg", label: "omg agent", scheduled: true });
+  expect(resolveInitialAgent("omg", "opencode")).toBe("omg");
+  expect(configuredAgentOptions(AGENT_CATALOG, [{ key: "omg", visible: true, status: { configured: true, accountConnected: true } }], "connected-or-opencode").map((item) => item.key)).toEqual(["omg"]);
+});

--- a/web/src/lib/coding-agent-options.ts
+++ b/web/src/lib/coding-agent-options.ts
@@ -4,6 +4,7 @@ export type AgentKind =
   | "codex"
   | "codex-aisdk"
   | "opencode"
+  | "omg"
   | "jcode"
   | "grok"
   | "cursor"
@@ -40,6 +41,7 @@ export const AGENT_CATALOG: readonly AgentCatalogEntry[] = [
   { key: "codex-aisdk", label: "codex", scheduled: true },
   { key: "grok", label: "grok", scheduled: true },
   { key: "cursor", label: "cursor", scheduled: true },
+  { key: "omg", label: "omg agent", scheduled: true },
   { key: "opencode", label: "opencode", scheduled: true },
   { key: "fx", label: "fx", scheduled: true },
   { key: "muse", label: "muse", scheduled: true },

--- a/web/src/lib/session-runtime.test.ts
+++ b/web/src/lib/session-runtime.test.ts
@@ -15,7 +15,7 @@ describe("command-file session visibility", () => {
   });
 
   test("keeps legacy harness rows that predate the runtime field", () => {
-    for (const agent of ["aisdk", "codex-aisdk", "opencode"] as const) {
+    for (const agent of ["aisdk", "codex-aisdk", "opencode", "omg"] as const) {
       expect(canDriveSession({ agent, tmuxTarget: null })).toBe(true);
     }
   });

--- a/web/src/lib/session-runtime.ts
+++ b/web/src/lib/session-runtime.ts
@@ -6,7 +6,7 @@ export type DriveableSession = {
 };
 
 function isLegacyHarnessAgent(agent?: string | null): boolean {
-  return agent === "aisdk" || agent === "codex-aisdk" || agent === "opencode";
+  return agent === "aisdk" || agent === "codex-aisdk" || agent === "opencode" || agent === "omg";
 }
 
 /** True when the Live view can control this session without a terminal pane. */

--- a/web/src/lib/session-ui.test.ts
+++ b/web/src/lib/session-ui.test.ts
@@ -87,3 +87,9 @@ describe("projectFaviconSrc", () => {
     expect(projectFaviconSrc("  ")).toBeNull();
   });
 });
+
+test("omg agent uses the existing omg icon", async () => {
+  const { agentIconSrc, agentIconAlt } = await import("./session-ui");
+  expect(agentIconSrc("omg")).toContain("/icon.svg?v=");
+  expect(agentIconAlt("omg")).toBe("omg agent");
+});

--- a/web/src/lib/session-ui.tsx
+++ b/web/src/lib/session-ui.tsx
@@ -28,6 +28,7 @@ export function agentIconSrc(agent?: string): string {
   if (agent === "muse") return omgAssetUrl(`/agent-muse.svg${v}`);
   if (agent === "deepseek") return omgAssetUrl(`/agent-deepseek.svg${v}`);
   if (agent === "hermes") return omgAssetUrl(`/agent-hermes.svg${v}`);
+  if (agent === "omg") return omgAssetUrl(`/icon.svg${v}`);
   if (agent === "opencode") return omgAssetUrl(`/agent-opencode.svg${v}`);
   if (agent === "jcode") return omgAssetUrl(`/agent-jcode.svg${v}`);
   if (agent === "pi") return omgAssetUrl(`/agent-pi.svg${v}`);
@@ -43,6 +44,7 @@ export function agentIconAlt(agent?: string): string {
   if (agent === "muse") return "Muse";
   if (agent === "deepseek") return "DeepSeek";
   if (agent === "hermes") return "Hermes";
+  if (agent === "omg") return "omg agent";
   if (agent === "opencode") return "OpenCode";
   if (agent === "jcode") return "Jcode";
   if (agent === "pi") return "pi";


### PR DESCRIPTION
## What changes

- New coding agent kind `omg`, label "omg agent". Same OpenCode backend and launch path.
- `OMG_MODELS`: 7 router ids prefixed `omg/`. Default `omg/deepseek/deepseek-v4-flash-0731`.
- `src/omg-provider.ts`: before launch, merges an `omg` provider into the OpenCode config.
  - Hosted sandbox (`OMG_AI_URL` at `169.254.0.1:9090`, or the guest config already has the provider): no-op.
  - Local: baseURL `<control-plane>/api/cli/llm/v1`, apiKey from `~/.omg/credentials.json`.
  - No credential: launch fails with "Sign in with `omg login` to use the omg agent."
- `omg` is enumerated everywhere agent kinds are listed (catalog, adapters, API, web client with the existing omg icon).

Hosted side: BennyKok/vibes#1659.

## Verification

- Touched test files: 92 pass. `bun run typecheck` passes.
- Full `bun run test`: 10 failures. 7 are mobile tests that fail identically on main. 3 in `reasoning.test.tsx` are timing flakes and pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)