### PR TITLE
fix(web): give the omg agent its own agent mark

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1681,6 +1681,7 @@ const STATIC_FILES: Record<string, { path: string; type: string }> = {
   "/agent-deepseek.svg": { path: join(WEB_DIR, "agent-deepseek.svg"), type: "image/svg+xml" },
   "/agent-opencode.svg": { path: join(WEB_DIR, "agent-opencode.svg"), type: "image/svg+xml" },
   "/agent-jcode.svg": { path: join(WEB_DIR, "agent-jcode.svg"), type: "image/svg+xml" },
+  "/agent-omg.svg": { path: join(WEB_DIR, "agent-omg.svg"), type: "image/svg+xml" },
   "/agent-grok.svg": { path: join(WEB_DIR, "agent-grok.svg"), type: "image/svg+xml" },
   "/agent-hermes.svg": { path: join(WEB_DIR, "agent-hermes.svg"), type: "image/svg+xml" },
   "/agent-pi.svg": { path: join(WEB_DIR, "agent-pi.svg"), type: "image/svg+xml" },

--- a/web/public/agent-omg.svg
+++ b/web/public/agent-omg.svg
@@ -1,0 +1,15 @@
+<svg height="1em" width="1em" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><title>omg agent</title>
+  <!-- The omg mark from icon-small.svg, sized like the other agent-*.svg marks. -->
+  <defs>
+    <radialGradient id="bg" cx="0" cy="0" r="1.2"><stop offset="0%" stop-color="#4a2417"/><stop offset="100%" stop-color="#120f0b"/></radialGradient>
+    <!-- The bite is a hole, not a dark dot: the tile gradient shows through it,
+         so it stays correct wherever the mark is placed. -->
+    <mask id="disc">
+      <rect width="512" height="512" fill="black"/>
+      <circle cx="254.7" cy="254.7" r="184" fill="white"/>
+      <circle cx="340" cy="169.3" r="53.3" fill="black"/>
+    </mask>
+  </defs>
+  <rect width="512" height="512" rx="115" ry="115" fill="url(#bg)"/>
+  <rect width="512" height="512" fill="#f6f2ec" mask="url(#disc)"/>
+</svg>

--- a/web/src/lib/session-ui.test.ts
+++ b/web/src/lib/session-ui.test.ts
@@ -90,6 +90,6 @@ describe("projectFaviconSrc", () => {
 
 test("omg agent uses the existing omg icon", async () => {
   const { agentIconSrc, agentIconAlt } = await import("./session-ui");
-  expect(agentIconSrc("omg")).toContain("/icon.svg?v=");
+  expect(agentIconSrc("omg")).toContain("/agent-omg.svg?v=");
   expect(agentIconAlt("omg")).toBe("omg agent");
 });

--- a/web/src/lib/session-ui.tsx
+++ b/web/src/lib/session-ui.tsx
@@ -28,7 +28,7 @@ export function agentIconSrc(agent?: string): string {
   if (agent === "muse") return omgAssetUrl(`/agent-muse.svg${v}`);
   if (agent === "deepseek") return omgAssetUrl(`/agent-deepseek.svg${v}`);
   if (agent === "hermes") return omgAssetUrl(`/agent-hermes.svg${v}`);
-  if (agent === "omg") return omgAssetUrl(`/icon.svg${v}`);
+  if (agent === "omg") return omgAssetUrl(`/agent-omg.svg${v}`);
   if (agent === "opencode") return omgAssetUrl(`/agent-opencode.svg${v}`);
   if (agent === "jcode") return omgAssetUrl(`/agent-jcode.svg${v}`);
   if (agent === "pi") return omgAssetUrl(`/agent-pi.svg${v}`);


### PR DESCRIPTION
The omg agent icon resolved to `/icon.svg` on the asset host. omg.dev serves only `agent-*.svg` marks from the LFG bundle, so the composer showed a broken image.

- `web/public/agent-omg.svg`: the omg mark, sized like the other agent marks.
- `agentIconSrc("omg")` now returns `/agent-omg.svg`.
- Standalone `serve.ts` allowlist includes it.

Verification: `session-ui.test.ts` passes, `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)