### PR TITLE
feat(usage): show the omg agent's AI credit, and stop rounding rail marks

### DIFF
--- a/src/usage-providers.test.ts
+++ b/src/usage-providers.test.ts
@@ -202,6 +202,7 @@ describe("usage providers", () => {
       "cursor",
       "grok",
       "opencode",
+      "omg",
       "muse",
     ]);
   });
@@ -387,5 +388,39 @@ describe("usage providers", () => {
     expect(claude.map((provider) => provider.windows?.[0]?.pct)).toEqual([10, 20]);
     // Every source answers, including the ones with nothing signed in.
     expect(all.every((provider) => typeof provider.available === "boolean")).toBe(true);
+  });
+});
+
+describe("omg agent usage", () => {
+  test("the omg agent is a usage source on every box", async () => {
+    const { listUsageProviders } = await import("./usage.ts");
+    expect(listUsageProviders().find((ref) => ref.kind === "omg")).toEqual({
+      id: "omg", kind: "omg", label: "omg agent",
+    });
+  });
+
+  test("maps the plan's monthly AI credit to one ring", async () => {
+    const { omgUsageFromBalance } = await import("./usage.ts");
+    const ref = { id: "omg", kind: "omg", label: "omg agent" };
+    const usage = omgUsageFromBalance(ref, {
+      plan: "computer_5",
+      build: { limitUsd: 38, usedUsd: 9.5, remainingUsd: 28.5, resetsAt: 1_800_000_000_000 },
+    });
+    expect(usage).toEqual({
+      ...ref,
+      available: true,
+      plan: "Personal",
+      windows: [{ label: "Monthly · $38", pct: 25, resetsAt: 1_800_000_000_000 }],
+      note: "AI credit: $28.50 of $38 left",
+    });
+  });
+
+  test("a plan without AI credit reads as unavailable, with the way out", async () => {
+    const { omgUsageFromBalance } = await import("./usage.ts");
+    const ref = { id: "omg", kind: "omg", label: "omg agent" };
+    const usage = omgUsageFromBalance(ref, { plan: "free", build: { limitUsd: 0, usedUsd: 0, remainingUsd: 0, resetsAt: null } });
+    expect(usage.available).toBe(false);
+    expect(usage.plan).toBe("free");
+    expect(usage.note).toContain("Upgrade on omg.dev");
   });
 });

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -34,6 +34,7 @@ import {
 import { defaultModelForAgent } from "./agent-catalog.ts";
 import { PATHS } from "./config.ts";
 import { museFetchInit } from "./muse-proxy.ts";
+import { cloudApiBaseUrl, createCloudAccount } from "./cloud-account.ts";
 
 export type UsageWindow = {
   label: string;
@@ -754,6 +755,76 @@ async function opencodeUsage(ref: UsageProviderRef): Promise<ProviderUsage> {
 }
 
 
+// ------------------------------------------------------------------- omg ----
+
+// The omg agent spends the AI credit included in the account's Computer plan.
+// The hosted side owns the ledger; this box reads the same balance the omg.dev
+// Settings page shows, through the CLI gate, with the `omg login` credential.
+export type OmgBalance = {
+  plan?: string | null;
+  build?: {
+    limitUsd: number;
+    usedUsd: number;
+    remainingUsd: number;
+    resetsAt: number | null;
+  } | null;
+};
+
+const OMG_PLAN_LABELS: Record<string, string> = {
+  computer_s40: "Starter Plus",
+  computer_5: "Personal",
+  computer_10: "Pro",
+};
+
+function usd(value: number): string {
+  return `$${value.toFixed(value >= 100 || Number.isInteger(value) ? 0 : 2)}`;
+}
+
+/** The composer ring for the plan's monthly AI credit. Exported for tests. */
+export function omgUsageFromBalance(
+  ref: UsageProviderRef,
+  balance: OmgBalance,
+): ProviderUsage {
+  const plan = balance.plan ? (OMG_PLAN_LABELS[balance.plan] ?? balance.plan) : null;
+  const build = balance.build;
+  if (!build || build.limitUsd <= 0) {
+    return {
+      ...ref,
+      available: false,
+      plan,
+      note: "Your plan includes no AI credit. Upgrade on omg.dev to use the omg agent.",
+    };
+  }
+  const pct = Math.max(0, Math.min(100, (build.usedUsd / build.limitUsd) * 100));
+  return {
+    ...ref,
+    available: true,
+    plan,
+    windows: [{ label: `Monthly · ${usd(build.limitUsd)}`, pct, resetsAt: build.resetsAt }],
+    note: `AI credit: ${usd(build.remainingUsd)} of ${usd(build.limitUsd)} left`,
+  };
+}
+
+async function omgUsage(ref: UsageProviderRef): Promise<ProviderUsage> {
+  let token: string | null = null;
+  try {
+    token = await createCloudAccount().getAccessToken();
+  } catch {
+    token = null;
+  }
+  if (!token) return staticProvider(ref, "Sign in with `omg login` to see your AI credit");
+  try {
+    const r = await fetch(`${cloudApiBaseUrl()}/api/cli/billing/balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) return staticProvider(ref, `omg.dev answered ${r.status}`);
+    return omgUsageFromBalance(ref, (await r.json()) as OmgBalance);
+  } catch {
+    return staticProvider(ref, "Could not reach omg.dev");
+  }
+}
+
 // ------------------------------------------------------------------ Muse ----
 
 // Meta ships no usage endpoint for Muse Code. The subscription snapshot rides
@@ -935,6 +1006,7 @@ const STATIC_PROVIDERS: UsageProviderRef[] = [
   { id: "cursor", kind: "cursor", label: "Cursor" },
   { id: "grok", kind: "grok", label: "Grok" },
   { id: "opencode", kind: "opencode", label: "OpenCode" },
+  { id: "omg", kind: "omg", label: "omg agent" },
   { id: "muse", kind: "muse", label: "Muse" },
 ];
 
@@ -966,6 +1038,7 @@ function collect(ref: UsageProviderRef, force = false): Promise<ProviderUsage> {
   if (ref.kind === "cursor") return cursorUsage(ref);
   if (ref.kind === "grok") return grokUsage(ref);
   if (ref.kind === "opencode") return opencodeUsage(ref);
+  if (ref.kind === "omg") return omgUsage(ref);
   if (ref.kind === "muse") return museUsage(ref, force);
   return Promise.resolve(staticProvider(ref, "Usage is unavailable for this provider"));
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9607,6 +9607,7 @@ export function App() {
             codex: ["codex-aisdk", "codex"],
             grok: ["grok"],
             opencode: ["opencode"],
+            omg: ["omg"],
             cursor: ["cursor"],
             copilot: ["copilot"],
             pi: ["pi"],
@@ -14033,7 +14034,7 @@ const RailItem = memo(function RailItem({
             <AgentMark
               session={session}
               busy={busy}
-              rounding="rounded-md"
+              rounding="rounded-none"
               showAccountNumber={false}
             />
           ) : (
@@ -14047,7 +14048,7 @@ const RailItem = memo(function RailItem({
               <AgentMark
                 session={session}
                 busy={false}
-                rounding="rounded-sm"
+                rounding="rounded-none"
                 compact
                 showAccountNumber={false}
               />


### PR DESCRIPTION
- Composer usage rings cover the omg agent: one monthly ring for the plan's AI credit, read from `GET <control-plane>/api/cli/billing/balance` with the `omg login` credential (route added in BennyKok/vibes#1661).
- Unavailable states say why: not signed in, plan without credit, omg.dev unreachable.
- Session rail agent marks are no longer rounded. The omg mark was clipped by the corner radius.

Verification: `usage-providers.test.ts` (with three new cases) and `session-ui.test.ts` pass; `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)