### PR TITLE
feat(transcript): rounder sent bubbles, copy moves into their long-press menu

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20257,10 +20257,30 @@ function MessageActions({
         selecting && "is-selecting",
       )}
     >
-      <div ref={contentRef} className="min-w-0 max-w-full">
-        {children}
-      </div>
-      {text ? (
+      {isUser ? (
+        // A sent message keeps its edge clean: no copy button in the gutter.
+        // Copy lives in the long-press (right-click on desktop) menu instead.
+        <ContextMenu>
+          <ContextMenuTrigger className="block min-w-0 max-w-full">
+            <div ref={contentRef} className="min-w-0 max-w-full">
+              {children}
+            </div>
+          </ContextMenuTrigger>
+          {text ? (
+            <ContextMenuContent className="min-w-40">
+              <ContextMenuItem onClick={() => void copy()}>
+                <Copy className="size-3.5" />
+                Copy message
+              </ContextMenuItem>
+            </ContextMenuContent>
+          ) : null}
+        </ContextMenu>
+      ) : (
+        <div ref={contentRef} className="min-w-0 max-w-full">
+          {children}
+        </div>
+      )}
+      {text && !isUser ? (
         <button
           type="button"
           onClick={() => void copy()}
@@ -20272,8 +20292,7 @@ function MessageActions({
           // message, costs no height, and — because it is never added or
           // removed on hover — shifts nothing when it appears.
           className={cn(
-            "message-copy-button absolute bottom-0 flex size-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none",
-            isUser ? "right-full mr-1" : "left-full ml-1",
+            "message-copy-button absolute bottom-0 left-full ml-1 flex size-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:text-foreground focus-visible:outline-none",
           )}
           aria-label={copied ? "Message copied" : "Copy message"}
           title={copied ? "Copied" : "Copy message"}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1018,7 +1018,7 @@ html[data-lfg-embed="true"].lfg-keyboard-open {
     z-index: 0;
     overflow: hidden;
     border: 1px solid transparent;
-    border-radius: 22px;
+    border-radius: 26px;
     padding: var(--user-bubble-padding);
     background:
       linear-gradient(var(--user-bubble-fill), var(--user-bubble-fill)) padding-box,

--- a/web/src/message-copy-button-layout.test.ts
+++ b/web/src/message-copy-button-layout.test.ts
@@ -61,13 +61,22 @@ describe("per-message copy button stays out of the transcript's vertical flow", 
     expect(BUTTON_CLASSES).not.toMatch(/\bmy-\d/);
   });
 
-  test("sits in the outward gutter on the side its speaker is aligned to", () => {
-    // Assistant bubbles hug the left edge, so their button goes right; user
-    // bubbles hug the right edge, so their button goes left. Either way it is
-    // beside its own bubble and reads as belonging to it.
+  test("sits in the gutter to the right of an assistant bubble", () => {
+    // Only assistant turns wear the button. A sent message keeps its trailing
+    // edge clean: its copy action lives in the long-press / right-click menu.
     expect(BUTTON_CLASSES).toContain("left-full");
-    expect(BUTTON_CLASSES).toContain("right-full");
-    expect(BUTTON_CLASSES).toMatch(/isUser \?[\s\S]*right-full[\s\S]*left-full/);
+    expect(BUTTON_CLASSES).not.toContain("right-full");
+    expect(MESSAGE_ACTIONS).toMatch(/text && !isUser \? \(/);
+  });
+
+  test("a sent message copies from its context menu instead", () => {
+    const userBranch = MESSAGE_ACTIONS.slice(
+      MESSAGE_ACTIONS.indexOf("{isUser ? ("),
+      MESSAGE_ACTIONS.indexOf("{text && !isUser ? ("),
+    );
+    expect(userBranch).toContain("<ContextMenu>");
+    expect(userBranch).toContain("Copy message");
+    expect(userBranch).not.toContain("message-copy-button");
   });
 });
 
@@ -86,7 +95,7 @@ describe("the out-of-flow button cannot overflow the row horizontally", () => {
 
   test("the reserved gutter is wider than the button plus its offset", () => {
     const buttonRem = spacingRem("size");
-    const offsetRem = Math.max(spacingRem("ml"), spacingRem("mr"));
+    const offsetRem = spacingRem("ml");
     expect(buttonRem * REM_PX).toBe(28);
     for (const cap of caps) {
       expect(Number(cap[2])).toBeGreaterThanOrEqual(buttonRem + offsetRem);


### PR DESCRIPTION
- Sent-message card radius 22px → 26px.
- The sent message's gutter copy button is removed. Copy now lives in its context menu: long-press on touch, right-click on desktop (Base UI ContextMenu).
- Assistant turns keep the hover copy button, unchanged.

Verification: `message-copy-button-layout.test.ts` (updated to the new contract), `mobile-copy-button.test.ts`, `chat-find-invariants.test.ts` pass; `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)