### PR TITLE
feat(usage): show AI credit inside a hosted Computer, and six more omg models

### DIFF
--- a/src/agent-catalog.test.ts
+++ b/src/agent-catalog.test.ts
@@ -300,7 +300,7 @@ describe("curateCursorModels", () => {
   });
 });
 
-test("omg agent lists the 7 routed models in hosted picker order", async () => {
+test("omg agent lists the 13 routed models in hosted picker order", async () => {
   const { OMG_MODELS } = await import("./agent-catalog.ts");
   expect(OMG_MODELS).toEqual([
     "omg/deepseek/deepseek-v4-flash-0731",
@@ -310,6 +310,12 @@ test("omg agent lists the 7 routed models in hosted picker order", async () => {
     "omg/qwen/qwen3.7-plus",
     "omg/qwen/qwen3-coder-next",
     "omg/minimax/minimax-m3",
+    "omg/anthropic/claude-fable-5.1",
+    "omg/anthropic/claude-opus-4.8",
+    "omg/anthropic/claude-sonnet-4.6",
+    "omg/openai/gpt-5.6-sol",
+    "omg/openai/gpt-5.6-terra",
+    "omg/openai/gpt-5.6-luna",
   ]);
   expect(defaultModelForAgent("omg")).toBe(OMG_MODELS[0]!);
   expect(modelsForAgent("omg")).toEqual(OMG_MODELS);

--- a/src/omg-models.ts
+++ b/src/omg-models.ts
@@ -7,4 +7,10 @@ export const OMG_MODELS: string[] = [
   "omg/qwen/qwen3.7-plus",
   "omg/qwen/qwen3-coder-next",
   "omg/minimax/minimax-m3",
+  "omg/anthropic/claude-fable-5.1",
+  "omg/anthropic/claude-opus-4.8",
+  "omg/anthropic/claude-sonnet-4.6",
+  "omg/openai/gpt-5.6-sol",
+  "omg/openai/gpt-5.6-terra",
+  "omg/openai/gpt-5.6-luna",
 ];

--- a/src/usage-providers.test.ts
+++ b/src/usage-providers.test.ts
@@ -424,3 +424,17 @@ describe("omg agent usage", () => {
     expect(usage.note).toContain("Upgrade on omg.dev");
   });
 });
+
+test("the in-guest router's micro-dollar balance normalizes like the control plane's", async () => {
+  const { normalizeOmgBalance } = await import("./usage.ts");
+  expect(normalizeOmgBalance({
+    plan: "computer_5",
+    build: { window: "month", limitMicros: 38_000_000, usedMicros: 1_498, remainingMicros: 37_998_502, resetsAt: 1_790_812_800_000 },
+  })).toEqual({
+    plan: "computer_5",
+    build: { limitUsd: 38, usedUsd: 0.001498, remainingUsd: 37.998502, resetsAt: 1_790_812_800_000 },
+  });
+  expect(normalizeOmgBalance({ plan: "computer_5", build: { limitUsd: 38, usedUsd: 1, remainingUsd: 37, resetsAt: null } }).build)
+    .toEqual({ limitUsd: 38, usedUsd: 1, remainingUsd: 37, resetsAt: null });
+  expect(normalizeOmgBalance({ plan: "free" }).build).toBeNull();
+});

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -35,6 +35,7 @@ import { defaultModelForAgent } from "./agent-catalog.ts";
 import { PATHS } from "./config.ts";
 import { museFetchInit } from "./muse-proxy.ts";
 import { cloudApiBaseUrl, createCloudAccount } from "./cloud-account.ts";
+import { isHostedOmgSandbox } from "./omg-provider.ts";
 
 export type UsageWindow = {
   label: string;
@@ -770,6 +771,32 @@ export type OmgBalance = {
   } | null;
 };
 
+/** The in-guest router of a hosted omg Computer. No credential: the VM is the identity. */
+const GUEST_BALANCE_URL = "http://169.254.0.1:9090/v1/billing/balance";
+
+/**
+ * The control plane answers in dollars; the in-guest router answers in the
+ * ledger's micro-dollars. Exported for tests.
+ */
+export function normalizeOmgBalance(raw: Record<string, any>): OmgBalance {
+  const build = raw?.build;
+  if (!build || typeof build !== "object") return { plan: raw?.plan ?? null, build: null };
+  const micros = typeof build.limitMicros === "number";
+  const usd = (key: string) => {
+    const value = micros ? build[`${key}Micros`] / 1_000_000 : build[`${key}Usd`];
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+  };
+  return {
+    plan: raw?.plan ?? null,
+    build: {
+      limitUsd: usd("limit"),
+      usedUsd: usd("used"),
+      remainingUsd: usd("remaining"),
+      resetsAt: typeof build.resetsAt === "number" ? build.resetsAt : null,
+    },
+  };
+}
+
 const OMG_PLAN_LABELS: Record<string, string> = {
   computer_s40: "Starter Plus",
   computer_5: "Personal",
@@ -806,6 +833,15 @@ export function omgUsageFromBalance(
 }
 
 async function omgUsage(ref: UsageProviderRef): Promise<ProviderUsage> {
+  if (isHostedOmgSandbox()) {
+    try {
+      const r = await fetch(GUEST_BALANCE_URL, { signal: AbortSignal.timeout(10_000) });
+      if (!r.ok) return staticProvider(ref, `omg router answered ${r.status}`);
+      return omgUsageFromBalance(ref, normalizeOmgBalance((await r.json()) as Record<string, any>));
+    } catch {
+      return staticProvider(ref, "Could not reach the omg router");
+    }
+  }
   let token: string | null = null;
   try {
     token = await createCloudAccount().getAccessToken();
@@ -819,7 +855,7 @@ async function omgUsage(ref: UsageProviderRef): Promise<ProviderUsage> {
       signal: AbortSignal.timeout(10_000),
     });
     if (!r.ok) return staticProvider(ref, `omg.dev answered ${r.status}`);
-    return omgUsageFromBalance(ref, (await r.json()) as OmgBalance);
+    return omgUsageFromBalance(ref, normalizeOmgBalance((await r.json()) as Record<string, any>));
   } catch {
     return staticProvider(ref, "Could not reach omg.dev");
   }


### PR DESCRIPTION
- Hosted sandbox: the omg usage provider reads `GET http://169.254.0.1:9090/v1/billing/balance` (route added in BennyKok/vibes#1663) and normalizes micro-dollars to the control plane's dollar shape.
- `OMG_MODELS` adds `omg/anthropic/claude-fable-5.1`, `omg/anthropic/claude-opus-4.8`, `omg/anthropic/claude-sonnet-4.6`, `omg/openai/gpt-5.6-sol`, `omg/openai/gpt-5.6-terra`, `omg/openai/gpt-5.6-luna`.

Verification: `usage-providers.test.ts`, `agent-catalog.test.ts`, `omg-provider.test.ts` pass (62 tests); `bun run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)